### PR TITLE
feat: drain phase output to file instead of streaming to stdout

### DIFF
--- a/cli/cmd/xylem/exec.go
+++ b/cli/cmd/xylem/exec.go
@@ -40,7 +40,7 @@ func (r *realCmdRunner) RunPhase(ctx context.Context, dir string, stdin io.Reade
 	cmd.Stderr = os.Stderr
 
 	var stdout bytes.Buffer
-	cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
+	cmd.Stdout = &stdout
 
 	err := cmd.Run()
 	return stdout.Bytes(), err

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -286,6 +286,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 			if wErr := os.WriteFile(outputPath, output, 0o644); wErr != nil {
 				log.Printf("warn: write output file %s: %v", outputPath, wErr)
 			}
+			fmt.Printf("Phase %s complete: %s\n", p.Name, outputPath)
 
 			phaseDuration := time.Since(phaseStart)
 


### PR DESCRIPTION
## Summary
- Stop streaming Claude's full stdout to the terminal during phase execution — only stderr (tool-use progress) is shown
- Print a summary line after each phase with the output file path (e.g. `Phase analysis complete: .xylem/phases/issue-1/analysis.output`)
- Phase output is still captured in the buffer and written to disk as before

Closes https://github.com/nicholls-inc/xylem/issues/5

## Test plan
- [ ] Run `go vet ./...` and `go test ./...` — both pass
- [ ] Run a vessel through `xylem drain` and verify stderr progress is visible but stdout is not streamed
- [ ] Verify the summary line prints the correct output path after each phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)