### PR TITLE
fix: validate workflow name at enqueue time

### DIFF
--- a/cli/cmd/xylem/enqueue.go
+++ b/cli/cmd/xylem/enqueue.go
@@ -3,6 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -21,7 +24,7 @@ func newEnqueueCmd() *cobra.Command {
 			promptFile, _ := cmd.Flags().GetString("prompt-file")
 			srcName, _ := cmd.Flags().GetString("source")
 			id, _ := cmd.Flags().GetString("id")
-			return cmdEnqueue(deps.q, wf, ref, prompt, promptFile, srcName, id)
+			return cmdEnqueue(deps.q, deps.cfg.StateDir, wf, ref, prompt, promptFile, srcName, id)
 		},
 	}
 	cmd.Flags().String("workflow", "", "Workflow to invoke (e.g., fix-bug, implement-feature)")
@@ -33,7 +36,7 @@ func newEnqueueCmd() *cobra.Command {
 	return cmd
 }
 
-func cmdEnqueue(q *queue.Queue, workflow, ref, prompt, promptFile, srcName, id string) error {
+func cmdEnqueue(q *queue.Queue, stateDir, workflow, ref, prompt, promptFile, srcName, id string) error {
 	if prompt != "" && promptFile != "" {
 		return fmt.Errorf("--prompt and --prompt-file are mutually exclusive")
 	}
@@ -48,6 +51,12 @@ func cmdEnqueue(q *queue.Queue, workflow, ref, prompt, promptFile, srcName, id s
 
 	if workflow == "" && prompt == "" {
 		return fmt.Errorf("at least one of --workflow or --prompt/--prompt-file is required")
+	}
+
+	if workflow != "" {
+		if err := validateWorkflow(stateDir, workflow); err != nil {
+			return err
+		}
 	}
 
 	if id == "" {
@@ -68,4 +77,33 @@ func cmdEnqueue(q *queue.Queue, workflow, ref, prompt, promptFile, srcName, id s
 	}
 	fmt.Printf("Enqueued vessel %s (workflow=%s, source=%s)\n", vessel.ID, vessel.Workflow, vessel.Source)
 	return nil
+}
+
+func validateWorkflow(stateDir, name string) error {
+	path := filepath.Join(stateDir, "workflows", name+".yaml")
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+
+	available := listWorkflows(stateDir)
+	if len(available) > 0 {
+		return fmt.Errorf("workflow %q not found at %s\navailable workflows: %s",
+			name, path, strings.Join(available, ", "))
+	}
+	return fmt.Errorf("workflow %q not found at %s", name, path)
+}
+
+func listWorkflows(stateDir string) []string {
+	pattern := filepath.Join(stateDir, "workflows", "*.yaml")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, m := range matches {
+		name := strings.TrimSuffix(filepath.Base(m), ".yaml")
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }

--- a/cli/cmd/xylem/enqueue_test.go
+++ b/cli/cmd/xylem/enqueue_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+func newEnqueueTestQueue(t *testing.T, dir string) *queue.Queue {
+	t.Helper()
+	return queue.New(filepath.Join(dir, "queue.jsonl"))
+}
+
+func setupWorkflowDir(t *testing.T, dir string, workflows ...string) {
+	t.Helper()
+	wfDir := filepath.Join(dir, ".xylem", "workflows")
+	if err := os.MkdirAll(wfDir, 0o755); err != nil {
+		t.Fatalf("create workflow dir: %v", err)
+	}
+	for _, name := range workflows {
+		path := filepath.Join(wfDir, name+".yaml")
+		if err := os.WriteFile(path, []byte("name: "+name+"\n"), 0o644); err != nil {
+			t.Fatalf("write workflow file: %v", err)
+		}
+	}
+}
+
+func TestEnqueueNonexistentWorkflowReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	setupWorkflowDir(t, dir, "fix-bug", "implement-feature", "refine-issue")
+	q := newEnqueueTestQueue(t, dir)
+	stateDir := filepath.Join(dir, ".xylem")
+
+	err := cmdEnqueue(q, stateDir, "refinement", "", "do something", "", "manual", "test-1")
+	if err == nil {
+		t.Fatal("expected error for nonexistent workflow")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected error to contain 'not found', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "refinement") {
+		t.Errorf("expected error to mention workflow name, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "available workflows:") {
+		t.Errorf("expected error to list available workflows, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "fix-bug") {
+		t.Errorf("expected available workflows to include fix-bug, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "refine-issue") {
+		t.Errorf("expected available workflows to include refine-issue, got: %v", err)
+	}
+}
+
+func TestEnqueuePromptOnlySkipsWorkflowValidation(t *testing.T) {
+	dir := t.TempDir()
+	q := newEnqueueTestQueue(t, dir)
+	stateDir := filepath.Join(dir, ".xylem")
+
+	err := cmdEnqueue(q, stateDir, "", "", "do something", "", "manual", "test-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	vessels, _ := q.List()
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	if vessels[0].Prompt != "do something" {
+		t.Errorf("expected prompt 'do something', got %q", vessels[0].Prompt)
+	}
+}
+
+func TestEnqueueValidWorkflowSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	setupWorkflowDir(t, dir, "fix-bug", "implement-feature")
+	q := newEnqueueTestQueue(t, dir)
+	stateDir := filepath.Join(dir, ".xylem")
+
+	err := cmdEnqueue(q, stateDir, "fix-bug", "https://github.com/owner/repo/issues/1", "", "", "manual", "test-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	vessels, _ := q.List()
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	if vessels[0].Workflow != "fix-bug" {
+		t.Errorf("expected workflow 'fix-bug', got %q", vessels[0].Workflow)
+	}
+}
+
+func TestEnqueueNonexistentWorkflowNoWorkflowsAvailable(t *testing.T) {
+	dir := t.TempDir()
+	q := newEnqueueTestQueue(t, dir)
+	stateDir := filepath.Join(dir, ".xylem")
+
+	err := cmdEnqueue(q, stateDir, "nonexistent", "", "do something", "", "manual", "test-1")
+	if err == nil {
+		t.Fatal("expected error for nonexistent workflow")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected error to contain 'not found', got: %v", err)
+	}
+	// When no workflows directory exists, should not mention "available workflows"
+	if strings.Contains(err.Error(), "available workflows:") {
+		t.Errorf("expected no available workflows listed when dir is missing, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Validates that the workflow YAML file exists at `.xylem/workflows/{name}.yaml` before creating a vessel in `cmdEnqueue`
- Lists available workflows in the error message when validation fails (e.g. `available workflows: fix-bug, implement-feature, refine-issue`)
- Skips validation when `--workflow` is empty (prompt-only mode)

## Test plan
- [x] `TestEnqueueNonexistentWorkflowReturnsError` -- verifies misspelled workflow name produces helpful error with available alternatives
- [x] `TestEnqueuePromptOnlySkipsWorkflowValidation` -- verifies prompt-only enqueue works without workflow validation
- [x] `TestEnqueueValidWorkflowSucceeds` -- verifies valid workflow name enqueues successfully
- [x] `TestEnqueueNonexistentWorkflowNoWorkflowsAvailable` -- verifies error when no workflows directory exists
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)