### PR TITLE
fix: allow re-enqueueing vessels in terminal states

### DIFF
--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -280,8 +280,11 @@ func (q *Queue) HasRef(ref string) bool {
 	}
 
 	for _, vessel := range vessels {
-		if vessel.Ref == ref && vessel.State != StateCancelled {
-			return true
+		if vessel.Ref == ref {
+			switch vessel.State {
+			case StatePending, StateRunning, StateWaiting:
+				return true
+			}
 		}
 	}
 	return false

--- a/cli/internal/queue/queue_test.go
+++ b/cli/internal/queue/queue_test.go
@@ -291,6 +291,54 @@ func TestHasRefCancelled(t *testing.T) {
 	}
 }
 
+func TestHasRefTerminalStates(t *testing.T) {
+	tests := []struct {
+		state       VesselState
+		transitions []VesselState
+	}{
+		{StateCompleted, []VesselState{StateRunning, StateCompleted}},
+		{StateFailed, []VesselState{StateRunning, StateFailed}},
+		{StateTimedOut, []VesselState{StateRunning, StateWaiting, StateTimedOut}},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			q, _ := newTestQueue(t)
+			vessel := testVessel(42)
+			if err := q.Enqueue(vessel); err != nil {
+				t.Fatalf("enqueue: %v", err)
+			}
+			for _, s := range tt.transitions {
+				if err := q.Update(vessel.ID, s, ""); err != nil {
+					t.Fatalf("update to %s: %v", s, err)
+				}
+			}
+			if q.HasRef("https://github.com/example/repo/issues/42") {
+				t.Fatalf("expected %s vessel to not block re-enqueueing", tt.state)
+			}
+		})
+	}
+}
+
+func TestHasRefActiveStates(t *testing.T) {
+	transitions := []VesselState{StatePending, StateRunning, StateWaiting}
+	q, _ := newTestQueue(t)
+	vessel := testVessel(42)
+	if err := q.Enqueue(vessel); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	for _, state := range transitions {
+		if state != StatePending {
+			if err := q.Update(vessel.ID, state, ""); err != nil {
+				t.Fatalf("update to %s: %v", state, err)
+			}
+		}
+		if !q.HasRef("https://github.com/example/repo/issues/42") {
+			t.Fatalf("expected %s vessel to block re-enqueueing", state)
+		}
+	}
+}
+
 func TestCorruption(t *testing.T) {
 	q, path := newTestQueue(t)
 	j1 := testVessel(7)


### PR DESCRIPTION
## Summary

- `HasRef()` previously blocked re-enqueueing for all non-cancelled vessel states, preventing completed, failed, and timed-out issues from ever being reprocessed after label changes
- Fix: only block on active states (`pending`, `running`, `waiting`); terminal states (`completed`, `failed`, `timed_out`, `cancelled`) now allow re-enqueueing
- Added `TestHasRefTerminalStates` and `TestHasRefActiveStates` to cover the new behaviour

Closes #11

## Test plan

- [ ] `go test ./internal/queue/...` passes (including new `TestHasRefTerminalStates` and `TestHasRefActiveStates`)
- [ ] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)