### PR TITLE
fix: use reverse iteration for duplicate vessel ID handling

### DIFF
--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -137,7 +137,7 @@ func (q *Queue) Update(id string, state VesselState, errMsg string) error {
 			return err
 		}
 
-		for i := range vessels {
+		for i := len(vessels) - 1; i >= 0; i-- {
 			if vessels[i].ID != id {
 				continue
 			}
@@ -200,7 +200,7 @@ func (q *Queue) FindByID(id string) (*Vessel, error) {
 		if readErr != nil {
 			return readErr
 		}
-		for i := range vessels {
+		for i := len(vessels) - 1; i >= 0; i-- {
 			if vessels[i].ID == id {
 				v := vessels[i]
 				found = &v
@@ -236,7 +236,7 @@ func (q *Queue) UpdateVessel(vessel Vessel) error {
 			return err
 		}
 
-		for i := range vessels {
+		for i := len(vessels) - 1; i >= 0; i-- {
 			if vessels[i].ID != vessel.ID {
 				continue
 			}
@@ -255,7 +255,7 @@ func (q *Queue) Cancel(id string) error {
 			return err
 		}
 
-		for i := range vessels {
+		for i := len(vessels) - 1; i >= 0; i-- {
 			if vessels[i].ID != id {
 				continue
 			}

--- a/cli/internal/queue/queue_test.go
+++ b/cli/internal/queue/queue_test.go
@@ -1089,6 +1089,138 @@ func TestFindByID(t *testing.T) {
 	})
 }
 
+// --- Duplicate-ID tests (re-enqueued vessels) ---
+
+// helperCompleteVessel transitions the first pending vessel through pending -> running -> completed.
+func helperCompleteVessel(t *testing.T, q *Queue, id string) {
+	t.Helper()
+	if _, err := q.Dequeue(); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if err := q.Update(id, StateCompleted, ""); err != nil {
+		t.Fatalf("update to completed: %v", err)
+	}
+}
+
+// helperEnqueueCompleteThenReenqueue creates a queue with two records for the
+// same vessel ID: the first completed, the second pending.
+func helperEnqueueCompleteThenReenqueue(t *testing.T) (*Queue, Vessel) {
+	t.Helper()
+	q, _ := newTestQueue(t)
+	vessel := testVessel(42)
+	if err := q.Enqueue(vessel); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	helperCompleteVessel(t, q, vessel.ID)
+	if err := q.Enqueue(testVessel(42)); err != nil {
+		t.Fatalf("re-enqueue: %v", err)
+	}
+	return q, vessel
+}
+
+func TestDuplicateID(t *testing.T) {
+	t.Run("Update", func(t *testing.T) {
+		q, vessel := helperEnqueueCompleteThenReenqueue(t)
+
+		// Dequeue the re-enqueued vessel (now running).
+		got, err := q.Dequeue()
+		if err != nil {
+			t.Fatalf("dequeue: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected vessel from dequeue")
+		}
+
+		// Update should target the re-enqueued (running) vessel, not the old completed one.
+		if err := q.Update(vessel.ID, StateFailed, "err"); err != nil {
+			t.Fatalf("update: %v", err)
+		}
+
+		vessels, err := q.List()
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(vessels) != 2 {
+			t.Fatalf("expected 2 vessels, got %d", len(vessels))
+		}
+		if vessels[0].State != StateCompleted {
+			t.Fatalf("expected first record (old) to be completed, got %s", vessels[0].State)
+		}
+		if vessels[1].State != StateFailed {
+			t.Fatalf("expected second record (re-enqueued) to be failed, got %s", vessels[1].State)
+		}
+	})
+
+	t.Run("UpdateVessel", func(t *testing.T) {
+		q, vessel := helperEnqueueCompleteThenReenqueue(t)
+
+		found, err := q.FindByID(vessel.ID)
+		if err != nil {
+			t.Fatalf("FindByID: %v", err)
+		}
+		found.WorktreePath = "/tmp/wt-updated"
+		found.CurrentPhase = 5
+
+		if err := q.UpdateVessel(*found); err != nil {
+			t.Fatalf("UpdateVessel: %v", err)
+		}
+
+		vessels, err := q.List()
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(vessels) != 2 {
+			t.Fatalf("expected 2 vessels, got %d", len(vessels))
+		}
+		if vessels[0].State != StateCompleted {
+			t.Fatalf("expected first record to remain completed, got %s", vessels[0].State)
+		}
+		if vessels[0].WorktreePath != "" {
+			t.Fatalf("expected first record WorktreePath empty, got %q", vessels[0].WorktreePath)
+		}
+		if vessels[1].WorktreePath != "/tmp/wt-updated" {
+			t.Fatalf("expected second record WorktreePath '/tmp/wt-updated', got %q", vessels[1].WorktreePath)
+		}
+		if vessels[1].CurrentPhase != 5 {
+			t.Fatalf("expected second record CurrentPhase 5, got %d", vessels[1].CurrentPhase)
+		}
+	})
+
+	t.Run("FindByID", func(t *testing.T) {
+		q, vessel := helperEnqueueCompleteThenReenqueue(t)
+
+		got, err := q.FindByID(vessel.ID)
+		if err != nil {
+			t.Fatalf("FindByID: %v", err)
+		}
+		if got.State != StatePending {
+			t.Fatalf("expected FindByID to return the re-enqueued pending vessel, got state %s", got.State)
+		}
+	})
+
+	t.Run("Cancel", func(t *testing.T) {
+		q, vessel := helperEnqueueCompleteThenReenqueue(t)
+
+		if err := q.Cancel(vessel.ID); err != nil {
+			t.Fatalf("cancel: %v", err)
+		}
+
+		vessels, err := q.List()
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(vessels) != 2 {
+			t.Fatalf("expected 2 vessels, got %d", len(vessels))
+		}
+		if vessels[0].State != StateCompleted {
+			t.Fatalf("expected first record (old) to remain completed, got %s", vessels[0].State)
+		}
+		if vessels[1].State != StateCancelled {
+			t.Fatalf("expected second record (re-enqueued) to be cancelled, got %s", vessels[1].State)
+		}
+	})
+}
+
 func TestCancelWaitingVessel(t *testing.T) {
 	q, _ := newTestQueue(t)
 	vessel := testVessel(900)


### PR DESCRIPTION
## Summary

- When vessels are re-enqueued after completion (same ID), `Update()`, `UpdateVessel()`, `FindByID()`, and `Cancel()` found the old completed record instead of the new one due to forward iteration
- State transitions silently failed (`completed → failed` is invalid), leaving vessels permanently stuck as "running"
- Fix: reverse iteration so these functions find the most recent (last-appended) record

## Test plan

- [x] `TestDuplicateID/Update` — re-enqueued vessel transitions correctly
- [x] `TestDuplicateID/UpdateVessel` — re-enqueued vessel fields updated, old record untouched
- [x] `TestDuplicateID/FindByID` — returns most recent vessel, not stale one
- [x] `TestDuplicateID/Cancel` — cancels re-enqueued vessel, old record untouched
- [x] All existing queue tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)