### PR TITLE
fix: use validTransitions in Cancel to allow running state (#20)

### DIFF
--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -259,7 +259,8 @@ func (q *Queue) Cancel(id string) error {
 			if vessels[i].ID != id {
 				continue
 			}
-			if vessels[i].State != StatePending && vessels[i].State != StateWaiting {
+			allowed, knownState := validTransitions[vessels[i].State]
+			if !knownState || !allowed[StateCancelled] {
 				return fmt.Errorf("cannot cancel vessel %s in state %s", id, vessels[i].State)
 			}
 			now := time.Now().UTC()

--- a/cli/internal/queue/queue_test.go
+++ b/cli/internal/queue/queue_test.go
@@ -227,8 +227,19 @@ func TestCancelRunning(t *testing.T) {
 		t.Fatalf("dequeue: %v", err)
 	}
 
-	if err := q.Cancel(vessel.ID); err == nil {
-		t.Fatal("expected error cancelling running vessel")
+	if err := q.Cancel(vessel.ID); err != nil {
+		t.Fatalf("cancel running vessel: %v", err)
+	}
+
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if vessels[0].State != StateCancelled {
+		t.Fatalf("expected cancelled, got %q", vessels[0].State)
+	}
+	if vessels[0].EndedAt == nil {
+		t.Fatal("expected EndedAt to be set")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace hard-coded state check in `Cancel()` with `validTransitions` map lookup, consistent with `Update()`
- `Cancel()` now accepts vessels in `running` state as the state machine intended
- Update `TestCancelRunning` to expect success and verify state/timestamp

## Test plan
- [x] `TestCancelRunning` updated to assert success, cancelled state, and EndedAt set
- [x] All existing cancel tests pass (pending, waiting, completed-rejection, not-found)
- [x] `go test ./internal/queue/...` passes
- [x] Verified via crosscheck:byfuglien with HIGH confidence

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)