### PR TITLE
fix: reject hyphenated phase names in workflow validation (#26)

### DIFF
--- a/cli/internal/phase/phase_test.go
+++ b/cli/internal/phase/phase_test.go
@@ -299,6 +299,38 @@ func TestPrepareDataDoesNotMutateOriginal(t *testing.T) {
 	}
 }
 
+func TestRenderPromptHyphenatedKeys(t *testing.T) {
+	t.Run("index syntax accesses hyphenated PreviousOutputs key", func(t *testing.T) {
+		data := TemplateData{
+			PreviousOutputs: map[string]string{
+				"create-issues": "created 3 issues",
+			},
+		}
+		got, err := RenderPrompt(`Result: {{index .PreviousOutputs "create-issues"}}`, data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "Result: created 3 issues" {
+			t.Fatalf("got %q, want %q", got, "Result: created 3 issues")
+		}
+	})
+
+	t.Run("index syntax returns empty for nonexistent hyphenated key", func(t *testing.T) {
+		data := TemplateData{
+			PreviousOutputs: map[string]string{
+				"analyze": "analysis result",
+			},
+		}
+		got, err := RenderPrompt(`Result: [{{index .PreviousOutputs "no-such-phase"}}]`, data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "Result: []" {
+			t.Fatalf("got %q, want %q", got, "Result: []")
+		}
+	})
+}
+
 func TestRenderPromptNilPreviousOutputs(t *testing.T) {
 	data := TemplateData{
 		PreviousOutputs: nil,

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -11,8 +11,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// validPhaseName matches lowercase alphanumeric names with underscores only.
-var validPhaseName = regexp.MustCompile(`^[a-z0-9_]+$`)
+// validPhaseName matches names starting with a lowercase letter, followed by
+// lowercase letters, digits, or underscores. Names must start with a letter so
+// they work as Go template identifiers in dot notation (e.g. .PreviousOutputs.analyze).
+var validPhaseName = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 // Workflow defines a multi-phase execution plan loaded from a YAML file.
 type Workflow struct {
@@ -90,7 +92,7 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 		seen[p.Name] = true
 
 		if !validPhaseName.MatchString(p.Name) {
-			return fmt.Errorf("phase name %q contains invalid characters; use only lowercase letters, digits, and underscores", p.Name)
+			return fmt.Errorf("phase name %q is invalid; must start with a lowercase letter and contain only lowercase letters, digits, and underscores", p.Name)
 		}
 
 		if p.PromptFile == "" {

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -4,11 +4,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
+
+// validPhaseName matches lowercase alphanumeric names with underscores only.
+var validPhaseName = regexp.MustCompile(`^[a-z0-9_]+$`)
 
 // Workflow defines a multi-phase execution plan loaded from a YAML file.
 type Workflow struct {
@@ -84,6 +88,10 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 			return fmt.Errorf("duplicate phase name %q", p.Name)
 		}
 		seen[p.Name] = true
+
+		if !validPhaseName.MatchString(p.Name) {
+			return fmt.Errorf("phase name %q contains invalid characters; use only lowercase letters, digits, and underscores", p.Name)
+		}
 
 		if p.PromptFile == "" {
 			return fmt.Errorf("phase %q: prompt_file is required", p.Name)

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -624,6 +624,52 @@ func TestValidate(t *testing.T) {
 			prompts: []string{"prompt.md"},
 			wantErr: `workflow name "wrong-name" does not match filename "test.yaml"`,
 		},
+		{
+			name:          "phase name with hyphens is rejected",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "create-issues", PromptFile: "prompt.md", MaxTurns: 5},
+				},
+			},
+			prompts: []string{"prompt.md"},
+			wantErr: `phase name "create-issues" contains invalid characters; use only lowercase letters, digits, and underscores`,
+		},
+		{
+			name:          "phase name with uppercase is rejected",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "CreateIssues", PromptFile: "prompt.md", MaxTurns: 5},
+				},
+			},
+			prompts: []string{"prompt.md"},
+			wantErr: `phase name "CreateIssues" contains invalid characters`,
+		},
+		{
+			name:          "phase name with underscores is accepted",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "create_issues", PromptFile: "prompt.md", MaxTurns: 5},
+				},
+			},
+			prompts: []string{"prompt.md"},
+		},
+		{
+			name:          "phase name with digits is accepted",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "step2", PromptFile: "prompt.md", MaxTurns: 5},
+				},
+			},
+			prompts: []string{"prompt.md"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -634,7 +634,7 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			prompts: []string{"prompt.md"},
-			wantErr: `phase name "create-issues" contains invalid characters; use only lowercase letters, digits, and underscores`,
+			wantErr: `phase name "create-issues" is invalid; must start with a lowercase letter and contain only lowercase letters, digits, and underscores`,
 		},
 		{
 			name:          "phase name with uppercase is rejected",
@@ -646,7 +646,7 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			prompts: []string{"prompt.md"},
-			wantErr: `phase name "CreateIssues" contains invalid characters`,
+			wantErr: `phase name "CreateIssues" is invalid`,
 		},
 		{
 			name:          "phase name with underscores is accepted",
@@ -658,6 +658,18 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			prompts: []string{"prompt.md"},
+		},
+		{
+			name:          "phase name starting with digit is rejected",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "2step", PromptFile: "prompt.md", MaxTurns: 5},
+				},
+			},
+			prompts: []string{"prompt.md"},
+			wantErr: `phase name "2step" is invalid`,
 		},
 		{
 			name:          "phase name with digits is accepted",


### PR DESCRIPTION
## Summary
- Add `validPhaseName` regex (`^[a-z0-9_]+$`) to reject phase names with hyphens/uppercase
- Prevents `text/template` parse errors when accessing `PreviousOutputs` via dot notation
- Add phase template tests proving `index` syntax works for hyphenated keys as a workaround

## Test plan
- [x] Workflow validation rejects `create-issues`, `CreateIssues` with clear error message
- [x] Workflow validation accepts `create_issues`, `step2`
- [x] `{{index .PreviousOutputs "hyphen-name"}}` returns correct value
- [x] `{{index .PreviousOutputs "nonexistent"}}` returns empty string (missingkey=zero)
- [x] `go test ./internal/workflow/... ./internal/phase/...` passes
- [x] Verified via crosscheck:byfuglien with HIGH confidence

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)