### PR TITLE
feat: add JSONL queue compaction to cleanup command (#21)

### DIFF
--- a/cli/cmd/xylem/cleanup.go
+++ b/cli/cmd/xylem/cleanup.go
@@ -34,8 +34,32 @@ func cmdCleanup(cfg *config.Config, q *queue.Queue, wt *worktree.Manager, dryRun
 	}
 
 	cleanupPhaseOutputs(cfg, q, dryRun)
+	compactQueue(q, dryRun)
 
 	return nil
+}
+
+func compactQueue(q *queue.Queue, dryRun bool) {
+	if dryRun {
+		removed, err := q.CompactDryRun()
+		if err != nil {
+			log.Printf("warn: could not check queue for compaction: %v", err)
+			return
+		}
+		if removed > 0 {
+			fmt.Printf("Would remove %d stale queue record(s) (dry-run — no changes made)\n", removed)
+		}
+		return
+	}
+
+	removed, err := q.Compact()
+	if err != nil {
+		log.Printf("warn: queue compaction failed: %v", err)
+		return
+	}
+	if removed > 0 {
+		fmt.Printf("Compacted queue: removed %d stale record(s)\n", removed)
+	}
 }
 
 func cleanupWorktrees(wt *worktree.Manager, dryRun bool) error {
@@ -89,9 +113,7 @@ func cleanupPhaseOutputs(cfg *config.Config, q *queue.Queue, dryRun bool) {
 	// Build set of terminal vessel IDs older than cutoff
 	terminalIDs := make(map[string]bool)
 	for _, v := range vessels {
-		isTerminal := v.State == queue.StateCompleted || v.State == queue.StateFailed ||
-			v.State == queue.StateCancelled || v.State == queue.StateTimedOut
-		if isTerminal && v.EndedAt != nil && v.EndedAt.Before(cutoff) {
+		if v.State.IsTerminal() && v.EndedAt != nil && v.EndedAt.Before(cutoff) {
 			terminalIDs[v.ID] = true
 		}
 	}

--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -56,6 +56,11 @@ var validTransitions = map[VesselState]map[VesselState]bool{
 // ErrInvalidTransition is returned when a state transition is not allowed.
 var ErrInvalidTransition = errors.New("invalid state transition")
 
+// IsTerminal reports whether s is a terminal vessel state.
+func (s VesselState) IsTerminal() bool {
+	return s == StateCompleted || s == StateFailed || s == StateCancelled || s == StateTimedOut
+}
+
 type Vessel struct {
 	ID        string            `json:"id"`
 	Source    string            `json:"source"`
@@ -271,6 +276,61 @@ func (q *Queue) Cancel(id string) error {
 
 		return fmt.Errorf("vessel %s not found", id)
 	})
+}
+
+// Compact rewrites the queue file keeping only the latest record per vessel ID.
+// Non-terminal records (pending, running, waiting) are always preserved.
+// For terminal records (completed, failed, cancelled, timed_out), only the
+// latest one per vessel ID is retained. Returns the number of records removed.
+func (q *Queue) Compact() (int, error) {
+	var removed int
+	err := q.withLock(func() error {
+		vessels, err := q.readAllVessels()
+		if err != nil {
+			return err
+		}
+		compacted, n := compactVessels(vessels)
+		removed = n
+		return q.writeAllVessels(compacted)
+	})
+	return removed, err
+}
+
+// CompactDryRun reports how many records would be removed by Compact without
+// modifying the queue file.
+func (q *Queue) CompactDryRun() (int, error) {
+	var removable int
+	err := q.withRLock(func() error {
+		vessels, err := q.readAllVessels()
+		if err != nil {
+			return err
+		}
+		_, removable = compactVessels(vessels)
+		return nil
+	})
+	return removable, err
+}
+
+// compactVessels returns the compacted vessel slice and the number of records
+// removed. For each vessel ID, only the latest record is kept; non-terminal
+// records are always preserved.
+func compactVessels(vessels []Vessel) ([]Vessel, int) {
+	seen := make(map[string]int, len(vessels)) // ID → index of latest record
+	for i, v := range vessels {
+		seen[v.ID] = i
+	}
+	var (
+		compacted []Vessel
+		removed   int
+	)
+	for i, v := range vessels {
+		if v.State.IsTerminal() && seen[v.ID] != i {
+			removed++
+		} else {
+			compacted = append(compacted, v)
+		}
+	}
+	return compacted, removed
 }
 
 func (q *Queue) HasRef(ref string) bool {

--- a/cli/internal/queue/queue_test.go
+++ b/cli/internal/queue/queue_test.go
@@ -1246,3 +1246,197 @@ func TestCancelWaitingVessel(t *testing.T) {
 	}
 }
 
+// --- Compaction tests ---
+
+func TestCompact(t *testing.T) {
+	t.Run("removes stale terminal records", func(t *testing.T) {
+		q, path := newTestQueue(t)
+
+		// Enqueue 3 vessels, complete 2, then re-enqueue them.
+		for _, id := range []int{1, 2, 3} {
+			if err := q.Enqueue(testVessel(id)); err != nil {
+				t.Fatalf("enqueue: %v", err)
+			}
+		}
+		// Complete vessel 1 and 2.
+		for _, id := range []int{1, 2} {
+			helperCompleteVessel(t, q, fmt.Sprintf("issue-%d", id))
+		}
+		// Re-enqueue vessel 1 and 2.
+		for _, id := range []int{1, 2} {
+			if err := q.Enqueue(testVessel(id)); err != nil {
+				t.Fatalf("re-enqueue: %v", err)
+			}
+		}
+
+		// Before compaction: 5 records (completed-1, completed-2, pending-3, pending-1, pending-2).
+		linesBefore := readNonEmptyLines(t, path)
+		if len(linesBefore) != 5 {
+			t.Fatalf("expected 5 records before compaction, got %d", len(linesBefore))
+		}
+
+		removed, err := q.Compact()
+		if err != nil {
+			t.Fatalf("compact: %v", err)
+		}
+		if removed != 2 {
+			t.Fatalf("expected 2 removed, got %d", removed)
+		}
+
+		// After compaction: 3 records (pending-3, pending-1, pending-2).
+		// The old completed records for vessel 1 and 2 are gone because
+		// the latest record for each is the re-enqueued pending one.
+		linesAfter := readNonEmptyLines(t, path)
+		if len(linesAfter) != 3 {
+			t.Fatalf("expected 3 records after compaction, got %d", len(linesAfter))
+		}
+	})
+
+	t.Run("preserves non-terminal records", func(t *testing.T) {
+		q, _ := newTestQueue(t)
+
+		// Enqueue vessels in various non-terminal states.
+		pending := testVessel(10)
+		running := testVessel(11)
+		running.State = StateRunning
+		waiting := testVessel(12)
+		waiting.State = StateWaiting
+
+		for _, v := range []Vessel{pending, running, waiting} {
+			if err := q.Enqueue(v); err != nil {
+				t.Fatalf("enqueue: %v", err)
+			}
+		}
+
+		removed, err := q.Compact()
+		if err != nil {
+			t.Fatalf("compact: %v", err)
+		}
+		if removed != 0 {
+			t.Fatalf("expected 0 removed (all non-terminal), got %d", removed)
+		}
+
+		vessels, err := q.List()
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(vessels) != 3 {
+			t.Fatalf("expected 3 vessels preserved, got %d", len(vessels))
+		}
+	})
+
+	t.Run("retains latest terminal record per ID", func(t *testing.T) {
+		q, _ := newTestQueue(t)
+
+		// Enqueue a vessel, complete it, re-enqueue, fail it.
+		if err := q.Enqueue(testVessel(20)); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		helperCompleteVessel(t, q, "issue-20")
+		if err := q.Enqueue(testVessel(20)); err != nil {
+			t.Fatalf("re-enqueue: %v", err)
+		}
+		// Dequeue and fail the re-enqueued vessel.
+		if _, err := q.Dequeue(); err != nil {
+			t.Fatalf("dequeue: %v", err)
+		}
+		if err := q.Update("issue-20", StateFailed, "boom"); err != nil {
+			t.Fatalf("update: %v", err)
+		}
+
+		// Before: completed-20 + failed-20 = 2 records.
+		vessels, err := q.List()
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(vessels) != 2 {
+			t.Fatalf("expected 2 records before compaction, got %d", len(vessels))
+		}
+
+		removed, err := q.Compact()
+		if err != nil {
+			t.Fatalf("compact: %v", err)
+		}
+		if removed != 1 {
+			t.Fatalf("expected 1 removed, got %d", removed)
+		}
+
+		// After: only the latest (failed) record remains.
+		vessels, err = q.List()
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(vessels) != 1 {
+			t.Fatalf("expected 1 vessel after compaction, got %d", len(vessels))
+		}
+		if vessels[0].State != StateFailed {
+			t.Fatalf("expected latest terminal record (failed), got %s", vessels[0].State)
+		}
+	})
+
+	t.Run("empty queue is a no-op", func(t *testing.T) {
+		q, _ := newTestQueue(t)
+
+		removed, err := q.Compact()
+		if err != nil {
+			t.Fatalf("compact: %v", err)
+		}
+		if removed != 0 {
+			t.Fatalf("expected 0 removed on empty queue, got %d", removed)
+		}
+	})
+
+	t.Run("single terminal record is preserved", func(t *testing.T) {
+		q, _ := newTestQueue(t)
+		if err := q.Enqueue(testVessel(30)); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		helperCompleteVessel(t, q, "issue-30")
+
+		removed, err := q.Compact()
+		if err != nil {
+			t.Fatalf("compact: %v", err)
+		}
+		if removed != 0 {
+			t.Fatalf("expected 0 removed (only one record per ID), got %d", removed)
+		}
+
+		vessels, err := q.List()
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(vessels) != 1 {
+			t.Fatalf("expected 1 vessel preserved, got %d", len(vessels))
+		}
+	})
+}
+
+func TestCompactDryRun(t *testing.T) {
+	q, path := newTestQueue(t)
+
+	// Enqueue, complete, and re-enqueue a vessel.
+	if err := q.Enqueue(testVessel(1)); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	helperCompleteVessel(t, q, "issue-1")
+	if err := q.Enqueue(testVessel(1)); err != nil {
+		t.Fatalf("re-enqueue: %v", err)
+	}
+
+	linesBefore := readNonEmptyLines(t, path)
+
+	removable, err := q.CompactDryRun()
+	if err != nil {
+		t.Fatalf("compact dry run: %v", err)
+	}
+	if removable != 1 {
+		t.Fatalf("expected 1 removable, got %d", removable)
+	}
+
+	// File should be unchanged.
+	linesAfter := readNonEmptyLines(t, path)
+	if len(linesAfter) != len(linesBefore) {
+		t.Fatalf("dry run modified the file: before=%d lines, after=%d lines", len(linesBefore), len(linesAfter))
+	}
+}
+


### PR DESCRIPTION
## Summary
- Add `Compact()` and `CompactDryRun()` methods to Queue
- Extract `IsTerminal()` method on `VesselState` to eliminate duplication
- Wire compaction into `xylem cleanup` with `--dry-run` support
- Keeps only latest record per vessel ID, preserves all non-terminal vessels

## Test plan
- [x] Enqueue + complete + re-enqueue + compact → latest record per ID retained
- [x] Non-terminal vessels never removed during compaction
- [x] Dry-run reports count but file unchanged
- [x] `go test ./internal/queue/...` passes

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)