### PR TITLE
feat: resume retry from failed phase instead of restarting (#6)

### DIFF
--- a/cli/cmd/xylem/retry.go
+++ b/cli/cmd/xylem/retry.go
@@ -2,28 +2,34 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
 
 func newRetryCmd() *cobra.Command {
+	var fromScratch bool
 	cmd := &cobra.Command{
 		Use:   "retry <vessel-id>",
 		Short: "Retry a failed vessel with failure context",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmdRetry(deps.q, args[0])
+			return cmdRetry(deps.q, deps.cfg, args[0], fromScratch)
 		},
 	}
+	cmd.Flags().BoolVar(&fromScratch, "from-scratch", false, "Re-execute all phases from scratch instead of resuming")
 	return cmd
 }
 
-func cmdRetry(q *queue.Queue, id string) error {
+func cmdRetry(q *queue.Queue, cfg *config.Config, id string, fromScratch bool) error {
 	vessel, err := q.FindByID(id)
 	if err != nil {
 		return fmt.Errorf("retry error: %w", err)
@@ -54,7 +60,7 @@ func cmdRetry(q *queue.Queue, id string) error {
 		ID:          newID,
 		Source:      vessel.Source,
 		Ref:         vessel.Ref,
-		Workflow:       vessel.Workflow,
+		Workflow:    vessel.Workflow,
 		Prompt:      vessel.Prompt,
 		Meta:        meta,
 		State:       queue.StatePending,
@@ -64,11 +70,88 @@ func cmdRetry(q *queue.Queue, id string) error {
 		GateOutput:  vessel.GateOutput,
 	}
 
+	// Resume from failed phase unless --from-scratch or no worktree exists
+	if !fromScratch && vessel.WorktreePath != "" {
+		newVessel.CurrentPhase = vessel.CurrentPhase
+		newVessel.WorktreePath = vessel.WorktreePath
+		newVessel.PhaseOutputs = rewritePhaseOutputs(vessel.PhaseOutputs, vessel.ID, newID)
+
+		if err := copyPhaseOutputFiles(cfg.StateDir, vessel.ID, newID); err != nil {
+			return fmt.Errorf("copy phase outputs: %w", err)
+		}
+	}
+
 	if _, err := q.Enqueue(newVessel); err != nil {
 		return fmt.Errorf("enqueue retry: %w", err)
 	}
 	fmt.Printf("Created retry vessel %s (retrying %s)\n", newVessel.ID, vessel.ID)
 	return nil
+}
+
+// rewritePhaseOutputs copies the PhaseOutputs map, replacing the old vessel ID
+// in file paths with the new vessel ID.
+func rewritePhaseOutputs(outputs map[string]string, oldID, newID string) map[string]string {
+	if len(outputs) == 0 {
+		return nil
+	}
+	rewritten := make(map[string]string, len(outputs))
+	oldSeg := string(filepath.Separator) + oldID + string(filepath.Separator)
+	newSeg := string(filepath.Separator) + newID + string(filepath.Separator)
+	for k, v := range outputs {
+		rewritten[k] = strings.Replace(v, oldSeg, newSeg, 1)
+	}
+	return rewritten
+}
+
+// copyPhaseOutputFiles copies all files from the original vessel's phase output
+// directory to the retry vessel's phase output directory.
+func copyPhaseOutputFiles(stateDir, oldID, newID string) error {
+	srcDir := filepath.Join(stateDir, "phases", oldID)
+	dstDir := filepath.Join(stateDir, "phases", newID)
+
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // no outputs to copy
+		}
+		return fmt.Errorf("read phase dir: %w", err)
+	}
+
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		return fmt.Errorf("create phase dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if err := copyFile(
+			filepath.Join(srcDir, entry.Name()),
+			filepath.Join(dstDir, entry.Name()),
+		); err != nil {
+			return fmt.Errorf("copy %s: %w", entry.Name(), err)
+		}
+	}
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
 }
 
 func retryID(originalID string, q *queue.Queue) string {

--- a/cli/cmd/xylem/retry_test.go
+++ b/cli/cmd/xylem/retry_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
 
@@ -14,8 +16,14 @@ func newRetryTestQueue(t *testing.T) *queue.Queue {
 	return queue.New(filepath.Join(t.TempDir(), "queue.jsonl"))
 }
 
+func newRetryTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	return &config.Config{StateDir: t.TempDir()}
+}
+
 func TestRetryCreatesNewVessel(t *testing.T) {
 	q := newRetryTestQueue(t)
+	cfg := newRetryTestConfig(t)
 	now := time.Now().UTC()
 	v := queue.Vessel{
 		ID: "issue-42", Source: "github-issue", Workflow: "fix-bug",
@@ -26,10 +34,10 @@ func TestRetryCreatesNewVessel(t *testing.T) {
 		GateOutput:  "exit code 1: tests failed",
 	}
 	q.Enqueue(v) //nolint:errcheck
-	q.Update("issue-42", queue.StateRunning, "")            //nolint:errcheck
-	q.Update("issue-42", queue.StateFailed, "test error")   //nolint:errcheck
+	q.Update("issue-42", queue.StateRunning, "")          //nolint:errcheck
+	q.Update("issue-42", queue.StateFailed, "test error") //nolint:errcheck
 
-	err := cmdRetry(q, "issue-42")
+	err := cmdRetry(q, cfg, "issue-42", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -107,9 +115,10 @@ func TestRetryNonFailedVessel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			q := newRetryTestQueue(t)
+			cfg := newRetryTestConfig(t)
 			tt.setup(t, q)
 
-			err := cmdRetry(q, "issue-1")
+			err := cmdRetry(q, cfg, "issue-1", false)
 			if err == nil {
 				t.Fatal("expected error retrying non-failed vessel")
 			}
@@ -122,8 +131,9 @@ func TestRetryNonFailedVessel(t *testing.T) {
 
 func TestRetryNonexistentVessel(t *testing.T) {
 	q := newRetryTestQueue(t)
+	cfg := newRetryTestConfig(t)
 
-	err := cmdRetry(q, "issue-999")
+	err := cmdRetry(q, cfg, "issue-999", false)
 	if err == nil {
 		t.Fatal("expected error retrying non-existent vessel")
 	}
@@ -134,19 +144,20 @@ func TestRetryNonexistentVessel(t *testing.T) {
 
 func TestRetryMultipleRetries(t *testing.T) {
 	q := newRetryTestQueue(t)
+	cfg := newRetryTestConfig(t)
 	now := time.Now().UTC()
 
 	q.Enqueue(queue.Vessel{ID: "issue-42", Source: "manual", Workflow: "fix-bug", State: queue.StatePending, CreatedAt: now}) //nolint:errcheck
-	q.Update("issue-42", queue.StateRunning, "")                                                                           //nolint:errcheck
-	q.Update("issue-42", queue.StateFailed, "first error")                                                                 //nolint:errcheck
+	q.Update("issue-42", queue.StateRunning, "")                                                                             //nolint:errcheck
+	q.Update("issue-42", queue.StateFailed, "first error")                                                                   //nolint:errcheck
 
 	// First retry
-	if err := cmdRetry(q, "issue-42"); err != nil {
+	if err := cmdRetry(q, cfg, "issue-42", false); err != nil {
 		t.Fatalf("first retry: %v", err)
 	}
 
 	// Second retry of the original
-	if err := cmdRetry(q, "issue-42"); err != nil {
+	if err := cmdRetry(q, cfg, "issue-42", false); err != nil {
 		t.Fatalf("second retry: %v", err)
 	}
 
@@ -216,16 +227,17 @@ func TestRetryIDGeneration(t *testing.T) {
 
 func TestRetryPreservesPrompt(t *testing.T) {
 	q := newRetryTestQueue(t)
+	cfg := newRetryTestConfig(t)
 	now := time.Now().UTC()
 
 	q.Enqueue(queue.Vessel{
 		ID: "task-1", Source: "manual", Prompt: "fix the thing",
 		State: queue.StatePending, CreatedAt: now,
 	}) //nolint:errcheck
-	q.Update("task-1", queue.StateRunning, "")        //nolint:errcheck
+	q.Update("task-1", queue.StateRunning, "")         //nolint:errcheck
 	q.Update("task-1", queue.StateFailed, "timed out") //nolint:errcheck
 
-	if err := cmdRetry(q, "task-1"); err != nil {
+	if err := cmdRetry(q, cfg, "task-1", false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -239,4 +251,201 @@ func TestRetryPreservesPrompt(t *testing.T) {
 		}
 	}
 	t.Error("retry vessel not found")
+}
+
+func TestRetryResumesFromFailedPhase(t *testing.T) {
+	q := newRetryTestQueue(t)
+	cfg := newRetryTestConfig(t)
+	now := time.Now().UTC()
+
+	// Create phase output directory with files for the original vessel
+	srcDir := filepath.Join(cfg.StateDir, "phases", "issue-10")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "plan.output"), []byte("plan result"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "implement.output"), []byte("impl result"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	phasePaths := map[string]string{
+		"plan":      filepath.Join(srcDir, "plan.output"),
+		"implement": filepath.Join(srcDir, "implement.output"),
+	}
+
+	v := queue.Vessel{
+		ID:           "issue-10",
+		Source:       "manual",
+		Workflow:     "fix-bug",
+		State:        queue.StatePending,
+		CreatedAt:    now,
+		CurrentPhase: 2,
+		WorktreePath: "/tmp/worktrees/issue-10",
+		PhaseOutputs: phasePaths,
+		FailedPhase:  "test",
+	}
+	q.Enqueue(v)                                       //nolint:errcheck
+	q.Update("issue-10", queue.StateRunning, "")       //nolint:errcheck
+	q.Update("issue-10", queue.StateFailed, "phase 3") //nolint:errcheck
+
+	err := cmdRetry(q, cfg, "issue-10", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	retry, err := q.FindByID("issue-10-retry-1")
+	if err != nil {
+		t.Fatalf("retry vessel not found: %v", err)
+	}
+
+	if retry.CurrentPhase != 2 {
+		t.Errorf("CurrentPhase = %d, want 2", retry.CurrentPhase)
+	}
+	if retry.WorktreePath != "/tmp/worktrees/issue-10" {
+		t.Errorf("WorktreePath = %q, want /tmp/worktrees/issue-10", retry.WorktreePath)
+	}
+
+	// PhaseOutputs should reference the new vessel ID
+	dstDir := filepath.Join(cfg.StateDir, "phases", "issue-10-retry-1")
+	for phase, path := range retry.PhaseOutputs {
+		if strings.Contains(path, "issue-10"+string(filepath.Separator)) && !strings.Contains(path, "issue-10-retry-1") {
+			t.Errorf("PhaseOutputs[%q] still references old ID: %s", phase, path)
+		}
+		expectedPath := filepath.Join(dstDir, phase+".output")
+		if path != expectedPath {
+			t.Errorf("PhaseOutputs[%q] = %q, want %q", phase, path, expectedPath)
+		}
+	}
+
+	// Verify files were copied
+	wantContent := map[string]string{
+		"plan.output":      "plan result",
+		"implement.output": "impl result",
+	}
+	for name, want := range wantContent {
+		data, err := os.ReadFile(filepath.Join(dstDir, name))
+		if err != nil {
+			t.Errorf("expected copied file %s: %v", name, err)
+			continue
+		}
+		if string(data) != want {
+			t.Errorf("file %s content = %q, want %q", name, string(data), want)
+		}
+	}
+}
+
+func TestRetryFromScratch(t *testing.T) {
+	q := newRetryTestQueue(t)
+	cfg := newRetryTestConfig(t)
+	now := time.Now().UTC()
+
+	v := queue.Vessel{
+		ID:           "issue-10",
+		Source:       "manual",
+		Workflow:     "fix-bug",
+		State:        queue.StatePending,
+		CreatedAt:    now,
+		CurrentPhase: 2,
+		WorktreePath: "/tmp/worktrees/issue-10",
+		PhaseOutputs: map[string]string{"plan": "/some/path/plan.output"},
+		FailedPhase:  "test",
+	}
+	q.Enqueue(v)                                       //nolint:errcheck
+	q.Update("issue-10", queue.StateRunning, "")       //nolint:errcheck
+	q.Update("issue-10", queue.StateFailed, "phase 3") //nolint:errcheck
+
+	err := cmdRetry(q, cfg, "issue-10", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	retry, err := q.FindByID("issue-10-retry-1")
+	if err != nil {
+		t.Fatalf("retry vessel not found: %v", err)
+	}
+
+	if retry.CurrentPhase != 0 {
+		t.Errorf("from-scratch: CurrentPhase = %d, want 0", retry.CurrentPhase)
+	}
+	if retry.WorktreePath != "" {
+		t.Errorf("from-scratch: WorktreePath = %q, want empty", retry.WorktreePath)
+	}
+	if len(retry.PhaseOutputs) != 0 {
+		t.Errorf("from-scratch: PhaseOutputs = %v, want empty", retry.PhaseOutputs)
+	}
+}
+
+func TestRetryEmptyWorktreePathFallsBackToFromScratch(t *testing.T) {
+	q := newRetryTestQueue(t)
+	cfg := newRetryTestConfig(t)
+	now := time.Now().UTC()
+
+	v := queue.Vessel{
+		ID:           "issue-10",
+		Source:       "manual",
+		Workflow:     "fix-bug",
+		State:        queue.StatePending,
+		CreatedAt:    now,
+		CurrentPhase: 1,
+		WorktreePath: "", // failed before worktree creation
+		FailedPhase:  "plan",
+	}
+	q.Enqueue(v)                                       //nolint:errcheck
+	q.Update("issue-10", queue.StateRunning, "")       //nolint:errcheck
+	q.Update("issue-10", queue.StateFailed, "no worktree") //nolint:errcheck
+
+	err := cmdRetry(q, cfg, "issue-10", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	retry, err := q.FindByID("issue-10-retry-1")
+	if err != nil {
+		t.Fatalf("retry vessel not found: %v", err)
+	}
+
+	if retry.CurrentPhase != 0 {
+		t.Errorf("empty worktree fallback: CurrentPhase = %d, want 0", retry.CurrentPhase)
+	}
+	if retry.WorktreePath != "" {
+		t.Errorf("empty worktree fallback: WorktreePath = %q, want empty", retry.WorktreePath)
+	}
+	if len(retry.PhaseOutputs) != 0 {
+		t.Errorf("empty worktree fallback: PhaseOutputs = %v, want empty", retry.PhaseOutputs)
+	}
+}
+
+func TestRewritePhaseOutputs(t *testing.T) {
+	outputs := map[string]string{
+		"plan":      "/home/user/.xylem/phases/issue-10/plan.output",
+		"implement": "/home/user/.xylem/phases/issue-10/implement.output",
+	}
+
+	rewritten := rewritePhaseOutputs(outputs, "issue-10", "issue-10-retry-1")
+
+	for phase, path := range rewritten {
+		if strings.Contains(path, "/issue-10/") {
+			t.Errorf("PhaseOutputs[%q] still has old ID: %s", phase, path)
+		}
+		if !strings.Contains(path, "/issue-10-retry-1/") {
+			t.Errorf("PhaseOutputs[%q] missing new ID: %s", phase, path)
+		}
+	}
+}
+
+func TestRewritePhaseOutputsNil(t *testing.T) {
+	result := rewritePhaseOutputs(nil, "old", "new")
+	if result != nil {
+		t.Errorf("expected nil for nil input, got %v", result)
+	}
+}
+
+func TestCopyPhaseOutputFilesMissingSrcDir(t *testing.T) {
+	stateDir := t.TempDir()
+	// Source directory does not exist — should be a no-op
+	if err := copyPhaseOutputFiles(stateDir, "nonexistent", "new"); err != nil {
+		t.Fatalf("expected no error for missing src dir, got: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary
- `xylem retry` now copies CurrentPhase, WorktreePath, and PhaseOutputs from the failed vessel
- Phase output files are copied to the retry vessel's output directory
- Add `--from-scratch` flag to force full restart (old behavior)
- Empty WorktreePath gracefully falls back to from-scratch

## Test plan
- [x] `TestRetryResumesFromFailedPhase` — copies phase state and output files
- [x] `TestRetryFromScratch` — starts fresh with --from-scratch flag
- [x] `TestRetryEmptyWorktreePathFallsBackToFromScratch` — graceful fallback
- [x] All existing retry tests pass
- [x] `go test ./cmd/xylem/ -run TestRetry` passes

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)