### PR TITLE
feat: add github-pr source type for PR-triggered workflows (#25)

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -153,7 +153,7 @@ func (c *Config) Validate() error {
 	// Validate sources
 	for name, src := range c.Sources {
 		switch src.Type {
-		case "github":
+		case "github", "github-pr":
 			if err := validateGitHubSource(name, src); err != nil {
 				return err
 			}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -491,24 +491,37 @@ func (r *Runner) readHarness() string {
 }
 
 func (r *Runner) fetchIssueData(ctx context.Context, vessel *queue.Vessel) phase.IssueData {
+	switch vessel.Source {
+	case "github-issue":
+		return r.fetchGitHubData(ctx, vessel, "issue", "issue")
+	case "github-pr":
+		return r.fetchGitHubData(ctx, vessel, "pr", "pr")
+	default:
+		return phase.IssueData{}
+	}
+}
+
+// fetchGitHubData fetches title/body/labels for an issue or PR.
+// ghCmd is the gh subcommand ("issue" or "pr"), metaPrefix is the Meta key prefix ("issue" or "pr").
+func (r *Runner) fetchGitHubData(ctx context.Context, vessel *queue.Vessel, ghCmd, metaPrefix string) phase.IssueData {
 	data := phase.IssueData{}
 
-	if vessel.Source != "github-issue" {
+	num := r.parseIssueNum(*vessel)
+	if num == 0 {
 		return data
 	}
 
-	issueNum := r.parseIssueNum(*vessel)
-	if issueNum == 0 {
-		return data
-	}
+	titleKey := metaPrefix + "_title"
+	bodyKey := metaPrefix + "_body"
+	labelsKey := metaPrefix + "_labels"
 
 	// Check if already cached in Meta
-	if vessel.Meta != nil && vessel.Meta["issue_title"] != "" {
-		data.Number = issueNum
-		data.Title = vessel.Meta["issue_title"]
-		data.Body = vessel.Meta["issue_body"]
+	if vessel.Meta != nil && vessel.Meta[titleKey] != "" {
+		data.Number = num
+		data.Title = vessel.Meta[titleKey]
+		data.Body = vessel.Meta[bodyKey]
 		data.URL = vessel.Ref
-		if labelsStr, ok := vessel.Meta["issue_labels"]; ok {
+		if labelsStr, ok := vessel.Meta[labelsKey]; ok {
 			data.Labels = strings.Split(labelsStr, ",")
 		}
 		return data
@@ -519,13 +532,13 @@ func (r *Runner) fetchIssueData(ctx context.Context, vessel *queue.Vessel) phase
 		return data
 	}
 
-	out, err := r.Runner.RunOutput(ctx, "gh", "issue", "view",
-		fmt.Sprintf("%d", issueNum),
+	out, err := r.Runner.RunOutput(ctx, "gh", ghCmd, "view",
+		fmt.Sprintf("%d", num),
 		"--repo", repo,
 		"--json", "title,body,labels,url",
 	)
 	if err != nil {
-		log.Printf("warn: fetch issue data for vessel %s: %v", vessel.ID, err)
+		log.Printf("warn: fetch %s data for vessel %s: %v", ghCmd, vessel.ID, err)
 		return data
 	}
 
@@ -538,11 +551,11 @@ func (r *Runner) fetchIssueData(ctx context.Context, vessel *queue.Vessel) phase
 		} `json:"labels"`
 	}
 	if err := json.Unmarshal(out, &resp); err != nil {
-		log.Printf("warn: parse issue data for vessel %s: %v", vessel.ID, err)
+		log.Printf("warn: parse %s data for vessel %s: %v", ghCmd, vessel.ID, err)
 		return data
 	}
 
-	data.Number = issueNum
+	data.Number = num
 	data.Title = resp.Title
 	data.Body = resp.Body
 	data.URL = resp.URL
@@ -554,9 +567,9 @@ func (r *Runner) fetchIssueData(ctx context.Context, vessel *queue.Vessel) phase
 	if vessel.Meta == nil {
 		vessel.Meta = make(map[string]string)
 	}
-	vessel.Meta["issue_title"] = resp.Title
-	vessel.Meta["issue_body"] = resp.Body
-	vessel.Meta["issue_labels"] = strings.Join(data.Labels, ",")
+	vessel.Meta[titleKey] = resp.Title
+	vessel.Meta[bodyKey] = resp.Body
+	vessel.Meta[labelsKey] = strings.Join(data.Labels, ",")
 
 	return data
 }
@@ -580,7 +593,10 @@ func (r *Runner) parseIssueNum(vessel queue.Vessel) int {
 	}
 	numStr, ok := vessel.Meta["issue_num"]
 	if !ok {
-		return 0
+		numStr, ok = vessel.Meta["pr_num"]
+		if !ok {
+			return 0
+		}
 	}
 	n, err := strconv.Atoi(numStr)
 	if err != nil {
@@ -597,16 +613,22 @@ func (r *Runner) resolveRepo(vessel queue.Vessel) string {
 	if !ok {
 		return ""
 	}
-	gh, ok := src.(*source.GitHub)
-	if !ok {
+	switch s := src.(type) {
+	case *source.GitHub:
+		return s.Repo
+	case *source.GitHubPR:
+		return s.Repo
+	default:
 		return ""
 	}
-	return gh.Repo
 }
 
 func vesselLabel(v queue.Vessel) string {
 	if v.Meta != nil {
 		if title := v.Meta["issue_title"]; title != "" {
+			return fmt.Sprintf("[%s] ", title)
+		}
+		if title := v.Meta["pr_title"]; title != "" {
 			return fmt.Sprintf("[%s] ", title)
 		}
 	}

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -68,15 +68,18 @@ func (s *Scanner) Scan(ctx context.Context) (ScanResult, error) {
 func (s *Scanner) buildSources() []source.Source {
 	var sources []source.Source
 	for _, srcCfg := range s.Config.Sources {
-		if srcCfg.Type == "github" {
-			tasks := make(map[string]source.GitHubTask, len(srcCfg.Tasks))
-			for name, t := range srcCfg.Tasks {
-				tasks[name] = source.GitHubTask{
-					Labels: t.Labels,
-					Workflow:  t.Workflow,
-				}
-			}
+		tasks := convertTasks(srcCfg.Tasks)
+		switch srcCfg.Type {
+		case "github":
 			sources = append(sources, &source.GitHub{
+				Repo:      srcCfg.Repo,
+				Tasks:     tasks,
+				Exclude:   srcCfg.Exclude,
+				Queue:     s.Queue,
+				CmdRunner: s.CmdRunner,
+			})
+		case "github-pr":
+			sources = append(sources, &source.GitHubPR{
 				Repo:      srcCfg.Repo,
 				Tasks:     tasks,
 				Exclude:   srcCfg.Exclude,
@@ -86,4 +89,15 @@ func (s *Scanner) buildSources() []source.Source {
 		}
 	}
 	return sources
+}
+
+func convertTasks(cfgTasks map[string]config.Task) map[string]source.GitHubTask {
+	tasks := make(map[string]source.GitHubTask, len(cfgTasks))
+	for name, t := range cfgTasks {
+		tasks[name] = source.GitHubTask{
+			Labels:   t.Labels,
+			Workflow: t.Workflow,
+		}
+	}
+	return tasks
 }

--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -1,0 +1,130 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+// GitHubPR scans GitHub pull requests and produces vessels.
+type GitHubPR struct {
+	Repo      string
+	Tasks     map[string]GitHubTask
+	Exclude   []string
+	Queue     *queue.Queue
+	CmdRunner CommandRunner
+}
+
+type ghPR struct {
+	Number      int    `json:"number"`
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+	HeadRefName string `json:"headRefName"`
+	Labels      []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+}
+
+func (g *GitHubPR) Name() string { return "github-pr" }
+
+func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
+	excludeSet := make(map[string]bool, len(g.Exclude))
+	for _, ex := range g.Exclude {
+		excludeSet[ex] = true
+	}
+
+	var vessels []queue.Vessel
+	seen := make(map[int]bool)
+
+	for _, task := range g.Tasks {
+		for _, label := range task.Labels {
+			args := []string{
+				"pr", "list",
+				"--repo", g.Repo,
+				"--state", "open",
+				"--label", label,
+				"--json", "number,title,url,labels,headRefName",
+				"--limit", "20",
+			}
+
+			out, err := g.CmdRunner.Run(ctx, "gh", args...)
+			if err != nil {
+				return vessels, fmt.Errorf("gh pr list: %w", err)
+			}
+
+			var prs []ghPR
+			if err := json.Unmarshal(out, &prs); err != nil {
+				return vessels, fmt.Errorf("parse gh pr list output: %w", err)
+			}
+
+			for _, pr := range prs {
+				if seen[pr.Number] {
+					continue
+				}
+				if g.hasExcludedLabel(pr, excludeSet) ||
+					g.Queue.HasRef(pr.URL) ||
+					g.hasBranch(ctx, pr.Number) {
+					continue
+				}
+				seen[pr.Number] = true
+				vessels = append(vessels, queue.Vessel{
+					ID:     fmt.Sprintf("pr-%d", pr.Number),
+					Source: "github-pr",
+					Ref:    pr.URL,
+					Workflow: task.Workflow,
+					Meta: map[string]string{
+						"pr_num": strconv.Itoa(pr.Number),
+					},
+					State:     queue.StatePending,
+					CreatedAt: time.Now().UTC(),
+				})
+			}
+		}
+	}
+	return vessels, nil
+}
+
+func (g *GitHubPR) OnStart(ctx context.Context, vessel queue.Vessel) error {
+	if g.CmdRunner == nil {
+		return nil
+	}
+	prNum := vessel.Meta["pr_num"]
+	if prNum == "" {
+		return nil
+	}
+	// Best-effort: add in-progress label
+	_, _ = g.CmdRunner.Run(ctx, "gh", "pr", "edit",
+		prNum,
+		"--repo", g.Repo,
+		"--add-label", "in-progress")
+	return nil
+}
+
+func (g *GitHubPR) BranchName(vessel queue.Vessel) string {
+	prNum := vessel.Meta["pr_num"]
+	slug := slugify(vessel.Ref)
+	return fmt.Sprintf("review/pr-%s-%s", prNum, slug)
+}
+
+func (g *GitHubPR) hasExcludedLabel(pr ghPR, excluded map[string]bool) bool {
+	for _, l := range pr.Labels {
+		if excluded[l.Name] {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *GitHubPR) hasBranch(ctx context.Context, prNum int) bool {
+	pattern := fmt.Sprintf("review/pr-%d-*", prNum)
+	out, err := g.CmdRunner.Run(ctx, "git", "ls-remote", "--heads", "origin", pattern)
+	if err == nil && strings.Contains(string(out), "\t") {
+		return true
+	}
+	return false
+}

--- a/cli/internal/source/github_pr_test.go
+++ b/cli/internal/source/github_pr_test.go
@@ -1,0 +1,339 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+type mockCmdRunner struct {
+	calls   [][]string
+	outputs map[string][]byte
+	errs    map[string]error
+}
+
+func newMock() *mockCmdRunner {
+	return &mockCmdRunner{
+		outputs: make(map[string][]byte),
+		errs:    make(map[string]error),
+	}
+}
+
+func (m *mockCmdRunner) set(out []byte, args ...string) {
+	m.outputs[strings.Join(args, " ")] = out
+}
+
+func (m *mockCmdRunner) setErr(err error, args ...string) {
+	m.errs[strings.Join(args, " ")] = err
+}
+
+func (m *mockCmdRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	parts := append([]string{name}, args...)
+	m.calls = append(m.calls, parts)
+	key := strings.Join(parts, " ")
+	if err, ok := m.errs[key]; ok {
+		return nil, err
+	}
+	if out, ok := m.outputs[key]; ok {
+		return out, nil
+	}
+	return []byte("[]"), nil
+}
+
+func prJSON(prs []ghPR) []byte {
+	b, _ := json.Marshal(prs)
+	return b
+}
+
+func TestGitHubPRScanFindsPRs(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "fix readme", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix-readme",
+			Labels: []struct{ Name string `json:"name"` }{{Name: "review-me"}}},
+		{Number: 20, Title: "add tests", URL: "https://github.com/owner/repo/pull/20", HeadRefName: "add-tests",
+			Labels: []struct{ Name string `json:"name"` }{{Name: "review-me"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		Exclude:   nil,
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 2 {
+		t.Fatalf("expected 2 vessels, got %d", len(vessels))
+	}
+	for _, v := range vessels {
+		if v.Source != "github-pr" {
+			t.Errorf("expected source github-pr, got %q", v.Source)
+		}
+		if v.Meta["pr_num"] == "" {
+			t.Error("expected Meta[pr_num] to be set")
+		}
+		if !strings.HasPrefix(v.ID, "pr-") {
+			t.Errorf("expected ID to start with pr-, got %q", v.ID)
+		}
+		if v.Workflow != "review-pr" {
+			t.Errorf("expected workflow review-pr, got %q", v.Workflow)
+		}
+	}
+}
+
+func TestGitHubPRScanExcludedLabel(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "excluded pr", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "excluded",
+			Labels: []struct{ Name string `json:"name"` }{{Name: "review-me"}, {Name: "wontfix"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		Exclude:   []string{"wontfix"},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Errorf("expected 0 vessels (excluded), got %d", len(vessels))
+	}
+}
+
+func TestGitHubPRScanAlreadyQueued(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	_ = q.Enqueue(queue.Vessel{
+		ID: "pr-10", Source: "github-pr",
+		Ref: "https://github.com/owner/repo/pull/10", Workflow: "review-pr",
+		Meta: map[string]string{"pr_num": "10"},
+		State: queue.StatePending,
+	})
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "already queued", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix",
+			Labels: []struct{ Name string `json:"name"` }{{Name: "review-me"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Errorf("expected 0 vessels (already queued), got %d", len(vessels))
+	}
+}
+
+func TestGitHubPRScanExistingBranch(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 42, Title: "has branch", URL: "https://github.com/owner/repo/pull/42", HeadRefName: "fix",
+			Labels: []struct{ Name string `json:"name"` }{{Name: "review-me"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+	r.set([]byte("abc123\trefs/heads/review/pr-42-something"), "git", "ls-remote", "--heads", "origin", "review/pr-42-*")
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Errorf("expected 0 vessels (existing branch), got %d", len(vessels))
+	}
+}
+
+func TestGitHubPRScanDeduplicates(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "dup pr", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix",
+			Labels: []struct{ Name string `json:"name"` }{{Name: "review-me"}, {Name: "urgent"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "urgent", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo: "owner/repo",
+		Tasks: map[string]GitHubTask{
+			"review":  {Labels: []string{"review-me"}, Workflow: "review-pr"},
+			"urgents": {Labels: []string{"urgent"}, Workflow: "review-pr"},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Errorf("expected 1 vessel (dedup), got %d", len(vessels))
+	}
+}
+
+func TestGitHubPRScanGHFailure(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	r.setErr(errTest, "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	_, err := src.Scan(context.Background())
+	if err == nil {
+		t.Fatal("expected error from gh failure, got nil")
+	}
+}
+
+func TestGitHubPRScanMalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	r.set([]byte(`{not valid`), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	_, err := src.Scan(context.Background())
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestGitHubPROnStart(t *testing.T) {
+	r := newMock()
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		CmdRunner: r,
+	}
+
+	vessel := queue.Vessel{
+		ID:     "pr-10",
+		Source: "github-pr",
+		Meta:   map[string]string{"pr_num": "10"},
+	}
+	err := src.OnStart(context.Background(), vessel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(r.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(r.calls))
+	}
+	call := strings.Join(r.calls[0], " ")
+	if !strings.Contains(call, "pr edit") {
+		t.Errorf("expected 'pr edit' in call, got %q", call)
+	}
+	if !strings.Contains(call, "in-progress") {
+		t.Errorf("expected 'in-progress' label in call, got %q", call)
+	}
+}
+
+func TestGitHubPROnStartNilRunner(t *testing.T) {
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		CmdRunner: nil,
+	}
+	vessel := queue.Vessel{
+		ID:   "pr-10",
+		Meta: map[string]string{"pr_num": "10"},
+	}
+	err := src.OnStart(context.Background(), vessel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGitHubPROnStartMissingMeta(t *testing.T) {
+	r := newMock()
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		CmdRunner: r,
+	}
+	vessel := queue.Vessel{ID: "pr-10", Meta: map[string]string{}}
+	err := src.OnStart(context.Background(), vessel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.calls) != 0 {
+		t.Errorf("expected no calls for missing pr_num, got %d", len(r.calls))
+	}
+}
+
+func TestGitHubPRBranchName(t *testing.T) {
+	src := &GitHubPR{Repo: "owner/repo"}
+	vessel := queue.Vessel{
+		ID:   "pr-42",
+		Ref:  "https://github.com/owner/repo/pull/42",
+		Meta: map[string]string{"pr_num": "42"},
+	}
+	branch := src.BranchName(vessel)
+	if !strings.HasPrefix(branch, "review/pr-42-") {
+		t.Errorf("expected branch to start with review/pr-42-, got %q", branch)
+	}
+}
+
+func TestGitHubPRName(t *testing.T) {
+	src := &GitHubPR{}
+	if src.Name() != "github-pr" {
+		t.Errorf("expected name github-pr, got %q", src.Name())
+	}
+}
+
+var errTest = &testError{"test error"}
+
+type testError struct{ msg string }
+
+func (e *testError) Error() string { return e.msg }


### PR DESCRIPTION
## Summary
- New `GitHubPR` source implementing the `Source` interface for PR discovery
- Uses `gh pr list`/`gh pr view` instead of issue equivalents
- Vessel ID format: `pr-<number>`, source: `github-pr`
- `BranchName()` returns `review/pr-<num>-<slug>` format
- Unified `fetchGitHubData` method in runner (parameterized by gh subcommand)
- Scanner `buildSources()` handles `type: github-pr`
- Config `Validate()` accepts `type: github-pr`

## Test plan
- [x] `TestGitHubPRScanFindsPRs` — discovers PRs by label with correct vessel format
- [x] `TestGitHubPRScanSkipsExcluded` — excluded labels filter correctly
- [x] `TestGitHubPRBranchName` — correct `review/pr-<num>-<slug>` format
- [x] `TestGitHubPROnStart` — adds in-progress label via `gh pr edit`
- [x] All existing tests pass (`go test ./...`)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)