### PR TITLE
feat: add per-workflow and per-phase model configuration (#13)

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -39,9 +39,10 @@ type Task struct {
 }
 
 type ClaudeConfig struct {
-	Command  string            `yaml:"command"`
-	Flags    string            `yaml:"flags,omitempty"`
-	Env      map[string]string `yaml:"env,omitempty"`
+	Command      string            `yaml:"command"`
+	Flags        string            `yaml:"flags,omitempty"`
+	Env          map[string]string `yaml:"env,omitempty"`
+	DefaultModel string            `yaml:"default_model,omitempty"`
 	// Template is kept for deserialization so we can detect and reject it.
 	Template     string   `yaml:"template,omitempty"`
 	AllowedTools []string `yaml:"allowed_tools,omitempty"`

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -536,6 +536,59 @@ claude:
 	requireErrorContains(t, err, "claude.allowed_tools is no longer supported")
 }
 
+func TestLoadDefaultModel(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-20250514"
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	if cfg.Claude.DefaultModel != "claude-sonnet-4-20250514" {
+		t.Fatalf("Claude.DefaultModel = %q, want claude-sonnet-4-20250514", cfg.Claude.DefaultModel)
+	}
+}
+
+func TestLoadDefaultModelEmpty(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	if cfg.Claude.DefaultModel != "" {
+		t.Fatalf("Claude.DefaultModel = %q, want empty", cfg.Claude.DefaultModel)
+	}
+}
+
 func TestLoadDaemonConfig(t *testing.T) {
 	path := writeConfigFile(t, `sources:
   github:

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -279,7 +279,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 			}
 
 			// Construct claude args
-			args := buildPhaseArgs(r.Config, &p, harnessContent)
+			args := buildPhaseArgs(r.Config, sk, &p, harnessContent)
 
 			// Run phase via stdin
 			output, runErr := r.Runner.RunPhase(ctx, worktreePath, strings.NewReader(rendered), r.Config.Claude.Command, args...)
@@ -636,12 +636,30 @@ func vesselLabel(v queue.Vessel) string {
 }
 
 // buildPhaseArgs constructs the claude CLI arguments for a phase invocation.
-func buildPhaseArgs(cfg *config.Config, p *workflow.Phase, harnessContent string) []string {
+func buildPhaseArgs(cfg *config.Config, wf *workflow.Workflow, p *workflow.Phase, harnessContent string) []string {
 	args := []string{"-p"}
 	args = append(args, "--max-turns", fmt.Sprintf("%d", p.MaxTurns))
 
+	// Resolve model: Phase > Workflow > Config default
+	model := ""
+	if p.Model != nil && *p.Model != "" {
+		model = *p.Model
+	} else if wf != nil && wf.Model != nil && *wf.Model != "" {
+		model = *wf.Model
+	} else if cfg.Claude.DefaultModel != "" {
+		model = cfg.Claude.DefaultModel
+	}
+
 	if cfg.Claude.Flags != "" {
-		args = append(args, strings.Fields(cfg.Claude.Flags)...)
+		fields := strings.Fields(cfg.Claude.Flags)
+		if model != "" {
+			fields = stripModelFlag(fields)
+		}
+		args = append(args, fields...)
+	}
+
+	if model != "" {
+		args = append(args, "--model", model)
 	}
 
 	if p.AllowedTools != nil && *p.AllowedTools != "" {
@@ -657,4 +675,17 @@ func buildPhaseArgs(cfg *config.Config, p *workflow.Phase, harnessContent string
 	}
 
 	return args
+}
+
+// stripModelFlag removes --model and its value from a slice of CLI args.
+func stripModelFlag(fields []string) []string {
+	var out []string
+	for i := 0; i < len(fields); i++ {
+		if fields[i] == "--model" {
+			i++ // skip the value
+			continue
+		}
+		out = append(out, fields[i])
+	}
+	return out
 }

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -1212,7 +1212,7 @@ func TestBuildPhaseArgs(t *testing.T) {
 			Claude: config.ClaudeConfig{Command: "claude"},
 		}
 		p := &workflow.Phase{Name: "analyze", MaxTurns: 5}
-		args := buildPhaseArgs(cfg, p, "")
+		args := buildPhaseArgs(cfg, nil, p, "")
 
 		if args[0] != "-p" {
 			t.Errorf("expected -p, got %s", args[0])
@@ -1227,7 +1227,7 @@ func TestBuildPhaseArgs(t *testing.T) {
 			Claude: config.ClaudeConfig{Command: "claude", Flags: "--bare --dangerously-skip-permissions"},
 		}
 		p := &workflow.Phase{Name: "analyze", MaxTurns: 5}
-		args := buildPhaseArgs(cfg, p, "")
+		args := buildPhaseArgs(cfg, nil, p, "")
 
 		joined := strings.Join(args, " ")
 		if !strings.Contains(joined, "--bare") {
@@ -1244,7 +1244,7 @@ func TestBuildPhaseArgs(t *testing.T) {
 		}
 		allowedTools := "Read,Edit"
 		p := &workflow.Phase{Name: "analyze", MaxTurns: 5, AllowedTools: &allowedTools}
-		args := buildPhaseArgs(cfg, p, "")
+		args := buildPhaseArgs(cfg, nil, p, "")
 
 		// Should have both phase-level and config-level tools
 		toolCount := 0
@@ -1263,7 +1263,7 @@ func TestBuildPhaseArgs(t *testing.T) {
 			Claude: config.ClaudeConfig{Command: "claude"},
 		}
 		p := &workflow.Phase{Name: "analyze", MaxTurns: 5}
-		args := buildPhaseArgs(cfg, p, "harness content")
+		args := buildPhaseArgs(cfg, nil, p, "harness content")
 
 		found := false
 		for i, a := range args {
@@ -1275,6 +1275,126 @@ func TestBuildPhaseArgs(t *testing.T) {
 			t.Errorf("expected --append-system-prompt with harness, got: %v", args)
 		}
 	})
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestBuildPhaseArgsModelResolution(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *config.Config
+		wf        *workflow.Workflow
+		phase     *workflow.Phase
+		wantModel string // expected --model value; empty means no --model flag
+	}{
+		{
+			name: "phase model takes priority",
+			cfg: &config.Config{
+				Claude: config.ClaudeConfig{Command: "claude", DefaultModel: "config-model"},
+			},
+			wf:        &workflow.Workflow{Model: strPtr("workflow-model")},
+			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5, Model: strPtr("phase-model")},
+			wantModel: "phase-model",
+		},
+		{
+			name: "workflow model when phase has no model",
+			cfg: &config.Config{
+				Claude: config.ClaudeConfig{Command: "claude", DefaultModel: "config-model"},
+			},
+			wf:        &workflow.Workflow{Model: strPtr("workflow-model")},
+			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5},
+			wantModel: "workflow-model",
+		},
+		{
+			name: "config default model when neither phase nor workflow set",
+			cfg: &config.Config{
+				Claude: config.ClaudeConfig{Command: "claude", DefaultModel: "config-model"},
+			},
+			wf:        &workflow.Workflow{},
+			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5},
+			wantModel: "config-model",
+		},
+		{
+			name: "no model when nothing set",
+			cfg: &config.Config{
+				Claude: config.ClaudeConfig{Command: "claude"},
+			},
+			wf:        &workflow.Workflow{},
+			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5},
+			wantModel: "",
+		},
+		{
+			name: "nil workflow still falls back to config",
+			cfg: &config.Config{
+				Claude: config.ClaudeConfig{Command: "claude", DefaultModel: "config-model"},
+			},
+			wf:        nil,
+			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5},
+			wantModel: "config-model",
+		},
+		{
+			name: "flags --model stripped when hierarchy resolves model",
+			cfg: &config.Config{
+				Claude: config.ClaudeConfig{Command: "claude", Flags: "--bare --model old-model --dangerously-skip-permissions"},
+			},
+			wf:        &workflow.Workflow{Model: strPtr("workflow-model")},
+			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5},
+			wantModel: "workflow-model",
+		},
+		{
+			name: "flags --model preserved when hierarchy does not resolve",
+			cfg: &config.Config{
+				Claude: config.ClaudeConfig{Command: "claude", Flags: "--bare --model flags-model"},
+			},
+			wf:        &workflow.Workflow{},
+			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5},
+			wantModel: "flags-model",
+		},
+		{
+			name: "empty string phase model falls through to workflow",
+			cfg: &config.Config{
+				Claude: config.ClaudeConfig{Command: "claude"},
+			},
+			wf:        &workflow.Workflow{Model: strPtr("workflow-model")},
+			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5, Model: strPtr("")},
+			wantModel: "workflow-model",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := buildPhaseArgs(tt.cfg, tt.wf, tt.phase, "")
+
+			// Find --model in args
+			foundModel := ""
+			for i, a := range args {
+				if a == "--model" && i+1 < len(args) {
+					foundModel = args[i+1]
+					break
+				}
+			}
+
+			if foundModel != tt.wantModel {
+				t.Errorf("model = %q, want %q (args: %v)", foundModel, tt.wantModel, args)
+			}
+
+			// When hierarchy resolves a model, --model from flags should be stripped
+			if tt.wantModel != "" && strings.Contains(tt.cfg.Claude.Flags, "--model") {
+				// Count --model occurrences; should be exactly 1
+				count := 0
+				for _, a := range args {
+					if a == "--model" {
+						count++
+					}
+				}
+				if count != 1 {
+					t.Errorf("expected exactly 1 --model flag, got %d (args: %v)", count, args)
+				}
+			}
+		})
+	}
 }
 
 func TestDrainTimeoutV2Phase(t *testing.T) {

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -20,6 +20,7 @@ var validPhaseName = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 type Workflow struct {
 	Name        string  `yaml:"name"`
 	Description string  `yaml:"description,omitempty"`
+	Model       *string `yaml:"model,omitempty"`
 	Phases      []Phase `yaml:"phases"`
 }
 
@@ -28,6 +29,7 @@ type Phase struct {
 	Name         string  `yaml:"name"`
 	PromptFile   string  `yaml:"prompt_file"`
 	MaxTurns     int     `yaml:"max_turns"`
+	Model        *string `yaml:"model,omitempty"`
 	Gate         *Gate   `yaml:"gate,omitempty"`
 	AllowedTools *string `yaml:"allowed_tools,omitempty"`
 }

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -143,6 +143,35 @@ phases:
 			},
 		},
 		{
+			name:         "valid workflow with model",
+			workflowName: "fix-bug",
+			yaml: `name: fix-bug
+description: Fix a bug
+model: claude-sonnet-4-20250514
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+  - name: implement
+    prompt_file: prompts/implement.md
+    max_turns: 20
+    model: claude-opus-4-20250514
+`,
+			prompts: []string{"prompts/analyze.md", "prompts/implement.md"},
+			checkFunc: func(t *testing.T, s *Workflow) {
+				t.Helper()
+				if s.Model == nil || *s.Model != "claude-sonnet-4-20250514" {
+					t.Fatalf("Workflow.Model = %v, want claude-sonnet-4-20250514", s.Model)
+				}
+				if s.Phases[0].Model != nil {
+					t.Fatalf("Phases[0].Model = %v, want nil", s.Phases[0].Model)
+				}
+				if s.Phases[1].Model == nil || *s.Phases[1].Model != "claude-opus-4-20250514" {
+					t.Fatalf("Phases[1].Model = %v, want claude-opus-4-20250514", s.Phases[1].Model)
+				}
+			},
+		},
+		{
 			name:      "missing phases key",
 			workflowName: "test-workflow",
 			yaml:      "name: test-workflow\n",


### PR DESCRIPTION
## Summary
- Add optional `model` field to `Workflow` and `Phase` structs
- Add `default_model` field to `ClaudeConfig`
- Implement model resolution hierarchy: Phase > Workflow > DefaultModel > Flags
- `stripModelFlag` prevents duplication when hierarchy resolves a model
- Backwards compatible: existing `claude.flags` configs work unchanged

## Test plan
- [x] 8 table-driven cases for model resolution hierarchy
- [x] Config YAML parsing of `default_model`
- [x] Workflow YAML parsing of `model` at both levels
- [x] Flag stripping when hierarchy resolves model
- [x] `go test ./internal/config/... ./internal/workflow/... ./internal/runner/...` passes

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)