### PR TITLE
feat: clean up worktrees after vessel completion in drain path (#22)

### DIFF
--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -32,6 +32,7 @@ type CommandRunner interface {
 // WorktreeManager abstracts worktree lifecycle for testing.
 type WorktreeManager interface {
 	Create(ctx context.Context, branchName string) (string, error)
+	Remove(ctx context.Context, worktreePath string) error
 }
 
 // DrainResult summarises a drain run.
@@ -143,6 +144,8 @@ func (r *Runner) CheckWaitingVessels(ctx context.Context) {
 				if updateErr := r.Queue.Update(vessel.ID, queue.StateTimedOut, "label gate timed out"); updateErr != nil {
 					log.Printf("warn: failed to update vessel %s to timed_out: %v", vessel.ID, updateErr)
 				}
+				// Clean up worktree (best-effort)
+				r.removeWorktree(vessel.WorktreePath, vessel.ID)
 				// Post timeout comment
 				issueNum := r.parseIssueNum(vessel)
 				if issueNum > 0 && r.Reporter != nil {
@@ -401,6 +404,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 		log.Printf("warn: failed to update vessel %s state: %v", vessel.ID, updateErr)
 	}
 
+	// Clean up worktree (best-effort)
+	r.removeWorktree(worktreePath, vessel.ID)
+
 	// Report completion
 	issueNum := r.parseIssueNum(vessel)
 	if issueNum > 0 && r.Reporter != nil {
@@ -435,6 +441,10 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 	if updateErr := r.Queue.Update(vessel.ID, queue.StateCompleted, ""); updateErr != nil {
 		log.Printf("warn: failed to update vessel %s state: %v", vessel.ID, updateErr)
 	}
+
+	// Clean up worktree (best-effort)
+	r.removeWorktree(worktreePath, vessel.ID)
+
 	return "completed"
 }
 
@@ -469,6 +479,15 @@ func buildCommand(cfg *config.Config, vessel *queue.Vessel) (string, []string, e
 		args = append(args, strings.Fields(cfg.Claude.Flags)...)
 	}
 	return cfg.Claude.Command, args, nil
+}
+
+func (r *Runner) removeWorktree(worktreePath, vesselID string) {
+	if worktreePath == "" {
+		return
+	}
+	if removeErr := r.Worktree.Remove(context.Background(), worktreePath); removeErr != nil {
+		log.Printf("warn: failed to remove worktree for %s: %v", vesselID, removeErr)
+	}
 }
 
 func (r *Runner) failVessel(id string, errMsg string) {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -139,8 +139,11 @@ func (c *countingCmdRunner) RunPhase(_ context.Context, _ string, stdin io.Reade
 }
 
 type mockWorktree struct {
-	createErr error
-	path      string
+	createErr    error
+	path         string
+	removeErr    error
+	removeCalled bool
+	removePath   string
 }
 
 func (m *mockWorktree) Create(_ context.Context, branchName string) (string, error) {
@@ -153,6 +156,12 @@ func (m *mockWorktree) Create(_ context.Context, branchName string) (string, err
 	return ".claude/worktrees/" + branchName, nil
 }
 
+func (m *mockWorktree) Remove(_ context.Context, worktreePath string) error {
+	m.removeCalled = true
+	m.removePath = worktreePath
+	return m.removeErr
+}
+
 type trackingWorktree struct {
 	lastBranch string
 }
@@ -160,6 +169,10 @@ type trackingWorktree struct {
 func (tw *trackingWorktree) Create(_ context.Context, branchName string) (string, error) {
 	tw.lastBranch = branchName
 	return ".claude/worktrees/" + branchName, nil
+}
+
+func (tw *trackingWorktree) Remove(_ context.Context, _ string) error {
+	return nil
 }
 
 // --- Helpers ---


### PR DESCRIPTION
## Summary
- Add `Remove(ctx, path) error` to `WorktreeManager` interface
- Runner cleans up worktrees after completed/timed_out vessels (best-effort)
- Failed vessels retain worktrees for debugging
- Uses `context.Background()` since vessel context may have timed out
- `removeWorktree` helper logs warnings on failure without blocking

## Test plan
- [x] Mock `WorktreeManager` updated with `Remove` tracking
- [x] All existing runner tests pass with new interface
- [x] `go test ./internal/runner/...` passes

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)