### PR TITLE
feat: add copilot as a first-class LLM provider

### DIFF
--- a/cli/cmd/xylem/init.go
+++ b/cli/cmd/xylem/init.go
@@ -131,6 +131,9 @@ max_turns: 50
 timeout: "30m"
 state_dir: ".xylem"
 
+# llm selects the global default LLM provider: "claude" (default) or "copilot"
+llm: claude
+
 claude:
   command: "claude"
   flags: "--bare --dangerously-skip-permissions"
@@ -140,6 +143,12 @@ claude:
   #   - "Bash(gh issue view *)"
   #   - "Bash(gh pr create *)"
   #   - "WebFetch"
+
+# copilot:
+#   command: "copilot"
+#   flags: ""
+#   default_model: ""
+#   env: {}
 `, repo, repo)
 
 	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -22,7 +22,9 @@ type Config struct {
 	Exclude       []string                `yaml:"exclude,omitempty"`
 	DefaultBranch string                  `yaml:"default_branch,omitempty"`
 	CleanupAfter  string                  `yaml:"cleanup_after,omitempty"`
+	LLM           string                  `yaml:"llm,omitempty"`
 	Claude        ClaudeConfig            `yaml:"claude"`
+	Copilot       CopilotConfig           `yaml:"copilot,omitempty"`
 	Daemon        DaemonConfig            `yaml:"daemon,omitempty"`
 }
 
@@ -48,6 +50,14 @@ type ClaudeConfig struct {
 	AllowedTools []string `yaml:"allowed_tools,omitempty"`
 }
 
+// CopilotConfig holds configuration for the GitHub Copilot CLI provider.
+type CopilotConfig struct {
+	Command      string            `yaml:"command"`
+	Flags        string            `yaml:"flags,omitempty"`
+	DefaultModel string            `yaml:"default_model,omitempty"`
+	Env          map[string]string `yaml:"env,omitempty"`
+}
+
 type DaemonConfig struct {
 	ScanInterval  string `yaml:"scan_interval,omitempty"`
 	DrainInterval string `yaml:"drain_interval,omitempty"`
@@ -68,6 +78,9 @@ func Load(path string) (*Config, error) {
 		Exclude:      []string{"wontfix", "duplicate", "in-progress", "no-bot"},
 		Claude: ClaudeConfig{
 			Command: "claude",
+		},
+		Copilot: CopilotConfig{
+			Command: "copilot",
 		},
 		Daemon: DaemonConfig{
 			ScanInterval:  "60s",
@@ -124,6 +137,13 @@ func (c *Config) Validate() error {
 		if _, err := time.ParseDuration(c.CleanupAfter); err != nil {
 			return fmt.Errorf("cleanup_after must be a valid duration: %w", err)
 		}
+	}
+
+	switch c.LLM {
+	case "", "claude", "copilot":
+		// valid
+	default:
+		return fmt.Errorf("llm must be \"claude\" or \"copilot\", got %q", c.LLM)
 	}
 
 	if c.Claude.Template != "" {

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -146,9 +146,10 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("llm must be \"claude\" or \"copilot\", got %q", c.LLM)
 	}
 
-	// Validate copilot config when copilot is the selected provider
-	if c.LLM == "copilot" && c.Copilot.Command == "" {
-		return fmt.Errorf("copilot.command must be non-empty when llm is \"copilot\"")
+	// Validate copilot config: command must always be set, since workflows/phases
+	// can select copilot even when the global llm is not "copilot".
+	if c.Copilot.Command == "" {
+		return fmt.Errorf("copilot.command must be non-empty")
 	}
 
 	if c.Claude.Template != "" {

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -146,9 +146,8 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("llm must be \"claude\" or \"copilot\", got %q", c.LLM)
 	}
 
-	// Validate copilot config: command must always be set, since workflows/phases
-	// can select copilot even when the global llm is not "copilot".
-	if c.Copilot.Command == "" {
+	// Validate copilot config: command must be set when copilot is the active provider.
+	if c.LLM == "copilot" && c.Copilot.Command == "" {
 		return fmt.Errorf("copilot.command must be non-empty")
 	}
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -36,8 +36,8 @@ type SourceConfig struct {
 }
 
 type Task struct {
-	Labels []string `yaml:"labels,omitempty"`
-	Workflow  string   `yaml:"workflow"`
+	Labels   []string `yaml:"labels,omitempty"`
+	Workflow string   `yaml:"workflow"`
 }
 
 type ClaudeConfig struct {
@@ -144,6 +144,11 @@ func (c *Config) Validate() error {
 		// valid
 	default:
 		return fmt.Errorf("llm must be \"claude\" or \"copilot\", got %q", c.LLM)
+	}
+
+	// Validate copilot config when copilot is the selected provider
+	if c.LLM == "copilot" && c.Copilot.Command == "" {
+		return fmt.Errorf("copilot.command must be non-empty when llm is \"copilot\"")
 	}
 
 	if c.Claude.Template != "" {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -621,35 +621,42 @@ daemon:
 	}
 }
 
-func TestValidateLLMClaudeExplicit(t *testing.T) {
-	cfg := validConfig()
-	cfg.LLM = "claude"
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("expected valid config with llm=claude, got: %v", err)
+func TestValidateLLM(t *testing.T) {
+	tests := []struct {
+		name    string
+		llm     string
+		wantErr string
+	}{
+		{"claude explicit", "claude", ""},
+		{"copilot explicit", "copilot", ""},
+		{"empty defaults to claude", "", ""},
+		{"invalid value", "gpt4", `llm must be "claude" or "copilot"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.LLM = tt.llm
+			// Ensure copilot command is set for "copilot" to avoid command validation failure
+			if tt.llm == "copilot" {
+				cfg.Copilot = CopilotConfig{Command: "copilot"}
+			}
+			err := cfg.Validate()
+			if tt.wantErr != "" {
+				requireErrorContains(t, err, tt.wantErr)
+			} else if err != nil {
+				t.Fatalf("expected valid config with llm=%q, got: %v", tt.llm, err)
+			}
+		})
 	}
 }
 
-func TestValidateLLMCopilotExplicit(t *testing.T) {
+func TestValidateCopilotEmptyCommand(t *testing.T) {
 	cfg := validConfig()
 	cfg.LLM = "copilot"
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("expected valid config with llm=copilot, got: %v", err)
-	}
-}
-
-func TestValidateLLMEmptyDefaultsClaude(t *testing.T) {
-	cfg := validConfig()
-	cfg.LLM = ""
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("expected valid config with empty llm (defaults to claude), got: %v", err)
-	}
-}
-
-func TestValidateLLMInvalidValue(t *testing.T) {
-	cfg := validConfig()
-	cfg.LLM = "gpt4"
+	cfg.Copilot = CopilotConfig{Command: ""}
 	err := cfg.Validate()
-	requireErrorContains(t, err, `llm must be "claude" or "copilot"`)
+	requireErrorContains(t, err, "copilot.command must be non-empty")
 }
 
 func TestLoadCopilotConfig(t *testing.T) {
@@ -749,4 +756,3 @@ claude:
 		t.Fatalf("LLM = %q, want empty (defaults to claude at runtime)", cfg.LLM)
 	}
 }
-

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -620,3 +620,133 @@ daemon:
 		t.Fatalf("Daemon.DrainInterval = %q, want 45s", cfg.Daemon.DrainInterval)
 	}
 }
+
+func TestValidateLLMClaudeExplicit(t *testing.T) {
+	cfg := validConfig()
+	cfg.LLM = "claude"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid config with llm=claude, got: %v", err)
+	}
+}
+
+func TestValidateLLMCopilotExplicit(t *testing.T) {
+	cfg := validConfig()
+	cfg.LLM = "copilot"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid config with llm=copilot, got: %v", err)
+	}
+}
+
+func TestValidateLLMEmptyDefaultsClaude(t *testing.T) {
+	cfg := validConfig()
+	cfg.LLM = ""
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid config with empty llm (defaults to claude), got: %v", err)
+	}
+}
+
+func TestValidateLLMInvalidValue(t *testing.T) {
+	cfg := validConfig()
+	cfg.LLM = "gpt4"
+	err := cfg.Validate()
+	requireErrorContains(t, err, `llm must be "claude" or "copilot"`)
+}
+
+func TestLoadCopilotConfig(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+llm: copilot
+copilot:
+  command: "copilot"
+  flags: "--headless"
+  default_model: "gpt-4o"
+  env:
+    GITHUB_TOKEN: "ghp-test"
+claude:
+  command: "claude"
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	if cfg.LLM != "copilot" {
+		t.Fatalf("LLM = %q, want copilot", cfg.LLM)
+	}
+	if cfg.Copilot.Command != "copilot" {
+		t.Fatalf("Copilot.Command = %q, want copilot", cfg.Copilot.Command)
+	}
+	if cfg.Copilot.Flags != "--headless" {
+		t.Fatalf("Copilot.Flags = %q, want --headless", cfg.Copilot.Flags)
+	}
+	if cfg.Copilot.DefaultModel != "gpt-4o" {
+		t.Fatalf("Copilot.DefaultModel = %q, want gpt-4o", cfg.Copilot.DefaultModel)
+	}
+	if cfg.Copilot.Env["GITHUB_TOKEN"] != "ghp-test" {
+		t.Fatalf("Copilot.Env[GITHUB_TOKEN] = %q, want ghp-test", cfg.Copilot.Env["GITHUB_TOKEN"])
+	}
+}
+
+func TestLoadCopilotDefaultCommand(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	// Default copilot command should be set even when copilot block is absent
+	if cfg.Copilot.Command != "copilot" {
+		t.Fatalf("Copilot.Command default = %q, want copilot", cfg.Copilot.Command)
+	}
+}
+
+func TestLoadLLMAbsentDefaultsClaude(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	if cfg.LLM != "" {
+		t.Fatalf("LLM = %q, want empty (defaults to claude at runtime)", cfg.LLM)
+	}
+}
+

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -281,11 +281,12 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 				log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
 			}
 
-			// Construct claude args
-			args := buildPhaseArgs(r.Config, sk, &p, harnessContent)
+			// Resolve provider and build args
+			provider := resolveProvider(r.Config, sk, &p)
+			cmd, args := buildProviderPhaseArgs(r.Config, sk, &p, harnessContent, provider)
 
 			// Run phase via stdin
-			output, runErr := r.Runner.RunPhase(ctx, worktreePath, strings.NewReader(rendered), r.Config.Claude.Command, args...)
+			output, runErr := r.Runner.RunPhase(ctx, worktreePath, strings.NewReader(rendered), cmd, args...)
 
 			// Write phase output
 			outputPath := filepath.Join(phasesDir, p.Name+".output")
@@ -423,15 +424,28 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 		prompt = fmt.Sprintf("Ref: %s\n\n%s", vessel.Ref, vessel.Prompt)
 	}
 
-	args := []string{"-p", "--max-turns", fmt.Sprintf("%d", r.Config.MaxTurns)}
-	if r.Config.Claude.Flags != "" {
-		args = append(args, strings.Fields(r.Config.Claude.Flags)...)
-	}
-	for _, tool := range r.Config.Claude.AllowedTools {
-		args = append(args, "--allowedTools", tool)
+	provider := resolveProvider(r.Config, nil, nil)
+	var cmd string
+	var args []string
+	switch provider {
+	case "copilot":
+		cmd = r.Config.Copilot.Command
+		args = []string{"--headless", "--max-turns", fmt.Sprintf("%d", r.Config.MaxTurns)}
+		if r.Config.Copilot.Flags != "" {
+			args = append(args, strings.Fields(r.Config.Copilot.Flags)...)
+		}
+	default: // "claude"
+		cmd = r.Config.Claude.Command
+		args = []string{"-p", "--max-turns", fmt.Sprintf("%d", r.Config.MaxTurns)}
+		if r.Config.Claude.Flags != "" {
+			args = append(args, strings.Fields(r.Config.Claude.Flags)...)
+		}
+		for _, tool := range r.Config.Claude.AllowedTools {
+			args = append(args, "--allowedTools", tool)
+		}
 	}
 
-	_, runErr := r.Runner.RunPhase(ctx, worktreePath, strings.NewReader(prompt), r.Config.Claude.Command, args...)
+	_, runErr := r.Runner.RunPhase(ctx, worktreePath, strings.NewReader(prompt), cmd, args...)
 
 	if runErr != nil {
 		r.failVessel(vessel.ID, runErr.Error())
@@ -457,28 +471,48 @@ func (r *Runner) resolveSource(name string) source.Source {
 	return &source.Manual{}
 }
 
-// buildCommand constructs the claude command and args from config and vessel.
+// buildCommand constructs the LLM command and args from config and vessel.
 func buildCommand(cfg *config.Config, vessel *queue.Vessel) (string, []string, error) {
+	provider := resolveProvider(cfg, nil, nil)
+
 	// Direct prompt mode
 	if vessel.Prompt != "" {
 		prompt := vessel.Prompt
 		if vessel.Ref != "" {
 			prompt = fmt.Sprintf("Ref: %s\n\n%s", vessel.Ref, vessel.Prompt)
 		}
-		args := []string{"-p", prompt, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns)}
+		switch provider {
+		case "copilot":
+			args := []string{"--headless", prompt, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns)}
+			if cfg.Copilot.Flags != "" {
+				args = append(args, strings.Fields(cfg.Copilot.Flags)...)
+			}
+			return cfg.Copilot.Command, args, nil
+		default: // "claude"
+			args := []string{"-p", prompt, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns)}
+			if cfg.Claude.Flags != "" {
+				args = append(args, strings.Fields(cfg.Claude.Flags)...)
+			}
+			return cfg.Claude.Command, args, nil
+		}
+	}
+
+	// Workflow-based mode: build command from flags (v2 phase-based execution will replace this)
+	wfPrompt := fmt.Sprintf("/%s %s", vessel.Workflow, vessel.Ref)
+	switch provider {
+	case "copilot":
+		args := []string{"--headless", wfPrompt, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns)}
+		if cfg.Copilot.Flags != "" {
+			args = append(args, strings.Fields(cfg.Copilot.Flags)...)
+		}
+		return cfg.Copilot.Command, args, nil
+	default: // "claude"
+		args := []string{"-p", wfPrompt, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns)}
 		if cfg.Claude.Flags != "" {
 			args = append(args, strings.Fields(cfg.Claude.Flags)...)
 		}
 		return cfg.Claude.Command, args, nil
 	}
-
-	// Workflow-based mode: build command from flags (v2 phase-based execution will replace this)
-	prompt := fmt.Sprintf("/%s %s", vessel.Workflow, vessel.Ref)
-	args := []string{"-p", prompt, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns)}
-	if cfg.Claude.Flags != "" {
-		args = append(args, strings.Fields(cfg.Claude.Flags)...)
-	}
-	return cfg.Claude.Command, args, nil
 }
 
 func (r *Runner) removeWorktree(worktreePath, vesselID string) {
@@ -661,15 +695,7 @@ func buildPhaseArgs(cfg *config.Config, wf *workflow.Workflow, p *workflow.Phase
 	args := []string{"-p"}
 	args = append(args, "--max-turns", fmt.Sprintf("%d", p.MaxTurns))
 
-	// Resolve model: Phase > Workflow > DefaultModel
-	model := ""
-	if p.Model != nil && *p.Model != "" {
-		model = *p.Model
-	} else if wf != nil && wf.Model != nil && *wf.Model != "" {
-		model = *wf.Model
-	} else if cfg.Claude.DefaultModel != "" {
-		model = cfg.Claude.DefaultModel
-	}
+	model := resolveModel(cfg, wf, p, "claude")
 
 	// Add flags, stripping --model if we resolved one from the hierarchy
 	if cfg.Claude.Flags != "" {
@@ -697,6 +723,84 @@ func buildPhaseArgs(cfg *config.Config, wf *workflow.Workflow, p *workflow.Phase
 	}
 
 	return args
+}
+
+// buildCopilotPhaseArgs constructs the GitHub Copilot CLI arguments for a phase invocation.
+// Model resolution follows the hierarchy: Phase.Model > Workflow.Model > CopilotConfig.DefaultModel.
+func buildCopilotPhaseArgs(cfg *config.Config, wf *workflow.Workflow, p *workflow.Phase, harnessContent string) []string {
+	args := []string{"--headless"}
+	args = append(args, "--max-turns", fmt.Sprintf("%d", p.MaxTurns))
+
+	model := resolveModel(cfg, wf, p, "copilot")
+
+	// Add flags, stripping --model if we resolved one from the hierarchy
+	if cfg.Copilot.Flags != "" {
+		fields := strings.Fields(cfg.Copilot.Flags)
+		if model != "" {
+			fields = stripModelFlag(fields)
+		}
+		args = append(args, fields...)
+	}
+
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+
+	if p.AllowedTools != nil && *p.AllowedTools != "" {
+		args = append(args, "--allowed-tools", *p.AllowedTools)
+	}
+
+	if harnessContent != "" {
+		args = append(args, "--system-prompt", harnessContent)
+	}
+
+	return args
+}
+
+// buildProviderPhaseArgs dispatches to the correct arg builder based on the resolved provider,
+// and returns the command binary and argument slice for the phase invocation.
+func buildProviderPhaseArgs(cfg *config.Config, wf *workflow.Workflow, p *workflow.Phase, harnessContent, provider string) (string, []string) {
+	switch provider {
+	case "copilot":
+		return cfg.Copilot.Command, buildCopilotPhaseArgs(cfg, wf, p, harnessContent)
+	default: // "claude"
+		return cfg.Claude.Command, buildPhaseArgs(cfg, wf, p, harnessContent)
+	}
+}
+
+// resolveProvider determines which LLM provider to use for a phase invocation.
+// Resolution order: Phase.LLM > Workflow.LLM > Config.LLM, defaulting to "claude".
+func resolveProvider(cfg *config.Config, wf *workflow.Workflow, p *workflow.Phase) string {
+	if p != nil && p.LLM != nil && *p.LLM != "" {
+		return *p.LLM
+	}
+	if wf != nil && wf.LLM != nil && *wf.LLM != "" {
+		return *wf.LLM
+	}
+	if cfg != nil && cfg.LLM != "" {
+		return cfg.LLM
+	}
+	return "claude"
+}
+
+// resolveModel determines the model string for a phase invocation.
+// Resolution order: Phase.Model > Workflow.Model > provider's DefaultModel from config.
+func resolveModel(cfg *config.Config, wf *workflow.Workflow, p *workflow.Phase, provider string) string {
+	if p != nil && p.Model != nil && *p.Model != "" {
+		return *p.Model
+	}
+	if wf != nil && wf.Model != nil && *wf.Model != "" {
+		return *wf.Model
+	}
+	if cfg == nil {
+		return ""
+	}
+	switch provider {
+	case "copilot":
+		return cfg.Copilot.DefaultModel
+	default:
+		return cfg.Claude.DefaultModel
+	}
 }
 
 // stripModelFlag removes --model and its value from a slice of CLI flag tokens.

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -18,8 +18,8 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
-	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 )
 
 // CommandRunner abstracts subprocess execution for testing.
@@ -424,26 +424,7 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 		prompt = fmt.Sprintf("Ref: %s\n\n%s", vessel.Ref, vessel.Prompt)
 	}
 
-	provider := resolveProvider(r.Config, nil, nil)
-	var cmd string
-	var args []string
-	switch provider {
-	case "copilot":
-		cmd = r.Config.Copilot.Command
-		args = []string{"--headless", "--max-turns", fmt.Sprintf("%d", r.Config.MaxTurns)}
-		if r.Config.Copilot.Flags != "" {
-			args = append(args, strings.Fields(r.Config.Copilot.Flags)...)
-		}
-	default: // "claude"
-		cmd = r.Config.Claude.Command
-		args = []string{"-p", "--max-turns", fmt.Sprintf("%d", r.Config.MaxTurns)}
-		if r.Config.Claude.Flags != "" {
-			args = append(args, strings.Fields(r.Config.Claude.Flags)...)
-		}
-		for _, tool := range r.Config.Claude.AllowedTools {
-			args = append(args, "--allowedTools", tool)
-		}
-	}
+	cmd, args := buildPromptOnlyCmdArgs(r.Config, "")
 
 	_, runErr := r.Runner.RunPhase(ctx, worktreePath, strings.NewReader(prompt), cmd, args...)
 
@@ -473,46 +454,20 @@ func (r *Runner) resolveSource(name string) source.Source {
 
 // buildCommand constructs the LLM command and args from config and vessel.
 func buildCommand(cfg *config.Config, vessel *queue.Vessel) (string, []string, error) {
-	provider := resolveProvider(cfg, nil, nil)
-
 	// Direct prompt mode
 	if vessel.Prompt != "" {
 		prompt := vessel.Prompt
 		if vessel.Ref != "" {
 			prompt = fmt.Sprintf("Ref: %s\n\n%s", vessel.Ref, vessel.Prompt)
 		}
-		switch provider {
-		case "copilot":
-			args := []string{"--headless", prompt, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns)}
-			if cfg.Copilot.Flags != "" {
-				args = append(args, strings.Fields(cfg.Copilot.Flags)...)
-			}
-			return cfg.Copilot.Command, args, nil
-		default: // "claude"
-			args := []string{"-p", prompt, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns)}
-			if cfg.Claude.Flags != "" {
-				args = append(args, strings.Fields(cfg.Claude.Flags)...)
-			}
-			return cfg.Claude.Command, args, nil
-		}
+		cmd, args := buildPromptOnlyCmdArgs(cfg, prompt)
+		return cmd, args, nil
 	}
 
 	// Workflow-based mode: build command from flags (v2 phase-based execution will replace this)
 	wfPrompt := fmt.Sprintf("/%s %s", vessel.Workflow, vessel.Ref)
-	switch provider {
-	case "copilot":
-		args := []string{"--headless", wfPrompt, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns)}
-		if cfg.Copilot.Flags != "" {
-			args = append(args, strings.Fields(cfg.Copilot.Flags)...)
-		}
-		return cfg.Copilot.Command, args, nil
-	default: // "claude"
-		args := []string{"-p", wfPrompt, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns)}
-		if cfg.Claude.Flags != "" {
-			args = append(args, strings.Fields(cfg.Claude.Flags)...)
-		}
-		return cfg.Claude.Command, args, nil
-	}
+	cmd, args := buildPromptOnlyCmdArgs(cfg, wfPrompt)
+	return cmd, args, nil
 }
 
 func (r *Runner) removeWorktree(worktreePath, vesselID string) {
@@ -710,6 +665,7 @@ func buildPhaseArgs(cfg *config.Config, wf *workflow.Workflow, p *workflow.Phase
 		args = append(args, "--model", model)
 	}
 
+	// Claude CLI uses --allowedTools (camelCase), unlike Copilot's --allowed-tools (kebab-case)
 	if p.AllowedTools != nil && *p.AllowedTools != "" {
 		args = append(args, "--allowedTools", *p.AllowedTools)
 	}
@@ -718,6 +674,7 @@ func buildPhaseArgs(cfg *config.Config, wf *workflow.Workflow, p *workflow.Phase
 		args = append(args, "--allowedTools", tool)
 	}
 
+	// Claude CLI uses --append-system-prompt, unlike Copilot's --system-prompt
 	if harnessContent != "" {
 		args = append(args, "--append-system-prompt", harnessContent)
 	}
@@ -733,9 +690,11 @@ func buildCopilotPhaseArgs(cfg *config.Config, wf *workflow.Workflow, p *workflo
 
 	model := resolveModel(cfg, wf, p, "copilot")
 
-	// Add flags, stripping --model if we resolved one from the hierarchy
+	// Add flags, stripping --headless (always prepended) and --model (resolved from hierarchy)
+	// to avoid duplication
 	if cfg.Copilot.Flags != "" {
 		fields := strings.Fields(cfg.Copilot.Flags)
+		fields = stripBoolFlag(fields, "--headless")
 		if model != "" {
 			fields = stripModelFlag(fields)
 		}
@@ -746,10 +705,12 @@ func buildCopilotPhaseArgs(cfg *config.Config, wf *workflow.Workflow, p *workflo
 		args = append(args, "--model", model)
 	}
 
+	// Copilot CLI uses kebab-case flags, unlike Claude's --allowedTools (camelCase)
 	if p.AllowedTools != nil && *p.AllowedTools != "" {
 		args = append(args, "--allowed-tools", *p.AllowedTools)
 	}
 
+	// Copilot CLI uses --system-prompt, unlike Claude's --append-system-prompt
 	if harnessContent != "" {
 		args = append(args, "--system-prompt", harnessContent)
 	}
@@ -800,6 +761,53 @@ func resolveModel(cfg *config.Config, wf *workflow.Workflow, p *workflow.Phase, 
 		return cfg.Copilot.DefaultModel
 	default:
 		return cfg.Claude.DefaultModel
+	}
+}
+
+// stripBoolFlag removes all occurrences of a boolean flag (no value) from a slice of CLI tokens.
+func stripBoolFlag(fields []string, flag string) []string {
+	var out []string
+	for _, f := range fields {
+		if f != flag {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// buildPromptOnlyCmdArgs returns the command and args for a prompt-only invocation.
+// If prompt is non-empty, it is included as a positional argument (for buildCommand).
+// If prompt is empty, the caller supplies it via stdin (for runPromptOnly).
+func buildPromptOnlyCmdArgs(cfg *config.Config, prompt string) (string, []string) {
+	provider := resolveProvider(cfg, nil, nil)
+	switch provider {
+	case "copilot":
+		cmd := cfg.Copilot.Command
+		args := []string{"--headless"}
+		if prompt != "" {
+			args = append(args, prompt)
+		}
+		args = append(args, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns))
+		if cfg.Copilot.Flags != "" {
+			// Strip --headless (always prepended) to avoid duplication
+			fields := stripBoolFlag(strings.Fields(cfg.Copilot.Flags), "--headless")
+			args = append(args, fields...)
+		}
+		return cmd, args
+	default: // "claude"
+		cmd := cfg.Claude.Command
+		args := []string{"-p"}
+		if prompt != "" {
+			args = append(args, prompt)
+		}
+		args = append(args, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns))
+		if cfg.Claude.Flags != "" {
+			args = append(args, strings.Fields(cfg.Claude.Flags)...)
+		}
+		for _, tool := range cfg.Claude.AllowedTools {
+			args = append(args, "--allowedTools", tool)
+		}
+		return cmd, args
 	}
 }
 

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -1441,3 +1441,217 @@ func TestDrainTimeoutV2Phase(t *testing.T) {
 		t.Errorf("expected timed-out vessel to be marked failed, got completed=%d failed=%d", result.Completed, result.Failed)
 	}
 }
+
+func TestResolveProvider(t *testing.T) {
+claude := "claude"
+copilot := "copilot"
+
+tests := []struct {
+name     string
+cfgLLM   string
+wfLLM    *string
+phaseLLM *string
+want     string
+}{
+{"all nil defaults to claude", "", nil, nil, "claude"},
+{"config claude", "claude", nil, nil, "claude"},
+{"config copilot", "copilot", nil, nil, "copilot"},
+{"workflow overrides config", "claude", &copilot, nil, "copilot"},
+{"phase overrides workflow", "claude", &claude, &copilot, "copilot"},
+{"phase overrides config", "claude", nil, &copilot, "copilot"},
+{"empty config falls back to claude", "", &copilot, nil, "copilot"},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+cfg := &config.Config{LLM: tt.cfgLLM}
+var wf *workflow.Workflow
+if tt.wfLLM != nil {
+wf = &workflow.Workflow{LLM: tt.wfLLM}
+}
+var p *workflow.Phase
+if tt.phaseLLM != nil {
+p = &workflow.Phase{LLM: tt.phaseLLM}
+}
+got := resolveProvider(cfg, wf, p)
+if got != tt.want {
+t.Errorf("resolveProvider() = %q, want %q", got, tt.want)
+}
+})
+}
+}
+
+func TestResolveModel(t *testing.T) {
+cfg := &config.Config{
+Claude:  config.ClaudeConfig{DefaultModel: "claude-default"},
+Copilot: config.CopilotConfig{DefaultModel: "copilot-default"},
+}
+
+phaseModel := "phase-model"
+wfModel := "wf-model"
+
+tests := []struct {
+name       string
+wfModel    *string
+phaseModel *string
+provider   string
+want       string
+}{
+{"phase model wins", &wfModel, &phaseModel, "claude", "phase-model"},
+{"workflow model wins over default", &wfModel, nil, "claude", "wf-model"},
+{"claude default when no override", nil, nil, "claude", "claude-default"},
+{"copilot default when provider copilot", nil, nil, "copilot", "copilot-default"},
+{"workflow model wins for copilot", &wfModel, nil, "copilot", "wf-model"},
+{"phase model wins for copilot", &wfModel, &phaseModel, "copilot", "phase-model"},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+var wf *workflow.Workflow
+if tt.wfModel != nil {
+wf = &workflow.Workflow{Model: tt.wfModel}
+}
+var p *workflow.Phase
+if tt.phaseModel != nil {
+p = &workflow.Phase{Model: tt.phaseModel}
+}
+got := resolveModel(cfg, wf, p, tt.provider)
+if got != tt.want {
+t.Errorf("resolveModel() = %q, want %q", got, tt.want)
+}
+})
+}
+}
+
+func TestBuildCopilotPhaseArgs(t *testing.T) {
+maxTurns := 10
+
+tests := []struct {
+name           string
+cfg            *config.Config
+wf             *workflow.Workflow
+phase          *workflow.Phase
+harness        string
+wantContains   []string
+wantNotContain []string
+}{
+{
+name: "basic copilot args",
+cfg:  &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
+phase: &workflow.Phase{MaxTurns: maxTurns},
+wantContains: []string{"--headless", "--max-turns", "10"},
+},
+{
+name: "copilot with model from config default",
+cfg: &config.Config{
+Copilot: config.CopilotConfig{Command: "copilot", DefaultModel: "gpt-4o"},
+},
+phase:        &workflow.Phase{MaxTurns: maxTurns},
+wantContains: []string{"--model", "gpt-4o"},
+},
+{
+name: "copilot with model from phase overrides default",
+cfg: &config.Config{
+Copilot: config.CopilotConfig{Command: "copilot", DefaultModel: "gpt-4o"},
+},
+phase:          &workflow.Phase{MaxTurns: maxTurns, Model: strPtrRunner("phase-model")},
+wantContains:   []string{"--model", "phase-model"},
+wantNotContain: []string{"gpt-4o"},
+},
+{
+name: "copilot with extra flags",
+cfg: &config.Config{
+Copilot: config.CopilotConfig{Command: "copilot", Flags: "--verbose"},
+},
+phase:        &workflow.Phase{MaxTurns: maxTurns},
+wantContains: []string{"--verbose"},
+},
+{
+name: "copilot with allowed_tools",
+cfg:  &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
+phase: &workflow.Phase{MaxTurns: maxTurns, AllowedTools: strPtrRunner("Bash,Read")},
+wantContains: []string{"--allowed-tools", "Bash,Read"},
+},
+{
+name:         "copilot with harness",
+cfg:          &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
+phase:        &workflow.Phase{MaxTurns: maxTurns},
+harness:      "harness instructions",
+wantContains: []string{"--system-prompt", "harness instructions"},
+},
+{
+name: "copilot strips --model from flags when model resolved",
+cfg: &config.Config{
+Copilot: config.CopilotConfig{
+Command: "copilot",
+Flags:   "--headless --model old-model",
+DefaultModel: "new-model",
+},
+},
+phase:          &workflow.Phase{MaxTurns: maxTurns},
+wantContains:   []string{"--model", "new-model"},
+wantNotContain: []string{"old-model"},
+},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+args := buildCopilotPhaseArgs(tt.cfg, tt.wf, tt.phase, tt.harness)
+for _, want := range tt.wantContains {
+found := false
+for _, a := range args {
+if a == want {
+found = true
+break
+}
+}
+if !found {
+t.Errorf("args %v: expected to contain %q", args, want)
+}
+}
+for _, notWant := range tt.wantNotContain {
+for _, a := range args {
+if a == notWant {
+t.Errorf("args %v: expected NOT to contain %q", args, notWant)
+break
+}
+}
+}
+})
+}
+}
+
+func TestBuildProviderPhaseArgsDispatch(t *testing.T) {
+claudeCmd := "claude"
+copilotCmd := "copilot"
+
+cfg := &config.Config{
+Claude:  config.ClaudeConfig{Command: claudeCmd},
+Copilot: config.CopilotConfig{Command: copilotCmd},
+}
+phase := &workflow.Phase{MaxTurns: 5}
+
+t.Run("claude provider returns claude command", func(t *testing.T) {
+cmd, args := buildProviderPhaseArgs(cfg, nil, phase, "", "claude")
+if cmd != claudeCmd {
+t.Errorf("cmd = %q, want %q", cmd, claudeCmd)
+}
+// claude args should start with -p
+if len(args) == 0 || args[0] != "-p" {
+t.Errorf("claude args[0] = %q, want -p (args: %v)", args[0], args)
+}
+})
+
+t.Run("copilot provider returns copilot command", func(t *testing.T) {
+cmd, args := buildProviderPhaseArgs(cfg, nil, phase, "", "copilot")
+if cmd != copilotCmd {
+t.Errorf("cmd = %q, want %q", cmd, copilotCmd)
+}
+// copilot args should start with --headless
+if len(args) == 0 || args[0] != "--headless" {
+t.Errorf("copilot args[0] = %q, want --headless (args: %v)", args[0], args)
+}
+})
+}
+
+func strPtrRunner(s string) *string { return &s }

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -1459,7 +1459,7 @@ func TestResolveProvider(t *testing.T) {
 		{"workflow overrides config", "claude", &copilot, nil, "copilot"},
 		{"phase overrides workflow", "claude", &claude, &copilot, "copilot"},
 		{"phase overrides config", "claude", nil, &copilot, "copilot"},
-		{"empty config falls back to claude", "", &copilot, nil, "copilot"},
+		{"workflow override wins when config empty", "", &copilot, nil, "copilot"},
 	}
 
 	for _, tt := range tests {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
-	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 )
 
 // --- Mock types ---
@@ -88,8 +88,8 @@ type mockExitError struct {
 	code int
 }
 
-func (e *mockExitError) Error() string    { return fmt.Sprintf("exit status %d", e.code) }
-func (e *mockExitError) ExitCode() int    { return e.code }
+func (e *mockExitError) Error() string { return fmt.Sprintf("exit status %d", e.code) }
+func (e *mockExitError) ExitCode() int { return e.code }
 
 type countingCmdRunner struct {
 	concurrent int32
@@ -199,22 +199,22 @@ func makeTestConfig(dir string, concurrency int) *config.Config {
 
 func makeVessel(num int, workflow string) queue.Vessel {
 	return queue.Vessel{
-		ID:     fmt.Sprintf("issue-%d", num),
-		Source: "github-issue",
-		Ref:    fmt.Sprintf("https://github.com/owner/repo/issues/%d", num),
+		ID:        fmt.Sprintf("issue-%d", num),
+		Source:    "github-issue",
+		Ref:       fmt.Sprintf("https://github.com/owner/repo/issues/%d", num),
 		Workflow:  workflow,
-		Meta:   map[string]string{"issue_num": strconv.Itoa(num)},
-		State:  queue.StatePending,
+		Meta:      map[string]string{"issue_num": strconv.Itoa(num)},
+		State:     queue.StatePending,
 		CreatedAt: time.Now().UTC(),
 	}
 }
 
 func makePromptVessel(num int, prompt string) queue.Vessel {
 	return queue.Vessel{
-		ID:     fmt.Sprintf("prompt-%d", num),
-		Source: "manual",
-		Prompt: prompt,
-		State:  queue.StatePending,
+		ID:        fmt.Sprintf("prompt-%d", num),
+		Source:    "manual",
+		Prompt:    prompt,
+		State:     queue.StatePending,
 		CreatedAt: time.Now().UTC(),
 	}
 }
@@ -233,9 +233,9 @@ func TestBuildCommand(t *testing.T) {
 		},
 	}
 	vessel := &queue.Vessel{
-		Source: "github-issue",
-		Workflow:  "fix-bug",
-		Ref:    "https://github.com/owner/repo/issues/42",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Ref:      "https://github.com/owner/repo/issues/42",
 	}
 	cmd, args, err := buildCommand(cfg, vessel)
 	if err != nil {
@@ -360,9 +360,9 @@ func TestBuildCommandWorkflowBased(t *testing.T) {
 		},
 	}
 	vessel := &queue.Vessel{
-		Source: "github-issue",
-		Workflow:  "fix-bug",
-		Ref:    "https://github.com/owner/repo/issues/42",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Ref:      "https://github.com/owner/repo/issues/42",
 	}
 	cmd, args, err := buildCommand(cfg, vessel)
 	if err != nil {
@@ -1093,7 +1093,7 @@ func TestDrainPreviousOutputsAvailable(t *testing.T) {
 
 func TestBranchPrefixSelection(t *testing.T) {
 	tests := []struct {
-		workflow      string
+		workflow   string
 		wantPrefix string
 	}{
 		{"fix-bug", "fix"},
@@ -1150,9 +1150,9 @@ func TestBuildCommandWithFlags(t *testing.T) {
 		},
 	}
 	vessel := &queue.Vessel{
-		Source: "github-issue",
-		Workflow:  "fix-bug",
-		Ref:    "https://github.com/owner/repo/issues/42",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Ref:      "https://github.com/owner/repo/issues/42",
 	}
 	_, args, err := buildCommand(cfg, vessel)
 	if err != nil {
@@ -1443,215 +1443,399 @@ func TestDrainTimeoutV2Phase(t *testing.T) {
 }
 
 func TestResolveProvider(t *testing.T) {
-claude := "claude"
-copilot := "copilot"
+	claude := "claude"
+	copilot := "copilot"
 
-tests := []struct {
-name     string
-cfgLLM   string
-wfLLM    *string
-phaseLLM *string
-want     string
-}{
-{"all nil defaults to claude", "", nil, nil, "claude"},
-{"config claude", "claude", nil, nil, "claude"},
-{"config copilot", "copilot", nil, nil, "copilot"},
-{"workflow overrides config", "claude", &copilot, nil, "copilot"},
-{"phase overrides workflow", "claude", &claude, &copilot, "copilot"},
-{"phase overrides config", "claude", nil, &copilot, "copilot"},
-{"empty config falls back to claude", "", &copilot, nil, "copilot"},
-}
+	tests := []struct {
+		name     string
+		cfgLLM   string
+		wfLLM    *string
+		phaseLLM *string
+		want     string
+	}{
+		{"all nil defaults to claude", "", nil, nil, "claude"},
+		{"config claude", "claude", nil, nil, "claude"},
+		{"config copilot", "copilot", nil, nil, "copilot"},
+		{"workflow overrides config", "claude", &copilot, nil, "copilot"},
+		{"phase overrides workflow", "claude", &claude, &copilot, "copilot"},
+		{"phase overrides config", "claude", nil, &copilot, "copilot"},
+		{"empty config falls back to claude", "", &copilot, nil, "copilot"},
+	}
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-cfg := &config.Config{LLM: tt.cfgLLM}
-var wf *workflow.Workflow
-if tt.wfLLM != nil {
-wf = &workflow.Workflow{LLM: tt.wfLLM}
-}
-var p *workflow.Phase
-if tt.phaseLLM != nil {
-p = &workflow.Phase{LLM: tt.phaseLLM}
-}
-got := resolveProvider(cfg, wf, p)
-if got != tt.want {
-t.Errorf("resolveProvider() = %q, want %q", got, tt.want)
-}
-})
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{LLM: tt.cfgLLM}
+			var wf *workflow.Workflow
+			if tt.wfLLM != nil {
+				wf = &workflow.Workflow{LLM: tt.wfLLM}
+			}
+			var p *workflow.Phase
+			if tt.phaseLLM != nil {
+				p = &workflow.Phase{LLM: tt.phaseLLM}
+			}
+			got := resolveProvider(cfg, wf, p)
+			if got != tt.want {
+				t.Errorf("resolveProvider() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestResolveModel(t *testing.T) {
-cfg := &config.Config{
-Claude:  config.ClaudeConfig{DefaultModel: "claude-default"},
-Copilot: config.CopilotConfig{DefaultModel: "copilot-default"},
-}
+	cfg := &config.Config{
+		Claude:  config.ClaudeConfig{DefaultModel: "claude-default"},
+		Copilot: config.CopilotConfig{DefaultModel: "copilot-default"},
+	}
 
-phaseModel := "phase-model"
-wfModel := "wf-model"
+	phaseModel := "phase-model"
+	wfModel := "wf-model"
 
-tests := []struct {
-name       string
-wfModel    *string
-phaseModel *string
-provider   string
-want       string
-}{
-{"phase model wins", &wfModel, &phaseModel, "claude", "phase-model"},
-{"workflow model wins over default", &wfModel, nil, "claude", "wf-model"},
-{"claude default when no override", nil, nil, "claude", "claude-default"},
-{"copilot default when provider copilot", nil, nil, "copilot", "copilot-default"},
-{"workflow model wins for copilot", &wfModel, nil, "copilot", "wf-model"},
-{"phase model wins for copilot", &wfModel, &phaseModel, "copilot", "phase-model"},
-}
+	tests := []struct {
+		name       string
+		wfModel    *string
+		phaseModel *string
+		provider   string
+		want       string
+	}{
+		{"phase model wins", &wfModel, &phaseModel, "claude", "phase-model"},
+		{"workflow model wins over default", &wfModel, nil, "claude", "wf-model"},
+		{"claude default when no override", nil, nil, "claude", "claude-default"},
+		{"copilot default when provider copilot", nil, nil, "copilot", "copilot-default"},
+		{"workflow model wins for copilot", &wfModel, nil, "copilot", "wf-model"},
+		{"phase model wins for copilot", &wfModel, &phaseModel, "copilot", "phase-model"},
+	}
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-var wf *workflow.Workflow
-if tt.wfModel != nil {
-wf = &workflow.Workflow{Model: tt.wfModel}
-}
-var p *workflow.Phase
-if tt.phaseModel != nil {
-p = &workflow.Phase{Model: tt.phaseModel}
-}
-got := resolveModel(cfg, wf, p, tt.provider)
-if got != tt.want {
-t.Errorf("resolveModel() = %q, want %q", got, tt.want)
-}
-})
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var wf *workflow.Workflow
+			if tt.wfModel != nil {
+				wf = &workflow.Workflow{Model: tt.wfModel}
+			}
+			var p *workflow.Phase
+			if tt.phaseModel != nil {
+				p = &workflow.Phase{Model: tt.phaseModel}
+			}
+			got := resolveModel(cfg, wf, p, tt.provider)
+			if got != tt.want {
+				t.Errorf("resolveModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestBuildCopilotPhaseArgs(t *testing.T) {
-maxTurns := 10
+	maxTurns := 10
 
-tests := []struct {
-name           string
-cfg            *config.Config
-wf             *workflow.Workflow
-phase          *workflow.Phase
-harness        string
-wantContains   []string
-wantNotContain []string
-}{
-{
-name: "basic copilot args",
-cfg:  &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
-phase: &workflow.Phase{MaxTurns: maxTurns},
-wantContains: []string{"--headless", "--max-turns", "10"},
-},
-{
-name: "copilot with model from config default",
-cfg: &config.Config{
-Copilot: config.CopilotConfig{Command: "copilot", DefaultModel: "gpt-4o"},
-},
-phase:        &workflow.Phase{MaxTurns: maxTurns},
-wantContains: []string{"--model", "gpt-4o"},
-},
-{
-name: "copilot with model from phase overrides default",
-cfg: &config.Config{
-Copilot: config.CopilotConfig{Command: "copilot", DefaultModel: "gpt-4o"},
-},
-phase:          &workflow.Phase{MaxTurns: maxTurns, Model: strPtrRunner("phase-model")},
-wantContains:   []string{"--model", "phase-model"},
-wantNotContain: []string{"gpt-4o"},
-},
-{
-name: "copilot with extra flags",
-cfg: &config.Config{
-Copilot: config.CopilotConfig{Command: "copilot", Flags: "--verbose"},
-},
-phase:        &workflow.Phase{MaxTurns: maxTurns},
-wantContains: []string{"--verbose"},
-},
-{
-name: "copilot with allowed_tools",
-cfg:  &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
-phase: &workflow.Phase{MaxTurns: maxTurns, AllowedTools: strPtrRunner("Bash,Read")},
-wantContains: []string{"--allowed-tools", "Bash,Read"},
-},
-{
-name:         "copilot with harness",
-cfg:          &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
-phase:        &workflow.Phase{MaxTurns: maxTurns},
-harness:      "harness instructions",
-wantContains: []string{"--system-prompt", "harness instructions"},
-},
-{
-name: "copilot strips --model from flags when model resolved",
-cfg: &config.Config{
-Copilot: config.CopilotConfig{
-Command: "copilot",
-Flags:   "--headless --model old-model",
-DefaultModel: "new-model",
-},
-},
-phase:          &workflow.Phase{MaxTurns: maxTurns},
-wantContains:   []string{"--model", "new-model"},
-wantNotContain: []string{"old-model"},
-},
-}
+	tests := []struct {
+		name           string
+		cfg            *config.Config
+		wf             *workflow.Workflow
+		phase          *workflow.Phase
+		harness        string
+		wantContains   []string
+		wantNotContain []string
+		wantPairs      [][2]string // [flag, value] pairs that must be adjacent
+	}{
+		{
+			name:         "basic copilot args",
+			cfg:          &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
+			phase:        &workflow.Phase{MaxTurns: maxTurns},
+			wantContains: []string{"--headless"},
+			wantPairs:    [][2]string{{"--max-turns", "10"}},
+		},
+		{
+			name: "copilot with model from config default",
+			cfg: &config.Config{
+				Copilot: config.CopilotConfig{Command: "copilot", DefaultModel: "gpt-4o"},
+			},
+			phase:     &workflow.Phase{MaxTurns: maxTurns},
+			wantPairs: [][2]string{{"--model", "gpt-4o"}},
+		},
+		{
+			name: "copilot with model from phase overrides default",
+			cfg: &config.Config{
+				Copilot: config.CopilotConfig{Command: "copilot", DefaultModel: "gpt-4o"},
+			},
+			phase:          &workflow.Phase{MaxTurns: maxTurns, Model: strPtrRunner("phase-model")},
+			wantPairs:      [][2]string{{"--model", "phase-model"}},
+			wantNotContain: []string{"gpt-4o"},
+		},
+		{
+			name: "copilot with extra flags",
+			cfg: &config.Config{
+				Copilot: config.CopilotConfig{Command: "copilot", Flags: "--verbose"},
+			},
+			phase:        &workflow.Phase{MaxTurns: maxTurns},
+			wantContains: []string{"--verbose"},
+		},
+		{
+			name:      "copilot with allowed_tools",
+			cfg:       &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
+			phase:     &workflow.Phase{MaxTurns: maxTurns, AllowedTools: strPtrRunner("Bash,Read")},
+			wantPairs: [][2]string{{"--allowed-tools", "Bash,Read"}},
+		},
+		{
+			name:      "copilot with harness",
+			cfg:       &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
+			phase:     &workflow.Phase{MaxTurns: maxTurns},
+			harness:   "harness instructions",
+			wantPairs: [][2]string{{"--system-prompt", "harness instructions"}},
+		},
+		{
+			name: "copilot strips --model from flags when model resolved",
+			cfg: &config.Config{
+				Copilot: config.CopilotConfig{
+					Command:      "copilot",
+					Flags:        "--headless --model old-model",
+					DefaultModel: "new-model",
+				},
+			},
+			phase:          &workflow.Phase{MaxTurns: maxTurns},
+			wantPairs:      [][2]string{{"--model", "new-model"}},
+			wantNotContain: []string{"old-model"},
+		},
+		{
+			name: "copilot strips duplicate --headless from flags",
+			cfg: &config.Config{
+				Copilot: config.CopilotConfig{
+					Command: "copilot",
+					Flags:   "--headless --verbose",
+				},
+			},
+			phase:        &workflow.Phase{MaxTurns: maxTurns},
+			wantContains: []string{"--verbose"},
+		},
+	}
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-args := buildCopilotPhaseArgs(tt.cfg, tt.wf, tt.phase, tt.harness)
-for _, want := range tt.wantContains {
-found := false
-for _, a := range args {
-if a == want {
-found = true
-break
-}
-}
-if !found {
-t.Errorf("args %v: expected to contain %q", args, want)
-}
-}
-for _, notWant := range tt.wantNotContain {
-for _, a := range args {
-if a == notWant {
-t.Errorf("args %v: expected NOT to contain %q", args, notWant)
-break
-}
-}
-}
-})
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := buildCopilotPhaseArgs(tt.cfg, tt.wf, tt.phase, tt.harness)
+
+			for _, want := range tt.wantContains {
+				found := false
+				for _, a := range args {
+					if a == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("args %v: expected to contain %q", args, want)
+				}
+			}
+
+			for _, notWant := range tt.wantNotContain {
+				for _, a := range args {
+					if a == notWant {
+						t.Errorf("args %v: expected NOT to contain %q", args, notWant)
+						break
+					}
+				}
+			}
+
+			for _, pair := range tt.wantPairs {
+				flag, value := pair[0], pair[1]
+				found := false
+				for i := 0; i < len(args)-1; i++ {
+					if args[i] == flag && args[i+1] == value {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("args %v: expected adjacent pair [%q, %q]", args, flag, value)
+				}
+			}
+
+			// Verify --headless appears exactly once
+			headlessCount := 0
+			for _, a := range args {
+				if a == "--headless" {
+					headlessCount++
+				}
+			}
+			if headlessCount != 1 {
+				t.Errorf("expected exactly 1 --headless, got %d (args: %v)", headlessCount, args)
+			}
+		})
+	}
 }
 
 func TestBuildProviderPhaseArgsDispatch(t *testing.T) {
-claudeCmd := "claude"
-copilotCmd := "copilot"
+	claudeCmd := "claude"
+	copilotCmd := "copilot"
 
-cfg := &config.Config{
-Claude:  config.ClaudeConfig{Command: claudeCmd},
-Copilot: config.CopilotConfig{Command: copilotCmd},
-}
-phase := &workflow.Phase{MaxTurns: 5}
+	cfg := &config.Config{
+		Claude:  config.ClaudeConfig{Command: claudeCmd},
+		Copilot: config.CopilotConfig{Command: copilotCmd},
+	}
+	phase := &workflow.Phase{MaxTurns: 5}
 
-t.Run("claude provider returns claude command", func(t *testing.T) {
-cmd, args := buildProviderPhaseArgs(cfg, nil, phase, "", "claude")
-if cmd != claudeCmd {
-t.Errorf("cmd = %q, want %q", cmd, claudeCmd)
-}
-// claude args should start with -p
-if len(args) == 0 || args[0] != "-p" {
-t.Errorf("claude args[0] = %q, want -p (args: %v)", args[0], args)
-}
-})
+	t.Run("claude provider returns claude command", func(t *testing.T) {
+		cmd, args := buildProviderPhaseArgs(cfg, nil, phase, "", "claude")
+		if cmd != claudeCmd {
+			t.Errorf("cmd = %q, want %q", cmd, claudeCmd)
+		}
+		if len(args) == 0 || args[0] != "-p" {
+			t.Errorf("claude args[0] = %q, want -p (args: %v)", args[0], args)
+		}
+		// Claude args must NOT contain copilot-specific flags
+		for _, a := range args {
+			if a == "--headless" || a == "--system-prompt" || a == "--allowed-tools" {
+				t.Errorf("claude args contain copilot-specific flag %q (args: %v)", a, args)
+			}
+		}
+	})
 
-t.Run("copilot provider returns copilot command", func(t *testing.T) {
-cmd, args := buildProviderPhaseArgs(cfg, nil, phase, "", "copilot")
-if cmd != copilotCmd {
-t.Errorf("cmd = %q, want %q", cmd, copilotCmd)
+	t.Run("copilot provider returns copilot command", func(t *testing.T) {
+		cmd, args := buildProviderPhaseArgs(cfg, nil, phase, "", "copilot")
+		if cmd != copilotCmd {
+			t.Errorf("cmd = %q, want %q", cmd, copilotCmd)
+		}
+		if len(args) == 0 || args[0] != "--headless" {
+			t.Errorf("copilot args[0] = %q, want --headless (args: %v)", args[0], args)
+		}
+		// Copilot args must NOT contain claude-specific flags
+		for _, a := range args {
+			if a == "-p" || a == "--append-system-prompt" || a == "--allowedTools" {
+				t.Errorf("copilot args contain claude-specific flag %q (args: %v)", a, args)
+			}
+		}
+	})
 }
-// copilot args should start with --headless
-if len(args) == 0 || args[0] != "--headless" {
-t.Errorf("copilot args[0] = %q, want --headless (args: %v)", args[0], args)
+
+func TestBuildCommandCopilotDirect(t *testing.T) {
+	cfg := &config.Config{
+		LLM:      "copilot",
+		MaxTurns: 50,
+		Copilot: config.CopilotConfig{
+			Command: "copilot",
+		},
+	}
+	vessel := &queue.Vessel{
+		Source: "manual",
+		Prompt: "Fix the null pointer in handler.go",
+	}
+	cmd, args, err := buildCommand(cfg, vessel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd != "copilot" {
+		t.Errorf("expected cmd 'copilot', got %q", cmd)
+	}
+	if len(args) < 4 {
+		t.Fatalf("expected at least 4 args, got %d: %v", len(args), args)
+	}
+	if args[0] != "--headless" {
+		t.Errorf("expected --headless flag, got %q", args[0])
+	}
+	if args[1] != "Fix the null pointer in handler.go" {
+		t.Errorf("expected prompt text, got %q", args[1])
+	}
+	// Must NOT contain claude-specific flags
+	for _, a := range args {
+		if a == "-p" {
+			t.Errorf("copilot buildCommand should not contain -p (args: %v)", args)
+		}
+	}
 }
-})
+
+func TestBuildCommandCopilotWorkflow(t *testing.T) {
+	cfg := &config.Config{
+		LLM:      "copilot",
+		MaxTurns: 50,
+		Copilot: config.CopilotConfig{
+			Command: "copilot",
+			Flags:   "--verbose",
+		},
+	}
+	vessel := &queue.Vessel{
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Ref:      "https://github.com/owner/repo/issues/42",
+	}
+	cmd, args, err := buildCommand(cfg, vessel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd != "copilot" {
+		t.Errorf("expected cmd 'copilot', got %q", cmd)
+	}
+	if args[0] != "--headless" {
+		t.Errorf("expected --headless flag, got %q", args[0])
+	}
+	if !strings.Contains(args[1], "/fix-bug") {
+		t.Errorf("expected workflow in prompt, got %q", args[1])
+	}
+	// Flags should be appended
+	found := false
+	for _, a := range args {
+		if a == "--verbose" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected --verbose in args, got: %v", args)
+	}
+}
+
+func TestBuildCommandCopilotDirectWithRef(t *testing.T) {
+	cfg := &config.Config{
+		LLM:      "copilot",
+		MaxTurns: 50,
+		Copilot: config.CopilotConfig{
+			Command: "copilot",
+		},
+	}
+	vessel := &queue.Vessel{
+		Source: "manual",
+		Prompt: "Fix the null pointer in handler.go",
+		Ref:    "https://github.com/owner/repo/issues/99",
+	}
+	cmd, args, err := buildCommand(cfg, vessel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd != "copilot" {
+		t.Errorf("expected cmd 'copilot', got %q", cmd)
+	}
+	if !strings.Contains(args[1], "Ref: https://github.com/owner/repo/issues/99") {
+		t.Errorf("expected ref URL in prompt, got %q", args[1])
+	}
+	if !strings.Contains(args[1], "Fix the null pointer in handler.go") {
+		t.Errorf("expected original prompt text, got %q", args[1])
+	}
+}
+
+func TestBuildPromptOnlyCmdArgsHeadlessDedup(t *testing.T) {
+	cfg := &config.Config{
+		LLM:      "copilot",
+		MaxTurns: 50,
+		Copilot: config.CopilotConfig{
+			Command: "copilot",
+			Flags:   "--headless --verbose",
+		},
+	}
+	_, args := buildPromptOnlyCmdArgs(cfg, "")
+	headlessCount := 0
+	for _, a := range args {
+		if a == "--headless" {
+			headlessCount++
+		}
+	}
+	if headlessCount != 1 {
+		t.Errorf("expected exactly 1 --headless, got %d (args: %v)", headlessCount, args)
+	}
+	// --verbose should still be present
+	found := false
+	for _, a := range args {
+		if a == "--verbose" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected --verbose in args, got: %v", args)
+	}
 }
 
 func strPtrRunner(s string) *string { return &s }

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -20,6 +20,7 @@ var validPhaseName = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 type Workflow struct {
 	Name        string  `yaml:"name"`
 	Description string  `yaml:"description,omitempty"`
+	LLM         *string `yaml:"llm,omitempty"`
 	Model       *string `yaml:"model,omitempty"`
 	Phases      []Phase `yaml:"phases"`
 }
@@ -29,6 +30,7 @@ type Phase struct {
 	Name         string  `yaml:"name"`
 	PromptFile   string  `yaml:"prompt_file"`
 	MaxTurns     int     `yaml:"max_turns"`
+	LLM          *string `yaml:"llm,omitempty"`
 	Model        *string `yaml:"model,omitempty"`
 	Gate         *Gate   `yaml:"gate,omitempty"`
 	AllowedTools *string `yaml:"allowed_tools,omitempty"`
@@ -82,6 +84,10 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 		return fmt.Errorf(`"phases" is required`)
 	}
 
+	if err := validateLLM(s.LLM, "workflow"); err != nil {
+		return err
+	}
+
 	seen := make(map[string]bool, len(s.Phases))
 	for _, p := range s.Phases {
 		if p.Name == "" {
@@ -118,6 +124,10 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 		if p.AllowedTools != nil && *p.AllowedTools == "" {
 			return fmt.Errorf("phase %q: allowed_tools must not be empty when specified", p.Name)
 		}
+
+		if err := validateLLM(p.LLM, fmt.Sprintf("phase %q", p.Name)); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -152,4 +162,18 @@ func validateGate(phaseName string, g *Gate) error {
 	}
 
 	return nil
+}
+
+// validateLLM checks that the llm field, if set, is a known provider.
+// context is a human-readable location string used in error messages (e.g. "workflow" or `phase "analyze"`).
+func validateLLM(llm *string, context string) error {
+	if llm == nil || *llm == "" {
+		return nil
+	}
+	switch *llm {
+	case "claude", "copilot":
+		return nil
+	default:
+		return fmt.Errorf("%s: llm must be \"claude\" or \"copilot\", got %q", context, *llm)
+	}
 }

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -807,3 +807,161 @@ phases:
 func strPtr(s string) *string {
 	return &s
 }
+
+func TestWorkflowLLMField(t *testing.T) {
+	tests := []struct {
+		name         string
+		workflowYAML string
+		prompts      []string
+		wantErr      string
+		checkFunc    func(t *testing.T, wf *Workflow)
+	}{
+		{
+			name: "workflow llm claude",
+			workflowYAML: `name: test-workflow
+llm: claude
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 5
+`,
+			prompts: []string{"prompts/analyze.md"},
+			checkFunc: func(t *testing.T, wf *Workflow) {
+				t.Helper()
+				if wf.LLM == nil || *wf.LLM != "claude" {
+					t.Fatalf("Workflow.LLM = %v, want claude", wf.LLM)
+				}
+			},
+		},
+		{
+			name: "workflow llm copilot",
+			workflowYAML: `name: test-workflow
+llm: copilot
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 5
+`,
+			prompts: []string{"prompts/analyze.md"},
+			checkFunc: func(t *testing.T, wf *Workflow) {
+				t.Helper()
+				if wf.LLM == nil || *wf.LLM != "copilot" {
+					t.Fatalf("Workflow.LLM = %v, want copilot", wf.LLM)
+				}
+			},
+		},
+		{
+			name: "workflow llm absent means nil",
+			workflowYAML: `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 5
+`,
+			prompts: []string{"prompts/analyze.md"},
+			checkFunc: func(t *testing.T, wf *Workflow) {
+				t.Helper()
+				if wf.LLM != nil {
+					t.Fatalf("Workflow.LLM = %v, want nil", wf.LLM)
+				}
+			},
+		},
+		{
+			name: "workflow llm invalid",
+			workflowYAML: `name: test-workflow
+llm: gpt4
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 5
+`,
+			prompts:  []string{"prompts/analyze.md"},
+			wantErr: `workflow: llm must be "claude" or "copilot"`,
+		},
+		{
+			name: "phase llm copilot",
+			workflowYAML: `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 5
+    llm: copilot
+`,
+			prompts: []string{"prompts/analyze.md"},
+			checkFunc: func(t *testing.T, wf *Workflow) {
+				t.Helper()
+				if wf.Phases[0].LLM == nil || *wf.Phases[0].LLM != "copilot" {
+					t.Fatalf("Phase.LLM = %v, want copilot", wf.Phases[0].LLM)
+				}
+			},
+		},
+		{
+			name: "phase llm invalid",
+			workflowYAML: `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 5
+    llm: openai
+`,
+			prompts: []string{"prompts/analyze.md"},
+			wantErr: `phase "analyze": llm must be "claude" or "copilot"`,
+		},
+		{
+			name: "workflow and phase llm with model",
+			workflowYAML: `name: test-workflow
+llm: copilot
+model: gpt-4o
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 5
+    llm: claude
+    model: claude-sonnet-4-5
+`,
+			prompts: []string{"prompts/analyze.md"},
+			checkFunc: func(t *testing.T, wf *Workflow) {
+				t.Helper()
+				if wf.LLM == nil || *wf.LLM != "copilot" {
+					t.Fatalf("Workflow.LLM = %v, want copilot", wf.LLM)
+				}
+				if wf.Model == nil || *wf.Model != "gpt-4o" {
+					t.Fatalf("Workflow.Model = %v, want gpt-4o", wf.Model)
+				}
+				if wf.Phases[0].LLM == nil || *wf.Phases[0].LLM != "claude" {
+					t.Fatalf("Phase.LLM = %v, want claude", wf.Phases[0].LLM)
+				}
+				if wf.Phases[0].Model == nil || *wf.Phases[0].Model != "claude-sonnet-4-5" {
+					t.Fatalf("Phase.Model = %v, want claude-sonnet-4-5", wf.Phases[0].Model)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			chdirTemp(t, dir)
+
+			for _, p := range tt.prompts {
+				createPromptFile(t, dir, p)
+			}
+
+			path := writeWorkflowFile(t, dir, "test-workflow", tt.workflowYAML)
+			wf, err := Load(path)
+
+			if tt.wantErr != "" {
+				requireErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Load returned unexpected error: %v", err)
+			}
+
+			if tt.checkFunc != nil {
+				tt.checkFunc(t, wf)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `copilot` as a first-class LLM provider alternative to `claude`. Both the provider and model are configurable at every level — global config, workflow, and phase — with a consistent resolution hierarchy.

## Resolution hierarchy

`Phase.llm` / `Phase.model` **>** `Workflow.llm` / `Workflow.model` **>** `Config.llm` / `Config.<provider>.default_model`

## Configuration

### `.xylem.yml`

```yaml
llm: claude  # or "copilot" — global default provider

claude:
  command: "claude"
  flags: "--bare --dangerously-skip-permissions"
  default_model: ""
  env:
    ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"

copilot:
  command: "copilot"
  flags: ""
  default_model: "gpt-4o"
  env: {}
```

### Workflow YAML

```yaml
name: fix-bug
llm: copilot       # override for entire workflow
model: gpt-4o
phases:
  - name: analyze
    llm: claude    # override for this phase only
    model: claude-sonnet-4-5
    max_turns: 5
```

## Changes

| File | What changed |
|------|-------------|
| `config/config.go` | `CopilotConfig` struct, `LLM` field on `Config`, validation |
| `workflow/workflow.go` | `LLM *string` on `Workflow` and `Phase`, `validateLLM()` helper |
| `runner/runner.go` | `resolveProvider()`, `resolveModel()`, `buildCopilotPhaseArgs()`, `buildProviderPhaseArgs()`, updated phase loop + `runPromptOnly` + `buildCommand` |
| `cmd/xylem/init.go` | Scaffold config includes `llm: claude` and commented `copilot:` block |
| Test files | Tests for all new functions and config/workflow fields |

## Copilot CLI flags

The copilot arg builder uses: `--headless`, `--max-turns`, `--model`, `--allowed-tools`, `--system-prompt`. Adjust these if the actual `copilot` binary uses different flag names.

## Backward compatibility

Existing configs without an `llm` field continue to work unchanged — they default to `claude`.