### PR TITLE
feat: reflect vessel lifecycle as configurable GitHub labels

### DIFF
--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -62,10 +62,7 @@ func buildSourceMap(cfg *config.Config, q *queue.Queue, cmdRunner source.Command
 		if srcCfg.Type == "github" {
 			tasks := make(map[string]source.GitHubTask, len(srcCfg.Tasks))
 			for name, t := range srcCfg.Tasks {
-				tasks[name] = source.GitHubTask{
-					Labels: t.Labels,
-					Workflow:  t.Workflow,
-				}
+				tasks[name] = source.GitHubTaskFromConfig(t)
 			}
 			gh := &source.GitHub{
 				Repo:      srcCfg.Repo,

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -35,9 +35,18 @@ type SourceConfig struct {
 	Tasks   map[string]Task `yaml:"tasks,omitempty"`
 }
 
+type StatusLabels struct {
+	Queued    string `yaml:"queued,omitempty"`
+	Running   string `yaml:"running,omitempty"`
+	Completed string `yaml:"completed,omitempty"`
+	Failed    string `yaml:"failed,omitempty"`
+	TimedOut  string `yaml:"timed_out,omitempty"`
+}
+
 type Task struct {
-	Labels   []string `yaml:"labels,omitempty"`
-	Workflow string   `yaml:"workflow"`
+	Labels       []string     `yaml:"labels,omitempty"`
+	Workflow     string       `yaml:"workflow"`
+	StatusLabels StatusLabels `yaml:"status_labels,omitempty"`
 }
 
 type ClaudeConfig struct {

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -44,9 +44,9 @@ type StatusLabels struct {
 }
 
 type Task struct {
-	Labels       []string     `yaml:"labels,omitempty"`
-	Workflow     string       `yaml:"workflow"`
-	StatusLabels StatusLabels `yaml:"status_labels,omitempty"`
+	Labels       []string      `yaml:"labels,omitempty"`
+	Workflow     string        `yaml:"workflow"`
+	StatusLabels *StatusLabels `yaml:"status_labels,omitempty"`
 }
 
 type ClaudeConfig struct {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -626,6 +626,9 @@ claude:
 	}
 
 	sl := task.StatusLabels
+	if sl == nil {
+		t.Fatal("StatusLabels should not be nil when status_labels block is present")
+	}
 	if sl.Queued != "queued" {
 		t.Errorf("StatusLabels.Queued = %q, want queued", sl.Queued)
 	}
@@ -665,9 +668,8 @@ claude:
 	}
 
 	task := cfg.Sources["github"].Tasks["fix-bugs"]
-	sl := task.StatusLabels
-	if sl.Queued != "" || sl.Running != "" || sl.Completed != "" || sl.Failed != "" || sl.TimedOut != "" {
-		t.Errorf("expected all StatusLabels empty when not configured, got %+v", sl)
+	if task.StatusLabels != nil {
+		t.Errorf("expected StatusLabels to be nil when status_labels block is omitted, got %+v", task.StatusLabels)
 	}
 }
 

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -589,6 +589,88 @@ claude:
 	}
 }
 
+func TestLoadStatusLabels(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+        status_labels:
+          queued: "queued"
+          running: "in-progress"
+          completed: "done"
+          failed: "failed"
+          timed_out: "timed-out"
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	src, ok := cfg.Sources["github"]
+	if !ok {
+		t.Fatal("missing github source")
+	}
+	task, ok := src.Tasks["fix-bugs"]
+	if !ok {
+		t.Fatal("missing fix-bugs task")
+	}
+
+	sl := task.StatusLabels
+	if sl.Queued != "queued" {
+		t.Errorf("StatusLabels.Queued = %q, want queued", sl.Queued)
+	}
+	if sl.Running != "in-progress" {
+		t.Errorf("StatusLabels.Running = %q, want in-progress", sl.Running)
+	}
+	if sl.Completed != "done" {
+		t.Errorf("StatusLabels.Completed = %q, want done", sl.Completed)
+	}
+	if sl.Failed != "failed" {
+		t.Errorf("StatusLabels.Failed = %q, want failed", sl.Failed)
+	}
+	if sl.TimedOut != "timed-out" {
+		t.Errorf("StatusLabels.TimedOut = %q, want timed-out", sl.TimedOut)
+	}
+}
+
+func TestLoadStatusLabelsOmitted(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	task := cfg.Sources["github"].Tasks["fix-bugs"]
+	sl := task.StatusLabels
+	if sl.Queued != "" || sl.Running != "" || sl.Completed != "" || sl.Failed != "" || sl.TimedOut != "" {
+		t.Errorf("expected all StatusLabels empty when not configured, got %+v", sl)
+	}
+}
+
 func TestLoadDaemonConfig(t *testing.T) {
 	path := writeConfigFile(t, `sources:
   github:

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -144,6 +144,8 @@ func (r *Runner) CheckWaitingVessels(ctx context.Context) {
 				if updateErr := r.Queue.Update(vessel.ID, queue.StateTimedOut, "label gate timed out"); updateErr != nil {
 					log.Printf("warn: failed to update vessel %s to timed_out: %v", vessel.ID, updateErr)
 				}
+				src := r.resolveSource(vessel.Source)
+				_ = src.OnTimedOut(ctx, vessel)
 				// Clean up worktree (best-effort)
 				r.removeWorktree(vessel.WorktreePath, vessel.ID)
 				// Post timeout comment
@@ -194,6 +196,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 		worktreePath, err = r.Worktree.Create(ctx, branchName)
 		if err != nil {
 			r.failVessel(vessel.ID, err.Error())
+			_ = src.OnFail(ctx, vessel)
 			return "failed"
 		}
 		vessel.WorktreePath = worktreePath
@@ -204,18 +207,20 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 
 	// Prompt-only vessel (no workflow): single claude -p invocation
 	if vessel.Workflow == "" && vessel.Prompt != "" {
-		return r.runPromptOnly(ctx, vessel, worktreePath)
+		return r.runPromptOnly(ctx, vessel, worktreePath, src)
 	}
 
 	// Load workflow definition
 	if vessel.Workflow == "" {
 		r.failVessel(vessel.ID, "vessel has neither workflow nor prompt")
+		_ = src.OnFail(ctx, vessel)
 		return "failed"
 	}
 
 	sk, err := r.loadWorkflow(vessel.Workflow)
 	if err != nil {
 		r.failVessel(vessel.ID, fmt.Sprintf("load workflow: %v", err))
+		_ = src.OnFail(ctx, vessel)
 		return "failed"
 	}
 
@@ -263,6 +268,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 			promptContent, err := os.ReadFile(p.PromptFile)
 			if err != nil {
 				r.failVessel(vessel.ID, fmt.Sprintf("read prompt file %s: %v", p.PromptFile, err))
+				_ = src.OnFail(ctx, vessel)
 				return "failed"
 			}
 
@@ -270,6 +276,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 			rendered, err := phase.RenderPrompt(string(promptContent), td)
 			if err != nil {
 				r.failVessel(vessel.ID, fmt.Sprintf("render prompt for phase %s: %v", p.Name, err))
+				_ = src.OnFail(ctx, vessel)
 				return "failed"
 			}
 
@@ -301,6 +308,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 				log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
 				vessel.FailedPhase = p.Name
 				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, runErr))
+				_ = src.OnFail(ctx, vessel)
 				issueNum := r.parseIssueNum(vessel)
 				if issueNum > 0 && r.Reporter != nil {
 					r.Reporter.VesselFailed(ctx, issueNum, p.Name, runErr.Error(), "")
@@ -351,6 +359,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 				gateOut, passed, gateErr := gate.RunCommandGate(ctx, r.Runner, worktreePath, p.Gate.Run)
 				if gateErr != nil {
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate error: %v", p.Name, gateErr))
+					_ = src.OnFail(ctx, vessel)
 					return "failed"
 				}
 				if passed {
@@ -371,6 +380,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 					vessel.FailedPhase = p.Name
 					vessel.GateOutput = gateOut
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s: gate failed, retries exhausted", p.Name))
+					_ = src.OnFail(ctx, vessel)
 					if issueNum > 0 && r.Reporter != nil {
 						r.Reporter.VesselFailed(ctx, issueNum, p.Name, "gate failed, retries exhausted", gateOut)
 					}
@@ -430,11 +440,12 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 
 	// All phases complete
 	log.Printf("%scompleted all phases", vesselLabel(vessel))
+	_ = src.OnComplete(ctx, vessel)
 	return r.completeVessel(ctx, vessel, worktreePath, phaseResults)
 }
 
 // runPromptOnly handles vessels with a prompt but no workflow.
-func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktreePath string) string {
+func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktreePath string, src source.Source) string {
 	prompt := vessel.Prompt
 	if vessel.Ref != "" {
 		prompt = fmt.Sprintf("Ref: %s\n\n%s", vessel.Ref, vessel.Prompt)
@@ -446,12 +457,14 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 
 	if runErr != nil {
 		r.failVessel(vessel.ID, runErr.Error())
+		_ = src.OnFail(ctx, vessel)
 		return "failed"
 	}
 
 	if updateErr := r.Queue.Update(vessel.ID, queue.StateCompleted, ""); updateErr != nil {
 		log.Printf("warn: failed to update vessel %s state: %v", vessel.ID, updateErr)
 	}
+	_ = src.OnComplete(ctx, vessel)
 
 	// Clean up worktree (best-effort)
 	r.removeWorktree(worktreePath, vessel.ID)

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -145,7 +145,9 @@ func (r *Runner) CheckWaitingVessels(ctx context.Context) {
 					log.Printf("warn: failed to update vessel %s to timed_out: %v", vessel.ID, updateErr)
 				}
 				src := r.resolveSource(vessel.Source)
-				_ = src.OnTimedOut(ctx, vessel)
+				if err := src.OnTimedOut(ctx, vessel); err != nil {
+					log.Printf("warn: OnTimedOut hook for vessel %s: %v", vessel.ID, err)
+				}
 				// Clean up worktree (best-effort)
 				r.removeWorktree(vessel.WorktreePath, vessel.ID)
 				// Post timeout comment
@@ -196,7 +198,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 		worktreePath, err = r.Worktree.Create(ctx, branchName)
 		if err != nil {
 			r.failVessel(vessel.ID, err.Error())
-			_ = src.OnFail(ctx, vessel)
+			if err := src.OnFail(ctx, vessel); err != nil {
+				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+			}
 			return "failed"
 		}
 		vessel.WorktreePath = worktreePath
@@ -213,14 +217,18 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 	// Load workflow definition
 	if vessel.Workflow == "" {
 		r.failVessel(vessel.ID, "vessel has neither workflow nor prompt")
-		_ = src.OnFail(ctx, vessel)
+		if err := src.OnFail(ctx, vessel); err != nil {
+			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+		}
 		return "failed"
 	}
 
 	sk, err := r.loadWorkflow(vessel.Workflow)
 	if err != nil {
 		r.failVessel(vessel.ID, fmt.Sprintf("load workflow: %v", err))
-		_ = src.OnFail(ctx, vessel)
+		if err := src.OnFail(ctx, vessel); err != nil {
+			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+		}
 		return "failed"
 	}
 
@@ -268,7 +276,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 			promptContent, err := os.ReadFile(p.PromptFile)
 			if err != nil {
 				r.failVessel(vessel.ID, fmt.Sprintf("read prompt file %s: %v", p.PromptFile, err))
-				_ = src.OnFail(ctx, vessel)
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
 				return "failed"
 			}
 
@@ -276,7 +286,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 			rendered, err := phase.RenderPrompt(string(promptContent), td)
 			if err != nil {
 				r.failVessel(vessel.ID, fmt.Sprintf("render prompt for phase %s: %v", p.Name, err))
-				_ = src.OnFail(ctx, vessel)
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
 				return "failed"
 			}
 
@@ -308,7 +320,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 				log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
 				vessel.FailedPhase = p.Name
 				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, runErr))
-				_ = src.OnFail(ctx, vessel)
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
 				issueNum := r.parseIssueNum(vessel)
 				if issueNum > 0 && r.Reporter != nil {
 					r.Reporter.VesselFailed(ctx, issueNum, p.Name, runErr.Error(), "")
@@ -359,7 +373,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 				gateOut, passed, gateErr := gate.RunCommandGate(ctx, r.Runner, worktreePath, p.Gate.Run)
 				if gateErr != nil {
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate error: %v", p.Name, gateErr))
-					_ = src.OnFail(ctx, vessel)
+					if err := src.OnFail(ctx, vessel); err != nil {
+						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+					}
 					return "failed"
 				}
 				if passed {
@@ -380,7 +396,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 					vessel.FailedPhase = p.Name
 					vessel.GateOutput = gateOut
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s: gate failed, retries exhausted", p.Name))
-					_ = src.OnFail(ctx, vessel)
+					if err := src.OnFail(ctx, vessel); err != nil {
+						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+					}
 					if issueNum > 0 && r.Reporter != nil {
 						r.Reporter.VesselFailed(ctx, issueNum, p.Name, "gate failed, retries exhausted", gateOut)
 					}
@@ -440,7 +458,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 
 	// All phases complete
 	log.Printf("%scompleted all phases", vesselLabel(vessel))
-	_ = src.OnComplete(ctx, vessel)
+	if err := src.OnComplete(ctx, vessel); err != nil {
+		log.Printf("warn: OnComplete hook for vessel %s: %v", vessel.ID, err)
+	}
 	return r.completeVessel(ctx, vessel, worktreePath, phaseResults)
 }
 
@@ -457,14 +477,18 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 
 	if runErr != nil {
 		r.failVessel(vessel.ID, runErr.Error())
-		_ = src.OnFail(ctx, vessel)
+		if err := src.OnFail(ctx, vessel); err != nil {
+			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+		}
 		return "failed"
 	}
 
 	if updateErr := r.Queue.Update(vessel.ID, queue.StateCompleted, ""); updateErr != nil {
 		log.Printf("warn: failed to update vessel %s state: %v", vessel.ID, updateErr)
 	}
-	_ = src.OnComplete(ctx, vessel)
+	if err := src.OnComplete(ctx, vessel); err != nil {
+		log.Printf("warn: OnComplete hook for vessel %s: %v", vessel.ID, err)
+	}
 
 	// Clean up worktree (best-effort)
 	r.removeWorktree(worktreePath, vessel.ID)

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -56,6 +56,7 @@ func (s *Scanner) Scan(ctx context.Context) (ScanResult, error) {
 			}
 			if enqueued {
 				result.Added++
+				_ = src.OnEnqueue(ctx, vessel) // best-effort
 			} else {
 				result.Skipped++
 			}
@@ -97,6 +98,13 @@ func convertTasks(cfgTasks map[string]config.Task) map[string]source.GitHubTask 
 		tasks[name] = source.GitHubTask{
 			Labels:   t.Labels,
 			Workflow: t.Workflow,
+			StatusLabels: source.StatusLabels{
+				Queued:    t.StatusLabels.Queued,
+				Running:   t.StatusLabels.Running,
+				Completed: t.StatusLabels.Completed,
+				Failed:    t.StatusLabels.Failed,
+				TimedOut:  t.StatusLabels.TimedOut,
+			},
 		}
 	}
 	return tasks

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"context"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -56,7 +57,9 @@ func (s *Scanner) Scan(ctx context.Context) (ScanResult, error) {
 			}
 			if enqueued {
 				result.Added++
-				_ = src.OnEnqueue(ctx, vessel) // best-effort
+				if err := src.OnEnqueue(ctx, vessel); err != nil {
+					log.Printf("warn: OnEnqueue hook for vessel %s failed: %v", vessel.ID, err)
+				}
 			} else {
 				result.Skipped++
 			}
@@ -95,17 +98,7 @@ func (s *Scanner) buildSources() []source.Source {
 func convertTasks(cfgTasks map[string]config.Task) map[string]source.GitHubTask {
 	tasks := make(map[string]source.GitHubTask, len(cfgTasks))
 	for name, t := range cfgTasks {
-		tasks[name] = source.GitHubTask{
-			Labels:   t.Labels,
-			Workflow: t.Workflow,
-			StatusLabels: source.StatusLabels{
-				Queued:    t.StatusLabels.Queued,
-				Running:   t.StatusLabels.Running,
-				Completed: t.StatusLabels.Completed,
-				Failed:    t.StatusLabels.Failed,
-				TimedOut:  t.StatusLabels.TimedOut,
-			},
-		}
+		tasks[name] = source.GitHubTaskFromConfig(t)
 	}
 	return tasks
 }

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -488,6 +488,89 @@ func TestScanExistingBranchFeatPrefix(t *testing.T) {
 	}
 }
 
+func TestScanAppliesQueuedLabel(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeConfig(dir)
+	cfg.Sources = map[string]config.SourceConfig{
+		"github": {
+			Type:    "github",
+			Repo:    "owner/repo",
+			Exclude: []string{"wontfix"},
+			Tasks: map[string]config.Task{
+				"fix-bugs": {
+					Labels:   []string{"bug"},
+					Workflow: "fix-bug",
+					StatusLabels: config.StatusLabels{
+						Queued: "queued",
+					},
+				},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{
+		{Number: 5, Title: "fix something", URL: "https://github.com/owner/repo/issues/5", Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}}},
+	}
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+
+	s := New(cfg, q, r)
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Added != 1 {
+		t.Fatalf("expected 1 added, got %d", result.Added)
+	}
+
+	// Verify OnEnqueue triggered gh issue edit --add-label queued
+	foundLabel := false
+	for _, call := range r.calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, "issue edit") && strings.Contains(joined, "queued") && strings.Contains(joined, "--add-label") {
+			foundLabel = true
+			break
+		}
+	}
+	if !foundLabel {
+		t.Errorf("expected gh issue edit --add-label queued call, calls were: %v", r.calls)
+	}
+}
+
+func TestScanNoQueuedLabelWhenNotConfigured(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{
+		{Number: 6, Title: "fix other", URL: "https://github.com/owner/repo/issues/6", Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}}},
+	}
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+
+	s := New(cfg, q, r)
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Added != 1 {
+		t.Fatalf("expected 1 added, got %d", result.Added)
+	}
+
+	// No gh issue edit calls expected when status_labels not configured
+	for _, call := range r.calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, "issue edit") {
+			t.Errorf("unexpected gh issue edit call when status_labels not configured: %v", joined)
+		}
+	}
+}
+
 func TestScanEmptyIssuesList(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeConfig(dir)

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -500,7 +500,7 @@ func TestScanAppliesQueuedLabel(t *testing.T) {
 				"fix-bugs": {
 					Labels:   []string{"bug"},
 					Workflow: "fix-bug",
-					StatusLabels: config.StatusLabels{
+					StatusLabels: &config.StatusLabels{
 						Queued: "queued",
 					},
 				},

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -15,7 +15,7 @@ import (
 type GitHubTask struct {
 	Labels       []string
 	Workflow     string
-	StatusLabels StatusLabels
+	StatusLabels *StatusLabels
 }
 
 // GitHub scans GitHub issues and produces vessels.
@@ -83,7 +83,7 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					"issue_num": strconv.Itoa(issue.Number),
 				}
 				sl := task.StatusLabels
-				if sl.Queued != "" || sl.Running != "" || sl.Completed != "" || sl.Failed != "" || sl.TimedOut != "" {
+				if sl != nil {
 					meta["status_label_queued"] = sl.Queued
 					meta["status_label_running"] = sl.Running
 					meta["status_label_completed"] = sl.Completed

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -13,8 +13,9 @@ import (
 
 // GitHubTask defines a label-based task for the GitHub source.
 type GitHubTask struct {
-	Labels []string
-	Workflow  string
+	Labels       []string
+	Workflow     string
+	StatusLabels StatusLabels
 }
 
 // GitHub scans GitHub issues and produces vessels.
@@ -78,14 +79,23 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					continue
 				}
 				seen[issue.Number] = true
+				meta := map[string]string{
+					"issue_num": strconv.Itoa(issue.Number),
+				}
+				sl := task.StatusLabels
+				if sl.Queued != "" || sl.Running != "" || sl.Completed != "" || sl.Failed != "" || sl.TimedOut != "" {
+					meta["status_label_queued"] = sl.Queued
+					meta["status_label_running"] = sl.Running
+					meta["status_label_completed"] = sl.Completed
+					meta["status_label_failed"] = sl.Failed
+					meta["status_label_timed_out"] = sl.TimedOut
+				}
 				vessels = append(vessels, queue.Vessel{
-					ID:     fmt.Sprintf("issue-%d", issue.Number),
-					Source: "github-issue",
-					Ref:    issue.URL,
+					ID:        fmt.Sprintf("issue-%d", issue.Number),
+					Source:    "github-issue",
+					Ref:       issue.URL,
 					Workflow:  task.Workflow,
-					Meta: map[string]string{
-						"issue_num": strconv.Itoa(issue.Number),
-					},
+					Meta:      meta,
 					State:     queue.StatePending,
 					CreatedAt: time.Now().UTC(),
 				})
@@ -93,6 +103,12 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 		}
 	}
 	return vessels, nil
+}
+
+func (g *GitHub) OnEnqueue(ctx context.Context, vessel queue.Vessel) error {
+	g.applyIssueLabel(ctx, vessel.Meta["issue_num"],
+		vessel.Meta["status_label_queued"], "")
+	return nil
 }
 
 func (g *GitHub) OnStart(ctx context.Context, vessel queue.Vessel) error {
@@ -103,12 +119,52 @@ func (g *GitHub) OnStart(ctx context.Context, vessel queue.Vessel) error {
 	if issueNum == "" {
 		return nil
 	}
-	// Best-effort: add in-progress label
-	_, _ = g.CmdRunner.Run(ctx, "gh", "issue", "edit",
-		issueNum,
-		"--repo", g.Repo,
-		"--add-label", "in-progress")
+	running, hasRunning := vessel.Meta["status_label_running"]
+	if !hasRunning {
+		running = "in-progress" // backward-compat: preserve old behaviour
+	}
+	g.applyIssueLabel(ctx, issueNum, running, vessel.Meta["status_label_queued"])
 	return nil
+}
+
+func (g *GitHub) OnComplete(ctx context.Context, vessel queue.Vessel) error {
+	g.applyIssueLabel(ctx, vessel.Meta["issue_num"],
+		vessel.Meta["status_label_completed"],
+		vessel.Meta["status_label_running"])
+	return nil
+}
+
+func (g *GitHub) OnFail(ctx context.Context, vessel queue.Vessel) error {
+	g.applyIssueLabel(ctx, vessel.Meta["issue_num"],
+		vessel.Meta["status_label_failed"],
+		vessel.Meta["status_label_running"])
+	return nil
+}
+
+func (g *GitHub) OnTimedOut(ctx context.Context, vessel queue.Vessel) error {
+	g.applyIssueLabel(ctx, vessel.Meta["issue_num"],
+		vessel.Meta["status_label_timed_out"],
+		vessel.Meta["status_label_running"])
+	return nil
+}
+
+// applyIssueLabel runs gh issue edit to add and/or remove a label on the issue.
+// Both add and remove are optional — empty string means skip that operation.
+func (g *GitHub) applyIssueLabel(ctx context.Context, issueNum, add, remove string) {
+	if g.CmdRunner == nil || issueNum == "" {
+		return
+	}
+	if add == "" && remove == "" {
+		return
+	}
+	args := []string{"issue", "edit", issueNum, "--repo", g.Repo}
+	if add != "" {
+		args = append(args, "--add-label", add)
+	}
+	if remove != "" {
+		args = append(args, "--remove-label", remove)
+	}
+	_, _ = g.CmdRunner.Run(ctx, "gh", args...)
 }
 
 func (g *GitHub) BranchName(vessel queue.Vessel) string {

--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -72,14 +72,23 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					continue
 				}
 				seen[pr.Number] = true
+				meta := map[string]string{
+					"pr_num": strconv.Itoa(pr.Number),
+				}
+				sl := task.StatusLabels
+				if sl.Queued != "" || sl.Running != "" || sl.Completed != "" || sl.Failed != "" || sl.TimedOut != "" {
+					meta["status_label_queued"] = sl.Queued
+					meta["status_label_running"] = sl.Running
+					meta["status_label_completed"] = sl.Completed
+					meta["status_label_failed"] = sl.Failed
+					meta["status_label_timed_out"] = sl.TimedOut
+				}
 				vessels = append(vessels, queue.Vessel{
-					ID:     fmt.Sprintf("pr-%d", pr.Number),
-					Source: "github-pr",
-					Ref:    pr.URL,
-					Workflow: task.Workflow,
-					Meta: map[string]string{
-						"pr_num": strconv.Itoa(pr.Number),
-					},
+					ID:        fmt.Sprintf("pr-%d", pr.Number),
+					Source:    "github-pr",
+					Ref:       pr.URL,
+					Workflow:  task.Workflow,
+					Meta:      meta,
 					State:     queue.StatePending,
 					CreatedAt: time.Now().UTC(),
 				})
@@ -87,6 +96,12 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 		}
 	}
 	return vessels, nil
+}
+
+func (g *GitHubPR) OnEnqueue(ctx context.Context, vessel queue.Vessel) error {
+	g.applyPRLabel(ctx, vessel.Meta["pr_num"],
+		vessel.Meta["status_label_queued"], "")
+	return nil
 }
 
 func (g *GitHubPR) OnStart(ctx context.Context, vessel queue.Vessel) error {
@@ -97,12 +112,52 @@ func (g *GitHubPR) OnStart(ctx context.Context, vessel queue.Vessel) error {
 	if prNum == "" {
 		return nil
 	}
-	// Best-effort: add in-progress label
-	_, _ = g.CmdRunner.Run(ctx, "gh", "pr", "edit",
-		prNum,
-		"--repo", g.Repo,
-		"--add-label", "in-progress")
+	running, hasRunning := vessel.Meta["status_label_running"]
+	if !hasRunning {
+		running = "in-progress" // backward-compat: preserve old behaviour
+	}
+	g.applyPRLabel(ctx, prNum, running, vessel.Meta["status_label_queued"])
 	return nil
+}
+
+func (g *GitHubPR) OnComplete(ctx context.Context, vessel queue.Vessel) error {
+	g.applyPRLabel(ctx, vessel.Meta["pr_num"],
+		vessel.Meta["status_label_completed"],
+		vessel.Meta["status_label_running"])
+	return nil
+}
+
+func (g *GitHubPR) OnFail(ctx context.Context, vessel queue.Vessel) error {
+	g.applyPRLabel(ctx, vessel.Meta["pr_num"],
+		vessel.Meta["status_label_failed"],
+		vessel.Meta["status_label_running"])
+	return nil
+}
+
+func (g *GitHubPR) OnTimedOut(ctx context.Context, vessel queue.Vessel) error {
+	g.applyPRLabel(ctx, vessel.Meta["pr_num"],
+		vessel.Meta["status_label_timed_out"],
+		vessel.Meta["status_label_running"])
+	return nil
+}
+
+// applyPRLabel runs gh pr edit to add and/or remove a label on the PR.
+// Both add and remove are optional — empty string means skip that operation.
+func (g *GitHubPR) applyPRLabel(ctx context.Context, prNum, add, remove string) {
+	if g.CmdRunner == nil || prNum == "" {
+		return
+	}
+	if add == "" && remove == "" {
+		return
+	}
+	args := []string{"pr", "edit", prNum, "--repo", g.Repo}
+	if add != "" {
+		args = append(args, "--add-label", add)
+	}
+	if remove != "" {
+		args = append(args, "--remove-label", remove)
+	}
+	_, _ = g.CmdRunner.Run(ctx, "gh", args...)
 }
 
 func (g *GitHubPR) BranchName(vessel queue.Vessel) string {

--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -76,7 +76,7 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					"pr_num": strconv.Itoa(pr.Number),
 				}
 				sl := task.StatusLabels
-				if sl.Queued != "" || sl.Running != "" || sl.Completed != "" || sl.Failed != "" || sl.TimedOut != "" {
+				if sl != nil {
 					meta["status_label_queued"] = sl.Queued
 					meta["status_label_running"] = sl.Running
 					meta["status_label_completed"] = sl.Completed

--- a/cli/internal/source/github_pr_test.go
+++ b/cli/internal/source/github_pr_test.go
@@ -332,6 +332,204 @@ func TestGitHubPRName(t *testing.T) {
 	}
 }
 
+func TestGitHubPROnEnqueue(t *testing.T) {
+	r := newMock()
+	src := &GitHubPR{Repo: "owner/repo", CmdRunner: r}
+	vessel := queue.Vessel{
+		ID:   "pr-10",
+		Meta: map[string]string{"pr_num": "10", "status_label_queued": "queued"},
+	}
+	if err := src.OnEnqueue(context.Background(), vessel); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, call := range r.calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, "pr edit") && strings.Contains(joined, "--add-label") && strings.Contains(joined, "queued") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected gh pr edit --add-label queued, calls: %v", r.calls)
+	}
+}
+
+func TestGitHubPROnEnqueueNoLabelConfigured(t *testing.T) {
+	r := newMock()
+	src := &GitHubPR{Repo: "owner/repo", CmdRunner: r}
+	vessel := queue.Vessel{ID: "pr-10", Meta: map[string]string{"pr_num": "10"}}
+	if err := src.OnEnqueue(context.Background(), vessel); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.calls) != 0 {
+		t.Errorf("expected no calls when queued label not configured, got %v", r.calls)
+	}
+}
+
+func TestGitHubPROnStartConfiguredLabel(t *testing.T) {
+	r := newMock()
+	src := &GitHubPR{Repo: "owner/repo", CmdRunner: r}
+	vessel := queue.Vessel{
+		ID:   "pr-10",
+		Meta: map[string]string{"pr_num": "10", "status_label_running": "wip", "status_label_queued": "queued"},
+	}
+	if err := src.OnStart(context.Background(), vessel); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d: %v", len(r.calls), r.calls)
+	}
+	joined := strings.Join(r.calls[0], " ")
+	if !strings.Contains(joined, "--add-label wip") {
+		t.Errorf("expected --add-label wip in call, got %q", joined)
+	}
+	if !strings.Contains(joined, "--remove-label queued") {
+		t.Errorf("expected --remove-label queued in call, got %q", joined)
+	}
+}
+
+func TestGitHubPROnComplete(t *testing.T) {
+	r := newMock()
+	src := &GitHubPR{Repo: "owner/repo", CmdRunner: r}
+	vessel := queue.Vessel{
+		ID:   "pr-10",
+		Meta: map[string]string{"pr_num": "10", "status_label_completed": "done", "status_label_running": "wip"},
+	}
+	if err := src.OnComplete(context.Background(), vessel); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d: %v", len(r.calls), r.calls)
+	}
+	joined := strings.Join(r.calls[0], " ")
+	if !strings.Contains(joined, "--add-label done") {
+		t.Errorf("expected --add-label done in call, got %q", joined)
+	}
+	if !strings.Contains(joined, "--remove-label wip") {
+		t.Errorf("expected --remove-label wip in call, got %q", joined)
+	}
+}
+
+func TestGitHubPROnFail(t *testing.T) {
+	r := newMock()
+	src := &GitHubPR{Repo: "owner/repo", CmdRunner: r}
+	vessel := queue.Vessel{
+		ID:   "pr-10",
+		Meta: map[string]string{"pr_num": "10", "status_label_failed": "failed", "status_label_running": "wip"},
+	}
+	if err := src.OnFail(context.Background(), vessel); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d: %v", len(r.calls), r.calls)
+	}
+	joined := strings.Join(r.calls[0], " ")
+	if !strings.Contains(joined, "--add-label failed") {
+		t.Errorf("expected --add-label failed in call, got %q", joined)
+	}
+	if !strings.Contains(joined, "--remove-label wip") {
+		t.Errorf("expected --remove-label wip in call, got %q", joined)
+	}
+}
+
+func TestGitHubPROnTimedOut(t *testing.T) {
+	r := newMock()
+	src := &GitHubPR{Repo: "owner/repo", CmdRunner: r}
+	vessel := queue.Vessel{
+		ID:   "pr-10",
+		Meta: map[string]string{"pr_num": "10", "status_label_timed_out": "timed-out", "status_label_running": "wip"},
+	}
+	if err := src.OnTimedOut(context.Background(), vessel); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d: %v", len(r.calls), r.calls)
+	}
+	joined := strings.Join(r.calls[0], " ")
+	if !strings.Contains(joined, "--add-label timed-out") {
+		t.Errorf("expected --add-label timed-out, got %q", joined)
+	}
+}
+
+func TestGitHubPRLifecycleNilRunner(t *testing.T) {
+	src := &GitHubPR{Repo: "owner/repo", CmdRunner: nil}
+	vessel := queue.Vessel{
+		ID:   "pr-10",
+		Meta: map[string]string{"pr_num": "10", "status_label_queued": "queued", "status_label_running": "wip", "status_label_failed": "failed"},
+	}
+	ctx := context.Background()
+	if err := src.OnEnqueue(ctx, vessel); err != nil {
+		t.Errorf("OnEnqueue with nil runner: %v", err)
+	}
+	if err := src.OnComplete(ctx, vessel); err != nil {
+		t.Errorf("OnComplete with nil runner: %v", err)
+	}
+	if err := src.OnFail(ctx, vessel); err != nil {
+		t.Errorf("OnFail with nil runner: %v", err)
+	}
+	if err := src.OnTimedOut(ctx, vessel); err != nil {
+		t.Errorf("OnTimedOut with nil runner: %v", err)
+	}
+}
+
+func TestGitHubIssueOnStartBackwardCompat(t *testing.T) {
+	// When status_label_running is absent (old vessel), OnStart should add "in-progress"
+	r := newMock()
+	src := &GitHub{Repo: "owner/repo", CmdRunner: r}
+	vessel := queue.Vessel{
+		ID:   "issue-1",
+		Meta: map[string]string{"issue_num": "1"},
+	}
+	if err := src.OnStart(context.Background(), vessel); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(r.calls))
+	}
+	joined := strings.Join(r.calls[0], " ")
+	if !strings.Contains(joined, "in-progress") {
+		t.Errorf("expected in-progress fallback label, got %q", joined)
+	}
+}
+
+func TestGitHubIssueOnStartConfiguredLabel(t *testing.T) {
+	r := newMock()
+	src := &GitHub{Repo: "owner/repo", CmdRunner: r}
+	vessel := queue.Vessel{
+		ID:   "issue-1",
+		Meta: map[string]string{"issue_num": "1", "status_label_running": "active", "status_label_queued": "queued"},
+	}
+	if err := src.OnStart(context.Background(), vessel); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d: %v", len(r.calls), r.calls)
+	}
+	joined := strings.Join(r.calls[0], " ")
+	if !strings.Contains(joined, "--add-label active") {
+		t.Errorf("expected --add-label active, got %q", joined)
+	}
+	if !strings.Contains(joined, "--remove-label queued") {
+		t.Errorf("expected --remove-label queued, got %q", joined)
+	}
+}
+
+func TestGitHubIssueOnCompleteNoLabels(t *testing.T) {
+	// When no status labels are configured, OnComplete should make no gh calls
+	r := newMock()
+	src := &GitHub{Repo: "owner/repo", CmdRunner: r}
+	vessel := queue.Vessel{
+		ID:   "issue-1",
+		Meta: map[string]string{"issue_num": "1"},
+	}
+	if err := src.OnComplete(context.Background(), vessel); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.calls) != 0 {
+		t.Errorf("expected no calls when no labels configured, got %v", r.calls)
+	}
+}
+
 var errTest = &testError{"test error"}
 
 type testError struct{ msg string }

--- a/cli/internal/source/manual.go
+++ b/cli/internal/source/manual.go
@@ -18,9 +18,11 @@ func (m *Manual) Scan(_ context.Context) ([]queue.Vessel, error) {
 	return nil, nil // manual source doesn't auto-discover
 }
 
-func (m *Manual) OnStart(_ context.Context, _ queue.Vessel) error {
-	return nil // no side effects
-}
+func (m *Manual) OnEnqueue(_ context.Context, _ queue.Vessel) error  { return nil }
+func (m *Manual) OnStart(_ context.Context, _ queue.Vessel) error    { return nil }
+func (m *Manual) OnComplete(_ context.Context, _ queue.Vessel) error { return nil }
+func (m *Manual) OnFail(_ context.Context, _ queue.Vessel) error     { return nil }
+func (m *Manual) OnTimedOut(_ context.Context, _ queue.Vessel) error { return nil }
 
 func (m *Manual) BranchName(vessel queue.Vessel) string {
 	slug := slugify(vessel.Ref)

--- a/cli/internal/source/source.go
+++ b/cli/internal/source/source.go
@@ -6,15 +6,34 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
 
+// StatusLabels holds the label names to apply at each vessel state transition.
+// An empty string means "no label operation" for that transition.
+type StatusLabels struct {
+	Queued    string
+	Running   string
+	Completed string
+	Failed    string
+	TimedOut  string
+}
+
 // Source discovers tasks and produces Vessels.
 type Source interface {
 	// Name returns the source identifier (e.g., "github-issue").
 	Name() string
 	// Scan discovers new tasks and returns vessels to enqueue.
 	Scan(ctx context.Context) ([]queue.Vessel, error)
+	// OnEnqueue is called after a vessel is successfully enqueued.
+	// Used for side effects like adding a "queued" label.
+	OnEnqueue(ctx context.Context, vessel queue.Vessel) error
 	// OnStart is called when a vessel from this source begins running.
 	// Used for side effects like adding an "in-progress" label.
 	OnStart(ctx context.Context, vessel queue.Vessel) error
+	// OnComplete is called when a vessel completes all phases successfully.
+	OnComplete(ctx context.Context, vessel queue.Vessel) error
+	// OnFail is called when a vessel fails (phase error or gate exhausted).
+	OnFail(ctx context.Context, vessel queue.Vessel) error
+	// OnTimedOut is called when a vessel's label gate times out.
+	OnTimedOut(ctx context.Context, vessel queue.Vessel) error
 	// BranchName generates the git branch name for this vessel.
 	BranchName(vessel queue.Vessel) string
 }

--- a/cli/internal/source/source.go
+++ b/cli/internal/source/source.go
@@ -3,6 +3,7 @@ package source
 import (
 	"context"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
 
@@ -14,6 +15,29 @@ type StatusLabels struct {
 	Completed string
 	Failed    string
 	TimedOut  string
+}
+
+// GitHubTaskFromConfig converts a config.Task to a GitHubTask.
+// When t.StatusLabels is nil (block omitted from config), the returned task's
+// StatusLabels is also nil, preserving the legacy "in-progress" fallback in
+// OnStart. When t.StatusLabels is non-nil (block present, even if all values
+// are empty), all status_label_* meta keys are populated so tasks can
+// explicitly opt out of any label operation.
+func GitHubTaskFromConfig(t config.Task) GitHubTask {
+	task := GitHubTask{
+		Labels:   t.Labels,
+		Workflow: t.Workflow,
+	}
+	if t.StatusLabels != nil {
+		task.StatusLabels = &StatusLabels{
+			Queued:    t.StatusLabels.Queued,
+			Running:   t.StatusLabels.Running,
+			Completed: t.StatusLabels.Completed,
+			Failed:    t.StatusLabels.Failed,
+			TimedOut:  t.StatusLabels.TimedOut,
+		}
+	}
+	return task
 }
 
 // Source discovers tasks and produces Vessels.


### PR DESCRIPTION
- [x] Understand existing code and review comments
- [x] Make `Task.StatusLabels` a pointer (`*StatusLabels`) in config to detect omission vs empty block
- [x] Update `GitHubTask.StatusLabels` to `*StatusLabels` in source package
- [x] Extract `GitHubTaskFromConfig` helper into `source` package (eliminates duplication between scanner and drain)
- [x] Update `convertTasks` in scanner to use the shared helper
- [x] Update `buildSourceMap` in drain.go to use the shared helper
- [x] Update meta population in `github.go` and `github_pr.go` to always persist all 5 keys when pointer is non-nil
- [x] Log warning for `OnEnqueue` errors in `scanner.go`
- [x] Log warnings for `OnTimedOut`, `OnFail`, `OnComplete` errors in `runner.go`
- [x] Update config tests for pointer check (nil = omitted, non-nil = present)
- [x] All tests pass, CodeQL clean