### PR TITLE
fix: daemon no longer blocks on drain; vessel stderr no longer bleeds to terminal

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os/signal"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -16,6 +17,10 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/scanner"
 	"github.com/nicholls-inc/xylem/cli/internal/worktree"
 )
+
+// drainShutdownTimeout is how long the daemon waits for an in-flight drain to
+// finish after receiving a shutdown signal before returning anyway.
+const drainShutdownTimeout = 30 * time.Second
 
 func newDaemonCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -34,7 +39,14 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	return daemonLoop(ctx, cfg, q, wt, scanInterval, drainInterval)
+	scan := func(ctx context.Context) (scanner.ScanResult, error) {
+		return runScan(ctx, cfg, q)
+	}
+	drain := func(ctx context.Context) (runner.DrainResult, error) {
+		return runDrain(ctx, cfg, q, wt)
+	}
+
+	return daemonLoop(ctx, q, scan, drain, scanInterval, drainInterval)
 }
 
 func parseDaemonIntervals(dc config.DaemonConfig) (scan, drain time.Duration) {
@@ -54,9 +66,14 @@ func parseDaemonIntervals(dc config.DaemonConfig) (scan, drain time.Duration) {
 	return scan, drain
 }
 
+// scanFunc and drainFunc abstract scan/drain for testability.
+type scanFunc func(ctx context.Context) (scanner.ScanResult, error)
+type drainFunc func(ctx context.Context) (runner.DrainResult, error)
+
 // daemonLoop is the core loop extracted for testability. It accepts an
-// externally-controlled context so tests can cancel it without signals.
-func daemonLoop(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *worktree.Manager, scanInterval, drainInterval time.Duration) error {
+// externally-controlled context so tests can cancel it without signals,
+// and injectable scan/drain functions so tests can use stubs.
+func daemonLoop(ctx context.Context, q *queue.Queue, scan scanFunc, drain drainFunc, scanInterval, drainInterval time.Duration) error {
 	tickInterval := scanInterval
 	if drainInterval < tickInterval {
 		tickInterval = drainInterval
@@ -64,13 +81,22 @@ func daemonLoop(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *wor
 
 	var lastScan, lastDrain time.Time
 	var draining int32 // 0=idle, 1=running
+	var drainWg sync.WaitGroup
 
 	log.Printf("daemon started: scan_interval=%s drain_interval=%s", scanInterval, drainInterval)
 
 	for {
 		select {
 		case <-ctx.Done():
-			log.Println("daemon: received shutdown signal")
+			log.Println("daemon: received shutdown signal, waiting for in-flight drain")
+			waitDone := make(chan struct{})
+			go func() { drainWg.Wait(); close(waitDone) }()
+			select {
+			case <-waitDone:
+				log.Println("daemon: in-flight drain finished")
+			case <-time.After(drainShutdownTimeout):
+				log.Println("daemon: drain shutdown timeout exceeded, exiting")
+			}
 			return nil
 		default:
 		}
@@ -78,7 +104,7 @@ func daemonLoop(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *wor
 		now := time.Now()
 
 		if now.Sub(lastScan) >= scanInterval {
-			scanResult, err := runScan(ctx, cfg, q)
+			scanResult, err := scan(ctx)
 			if err != nil {
 				log.Printf("daemon: scan error: %v", err)
 			} else {
@@ -90,9 +116,11 @@ func daemonLoop(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *wor
 		if now.Sub(lastDrain) >= drainInterval {
 			if atomic.CompareAndSwapInt32(&draining, 0, 1) {
 				lastDrain = now
+				drainWg.Add(1)
 				go func() {
+					defer drainWg.Done()
 					defer atomic.StoreInt32(&draining, 0)
-					drainResult, err := runDrain(ctx, cfg, q, wt)
+					drainResult, err := drain(ctx)
 					if err != nil {
 						log.Printf("daemon: drain error: %v", err)
 						return
@@ -107,7 +135,15 @@ func daemonLoop(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *wor
 
 		select {
 		case <-ctx.Done():
-			log.Println("daemon: shutting down gracefully")
+			log.Println("daemon: received shutdown signal, waiting for in-flight drain")
+			waitDone := make(chan struct{})
+			go func() { drainWg.Wait(); close(waitDone) }()
+			select {
+			case <-waitDone:
+				log.Println("daemon: in-flight drain finished")
+			case <-time.After(drainShutdownTimeout):
+				log.Println("daemon: drain shutdown timeout exceeded, exiting")
+			}
 			return nil
 		case <-time.After(tickInterval):
 		}

--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -62,6 +63,7 @@ func daemonLoop(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *wor
 	}
 
 	var lastScan, lastDrain time.Time
+	var draining int32 // 0=idle, 1=running
 
 	log.Printf("daemon started: scan_interval=%s drain_interval=%s", scanInterval, drainInterval)
 
@@ -86,13 +88,18 @@ func daemonLoop(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *wor
 		}
 
 		if now.Sub(lastDrain) >= drainInterval {
-			drainResult, err := runDrain(ctx, cfg, q, wt)
-			if err != nil {
-				log.Printf("daemon: drain error: %v", err)
-			} else {
+			if atomic.CompareAndSwapInt32(&draining, 0, 1) {
 				lastDrain = now
-				log.Printf("daemon: drain complete — completed=%d failed=%d skipped=%d",
-					drainResult.Completed, drainResult.Failed, drainResult.Skipped)
+				go func() {
+					defer atomic.StoreInt32(&draining, 0)
+					drainResult, err := runDrain(ctx, cfg, q, wt)
+					if err != nil {
+						log.Printf("daemon: drain error: %v", err)
+						return
+					}
+					log.Printf("daemon: drain complete — completed=%d failed=%d skipped=%d",
+						drainResult.Completed, drainResult.Failed, drainResult.Skipped)
+				}()
 			}
 		}
 

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -74,6 +74,35 @@ func TestParseDaemonIntervals(t *testing.T) {
 	}
 }
 
+func TestDaemonNonBlockingDrain(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeDaemonConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	wt := worktree.New(dir, &emptyWorktreeRunner{})
+
+	now := time.Now().UTC()
+	q.Enqueue(queue.Vessel{ID: "v1", Source: "manual", State: queue.StatePending, CreatedAt: now}) //nolint:errcheck
+
+	// drainInterval=1ms ensures the drain fires immediately. The loop should
+	// return promptly when the context is cancelled — it must NOT block waiting
+	// for the drain to finish.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := daemonLoop(ctx, cfg, q, wt, time.Hour, time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected nil error on shutdown, got: %v", err)
+	}
+	// If drain were blocking, this would hang for the full vessel timeout.
+	// 500ms is generous: the loop should return well within the 200ms ctx timeout.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("daemonLoop blocked for %s — drain is not running in background", elapsed)
+	}
+}
+
 func TestLogTickSummary(t *testing.T) {
 	dir := t.TempDir()
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -3,42 +3,32 @@ package main
 import (
 	"context"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
-	"github.com/nicholls-inc/xylem/cli/internal/worktree"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+	"github.com/nicholls-inc/xylem/cli/internal/scanner"
 )
 
-func makeDaemonConfig(dir string) *config.Config {
-	return &config.Config{
-		Concurrency: 2,
-		MaxTurns:    50,
-		Timeout:     "30m",
-		StateDir:    dir,
-		Claude:      config.ClaudeConfig{Command: "claude", Template: "{{.Command}} -p \"/{{.Workflow}} {{.Ref}}\" --max-turns {{.MaxTurns}}"},
-		Sources: map[string]config.SourceConfig{
-			"github": {
-				Type:    "github",
-				Repo:    "owner/repo",
-				Exclude: []string{"wontfix"},
-				Tasks:   map[string]config.Task{"fix-bugs": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
-			},
-		},
-	}
+func noopScan(_ context.Context) (scanner.ScanResult, error) {
+	return scanner.ScanResult{}, nil
+}
+
+func noopDrain(_ context.Context) (runner.DrainResult, error) {
+	return runner.DrainResult{}, nil
 }
 
 func TestDaemonShutdown(t *testing.T) {
 	dir := t.TempDir()
-	cfg := makeDaemonConfig(dir)
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
-	wt := worktree.New(dir, &emptyWorktreeRunner{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, cfg, q, wt, time.Hour, time.Hour)
+	err := daemonLoop(ctx, q, noopScan, noopDrain, time.Hour, time.Hour)
 	if err != nil {
 		t.Fatalf("expected nil error on shutdown, got: %v", err)
 	}
@@ -46,11 +36,11 @@ func TestDaemonShutdown(t *testing.T) {
 
 func TestParseDaemonIntervals(t *testing.T) {
 	tests := []struct {
-		name              string
-		scanInterval      string
-		drainInterval     string
-		expectedScan      time.Duration
-		expectedDrain     time.Duration
+		name          string
+		scanInterval  string
+		drainInterval string
+		expectedScan  time.Duration
+		expectedDrain time.Duration
 	}{
 		{"defaults", "", "", 60 * time.Second, 30 * time.Second},
 		{"custom scan", "120s", "", 120 * time.Second, 30 * time.Second},
@@ -76,30 +66,46 @@ func TestParseDaemonIntervals(t *testing.T) {
 
 func TestDaemonNonBlockingDrain(t *testing.T) {
 	dir := t.TempDir()
-	cfg := makeDaemonConfig(dir)
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
-	wt := worktree.New(dir, &emptyWorktreeRunner{})
 
 	now := time.Now().UTC()
 	q.Enqueue(queue.Vessel{ID: "v1", Source: "manual", State: queue.StatePending, CreatedAt: now}) //nolint:errcheck
 
-	// drainInterval=1ms ensures the drain fires immediately. The loop should
-	// return promptly when the context is cancelled — it must NOT block waiting
-	// for the drain to finish.
+	// slowDrain simulates a drain that takes 5 seconds. The context should
+	// cancel well before that, and the daemon should wait for the in-flight
+	// drain to finish (or timeout) rather than abandoning it.
+	var drainStarted int32
+	slowDrain := func(ctx context.Context) (runner.DrainResult, error) {
+		atomic.StoreInt32(&drainStarted, 1)
+		select {
+		case <-ctx.Done():
+			return runner.DrainResult{}, ctx.Err()
+		case <-time.After(5 * time.Second):
+			return runner.DrainResult{Completed: 1}, nil
+		}
+	}
+
+	// drainInterval=1ms ensures the drain fires immediately.
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
 	start := time.Now()
-	err := daemonLoop(ctx, cfg, q, wt, time.Hour, time.Millisecond)
+	err := daemonLoop(ctx, q, noopScan, slowDrain, time.Hour, time.Millisecond)
 	elapsed := time.Since(start)
 
 	if err != nil {
 		t.Fatalf("expected nil error on shutdown, got: %v", err)
 	}
-	// If drain were blocking, this would hang for the full vessel timeout.
-	// 500ms is generous: the loop should return well within the 200ms ctx timeout.
-	if elapsed > 500*time.Millisecond {
-		t.Errorf("daemonLoop blocked for %s — drain is not running in background", elapsed)
+
+	// The drain goroutine should have been started.
+	if atomic.LoadInt32(&drainStarted) == 0 {
+		t.Error("drain goroutine was never started")
+	}
+
+	// The loop should return after the context cancels and the drain
+	// goroutine observes the cancellation — well under 2 seconds.
+	if elapsed > 2*time.Second {
+		t.Errorf("daemonLoop took %s — drain shutdown wait may be broken", elapsed)
 	}
 }
 

--- a/cli/cmd/xylem/exec.go
+++ b/cli/cmd/xylem/exec.go
@@ -7,13 +7,64 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sync"
 )
+
+// maxStderrBytes is the maximum amount of stderr captured from a phase subprocess.
+// Anything beyond this limit is silently discarded to prevent unbounded memory growth.
+const maxStderrBytes = 256 * 1024 // 256 KiB
 
 func truncate(s string, max int) string {
 	if len(s) <= max {
 		return s
 	}
 	return s[:max-3] + "..."
+}
+
+// limitedWriter captures up to max bytes; additional writes are silently discarded.
+type limitedWriter struct {
+	mu        sync.Mutex
+	buf       bytes.Buffer
+	max       int
+	truncated bool
+}
+
+func newLimitedWriter(max int) *limitedWriter {
+	return &limitedWriter{max: max}
+}
+
+func (lw *limitedWriter) Write(p []byte) (int, error) {
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+
+	remaining := lw.max - lw.buf.Len()
+	if remaining <= 0 {
+		lw.truncated = true
+		return len(p), nil // discard silently so the subprocess doesn't block
+	}
+	if len(p) > remaining {
+		lw.buf.Write(p[:remaining])
+		lw.truncated = true
+		return len(p), nil
+	}
+	lw.buf.Write(p)
+	return len(p), nil
+}
+
+func (lw *limitedWriter) String() string {
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+
+	if lw.truncated {
+		return lw.buf.String() + "\n... [stderr truncated]"
+	}
+	return lw.buf.String()
+}
+
+func (lw *limitedWriter) Len() int {
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+	return lw.buf.Len()
 }
 
 type realCmdRunner struct{}
@@ -39,9 +90,10 @@ func (r *realCmdRunner) RunPhase(ctx context.Context, dir string, stdin io.Reade
 	cmd.Dir = dir
 	cmd.Stdin = stdin
 
-	var stdout, stderr bytes.Buffer
+	var stdout bytes.Buffer
+	stderr := newLimitedWriter(maxStderrBytes)
 	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stderr = stderr
 
 	err := cmd.Run()
 	if err != nil && stderr.Len() > 0 {

--- a/cli/cmd/xylem/exec.go
+++ b/cli/cmd/xylem/exec.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -37,11 +38,14 @@ func (r *realCmdRunner) RunPhase(ctx context.Context, dir string, stdin io.Reade
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
 	cmd.Stdin = stdin
-	cmd.Stderr = os.Stderr
 
-	var stdout bytes.Buffer
+	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
 	err := cmd.Run()
+	if err != nil && stderr.Len() > 0 {
+		return stdout.Bytes(), fmt.Errorf("%w\nstderr: %s", err, stderr.String())
+	}
 	return stdout.Bytes(), err
 }


### PR DESCRIPTION
## Summary

- **Non-blocking drain**: `daemonLoop` previously called `runDrain` synchronously, which blocked the tick loop until every vessel in the batch completed. Drain is now fired in a background goroutine guarded by an `int32` atomic CAS flag — only one drain runs at a time, but the loop continues scanning and responding to shutdown signals while vessels execute.
- **Vessel stderr capture**: `RunPhase` was wiring subprocess stderr directly to `os.Stderr`, causing vessel error output to bleed into the daemon terminal. Stderr is now captured into a `bytes.Buffer`; on failure it is wrapped into the returned error (via `%w`) so it surfaces in runner logs without polluting the terminal.

Fixes https://github.com/nicholls-inc/xylem/issues/9

## Test plan

- [ ] `go vet ./...` passes
- [ ] `go test ./cmd/xylem/...` passes, including new `TestDaemonNonBlockingDrain` which verifies the loop returns within 500ms even with a pending vessel (would hang indefinitely with the old blocking drain)
- [ ] Existing `TestDaemonShutdown` and `TestParseDaemonIntervals` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)