### PR TITLE
fix: harden copilot provider and eliminate duplication

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -36,8 +36,8 @@ type SourceConfig struct {
 }
 
 type Task struct {
-	Labels []string `yaml:"labels,omitempty"`
-	Workflow  string   `yaml:"workflow"`
+	Labels   []string `yaml:"labels,omitempty"`
+	Workflow string   `yaml:"workflow"`
 }
 
 type ClaudeConfig struct {
@@ -144,6 +144,11 @@ func (c *Config) Validate() error {
 		// valid
 	default:
 		return fmt.Errorf("llm must be \"claude\" or \"copilot\", got %q", c.LLM)
+	}
+
+	// Validate copilot config when copilot is the selected provider
+	if c.LLM == "copilot" && c.Copilot.Command == "" {
+		return fmt.Errorf("copilot.command must be non-empty when llm is \"copilot\"")
 	}
 
 	if c.Claude.Template != "" {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -621,35 +621,42 @@ daemon:
 	}
 }
 
-func TestValidateLLMClaudeExplicit(t *testing.T) {
-	cfg := validConfig()
-	cfg.LLM = "claude"
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("expected valid config with llm=claude, got: %v", err)
+func TestValidateLLM(t *testing.T) {
+	tests := []struct {
+		name    string
+		llm     string
+		wantErr string
+	}{
+		{"claude explicit", "claude", ""},
+		{"copilot explicit", "copilot", ""},
+		{"empty defaults to claude", "", ""},
+		{"invalid value", "gpt4", `llm must be "claude" or "copilot"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.LLM = tt.llm
+			// Ensure copilot command is set for "copilot" to avoid command validation failure
+			if tt.llm == "copilot" {
+				cfg.Copilot = CopilotConfig{Command: "copilot"}
+			}
+			err := cfg.Validate()
+			if tt.wantErr != "" {
+				requireErrorContains(t, err, tt.wantErr)
+			} else if err != nil {
+				t.Fatalf("expected valid config with llm=%q, got: %v", tt.llm, err)
+			}
+		})
 	}
 }
 
-func TestValidateLLMCopilotExplicit(t *testing.T) {
+func TestValidateCopilotEmptyCommand(t *testing.T) {
 	cfg := validConfig()
 	cfg.LLM = "copilot"
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("expected valid config with llm=copilot, got: %v", err)
-	}
-}
-
-func TestValidateLLMEmptyDefaultsClaude(t *testing.T) {
-	cfg := validConfig()
-	cfg.LLM = ""
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("expected valid config with empty llm (defaults to claude), got: %v", err)
-	}
-}
-
-func TestValidateLLMInvalidValue(t *testing.T) {
-	cfg := validConfig()
-	cfg.LLM = "gpt4"
+	cfg.Copilot = CopilotConfig{Command: ""}
 	err := cfg.Validate()
-	requireErrorContains(t, err, `llm must be "claude" or "copilot"`)
+	requireErrorContains(t, err, "copilot.command must be non-empty")
 }
 
 func TestLoadCopilotConfig(t *testing.T) {
@@ -749,4 +756,3 @@ claude:
 		t.Fatalf("LLM = %q, want empty (defaults to claude at runtime)", cfg.LLM)
 	}
 }
-

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -18,8 +18,8 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
-	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 )
 
 // CommandRunner abstracts subprocess execution for testing.
@@ -424,26 +424,7 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 		prompt = fmt.Sprintf("Ref: %s\n\n%s", vessel.Ref, vessel.Prompt)
 	}
 
-	provider := resolveProvider(r.Config, nil, nil)
-	var cmd string
-	var args []string
-	switch provider {
-	case "copilot":
-		cmd = r.Config.Copilot.Command
-		args = []string{"--headless", "--max-turns", fmt.Sprintf("%d", r.Config.MaxTurns)}
-		if r.Config.Copilot.Flags != "" {
-			args = append(args, strings.Fields(r.Config.Copilot.Flags)...)
-		}
-	default: // "claude"
-		cmd = r.Config.Claude.Command
-		args = []string{"-p", "--max-turns", fmt.Sprintf("%d", r.Config.MaxTurns)}
-		if r.Config.Claude.Flags != "" {
-			args = append(args, strings.Fields(r.Config.Claude.Flags)...)
-		}
-		for _, tool := range r.Config.Claude.AllowedTools {
-			args = append(args, "--allowedTools", tool)
-		}
-	}
+	cmd, args := buildPromptOnlyCmdArgs(r.Config, "")
 
 	_, runErr := r.Runner.RunPhase(ctx, worktreePath, strings.NewReader(prompt), cmd, args...)
 
@@ -473,46 +454,20 @@ func (r *Runner) resolveSource(name string) source.Source {
 
 // buildCommand constructs the LLM command and args from config and vessel.
 func buildCommand(cfg *config.Config, vessel *queue.Vessel) (string, []string, error) {
-	provider := resolveProvider(cfg, nil, nil)
-
 	// Direct prompt mode
 	if vessel.Prompt != "" {
 		prompt := vessel.Prompt
 		if vessel.Ref != "" {
 			prompt = fmt.Sprintf("Ref: %s\n\n%s", vessel.Ref, vessel.Prompt)
 		}
-		switch provider {
-		case "copilot":
-			args := []string{"--headless", prompt, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns)}
-			if cfg.Copilot.Flags != "" {
-				args = append(args, strings.Fields(cfg.Copilot.Flags)...)
-			}
-			return cfg.Copilot.Command, args, nil
-		default: // "claude"
-			args := []string{"-p", prompt, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns)}
-			if cfg.Claude.Flags != "" {
-				args = append(args, strings.Fields(cfg.Claude.Flags)...)
-			}
-			return cfg.Claude.Command, args, nil
-		}
+		cmd, args := buildPromptOnlyCmdArgs(cfg, prompt)
+		return cmd, args, nil
 	}
 
 	// Workflow-based mode: build command from flags (v2 phase-based execution will replace this)
 	wfPrompt := fmt.Sprintf("/%s %s", vessel.Workflow, vessel.Ref)
-	switch provider {
-	case "copilot":
-		args := []string{"--headless", wfPrompt, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns)}
-		if cfg.Copilot.Flags != "" {
-			args = append(args, strings.Fields(cfg.Copilot.Flags)...)
-		}
-		return cfg.Copilot.Command, args, nil
-	default: // "claude"
-		args := []string{"-p", wfPrompt, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns)}
-		if cfg.Claude.Flags != "" {
-			args = append(args, strings.Fields(cfg.Claude.Flags)...)
-		}
-		return cfg.Claude.Command, args, nil
-	}
+	cmd, args := buildPromptOnlyCmdArgs(cfg, wfPrompt)
+	return cmd, args, nil
 }
 
 func (r *Runner) removeWorktree(worktreePath, vesselID string) {
@@ -710,6 +665,7 @@ func buildPhaseArgs(cfg *config.Config, wf *workflow.Workflow, p *workflow.Phase
 		args = append(args, "--model", model)
 	}
 
+	// Claude CLI uses --allowedTools (camelCase), unlike Copilot's --allowed-tools (kebab-case)
 	if p.AllowedTools != nil && *p.AllowedTools != "" {
 		args = append(args, "--allowedTools", *p.AllowedTools)
 	}
@@ -718,6 +674,7 @@ func buildPhaseArgs(cfg *config.Config, wf *workflow.Workflow, p *workflow.Phase
 		args = append(args, "--allowedTools", tool)
 	}
 
+	// Claude CLI uses --append-system-prompt, unlike Copilot's --system-prompt
 	if harnessContent != "" {
 		args = append(args, "--append-system-prompt", harnessContent)
 	}
@@ -733,9 +690,11 @@ func buildCopilotPhaseArgs(cfg *config.Config, wf *workflow.Workflow, p *workflo
 
 	model := resolveModel(cfg, wf, p, "copilot")
 
-	// Add flags, stripping --model if we resolved one from the hierarchy
+	// Add flags, stripping --headless (always prepended) and --model (resolved from hierarchy)
+	// to avoid duplication
 	if cfg.Copilot.Flags != "" {
 		fields := strings.Fields(cfg.Copilot.Flags)
+		fields = stripBoolFlag(fields, "--headless")
 		if model != "" {
 			fields = stripModelFlag(fields)
 		}
@@ -746,10 +705,12 @@ func buildCopilotPhaseArgs(cfg *config.Config, wf *workflow.Workflow, p *workflo
 		args = append(args, "--model", model)
 	}
 
+	// Copilot CLI uses kebab-case flags, unlike Claude's --allowedTools (camelCase)
 	if p.AllowedTools != nil && *p.AllowedTools != "" {
 		args = append(args, "--allowed-tools", *p.AllowedTools)
 	}
 
+	// Copilot CLI uses --system-prompt, unlike Claude's --append-system-prompt
 	if harnessContent != "" {
 		args = append(args, "--system-prompt", harnessContent)
 	}
@@ -800,6 +761,53 @@ func resolveModel(cfg *config.Config, wf *workflow.Workflow, p *workflow.Phase, 
 		return cfg.Copilot.DefaultModel
 	default:
 		return cfg.Claude.DefaultModel
+	}
+}
+
+// stripBoolFlag removes all occurrences of a boolean flag (no value) from a slice of CLI tokens.
+func stripBoolFlag(fields []string, flag string) []string {
+	var out []string
+	for _, f := range fields {
+		if f != flag {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// buildPromptOnlyCmdArgs returns the command and args for a prompt-only invocation.
+// If prompt is non-empty, it is included as a positional argument (for buildCommand).
+// If prompt is empty, the caller supplies it via stdin (for runPromptOnly).
+func buildPromptOnlyCmdArgs(cfg *config.Config, prompt string) (string, []string) {
+	provider := resolveProvider(cfg, nil, nil)
+	switch provider {
+	case "copilot":
+		cmd := cfg.Copilot.Command
+		args := []string{"--headless"}
+		if prompt != "" {
+			args = append(args, prompt)
+		}
+		args = append(args, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns))
+		if cfg.Copilot.Flags != "" {
+			// Strip --headless (always prepended) to avoid duplication
+			fields := stripBoolFlag(strings.Fields(cfg.Copilot.Flags), "--headless")
+			args = append(args, fields...)
+		}
+		return cmd, args
+	default: // "claude"
+		cmd := cfg.Claude.Command
+		args := []string{"-p"}
+		if prompt != "" {
+			args = append(args, prompt)
+		}
+		args = append(args, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns))
+		if cfg.Claude.Flags != "" {
+			args = append(args, strings.Fields(cfg.Claude.Flags)...)
+		}
+		for _, tool := range cfg.Claude.AllowedTools {
+			args = append(args, "--allowedTools", tool)
+		}
+		return cmd, args
 	}
 }
 

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
-	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 )
 
 // --- Mock types ---
@@ -88,8 +88,8 @@ type mockExitError struct {
 	code int
 }
 
-func (e *mockExitError) Error() string    { return fmt.Sprintf("exit status %d", e.code) }
-func (e *mockExitError) ExitCode() int    { return e.code }
+func (e *mockExitError) Error() string { return fmt.Sprintf("exit status %d", e.code) }
+func (e *mockExitError) ExitCode() int { return e.code }
 
 type countingCmdRunner struct {
 	concurrent int32
@@ -199,22 +199,22 @@ func makeTestConfig(dir string, concurrency int) *config.Config {
 
 func makeVessel(num int, workflow string) queue.Vessel {
 	return queue.Vessel{
-		ID:     fmt.Sprintf("issue-%d", num),
-		Source: "github-issue",
-		Ref:    fmt.Sprintf("https://github.com/owner/repo/issues/%d", num),
+		ID:        fmt.Sprintf("issue-%d", num),
+		Source:    "github-issue",
+		Ref:       fmt.Sprintf("https://github.com/owner/repo/issues/%d", num),
 		Workflow:  workflow,
-		Meta:   map[string]string{"issue_num": strconv.Itoa(num)},
-		State:  queue.StatePending,
+		Meta:      map[string]string{"issue_num": strconv.Itoa(num)},
+		State:     queue.StatePending,
 		CreatedAt: time.Now().UTC(),
 	}
 }
 
 func makePromptVessel(num int, prompt string) queue.Vessel {
 	return queue.Vessel{
-		ID:     fmt.Sprintf("prompt-%d", num),
-		Source: "manual",
-		Prompt: prompt,
-		State:  queue.StatePending,
+		ID:        fmt.Sprintf("prompt-%d", num),
+		Source:    "manual",
+		Prompt:    prompt,
+		State:     queue.StatePending,
 		CreatedAt: time.Now().UTC(),
 	}
 }
@@ -233,9 +233,9 @@ func TestBuildCommand(t *testing.T) {
 		},
 	}
 	vessel := &queue.Vessel{
-		Source: "github-issue",
-		Workflow:  "fix-bug",
-		Ref:    "https://github.com/owner/repo/issues/42",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Ref:      "https://github.com/owner/repo/issues/42",
 	}
 	cmd, args, err := buildCommand(cfg, vessel)
 	if err != nil {
@@ -360,9 +360,9 @@ func TestBuildCommandWorkflowBased(t *testing.T) {
 		},
 	}
 	vessel := &queue.Vessel{
-		Source: "github-issue",
-		Workflow:  "fix-bug",
-		Ref:    "https://github.com/owner/repo/issues/42",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Ref:      "https://github.com/owner/repo/issues/42",
 	}
 	cmd, args, err := buildCommand(cfg, vessel)
 	if err != nil {
@@ -1093,7 +1093,7 @@ func TestDrainPreviousOutputsAvailable(t *testing.T) {
 
 func TestBranchPrefixSelection(t *testing.T) {
 	tests := []struct {
-		workflow      string
+		workflow   string
 		wantPrefix string
 	}{
 		{"fix-bug", "fix"},
@@ -1150,9 +1150,9 @@ func TestBuildCommandWithFlags(t *testing.T) {
 		},
 	}
 	vessel := &queue.Vessel{
-		Source: "github-issue",
-		Workflow:  "fix-bug",
-		Ref:    "https://github.com/owner/repo/issues/42",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Ref:      "https://github.com/owner/repo/issues/42",
 	}
 	_, args, err := buildCommand(cfg, vessel)
 	if err != nil {
@@ -1443,215 +1443,399 @@ func TestDrainTimeoutV2Phase(t *testing.T) {
 }
 
 func TestResolveProvider(t *testing.T) {
-claude := "claude"
-copilot := "copilot"
+	claude := "claude"
+	copilot := "copilot"
 
-tests := []struct {
-name     string
-cfgLLM   string
-wfLLM    *string
-phaseLLM *string
-want     string
-}{
-{"all nil defaults to claude", "", nil, nil, "claude"},
-{"config claude", "claude", nil, nil, "claude"},
-{"config copilot", "copilot", nil, nil, "copilot"},
-{"workflow overrides config", "claude", &copilot, nil, "copilot"},
-{"phase overrides workflow", "claude", &claude, &copilot, "copilot"},
-{"phase overrides config", "claude", nil, &copilot, "copilot"},
-{"empty config falls back to claude", "", &copilot, nil, "copilot"},
-}
+	tests := []struct {
+		name     string
+		cfgLLM   string
+		wfLLM    *string
+		phaseLLM *string
+		want     string
+	}{
+		{"all nil defaults to claude", "", nil, nil, "claude"},
+		{"config claude", "claude", nil, nil, "claude"},
+		{"config copilot", "copilot", nil, nil, "copilot"},
+		{"workflow overrides config", "claude", &copilot, nil, "copilot"},
+		{"phase overrides workflow", "claude", &claude, &copilot, "copilot"},
+		{"phase overrides config", "claude", nil, &copilot, "copilot"},
+		{"empty config falls back to claude", "", &copilot, nil, "copilot"},
+	}
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-cfg := &config.Config{LLM: tt.cfgLLM}
-var wf *workflow.Workflow
-if tt.wfLLM != nil {
-wf = &workflow.Workflow{LLM: tt.wfLLM}
-}
-var p *workflow.Phase
-if tt.phaseLLM != nil {
-p = &workflow.Phase{LLM: tt.phaseLLM}
-}
-got := resolveProvider(cfg, wf, p)
-if got != tt.want {
-t.Errorf("resolveProvider() = %q, want %q", got, tt.want)
-}
-})
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{LLM: tt.cfgLLM}
+			var wf *workflow.Workflow
+			if tt.wfLLM != nil {
+				wf = &workflow.Workflow{LLM: tt.wfLLM}
+			}
+			var p *workflow.Phase
+			if tt.phaseLLM != nil {
+				p = &workflow.Phase{LLM: tt.phaseLLM}
+			}
+			got := resolveProvider(cfg, wf, p)
+			if got != tt.want {
+				t.Errorf("resolveProvider() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestResolveModel(t *testing.T) {
-cfg := &config.Config{
-Claude:  config.ClaudeConfig{DefaultModel: "claude-default"},
-Copilot: config.CopilotConfig{DefaultModel: "copilot-default"},
-}
+	cfg := &config.Config{
+		Claude:  config.ClaudeConfig{DefaultModel: "claude-default"},
+		Copilot: config.CopilotConfig{DefaultModel: "copilot-default"},
+	}
 
-phaseModel := "phase-model"
-wfModel := "wf-model"
+	phaseModel := "phase-model"
+	wfModel := "wf-model"
 
-tests := []struct {
-name       string
-wfModel    *string
-phaseModel *string
-provider   string
-want       string
-}{
-{"phase model wins", &wfModel, &phaseModel, "claude", "phase-model"},
-{"workflow model wins over default", &wfModel, nil, "claude", "wf-model"},
-{"claude default when no override", nil, nil, "claude", "claude-default"},
-{"copilot default when provider copilot", nil, nil, "copilot", "copilot-default"},
-{"workflow model wins for copilot", &wfModel, nil, "copilot", "wf-model"},
-{"phase model wins for copilot", &wfModel, &phaseModel, "copilot", "phase-model"},
-}
+	tests := []struct {
+		name       string
+		wfModel    *string
+		phaseModel *string
+		provider   string
+		want       string
+	}{
+		{"phase model wins", &wfModel, &phaseModel, "claude", "phase-model"},
+		{"workflow model wins over default", &wfModel, nil, "claude", "wf-model"},
+		{"claude default when no override", nil, nil, "claude", "claude-default"},
+		{"copilot default when provider copilot", nil, nil, "copilot", "copilot-default"},
+		{"workflow model wins for copilot", &wfModel, nil, "copilot", "wf-model"},
+		{"phase model wins for copilot", &wfModel, &phaseModel, "copilot", "phase-model"},
+	}
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-var wf *workflow.Workflow
-if tt.wfModel != nil {
-wf = &workflow.Workflow{Model: tt.wfModel}
-}
-var p *workflow.Phase
-if tt.phaseModel != nil {
-p = &workflow.Phase{Model: tt.phaseModel}
-}
-got := resolveModel(cfg, wf, p, tt.provider)
-if got != tt.want {
-t.Errorf("resolveModel() = %q, want %q", got, tt.want)
-}
-})
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var wf *workflow.Workflow
+			if tt.wfModel != nil {
+				wf = &workflow.Workflow{Model: tt.wfModel}
+			}
+			var p *workflow.Phase
+			if tt.phaseModel != nil {
+				p = &workflow.Phase{Model: tt.phaseModel}
+			}
+			got := resolveModel(cfg, wf, p, tt.provider)
+			if got != tt.want {
+				t.Errorf("resolveModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestBuildCopilotPhaseArgs(t *testing.T) {
-maxTurns := 10
+	maxTurns := 10
 
-tests := []struct {
-name           string
-cfg            *config.Config
-wf             *workflow.Workflow
-phase          *workflow.Phase
-harness        string
-wantContains   []string
-wantNotContain []string
-}{
-{
-name: "basic copilot args",
-cfg:  &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
-phase: &workflow.Phase{MaxTurns: maxTurns},
-wantContains: []string{"--headless", "--max-turns", "10"},
-},
-{
-name: "copilot with model from config default",
-cfg: &config.Config{
-Copilot: config.CopilotConfig{Command: "copilot", DefaultModel: "gpt-4o"},
-},
-phase:        &workflow.Phase{MaxTurns: maxTurns},
-wantContains: []string{"--model", "gpt-4o"},
-},
-{
-name: "copilot with model from phase overrides default",
-cfg: &config.Config{
-Copilot: config.CopilotConfig{Command: "copilot", DefaultModel: "gpt-4o"},
-},
-phase:          &workflow.Phase{MaxTurns: maxTurns, Model: strPtrRunner("phase-model")},
-wantContains:   []string{"--model", "phase-model"},
-wantNotContain: []string{"gpt-4o"},
-},
-{
-name: "copilot with extra flags",
-cfg: &config.Config{
-Copilot: config.CopilotConfig{Command: "copilot", Flags: "--verbose"},
-},
-phase:        &workflow.Phase{MaxTurns: maxTurns},
-wantContains: []string{"--verbose"},
-},
-{
-name: "copilot with allowed_tools",
-cfg:  &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
-phase: &workflow.Phase{MaxTurns: maxTurns, AllowedTools: strPtrRunner("Bash,Read")},
-wantContains: []string{"--allowed-tools", "Bash,Read"},
-},
-{
-name:         "copilot with harness",
-cfg:          &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
-phase:        &workflow.Phase{MaxTurns: maxTurns},
-harness:      "harness instructions",
-wantContains: []string{"--system-prompt", "harness instructions"},
-},
-{
-name: "copilot strips --model from flags when model resolved",
-cfg: &config.Config{
-Copilot: config.CopilotConfig{
-Command: "copilot",
-Flags:   "--headless --model old-model",
-DefaultModel: "new-model",
-},
-},
-phase:          &workflow.Phase{MaxTurns: maxTurns},
-wantContains:   []string{"--model", "new-model"},
-wantNotContain: []string{"old-model"},
-},
-}
+	tests := []struct {
+		name           string
+		cfg            *config.Config
+		wf             *workflow.Workflow
+		phase          *workflow.Phase
+		harness        string
+		wantContains   []string
+		wantNotContain []string
+		wantPairs      [][2]string // [flag, value] pairs that must be adjacent
+	}{
+		{
+			name:         "basic copilot args",
+			cfg:          &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
+			phase:        &workflow.Phase{MaxTurns: maxTurns},
+			wantContains: []string{"--headless"},
+			wantPairs:    [][2]string{{"--max-turns", "10"}},
+		},
+		{
+			name: "copilot with model from config default",
+			cfg: &config.Config{
+				Copilot: config.CopilotConfig{Command: "copilot", DefaultModel: "gpt-4o"},
+			},
+			phase:     &workflow.Phase{MaxTurns: maxTurns},
+			wantPairs: [][2]string{{"--model", "gpt-4o"}},
+		},
+		{
+			name: "copilot with model from phase overrides default",
+			cfg: &config.Config{
+				Copilot: config.CopilotConfig{Command: "copilot", DefaultModel: "gpt-4o"},
+			},
+			phase:          &workflow.Phase{MaxTurns: maxTurns, Model: strPtrRunner("phase-model")},
+			wantPairs:      [][2]string{{"--model", "phase-model"}},
+			wantNotContain: []string{"gpt-4o"},
+		},
+		{
+			name: "copilot with extra flags",
+			cfg: &config.Config{
+				Copilot: config.CopilotConfig{Command: "copilot", Flags: "--verbose"},
+			},
+			phase:        &workflow.Phase{MaxTurns: maxTurns},
+			wantContains: []string{"--verbose"},
+		},
+		{
+			name:      "copilot with allowed_tools",
+			cfg:       &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
+			phase:     &workflow.Phase{MaxTurns: maxTurns, AllowedTools: strPtrRunner("Bash,Read")},
+			wantPairs: [][2]string{{"--allowed-tools", "Bash,Read"}},
+		},
+		{
+			name:      "copilot with harness",
+			cfg:       &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}},
+			phase:     &workflow.Phase{MaxTurns: maxTurns},
+			harness:   "harness instructions",
+			wantPairs: [][2]string{{"--system-prompt", "harness instructions"}},
+		},
+		{
+			name: "copilot strips --model from flags when model resolved",
+			cfg: &config.Config{
+				Copilot: config.CopilotConfig{
+					Command:      "copilot",
+					Flags:        "--headless --model old-model",
+					DefaultModel: "new-model",
+				},
+			},
+			phase:          &workflow.Phase{MaxTurns: maxTurns},
+			wantPairs:      [][2]string{{"--model", "new-model"}},
+			wantNotContain: []string{"old-model"},
+		},
+		{
+			name: "copilot strips duplicate --headless from flags",
+			cfg: &config.Config{
+				Copilot: config.CopilotConfig{
+					Command: "copilot",
+					Flags:   "--headless --verbose",
+				},
+			},
+			phase:        &workflow.Phase{MaxTurns: maxTurns},
+			wantContains: []string{"--verbose"},
+		},
+	}
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-args := buildCopilotPhaseArgs(tt.cfg, tt.wf, tt.phase, tt.harness)
-for _, want := range tt.wantContains {
-found := false
-for _, a := range args {
-if a == want {
-found = true
-break
-}
-}
-if !found {
-t.Errorf("args %v: expected to contain %q", args, want)
-}
-}
-for _, notWant := range tt.wantNotContain {
-for _, a := range args {
-if a == notWant {
-t.Errorf("args %v: expected NOT to contain %q", args, notWant)
-break
-}
-}
-}
-})
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := buildCopilotPhaseArgs(tt.cfg, tt.wf, tt.phase, tt.harness)
+
+			for _, want := range tt.wantContains {
+				found := false
+				for _, a := range args {
+					if a == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("args %v: expected to contain %q", args, want)
+				}
+			}
+
+			for _, notWant := range tt.wantNotContain {
+				for _, a := range args {
+					if a == notWant {
+						t.Errorf("args %v: expected NOT to contain %q", args, notWant)
+						break
+					}
+				}
+			}
+
+			for _, pair := range tt.wantPairs {
+				flag, value := pair[0], pair[1]
+				found := false
+				for i := 0; i < len(args)-1; i++ {
+					if args[i] == flag && args[i+1] == value {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("args %v: expected adjacent pair [%q, %q]", args, flag, value)
+				}
+			}
+
+			// Verify --headless appears exactly once
+			headlessCount := 0
+			for _, a := range args {
+				if a == "--headless" {
+					headlessCount++
+				}
+			}
+			if headlessCount != 1 {
+				t.Errorf("expected exactly 1 --headless, got %d (args: %v)", headlessCount, args)
+			}
+		})
+	}
 }
 
 func TestBuildProviderPhaseArgsDispatch(t *testing.T) {
-claudeCmd := "claude"
-copilotCmd := "copilot"
+	claudeCmd := "claude"
+	copilotCmd := "copilot"
 
-cfg := &config.Config{
-Claude:  config.ClaudeConfig{Command: claudeCmd},
-Copilot: config.CopilotConfig{Command: copilotCmd},
-}
-phase := &workflow.Phase{MaxTurns: 5}
+	cfg := &config.Config{
+		Claude:  config.ClaudeConfig{Command: claudeCmd},
+		Copilot: config.CopilotConfig{Command: copilotCmd},
+	}
+	phase := &workflow.Phase{MaxTurns: 5}
 
-t.Run("claude provider returns claude command", func(t *testing.T) {
-cmd, args := buildProviderPhaseArgs(cfg, nil, phase, "", "claude")
-if cmd != claudeCmd {
-t.Errorf("cmd = %q, want %q", cmd, claudeCmd)
-}
-// claude args should start with -p
-if len(args) == 0 || args[0] != "-p" {
-t.Errorf("claude args[0] = %q, want -p (args: %v)", args[0], args)
-}
-})
+	t.Run("claude provider returns claude command", func(t *testing.T) {
+		cmd, args := buildProviderPhaseArgs(cfg, nil, phase, "", "claude")
+		if cmd != claudeCmd {
+			t.Errorf("cmd = %q, want %q", cmd, claudeCmd)
+		}
+		if len(args) == 0 || args[0] != "-p" {
+			t.Errorf("claude args[0] = %q, want -p (args: %v)", args[0], args)
+		}
+		// Claude args must NOT contain copilot-specific flags
+		for _, a := range args {
+			if a == "--headless" || a == "--system-prompt" || a == "--allowed-tools" {
+				t.Errorf("claude args contain copilot-specific flag %q (args: %v)", a, args)
+			}
+		}
+	})
 
-t.Run("copilot provider returns copilot command", func(t *testing.T) {
-cmd, args := buildProviderPhaseArgs(cfg, nil, phase, "", "copilot")
-if cmd != copilotCmd {
-t.Errorf("cmd = %q, want %q", cmd, copilotCmd)
+	t.Run("copilot provider returns copilot command", func(t *testing.T) {
+		cmd, args := buildProviderPhaseArgs(cfg, nil, phase, "", "copilot")
+		if cmd != copilotCmd {
+			t.Errorf("cmd = %q, want %q", cmd, copilotCmd)
+		}
+		if len(args) == 0 || args[0] != "--headless" {
+			t.Errorf("copilot args[0] = %q, want --headless (args: %v)", args[0], args)
+		}
+		// Copilot args must NOT contain claude-specific flags
+		for _, a := range args {
+			if a == "-p" || a == "--append-system-prompt" || a == "--allowedTools" {
+				t.Errorf("copilot args contain claude-specific flag %q (args: %v)", a, args)
+			}
+		}
+	})
 }
-// copilot args should start with --headless
-if len(args) == 0 || args[0] != "--headless" {
-t.Errorf("copilot args[0] = %q, want --headless (args: %v)", args[0], args)
+
+func TestBuildCommandCopilotDirect(t *testing.T) {
+	cfg := &config.Config{
+		LLM:      "copilot",
+		MaxTurns: 50,
+		Copilot: config.CopilotConfig{
+			Command: "copilot",
+		},
+	}
+	vessel := &queue.Vessel{
+		Source: "manual",
+		Prompt: "Fix the null pointer in handler.go",
+	}
+	cmd, args, err := buildCommand(cfg, vessel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd != "copilot" {
+		t.Errorf("expected cmd 'copilot', got %q", cmd)
+	}
+	if len(args) < 4 {
+		t.Fatalf("expected at least 4 args, got %d: %v", len(args), args)
+	}
+	if args[0] != "--headless" {
+		t.Errorf("expected --headless flag, got %q", args[0])
+	}
+	if args[1] != "Fix the null pointer in handler.go" {
+		t.Errorf("expected prompt text, got %q", args[1])
+	}
+	// Must NOT contain claude-specific flags
+	for _, a := range args {
+		if a == "-p" {
+			t.Errorf("copilot buildCommand should not contain -p (args: %v)", args)
+		}
+	}
 }
-})
+
+func TestBuildCommandCopilotWorkflow(t *testing.T) {
+	cfg := &config.Config{
+		LLM:      "copilot",
+		MaxTurns: 50,
+		Copilot: config.CopilotConfig{
+			Command: "copilot",
+			Flags:   "--verbose",
+		},
+	}
+	vessel := &queue.Vessel{
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Ref:      "https://github.com/owner/repo/issues/42",
+	}
+	cmd, args, err := buildCommand(cfg, vessel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd != "copilot" {
+		t.Errorf("expected cmd 'copilot', got %q", cmd)
+	}
+	if args[0] != "--headless" {
+		t.Errorf("expected --headless flag, got %q", args[0])
+	}
+	if !strings.Contains(args[1], "/fix-bug") {
+		t.Errorf("expected workflow in prompt, got %q", args[1])
+	}
+	// Flags should be appended
+	found := false
+	for _, a := range args {
+		if a == "--verbose" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected --verbose in args, got: %v", args)
+	}
+}
+
+func TestBuildCommandCopilotDirectWithRef(t *testing.T) {
+	cfg := &config.Config{
+		LLM:      "copilot",
+		MaxTurns: 50,
+		Copilot: config.CopilotConfig{
+			Command: "copilot",
+		},
+	}
+	vessel := &queue.Vessel{
+		Source: "manual",
+		Prompt: "Fix the null pointer in handler.go",
+		Ref:    "https://github.com/owner/repo/issues/99",
+	}
+	cmd, args, err := buildCommand(cfg, vessel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd != "copilot" {
+		t.Errorf("expected cmd 'copilot', got %q", cmd)
+	}
+	if !strings.Contains(args[1], "Ref: https://github.com/owner/repo/issues/99") {
+		t.Errorf("expected ref URL in prompt, got %q", args[1])
+	}
+	if !strings.Contains(args[1], "Fix the null pointer in handler.go") {
+		t.Errorf("expected original prompt text, got %q", args[1])
+	}
+}
+
+func TestBuildPromptOnlyCmdArgsHeadlessDedup(t *testing.T) {
+	cfg := &config.Config{
+		LLM:      "copilot",
+		MaxTurns: 50,
+		Copilot: config.CopilotConfig{
+			Command: "copilot",
+			Flags:   "--headless --verbose",
+		},
+	}
+	_, args := buildPromptOnlyCmdArgs(cfg, "")
+	headlessCount := 0
+	for _, a := range args {
+		if a == "--headless" {
+			headlessCount++
+		}
+	}
+	if headlessCount != 1 {
+		t.Errorf("expected exactly 1 --headless, got %d (args: %v)", headlessCount, args)
+	}
+	// --verbose should still be present
+	found := false
+	for _, a := range args {
+		if a == "--verbose" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected --verbose in args, got: %v", args)
+	}
 }
 
 func strPtrRunner(s string) *string { return &s }


### PR DESCRIPTION
## Summary

- **Eliminate code duplication**: Extract `buildPromptOnlyCmdArgs` helper so both `runPromptOnly` and `buildCommand` share one provider-dispatch path instead of maintaining parallel switch blocks
- **Prevent double `--headless`**: Add `stripBoolFlag` helper and use it in `buildCopilotPhaseArgs` and `buildPromptOnlyCmdArgs` to deduplicate boolean flags from user-supplied `copilot.flags`
- **Config validation**: Reject `copilot.command == ""` when `llm: copilot` is selected, catching misconfiguration at load time
- **Test improvements**: Collapse 4 carbon-copy `TestValidateLLM*` functions into 1 table-driven test, add `wantPairs` adjacency assertions and negative cross-contamination checks for provider flag isolation, add tests for previously untested copilot paths in `buildCommand` and `buildPromptOnlyCmdArgs`

## Test plan

- [ ] `go test ./internal/runner/... ./internal/config/...` passes (22/22 packages)
- [ ] `gofmt -l` reports no formatting issues on changed files
- [ ] Copilot provider builds correct args with `--headless` appearing exactly once
- [ ] Claude provider args do not contain copilot-specific flags and vice versa
- [ ] Config with `llm: copilot` and empty `copilot.command` is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)