### PR TITLE
fix: reset GateRetries when advancing to next phase

### DIFF
--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -401,13 +401,18 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 		// This is only reached after the inner loop exits via break (gate passed or no gate),
 		// never after a retry continue or early return.
 		//
-		// Also persist the reset: the UpdateVessel inside the inner loop may have written a
-		// non-zero GateRetries from this phase (e.g. retries:2 that passed on the first
-		// attempt). Without this write, a daemon restart during the next phase's RunPhase
-		// execution would load the stale non-zero count and give that phase phantom retries.
+		// Also persist the reset when needed: the UpdateVessel inside the inner loop may have
+		// written a non-zero GateRetries from this phase (e.g. retries:2 that passed on the
+		// first attempt). Without this write, a daemon restart during the next phase's
+		// RunPhase execution would load the stale non-zero count and give that phase
+		// phantom retries. If GateRetries is already zero, skip the write to avoid an
+		// unnecessary full queue rewrite under lock.
+		prevRetries := vessel.GateRetries
 		vessel.GateRetries = 0
-		if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
-			log.Printf("warn: persist gate retry reset for %s: %v", vessel.ID, updateErr)
+		if prevRetries != 0 {
+			if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
+				log.Printf("warn: persist gate retry reset for %s: %v", vessel.ID, updateErr)
+			}
 		}
 	}
 

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -396,6 +396,19 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 
 			break // gate passed or unknown gate type
 		}
+
+		// Reset gate retries so the next phase's initialization guard fires correctly.
+		// This is only reached after the inner loop exits via break (gate passed or no gate),
+		// never after a retry continue or early return.
+		//
+		// Also persist the reset: the UpdateVessel inside the inner loop may have written a
+		// non-zero GateRetries from this phase (e.g. retries:2 that passed on the first
+		// attempt). Without this write, a daemon restart during the next phase's RunPhase
+		// execution would load the stale non-zero count and give that phase phantom retries.
+		vessel.GateRetries = 0
+		if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
+			log.Printf("warn: persist gate retry reset for %s: %v", vessel.ID, updateErr)
+		}
 	}
 
 	// All phases complete

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -53,13 +53,11 @@ type phaseCall struct {
 
 func (m *mockCmdRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
 	m.outputArgs = append(m.outputArgs, append([]string{name}, args...))
-	// If the command looks like a gate command (sh -c), check for per-call results first
+	// Detect gate commands by matching the exact shape produced by gate.RunCommandGate:
+	// RunOutput("sh", "-c", "cd <dir> && <cmd>")
 	isGate := false
-	for _, a := range args {
-		if strings.Contains(a, "cd ") {
-			isGate = true
-			break
-		}
+	if name == "sh" && len(args) >= 2 && args[0] == "-c" && strings.Contains(args[1], "cd ") {
+		isGate = true
 	}
 	if isGate && m.gateCallResults != nil {
 		idx := int(atomic.AddInt32(&m.gateCallCount, 1) - 1)

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -31,9 +31,17 @@ type mockCmdRunner struct {
 	started      int32
 	gateOutput   []byte
 	gateErr      error
+	// Per-call gate results; when non-nil, overrides gateOutput/gateErr by call index
+	gateCallResults []gateCallResult
+	gateCallCount   int32
 	// Track calls for assertion
 	phaseCalls []phaseCall
 	outputArgs [][]string
+}
+
+type gateCallResult struct {
+	output []byte
+	err    error
 }
 
 type phaseCall struct {
@@ -45,13 +53,24 @@ type phaseCall struct {
 
 func (m *mockCmdRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
 	m.outputArgs = append(m.outputArgs, append([]string{name}, args...))
-	if m.gateOutput != nil {
-		// If the command looks like a gate command (sh -c), return gate output
-		for _, a := range args {
-			if strings.Contains(a, "cd ") {
-				return m.gateOutput, m.gateErr
-			}
+	// If the command looks like a gate command (sh -c), check for per-call results first
+	isGate := false
+	for _, a := range args {
+		if strings.Contains(a, "cd ") {
+			isGate = true
+			break
 		}
+	}
+	if isGate && m.gateCallResults != nil {
+		idx := int(atomic.AddInt32(&m.gateCallCount, 1) - 1)
+		if idx < len(m.gateCallResults) {
+			return m.gateCallResults[idx].output, m.gateCallResults[idx].err
+		}
+		last := m.gateCallResults[len(m.gateCallResults)-1]
+		return last.output, last.err
+	}
+	if m.gateOutput != nil && isGate {
+		return m.gateOutput, m.gateErr
 	}
 	if m.outputData != nil {
 		return m.outputData, m.outputErr
@@ -695,6 +714,62 @@ func TestDrainCommandGateFailsNoRetries(t *testing.T) {
 	// Only 1 phase call (gate failed, no retry, phase 2 not invoked)
 	if len(cmdRunner.phaseCalls) != 1 {
 		t.Errorf("expected 1 phase call, got %d", len(cmdRunner.phaseCalls))
+	}
+}
+
+func TestDrainGateRetriesNotBleedBetweenPhases(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fix-bug"))
+
+	// Phase A has retries:2 but its gate passes on the first attempt.
+	// Phase B has retries:0 and its gate always fails.
+	// Without the fix, Phase A's leftover GateRetries bleeds into Phase B,
+	// giving it phantom retries and causing Phase B to run 3 times instead of once.
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{
+			name: "implement", promptContent: "Implement fix", maxTurns: 10,
+			gate: "      type: command\n      run: \"make test\"\n      retries: 2\n      retry_delay: \"1ms\"",
+		},
+		{
+			name: "pr", promptContent: "Create PR", maxTurns: 3,
+			gate: "      type: command\n      run: \"make lint\"\n      retries: 0",
+		},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{
+		// First gate call (Phase A): passes. Second gate call (Phase B): fails with a
+		// non-zero exit code. Use mockExitError so RunCommandGate returns (output, false, nil)
+		// and the retry-check path (vessel.GateRetries <= 0) is exercised.
+		// errors.New("exit status 1") would NOT satisfy the exitCoder interface, causing
+		// a system error that bypasses the retry check entirely and masking the bleed bug.
+		gateCallResults: []gateCallResult{
+			{output: []byte("ok"), err: nil},
+			{output: []byte("FAIL: lint"), err: &mockExitError{code: 1}},
+		},
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Failed != 1 {
+		t.Errorf("expected 1 failed, got %d", result.Failed)
+	}
+	// Phase A ran once, Phase B ran once — no phantom retries from bleed.
+	if len(cmdRunner.phaseCalls) != 2 {
+		t.Errorf("expected 2 phase calls (one per phase, no phantom retries), got %d", len(cmdRunner.phaseCalls))
 	}
 }
 


### PR DESCRIPTION
## Summary

- `vessel.GateRetries` was never zeroed when `vessel.CurrentPhase` was incremented
- If Phase A's gate passed early (leaving `GateRetries` at a non-zero value), Phase B's initialization guard (`GateRetries == 0`) was skipped — Phase B inherited phantom retries it was never configured for
- This allowed a gate failure that should have stopped the workflow to silently retry (and potentially pass), continuing execution incorrectly

## Fix

Reset `vessel.GateRetries = 0` immediately after `vessel.CurrentPhase` is incremented, and persist via `UpdateVessel` before the next phase runs.

The resume-after-restart invariant is preserved: the reset is only reachable after a phase **fully completes** (inner loop exited via `break`), never mid-retry — so a restarted daemon still loads the correct in-progress counter from the persisted state.

## Test plan

- [ ] `TestDrainGateRetriesNotBleedBetweenPhases` — new regression test: two-phase workflow where Phase A has `retries: 2` (gate passes first attempt) and Phase B has `retries: 0` (gate fails). Asserts vessel fails and exactly 2 phase calls are made (no phantom retries on Phase B)
- [ ] All existing gate tests pass unchanged: `TestDrainCommandGateFailsNoRetries`, `TestDrainCommandGateFailsWithRetries`, `TestDrainLabelGateTransitionsToWaiting`

Fixes https://github.com/nicholls-inc/xylem/issues/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)