### PR TITLE
feat: add GitHub Copilot code review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,36 @@
+# Code Review Guidelines
+
+## Repository Context
+
+xylem is a Go CLI that schedules and runs autonomous Claude Code sessions against GitHub issues. It uses a JSONL-backed queue of "vessels" (units of work) that are drained through multi-phase YAML workflows executed in isolated git worktrees.
+
+## Architecture Awareness
+
+- The codebase has two distinct layers: CLI commands (`cli/cmd/xylem/`) that wire things together, and internal packages (`cli/internal/`) that contain all business logic
+- `cli/internal/` contains both the core CLI pipeline (queue, runner, scanner, worktree, config, gate, workflow, phase, source, reporter) and a standalone agent harness library (orchestrator, mission, memory, signal, evaluator, cost, ctxmgr, intermediary, bootstrap, catalog, observability) — these are separate systems
+- All state flows through the `Vessel` struct and its state machine: `pending -> running -> completed/failed/waiting/timed_out/cancelled`. Verify state transitions use `validTransitions` and never bypass the state machine
+- The queue uses file-level locking via `gofrs/flock`. Mutations must go through `withLock`, reads through `withRLock`
+
+## Error Handling
+
+- Errors must be wrapped with context using `fmt.Errorf("description: %w", err)` — never return bare errors from functions that call other functions
+- Sentinel errors (like `ErrInvalidTransition`) should use `errors.New` and be checked with `errors.Is`
+- Functions that distinguish "not found" from other errors should return a specific error, not nil
+
+## Concurrency
+
+- The runner uses bounded concurrency via semaphore channels (`sem := make(chan struct{}, n)`)
+- Queue operations are protected by file locks, not mutexes — any new queue method must use `withLock` or `withRLock`
+- Check for race conditions when vessels are accessed concurrently across goroutines
+
+## Configuration
+
+- `config.Load` provides defaults for all fields — PRs should not duplicate defaults in call sites
+- Legacy config migration happens in `normalize()` — new fields must not break old `.xylem.yml` files
+- `claude.template` and `claude.allowed_tools` at the top level are rejected with migration guidance; preserve this invariant
+
+## Security
+
+- Check for hardcoded secrets, API keys, or credentials
+- The runner shells out to `claude` and `gh` CLIs — verify that user-supplied values (issue titles, branch names, labels) are never interpolated into shell commands without `shellQuote`
+- File paths from config or queue entries must not enable path traversal outside the worktree

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,52 @@
+---
+applyTo: "**/*.go"
+---
+# Go Code Review Standards
+
+## Testing Patterns
+
+- Tests must use interfaces and stubs for external dependencies (subprocess execution, git operations, GitHub API) — never shell out to real processes in unit tests
+- Prefer `t.Helper()` in test helpers so failure messages point to the caller
+- Use table-driven tests with `t.Run` subtests for cases that vary only by input/expected output
+- Property-based tests use `pgregory.net/rapid` and must be named `TestProp*` in `*_prop_test.go` files
+- Test queue and worktree operations use `t.TempDir()` for isolation — never write to fixed paths
+- Prefer `t.Fatalf` for setup failures, `t.Errorf` for assertion failures that should not stop the test
+
+## Naming and Style
+
+- Prefer short, clear variable names: `cfg` not `configuration`, `q` not `queue`, `wt` not `worktreeManager`
+- Interface names should describe the capability: `CommandRunner`, `WorktreeManager` — not the implementation
+- Exported types that are only used as function parameters or return values in one package probably should not be exported
+- Receiver names are single-letter or short abbreviations: `(q *Queue)`, `(r *Runner)`, `(s *Scanner)`
+
+## Struct and Interface Design
+
+- Interfaces are defined where they are consumed, not where they are implemented (e.g., `runner.CommandRunner` lives in `runner`, not in a shared package)
+- Prefer accepting interfaces and returning concrete types
+- Avoid `interface{}` / `any` when a concrete type or small interface suffices
+
+## Error Patterns
+
+```go
+// Preferred: wrapped with context
+return fmt.Errorf("dequeue vessel: %w", err)
+
+// Avoid: bare error propagation
+return err
+```
+
+## State Machine Discipline
+
+- All vessel state changes must go through `queue.Update` or `queue.UpdateVessel` — never mutate `Vessel.State` directly and rewrite the file
+- New states require updating `validTransitions`, `IsTerminal()`, and the `Update` switch
+- Gate results (pass/fail) map to state transitions — verify the mapping is correct
+
+## Go Template Usage
+
+- Workflow prompts are rendered via `text/template` — verify that template variables match the `PhaseContext` struct fields
+- Missing template variables silently render as empty strings — flag any `{{.FieldName}}` where `FieldName` does not exist on the context struct
+
+## Dependencies
+
+- This project has minimal dependencies by design — flag any new third-party imports and verify they are justified
+- Prefer stdlib over external packages for common tasks (e.g., `encoding/json`, `os/exec`, `text/template`)


### PR DESCRIPTION
## Summary
- Adds `.github/copilot-instructions.md` with repo-wide review guidelines covering architecture awareness, vessel state machine discipline, error handling, concurrency, config invariants, and security (shell injection, path traversal)
- Adds `.github/instructions/go.instructions.md` with Go-specific review standards scoped to `**/*.go` covering testing patterns (interfaces/stubs, rapid property tests), naming conventions, interface design, template correctness, and minimal dependency policy
- Both files stay well under Copilot's 4,000 character limit (~2,500 chars each)

## Test plan
- [ ] Verify `.github/copilot-instructions.md` renders correctly on GitHub
- [ ] Verify `.github/instructions/go.instructions.md` frontmatter `applyTo` glob is recognized
- [ ] Open a test PR touching a `.go` file and confirm Copilot review references these instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)