### PR TITLE
Add phase-level workflow no-op support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ phases:
   - name: analyze
     prompt_file: .xylem/prompts/fix-bug/analyze.md
     max_turns: 5
+    noop:
+      match: XYLEM_NOOP
   - name: implement
     prompt_file: .xylem/prompts/fix-bug/implement.md
     max_turns: 15
@@ -114,6 +116,8 @@ phases:
 |------|-------------|
 | `command` | Runs a shell command; phase retries if it fails |
 | `label` | Polls a GitHub issue for a label; blocks until found (human-in-the-loop approval) |
+
+Use `noop.match` on a phase to let that phase complete the workflow early when its output contains a configured marker such as `XYLEM_NOOP`.
 
 **Built-in workflows:**
 

--- a/cli/cmd/xylem/init.go
+++ b/cli/cmd/xylem/init.go
@@ -207,6 +207,8 @@ phases:
   - name: analyze
     prompt_file: .xylem/prompts/fix-bug/analyze.md
     max_turns: 5
+    noop:
+      match: XYLEM_NOOP
   - name: plan
     prompt_file: .xylem/prompts/fix-bug/plan.md
     max_turns: 3
@@ -228,6 +230,8 @@ phases:
   - name: analyze
     prompt_file: .xylem/prompts/implement-feature/analyze.md
     max_turns: 5
+    noop:
+      match: XYLEM_NOOP
   - name: plan
     prompt_file: .xylem/prompts/implement-feature/plan.md
     max_turns: 3
@@ -258,6 +262,8 @@ Read the codebase and identify:
 1. Which files are relevant to this issue
 2. The root cause (for bugs) or the requirements (for features)
 3. Any dependencies or constraints
+
+If you determine the issue is already resolved in the default branch or no code changes are needed, include the exact standalone line "XYLEM_NOOP" in your final output and explain why no further phases should run.
 
 Write your analysis clearly and concisely.
 `

--- a/cli/internal/reporter/reporter.go
+++ b/cli/internal/reporter/reporter.go
@@ -26,7 +26,7 @@ type Reporter struct {
 type PhaseResult struct {
 	Name     string
 	Duration time.Duration
-	Status   string // "completed" or "failed"
+	Status   string // "completed", "failed", or "no-op"
 }
 
 // PhaseComplete posts a comment on the GitHub issue when a phase completes successfully.
@@ -62,7 +62,12 @@ func (r *Reporter) VesselFailed(ctx context.Context, issueNum int, phaseName str
 // VesselCompleted posts a summary comment when all phases complete.
 func (r *Reporter) VesselCompleted(ctx context.Context, issueNum int, phases []PhaseResult) error {
 	var sb strings.Builder
-	sb.WriteString("**xylem — all phases completed**\n\n")
+	if workflowCompletedViaNoOp(phases) {
+		sb.WriteString("**xylem — workflow completed early via no-op**\n\n")
+		sb.WriteString("Remaining phases were skipped intentionally because a phase output matched its configured no-op marker.\n\n")
+	} else {
+		sb.WriteString("**xylem — all phases completed**\n\n")
+	}
 	sb.WriteString("| Phase | Duration | Status |\n")
 	sb.WriteString("|-------|----------|--------|\n")
 
@@ -78,6 +83,15 @@ func (r *Reporter) VesselCompleted(ctx context.Context, issueNum int, phases []P
 		log.Printf("warn: failed to post vessel-completed comment for issue %d: %v", issueNum, err)
 	}
 	return nil
+}
+
+func workflowCompletedViaNoOp(phases []PhaseResult) bool {
+	for _, p := range phases {
+		if p.Status == "no-op" {
+			return true
+		}
+	}
+	return false
 }
 
 // LabelTimeout posts a timeout comment on the GitHub issue.

--- a/cli/internal/reporter/reporter_test.go
+++ b/cli/internal/reporter/reporter_test.go
@@ -177,6 +177,27 @@ func TestVesselCompleted(t *testing.T) {
 	}
 }
 
+func TestVesselCompletedNoOp(t *testing.T) {
+	mock := &mockRunner{}
+	r := &Reporter{Runner: mock, Repo: "owner/repo"}
+
+	phases := []PhaseResult{
+		{Name: "analyze", Duration: 2 * time.Second, Status: "no-op"},
+	}
+
+	err := r.VesselCompleted(context.Background(), 5, phases)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(mock.lastBody, "workflow completed early via no-op") {
+		t.Fatalf("expected no-op completion header, got: %s", mock.lastBody)
+	}
+	if !strings.Contains(mock.lastBody, "| analyze | 2s | no-op |") {
+		t.Fatalf("expected no-op row in table, got: %s", mock.lastBody)
+	}
+}
+
 func TestLabelTimeout(t *testing.T) {
 	mock := &mockRunner{}
 	r := &Reporter{Runner: mock, Repo: "owner/repo"}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -18,8 +18,8 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
-	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 )
 
 // CommandRunner abstracts subprocess execution for testing.
@@ -322,11 +322,22 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 
 			log.Printf("%sphase %q completed (%s)", vesselLabel(vessel), p.Name, phaseDuration.Truncate(time.Second))
 
-			// Report phase completion (non-fatal)
-			phaseResults = append(phaseResults, reporter.PhaseResult{Name: p.Name, Duration: phaseDuration})
 			issueNum := r.parseIssueNum(vessel)
+
+			phaseStatus := "completed"
+			if phaseMatchedNoOp(&p, string(output)) {
+				phaseStatus = "no-op"
+			}
+
+			// Report phase completion (non-fatal)
+			phaseResults = append(phaseResults, reporter.PhaseResult{Name: p.Name, Duration: phaseDuration, Status: phaseStatus})
 			if issueNum > 0 && r.Reporter != nil {
 				r.Reporter.PhaseComplete(ctx, issueNum, p.Name, phaseDuration, string(output))
+			}
+
+			if phaseStatus == "no-op" {
+				log.Printf("%sphase %q triggered no-op; completing workflow early", vesselLabel(vessel), p.Name)
+				return r.completeVessel(ctx, vessel, worktreePath, phaseResults)
 			}
 
 			// Handle gate
@@ -400,20 +411,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 
 	// All phases complete
 	log.Printf("%scompleted all phases", vesselLabel(vessel))
-	if updateErr := r.Queue.Update(vessel.ID, queue.StateCompleted, ""); updateErr != nil {
-		log.Printf("warn: failed to update vessel %s state: %v", vessel.ID, updateErr)
-	}
-
-	// Clean up worktree (best-effort)
-	r.removeWorktree(worktreePath, vessel.ID)
-
-	// Report completion
-	issueNum := r.parseIssueNum(vessel)
-	if issueNum > 0 && r.Reporter != nil {
-		r.Reporter.VesselCompleted(ctx, issueNum, phaseResults)
-	}
-
-	return "completed"
+	return r.completeVessel(ctx, vessel, worktreePath, phaseResults)
 }
 
 // runPromptOnly handles vessels with a prompt but no workflow.
@@ -494,6 +492,27 @@ func (r *Runner) failVessel(id string, errMsg string) {
 	if updateErr := r.Queue.Update(id, queue.StateFailed, errMsg); updateErr != nil {
 		log.Printf("warn: failed to update vessel %s state: %v", id, updateErr)
 	}
+}
+
+func (r *Runner) completeVessel(ctx context.Context, vessel queue.Vessel, worktreePath string, phaseResults []reporter.PhaseResult) string {
+	if updateErr := r.Queue.Update(vessel.ID, queue.StateCompleted, ""); updateErr != nil {
+		log.Printf("warn: failed to update vessel %s state: %v", vessel.ID, updateErr)
+	}
+
+	// Clean up worktree (best-effort)
+	r.removeWorktree(worktreePath, vessel.ID)
+
+	// Report completion
+	issueNum := r.parseIssueNum(vessel)
+	if issueNum > 0 && r.Reporter != nil {
+		r.Reporter.VesselCompleted(ctx, issueNum, phaseResults)
+	}
+
+	return "completed"
+}
+
+func phaseMatchedNoOp(p *workflow.Phase, output string) bool {
+	return p != nil && p.NoOp != nil && strings.Contains(output, p.NoOp.Match)
 }
 
 func (r *Runner) loadWorkflow(name string) (*workflow.Workflow, error) {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
-	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 )
 
 // --- Mock types ---
@@ -88,8 +88,8 @@ type mockExitError struct {
 	code int
 }
 
-func (e *mockExitError) Error() string    { return fmt.Sprintf("exit status %d", e.code) }
-func (e *mockExitError) ExitCode() int    { return e.code }
+func (e *mockExitError) Error() string { return fmt.Sprintf("exit status %d", e.code) }
+func (e *mockExitError) ExitCode() int { return e.code }
 
 type countingCmdRunner struct {
 	concurrent int32
@@ -199,22 +199,22 @@ func makeTestConfig(dir string, concurrency int) *config.Config {
 
 func makeVessel(num int, workflow string) queue.Vessel {
 	return queue.Vessel{
-		ID:     fmt.Sprintf("issue-%d", num),
-		Source: "github-issue",
-		Ref:    fmt.Sprintf("https://github.com/owner/repo/issues/%d", num),
+		ID:        fmt.Sprintf("issue-%d", num),
+		Source:    "github-issue",
+		Ref:       fmt.Sprintf("https://github.com/owner/repo/issues/%d", num),
 		Workflow:  workflow,
-		Meta:   map[string]string{"issue_num": strconv.Itoa(num)},
-		State:  queue.StatePending,
+		Meta:      map[string]string{"issue_num": strconv.Itoa(num)},
+		State:     queue.StatePending,
 		CreatedAt: time.Now().UTC(),
 	}
 }
 
 func makePromptVessel(num int, prompt string) queue.Vessel {
 	return queue.Vessel{
-		ID:     fmt.Sprintf("prompt-%d", num),
-		Source: "manual",
-		Prompt: prompt,
-		State:  queue.StatePending,
+		ID:        fmt.Sprintf("prompt-%d", num),
+		Source:    "manual",
+		Prompt:    prompt,
+		State:     queue.StatePending,
 		CreatedAt: time.Now().UTC(),
 	}
 }
@@ -233,9 +233,9 @@ func TestBuildCommand(t *testing.T) {
 		},
 	}
 	vessel := &queue.Vessel{
-		Source: "github-issue",
-		Workflow:  "fix-bug",
-		Ref:    "https://github.com/owner/repo/issues/42",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Ref:      "https://github.com/owner/repo/issues/42",
 	}
 	cmd, args, err := buildCommand(cfg, vessel)
 	if err != nil {
@@ -271,6 +271,10 @@ func writeWorkflowFile(t *testing.T, dir, name string, phases []testPhase) {
 		phaseYAML.WriteString(fmt.Sprintf("  - name: %s\n", p.name))
 		phaseYAML.WriteString(fmt.Sprintf("    prompt_file: %s\n", promptPath))
 		phaseYAML.WriteString(fmt.Sprintf("    max_turns: %d\n", p.maxTurns))
+		if p.noopMatch != "" {
+			phaseYAML.WriteString("    noop:\n")
+			phaseYAML.WriteString(fmt.Sprintf("      match: %q\n", p.noopMatch))
+		}
 		if p.gate != "" {
 			phaseYAML.WriteString(fmt.Sprintf("    gate:\n%s\n", p.gate))
 		}
@@ -360,9 +364,9 @@ func TestBuildCommandWorkflowBased(t *testing.T) {
 		},
 	}
 	vessel := &queue.Vessel{
-		Source: "github-issue",
-		Workflow:  "fix-bug",
-		Ref:    "https://github.com/owner/repo/issues/42",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Ref:      "https://github.com/owner/repo/issues/42",
 	}
 	cmd, args, err := buildCommand(cfg, vessel)
 	if err != nil {
@@ -387,6 +391,7 @@ type testPhase struct {
 	name          string
 	promptContent string
 	maxTurns      int
+	noopMatch     string
 	gate          string
 	allowedTools  string
 }
@@ -485,6 +490,83 @@ func TestDrainMultiPhaseWorkflow(t *testing.T) {
 		if _, err := os.Stat(outputPath); os.IsNotExist(err) {
 			t.Errorf("expected output file %s to exist", outputPath)
 		}
+	}
+}
+
+func TestDrainPhaseNoOpCompletesWorkflowEarly(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fix-bug"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{
+			name:          "analyze",
+			promptContent: "Analyze: {{.Issue.Title}}",
+			maxTurns:      5,
+			noopMatch:     "XYLEM_NOOP",
+			gate:          "      type: command\n      run: \"make test\"",
+		},
+		{name: "implement", promptContent: "Implement", maxTurns: 10},
+		{name: "pr", promptContent: "Create PR", maxTurns: 3},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Analyze": []byte("Already fixed in main.\n\nXYLEM_NOOP\n"),
+		},
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Completed != 1 {
+		t.Fatalf("expected 1 completed, got %d", result.Completed)
+	}
+	if len(cmdRunner.phaseCalls) != 1 {
+		t.Fatalf("expected only the noop phase to run, got %d phase calls", len(cmdRunner.phaseCalls))
+	}
+	for _, args := range cmdRunner.outputArgs {
+		if strings.Contains(strings.Join(args, " "), "make test") {
+			t.Fatalf("expected noop to skip gate execution, got output args %v", cmdRunner.outputArgs)
+		}
+	}
+	if !wt.removeCalled {
+		t.Fatal("expected worktree cleanup after noop completion")
+	}
+
+	vessels, _ := q.List()
+	if vessels[0].State != queue.StateCompleted {
+		t.Fatalf("expected vessel completed, got %s", vessels[0].State)
+	}
+	if vessels[0].CurrentPhase != 1 {
+		t.Fatalf("expected CurrentPhase 1, got %d", vessels[0].CurrentPhase)
+	}
+	if len(vessels[0].PhaseOutputs) != 1 {
+		t.Fatalf("expected only one phase output, got %v", vessels[0].PhaseOutputs)
+	}
+	if _, ok := vessels[0].PhaseOutputs["analyze"]; !ok {
+		t.Fatalf("expected analyze output path to be persisted, got %v", vessels[0].PhaseOutputs)
+	}
+
+	analyzeOutputPath := filepath.Join(dir, ".xylem", "phases", "issue-1", "analyze.output")
+	if _, err := os.Stat(analyzeOutputPath); err != nil {
+		t.Fatalf("expected analyze output file to exist: %v", err)
+	}
+	implementOutputPath := filepath.Join(dir, ".xylem", "phases", "issue-1", "implement.output")
+	if _, err := os.Stat(implementOutputPath); !os.IsNotExist(err) {
+		t.Fatalf("expected implement output file not to exist, got err=%v", err)
 	}
 }
 
@@ -1093,7 +1175,7 @@ func TestDrainPreviousOutputsAvailable(t *testing.T) {
 
 func TestBranchPrefixSelection(t *testing.T) {
 	tests := []struct {
-		workflow      string
+		workflow   string
 		wantPrefix string
 	}{
 		{"fix-bug", "fix"},
@@ -1150,9 +1232,9 @@ func TestBuildCommandWithFlags(t *testing.T) {
 		},
 	}
 	vessel := &queue.Vessel{
-		Source: "github-issue",
-		Workflow:  "fix-bug",
-		Ref:    "https://github.com/owner/repo/issues/42",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Ref:      "https://github.com/owner/repo/issues/42",
 	}
 	_, args, err := buildCommand(cfg, vessel)
 	if err != nil {

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -30,13 +30,19 @@ type Phase struct {
 	PromptFile   string  `yaml:"prompt_file"`
 	MaxTurns     int     `yaml:"max_turns"`
 	Model        *string `yaml:"model,omitempty"`
+	NoOp         *NoOp   `yaml:"noop,omitempty"`
 	Gate         *Gate   `yaml:"gate,omitempty"`
 	AllowedTools *string `yaml:"allowed_tools,omitempty"`
 }
 
+// NoOp defines an early-success completion rule for a phase.
+type NoOp struct {
+	Match string `yaml:"match"`
+}
+
 // Gate defines an inter-phase quality gate that must pass before the next phase begins.
 type Gate struct {
-	Type         string `yaml:"type"`                   // "command" or "label"
+	Type         string `yaml:"type"`                    // "command" or "label"
 	Run          string `yaml:"run,omitempty"`           // shell command (type=command)
 	Retries      int    `yaml:"retries,omitempty"`       // default 0
 	RetryDelay   string `yaml:"retry_delay,omitempty"`   // default "10s"
@@ -115,11 +121,24 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 			}
 		}
 
+		if p.NoOp != nil {
+			if err := validateNoOp(p.Name, p.NoOp); err != nil {
+				return err
+			}
+		}
+
 		if p.AllowedTools != nil && *p.AllowedTools == "" {
 			return fmt.Errorf("phase %q: allowed_tools must not be empty when specified", p.Name)
 		}
 	}
 
+	return nil
+}
+
+func validateNoOp(phaseName string, n *NoOp) error {
+	if strings.TrimSpace(n.Match) == "" {
+		return fmt.Errorf("phase %q: noop: match is required", phaseName)
+	}
 	return nil
 }
 

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -58,15 +58,15 @@ func chdirTemp(t *testing.T, dir string) {
 
 func TestLoad(t *testing.T) {
 	tests := []struct {
-		name      string
+		name         string
 		workflowName string // filename stem; defaults to "fix-bug"
-		yaml      string
-		prompts   []string // prompt files to create relative to repo root (cwd)
-		wantErr   string   // empty means no error expected
-		checkFunc func(t *testing.T, s *Workflow)
+		yaml         string
+		prompts      []string // prompt files to create relative to repo root (cwd)
+		wantErr      string   // empty means no error expected
+		checkFunc    func(t *testing.T, s *Workflow)
 	}{
 		{
-			name:      "valid workflow file",
+			name:         "valid workflow file",
 			workflowName: "fix-bug",
 			yaml: `name: fix-bug
 description: Fix a bug
@@ -99,7 +99,7 @@ phases:
 			},
 		},
 		{
-			name:      "valid workflow with all features",
+			name:         "valid workflow with all features",
 			workflowName: "deploy",
 			yaml: `name: deploy
 description: Deploy with gates
@@ -172,13 +172,13 @@ phases:
 			},
 		},
 		{
-			name:      "missing phases key",
+			name:         "missing phases key",
 			workflowName: "test-workflow",
-			yaml:      "name: test-workflow\n",
-			wantErr:   `"phases" is required`,
+			yaml:         "name: test-workflow\n",
+			wantErr:      `"phases" is required`,
 		},
 		{
-			name:      "empty name",
+			name:         "empty name",
 			workflowName: "test-workflow",
 			yaml: `phases:
   - name: analyze
@@ -189,7 +189,7 @@ phases:
 			wantErr: `"name" is required`,
 		},
 		{
-			name:      "duplicate phase names",
+			name:         "duplicate phase names",
 			workflowName: "test-workflow",
 			yaml: `name: test-workflow
 phases:
@@ -204,7 +204,7 @@ phases:
 			wantErr: `duplicate phase name "implement"`,
 		},
 		{
-			name:      "missing prompt_file",
+			name:         "missing prompt_file",
 			workflowName: "test-workflow",
 			yaml: `name: test-workflow
 phases:
@@ -214,7 +214,7 @@ phases:
 			wantErr: "prompt_file is required",
 		},
 		{
-			name:      "non-existent prompt_file",
+			name:         "non-existent prompt_file",
 			workflowName: "test-workflow",
 			yaml: `name: test-workflow
 phases:
@@ -225,7 +225,7 @@ phases:
 			wantErr: "prompt_file not found: prompts/missing.md",
 		},
 		{
-			name:      "invalid gate type",
+			name:         "invalid gate type",
 			workflowName: "test-workflow",
 			yaml: `name: test-workflow
 phases:
@@ -239,7 +239,7 @@ phases:
 			wantErr: `type must be "command" or "label"`,
 		},
 		{
-			name:      "command gate missing run",
+			name:         "command gate missing run",
 			workflowName: "test-workflow",
 			yaml: `name: test-workflow
 phases:
@@ -253,7 +253,7 @@ phases:
 			wantErr: "run is required for command gate",
 		},
 		{
-			name:      "label gate missing wait_for",
+			name:         "label gate missing wait_for",
 			workflowName: "test-workflow",
 			yaml: `name: test-workflow
 phases:
@@ -267,7 +267,7 @@ phases:
 			wantErr: "wait_for is required for label gate",
 		},
 		{
-			name:      "invalid duration string",
+			name:         "invalid duration string",
 			workflowName: "test-workflow",
 			yaml: `name: test-workflow
 phases:
@@ -283,7 +283,7 @@ phases:
 			wantErr: `invalid retry_delay "not-a-duration"`,
 		},
 		{
-			name:      "max_turns zero",
+			name:         "max_turns zero",
 			workflowName: "test-workflow",
 			yaml: `name: test-workflow
 phases:
@@ -295,7 +295,7 @@ phases:
 			wantErr: "max_turns must be greater than 0",
 		},
 		{
-			name:      "allowed_tools empty string",
+			name:         "allowed_tools empty string",
 			workflowName: "test-workflow",
 			yaml: `name: test-workflow
 phases:
@@ -308,7 +308,7 @@ phases:
 			wantErr: "allowed_tools must not be empty when specified",
 		},
 		{
-			name:      "name does not match filename",
+			name:         "name does not match filename",
 			workflowName: "fix-bug",
 			yaml: `name: wrong-name
 phases:
@@ -370,16 +370,60 @@ func TestLoadMalformedYAML(t *testing.T) {
 	}
 }
 
+func TestLoadWorkflowWithNoOp(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "fix-bug", `name: fix-bug
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+    noop:
+      match: XYLEM_NOOP
+`)
+
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wf.Phases[0].NoOp == nil {
+		t.Fatal("expected noop config to be loaded")
+	}
+	if wf.Phases[0].NoOp.Match != "XYLEM_NOOP" {
+		t.Fatalf("expected noop match XYLEM_NOOP, got %q", wf.Phases[0].NoOp.Match)
+	}
+}
+
+func TestLoadWorkflowNoOpRequiresMatch(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "fix-bug", `name: fix-bug
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+    noop:
+      match: ""
+`)
+
+	_, err := Load(path)
+	requireErrorContains(t, err, `phase "analyze": noop: match is required`)
+}
+
 func TestValidate(t *testing.T) {
 	tests := []struct {
-		name          string
+		name             string
 		workflowFileName string // filename stem for the workflow file (used for name validation)
-		wf         Workflow
-		prompts       []string // prompt files to create relative to cwd
-		wantErr       string
+		wf               Workflow
+		prompts          []string // prompt files to create relative to cwd
+		wantErr          string
 	}{
 		{
-			name:          "valid minimal workflow",
+			name:             "valid minimal workflow",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -390,7 +434,7 @@ func TestValidate(t *testing.T) {
 			prompts: []string{"prompt.md"},
 		},
 		{
-			name:          "empty name",
+			name:             "empty name",
 			workflowFileName: "test",
 			wf: Workflow{
 				Phases: []Phase{
@@ -401,7 +445,7 @@ func TestValidate(t *testing.T) {
 			wantErr: `"name" is required`,
 		},
 		{
-			name:          "no phases",
+			name:             "no phases",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -409,7 +453,7 @@ func TestValidate(t *testing.T) {
 			wantErr: `"phases" is required`,
 		},
 		{
-			name:          "phase with empty name",
+			name:             "phase with empty name",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -421,7 +465,7 @@ func TestValidate(t *testing.T) {
 			wantErr: "each phase must have a non-empty name",
 		},
 		{
-			name:          "duplicate phase names",
+			name:             "duplicate phase names",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -434,7 +478,7 @@ func TestValidate(t *testing.T) {
 			wantErr: `duplicate phase name "build"`,
 		},
 		{
-			name:          "missing prompt_file value",
+			name:             "missing prompt_file value",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -445,7 +489,7 @@ func TestValidate(t *testing.T) {
 			wantErr: "prompt_file is required",
 		},
 		{
-			name:          "non-existent prompt_file",
+			name:             "non-existent prompt_file",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -456,7 +500,7 @@ func TestValidate(t *testing.T) {
 			wantErr: "prompt_file not found: does-not-exist.md",
 		},
 		{
-			name:          "max_turns zero",
+			name:             "max_turns zero",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -468,7 +512,7 @@ func TestValidate(t *testing.T) {
 			wantErr: "max_turns must be greater than 0",
 		},
 		{
-			name:          "max_turns negative",
+			name:             "max_turns negative",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -480,7 +524,7 @@ func TestValidate(t *testing.T) {
 			wantErr: "max_turns must be greater than 0",
 		},
 		{
-			name:          "invalid gate type",
+			name:             "invalid gate type",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -495,7 +539,7 @@ func TestValidate(t *testing.T) {
 			wantErr: `type must be "command" or "label"`,
 		},
 		{
-			name:          "command gate missing run",
+			name:             "command gate missing run",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -510,7 +554,7 @@ func TestValidate(t *testing.T) {
 			wantErr: "run is required for command gate",
 		},
 		{
-			name:          "label gate missing wait_for",
+			name:             "label gate missing wait_for",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -525,7 +569,7 @@ func TestValidate(t *testing.T) {
 			wantErr: "wait_for is required for label gate",
 		},
 		{
-			name:          "invalid retry_delay duration",
+			name:             "invalid retry_delay duration",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -540,7 +584,7 @@ func TestValidate(t *testing.T) {
 			wantErr: `invalid retry_delay "bad"`,
 		},
 		{
-			name:          "invalid timeout duration",
+			name:             "invalid timeout duration",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -555,7 +599,7 @@ func TestValidate(t *testing.T) {
 			wantErr: `invalid timeout "forever"`,
 		},
 		{
-			name:          "invalid poll_interval duration",
+			name:             "invalid poll_interval duration",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -570,7 +614,7 @@ func TestValidate(t *testing.T) {
 			wantErr: `invalid poll_interval "nope"`,
 		},
 		{
-			name:          "allowed_tools empty string",
+			name:             "allowed_tools empty string",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -582,7 +626,7 @@ func TestValidate(t *testing.T) {
 			wantErr: "allowed_tools must not be empty when specified",
 		},
 		{
-			name:          "allowed_tools nil is valid",
+			name:             "allowed_tools nil is valid",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -593,7 +637,7 @@ func TestValidate(t *testing.T) {
 			prompts: []string{"prompt.md"},
 		},
 		{
-			name:          "allowed_tools with value is valid",
+			name:             "allowed_tools with value is valid",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -604,7 +648,7 @@ func TestValidate(t *testing.T) {
 			prompts: []string{"prompt.md"},
 		},
 		{
-			name:          "valid command gate with all fields",
+			name:             "valid command gate with all fields",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -623,7 +667,7 @@ func TestValidate(t *testing.T) {
 			prompts: []string{"prompt.md"},
 		},
 		{
-			name:          "valid label gate with all fields",
+			name:             "valid label gate with all fields",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -642,7 +686,7 @@ func TestValidate(t *testing.T) {
 			prompts: []string{"prompt.md"},
 		},
 		{
-			name:          "name does not match filename",
+			name:             "name does not match filename",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "wrong-name",
@@ -654,7 +698,7 @@ func TestValidate(t *testing.T) {
 			wantErr: `workflow name "wrong-name" does not match filename "test.yaml"`,
 		},
 		{
-			name:          "phase name with hyphens is rejected",
+			name:             "phase name with hyphens is rejected",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -666,7 +710,7 @@ func TestValidate(t *testing.T) {
 			wantErr: `phase name "create-issues" is invalid; must start with a lowercase letter and contain only lowercase letters, digits, and underscores`,
 		},
 		{
-			name:          "phase name with uppercase is rejected",
+			name:             "phase name with uppercase is rejected",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -678,7 +722,7 @@ func TestValidate(t *testing.T) {
 			wantErr: `phase name "CreateIssues" is invalid`,
 		},
 		{
-			name:          "phase name with underscores is accepted",
+			name:             "phase name with underscores is accepted",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -689,7 +733,7 @@ func TestValidate(t *testing.T) {
 			prompts: []string{"prompt.md"},
 		},
 		{
-			name:          "phase name starting with digit is rejected",
+			name:             "phase name starting with digit is rejected",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",
@@ -701,7 +745,7 @@ func TestValidate(t *testing.T) {
 			wantErr: `phase name "2step" is invalid`,
 		},
 		{
-			name:          "phase name with digits is accepted",
+			name:             "phase name with digits is accepted",
 			workflowFileName: "test",
 			wf: Workflow{
 				Name: "test",

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -47,6 +47,8 @@ phases:
   - name: analyze                                  # Unique name within this workflow
     prompt_file: .xylem/prompts/fix-bug/analyze.md # Path to the Go template file
     max_turns: 5                                   # Max Claude turns for this phase
+    noop:                                          # Optional early-success completion rule
+      match: XYLEM_NOOP                            # Complete the workflow if phase output contains this marker
 
   - name: plan
     prompt_file: .xylem/prompts/fix-bug/plan.md
@@ -84,8 +86,15 @@ phases:
 | `name` | Yes | Unique name within the workflow. Used to key previous outputs in templates. |
 | `prompt_file` | Yes | Path to the prompt template file, relative to the repo root. |
 | `max_turns` | Yes | Maximum number of Claude turns for this phase. Must be greater than 0. |
+| `noop` | No | Early-success completion rule checked against the phase output before any gate runs. |
 | `allowed_tools` | No | Comma-separated list of tools Claude can use in this phase. |
 | `gate` | No | Quality gate that must pass after this phase completes. |
+
+**No-op fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `match` | Yes | Substring marker that, when present in successful phase output, completes the workflow early. |
 
 **Gate fields (when `type: command`):**
 
@@ -116,11 +125,14 @@ A phase is a single step within a workflow, executed as its own Claude Code sess
 3. The rendered prompt is piped to `claude -p` via stdin, launching a new Claude session in the worktree directory.
 4. Claude runs for up to `max_turns` turns.
 5. The session output is captured and persisted to `.xylem/phases/<vessel-id>/`.
-6. If the phase has a gate, the gate is evaluated. If it fails and retries remain, the phase re-executes with the gate failure output injected into the template via `{{.GateResult}}`.
+6. If the phase has a `noop` rule and the successful phase output contains `noop.match`, the vessel is marked `completed`, remaining phases are skipped, and no gate is evaluated for that phase.
+7. Otherwise, if the phase has a gate, the gate is evaluated. If it fails and retries remain, the phase re-executes with the gate failure output injected into the template via `{{.GateResult}}`.
 
 ### Output persistence
 
 Each phase's output is saved to disk under `.xylem/phases/<vessel-id>/`. These outputs are then available to subsequent phases via `{{.PreviousOutputs.<phase-name>}}` in their prompt templates.
+
+No-op-triggering outputs are persisted the same way, so you can inspect exactly why the workflow stopped early.
 
 ### Turn limits
 


### PR DESCRIPTION
## Summary
- add phase-level noop.match workflow config for early successful completion
- complete vessels early in the runner when a phase output matches the configured marker
- update reporting, docs, and tests for the new no-op behavior

## Testing
- cd cli && go test ./...
