### PR TITLE
feat: add command/script phase type for workflows

### DIFF
--- a/cli/internal/gate/gate.go
+++ b/cli/internal/gate/gate.go
@@ -32,6 +32,13 @@ func RunCommandGate(ctx context.Context, r Runner, dir string, command string) (
 	return string(output), true, nil
 }
 
+// RunCommand executes a shell command in the given directory and returns its
+// output. Unlike RunCommandGate, a non-zero exit code IS returned as an error.
+func RunCommand(ctx context.Context, r Runner, dir string, command string) (string, error) {
+	output, err := r.RunOutput(ctx, "sh", "-c", fmt.Sprintf("cd %s && %s", shellQuote(dir), command))
+	return string(output), err
+}
+
 // ghLabelsResponse is the JSON shape returned by `gh issue view --json labels`.
 type ghLabelsResponse struct {
 	Labels []struct {

--- a/cli/internal/gate/gate_test.go
+++ b/cli/internal/gate/gate_test.go
@@ -83,6 +83,33 @@ func TestRunCommandGateShellQuotesDir(t *testing.T) {
 	}
 }
 
+// --- RunCommand tests ---
+
+func TestRunCommandSuccess(t *testing.T) {
+	r := &mockRunner{output: []byte("build ok\n")}
+	out, err := RunCommand(context.Background(), r, "/tmp/work", "make build")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "build ok\n" {
+		t.Errorf("expected output %q, got %q", "build ok\n", out)
+	}
+}
+
+func TestRunCommandNonZeroExit(t *testing.T) {
+	r := &mockRunner{
+		output: []byte("error: compilation failed\n"),
+		err:    &exitError{code: 1},
+	}
+	out, err := RunCommand(context.Background(), r, "/tmp/work", "make build")
+	if err == nil {
+		t.Fatal("expected error for non-zero exit, got nil")
+	}
+	if out != "error: compilation failed\n" {
+		t.Errorf("expected output %q, got %q", "error: compilation failed\n", out)
+	}
+}
+
 // --- CheckLabel tests ---
 
 func TestCheckLabelPresent(t *testing.T) {

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -259,34 +259,43 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 				},
 			}
 
-			// Read prompt template
-			promptContent, err := os.ReadFile(p.PromptFile)
-			if err != nil {
-				r.failVessel(vessel.ID, fmt.Sprintf("read prompt file %s: %v", p.PromptFile, err))
-				return "failed"
-			}
-
-			// Render prompt
-			rendered, err := phase.RenderPrompt(string(promptContent), td)
-			if err != nil {
-				r.failVessel(vessel.ID, fmt.Sprintf("render prompt for phase %s: %v", p.Name, err))
-				return "failed"
-			}
-
-			// Write prompt to file for debugging
 			phasesDir := filepath.Join(r.Config.StateDir, "phases", vessel.ID)
 			os.MkdirAll(phasesDir, 0o755)
-			promptPath := filepath.Join(phasesDir, p.Name+".prompt")
-			if wErr := os.WriteFile(promptPath, []byte(rendered), 0o644); wErr != nil {
-				log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
+
+			var output []byte
+			var runErr error
+
+			if p.Type == "command" {
+				rendered, err := phase.RenderPrompt(p.Run, td)
+				if err != nil {
+					r.failVessel(vessel.ID, fmt.Sprintf("render command for phase %s: %v", p.Name, err))
+					return "failed"
+				}
+				if wErr := os.WriteFile(filepath.Join(phasesDir, p.Name+".command"), []byte(rendered), 0o644); wErr != nil {
+					log.Printf("warn: write command file: %v", wErr)
+				}
+				cmdOut, cmdErr := gate.RunCommand(ctx, r.Runner, worktreePath, rendered)
+				output = []byte(cmdOut)
+				runErr = cmdErr
+			} else {
+				promptContent, err := os.ReadFile(p.PromptFile)
+				if err != nil {
+					r.failVessel(vessel.ID, fmt.Sprintf("read prompt file %s: %v", p.PromptFile, err))
+					return "failed"
+				}
+				rendered, err := phase.RenderPrompt(string(promptContent), td)
+				if err != nil {
+					r.failVessel(vessel.ID, fmt.Sprintf("render prompt for phase %s: %v", p.Name, err))
+					return "failed"
+				}
+				promptPath := filepath.Join(phasesDir, p.Name+".prompt")
+				if wErr := os.WriteFile(promptPath, []byte(rendered), 0o644); wErr != nil {
+					log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
+				}
+				provider := resolveProvider(r.Config, sk, &p)
+				cmd, args := buildProviderPhaseArgs(r.Config, sk, &p, harnessContent, provider)
+				output, runErr = r.Runner.RunPhase(ctx, worktreePath, strings.NewReader(rendered), cmd, args...)
 			}
-
-			// Resolve provider and build args
-			provider := resolveProvider(r.Config, sk, &p)
-			cmd, args := buildProviderPhaseArgs(r.Config, sk, &p, harnessContent, provider)
-
-			// Run phase via stdin
-			output, runErr := r.Runner.RunPhase(ctx, worktreePath, strings.NewReader(rendered), cmd, args...)
 
 			// Write phase output
 			outputPath := filepath.Join(phasesDir, p.Name+".output")

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -281,13 +281,19 @@ func writeWorkflowFile(t *testing.T, dir, name string, phases []testPhase) {
 
 	var phaseYAML strings.Builder
 	for _, p := range phases {
-		promptPath := filepath.Join(dir, ".xylem", "prompts", name, p.name+".md")
-		os.MkdirAll(filepath.Dir(promptPath), 0o755)
-		os.WriteFile(promptPath, []byte(p.promptContent), 0o644)
-
 		phaseYAML.WriteString(fmt.Sprintf("  - name: %s\n", p.name))
-		phaseYAML.WriteString(fmt.Sprintf("    prompt_file: %s\n", promptPath))
-		phaseYAML.WriteString(fmt.Sprintf("    max_turns: %d\n", p.maxTurns))
+
+		if p.phaseType == "command" {
+			phaseYAML.WriteString("    type: command\n")
+			phaseYAML.WriteString(fmt.Sprintf("    run: %q\n", p.run))
+		} else {
+			promptPath := filepath.Join(dir, ".xylem", "prompts", name, p.name+".md")
+			os.MkdirAll(filepath.Dir(promptPath), 0o755)
+			os.WriteFile(promptPath, []byte(p.promptContent), 0o644)
+			phaseYAML.WriteString(fmt.Sprintf("    prompt_file: %s\n", promptPath))
+			phaseYAML.WriteString(fmt.Sprintf("    max_turns: %d\n", p.maxTurns))
+		}
+
 		if p.noopMatch != "" {
 			phaseYAML.WriteString("    noop:\n")
 			phaseYAML.WriteString(fmt.Sprintf("      match: %q\n", p.noopMatch))
@@ -411,6 +417,8 @@ type testPhase struct {
 	noopMatch     string
 	gate          string
 	allowedTools  string
+	phaseType     string // "command" or empty for prompt
+	run           string // shell command for type=command
 }
 
 // --- Tests ---
@@ -1990,6 +1998,184 @@ func TestBuildPromptOnlyCmdArgsHeadlessDedup(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected --verbose in args, got: %v", args)
+	}
+}
+
+func TestDrainCommandPhase(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fix-bug"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{name: "build", phaseType: "command", run: "go build ./..."},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{
+		gateOutput: []byte("build succeeded\n"),
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Completed != 1 {
+		t.Errorf("expected 1 completed, got %d", result.Completed)
+	}
+
+	vessels, _ := q.List()
+	if vessels[0].State != queue.StateCompleted {
+		t.Errorf("expected vessel completed, got %s", vessels[0].State)
+	}
+
+	// Verify output file was written
+	outputPath := filepath.Join(dir, ".xylem", "phases", "issue-1", "build.output")
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
+		t.Errorf("expected output file %s to exist", outputPath)
+	}
+
+	// Verify command file was written
+	commandPath := filepath.Join(dir, ".xylem", "phases", "issue-1", "build.command")
+	if _, err := os.Stat(commandPath); os.IsNotExist(err) {
+		t.Errorf("expected command file %s to exist", commandPath)
+	}
+}
+
+func TestDrainCommandPhaseFailure(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fix-bug"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{name: "build", phaseType: "command", run: "go build ./..."},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{
+		gateOutput: []byte("build failed\n"),
+		gateErr:    errors.New("exit status 1"),
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Failed != 1 {
+		t.Errorf("expected 1 failed, got %d", result.Failed)
+	}
+
+	vessels, _ := q.List()
+	if vessels[0].State != queue.StateFailed {
+		t.Errorf("expected vessel failed, got %s", vessels[0].State)
+	}
+}
+
+func TestDrainCommandPhaseWithGate(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fix-bug"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{
+			name: "build", phaseType: "command", run: "make build",
+			gate: "      type: command\n      run: \"make test\"",
+		},
+		{name: "pr", promptContent: "Create PR", maxTurns: 3},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{
+		gateOutput: []byte("all passed\n"),
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Completed != 1 {
+		t.Errorf("expected 1 completed, got %d", result.Completed)
+	}
+
+	// Command phase + LLM phase = 1 RunPhase call (only the pr phase uses RunPhase)
+	if len(cmdRunner.phaseCalls) != 1 {
+		t.Errorf("expected 1 RunPhase call (only LLM phase), got %d", len(cmdRunner.phaseCalls))
+	}
+}
+
+func TestDrainCommandPhaseWithNoOp(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fix-bug"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{
+			name: "check", phaseType: "command", run: "echo already done",
+			noopMatch: "XYLEM_NOOP",
+		},
+		{name: "implement", promptContent: "Implement", maxTurns: 10},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{
+		gateOutput: []byte("XYLEM_NOOP\n"),
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Completed != 1 {
+		t.Errorf("expected 1 completed, got %d", result.Completed)
+	}
+
+	// No RunPhase calls because the command phase triggers noop before the LLM phase
+	if len(cmdRunner.phaseCalls) != 0 {
+		t.Errorf("expected 0 RunPhase calls (noop before LLM phase), got %d", len(cmdRunner.phaseCalls))
+	}
+
+	vessels, _ := q.List()
+	if vessels[0].State != queue.StateCompleted {
+		t.Errorf("expected vessel completed, got %s", vessels[0].State)
 	}
 }
 

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -28,8 +28,10 @@ type Workflow struct {
 // Phase represents a single step in a workflow's execution pipeline.
 type Phase struct {
 	Name         string  `yaml:"name"`
+	Type         string  `yaml:"type,omitempty"`
 	PromptFile   string  `yaml:"prompt_file"`
 	MaxTurns     int     `yaml:"max_turns"`
+	Run          string  `yaml:"run,omitempty"`
 	LLM          *string `yaml:"llm,omitempty"`
 	Model        *string `yaml:"model,omitempty"`
 	NoOp         *NoOp   `yaml:"noop,omitempty"`
@@ -109,16 +111,23 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 			return fmt.Errorf("phase name %q is invalid; must start with a lowercase letter and contain only lowercase letters, digits, and underscores", p.Name)
 		}
 
-		if p.PromptFile == "" {
-			return fmt.Errorf("phase %q: prompt_file is required", p.Name)
-		}
-
-		if _, err := os.Stat(p.PromptFile); err != nil {
-			return fmt.Errorf("phase %q: prompt_file not found: %s", p.Name, p.PromptFile)
-		}
-
-		if p.MaxTurns <= 0 {
-			return fmt.Errorf("phase %q: max_turns must be greater than 0", p.Name)
+		switch p.Type {
+		case "", "prompt":
+			if p.PromptFile == "" {
+				return fmt.Errorf("phase %q: prompt_file is required", p.Name)
+			}
+			if _, err := os.Stat(p.PromptFile); err != nil {
+				return fmt.Errorf("phase %q: prompt_file not found: %s", p.Name, p.PromptFile)
+			}
+			if p.MaxTurns <= 0 {
+				return fmt.Errorf("phase %q: max_turns must be greater than 0", p.Name)
+			}
+		case "command":
+			if strings.TrimSpace(p.Run) == "" {
+				return fmt.Errorf("phase %q: run is required for command phase", p.Name)
+			}
+		default:
+			return fmt.Errorf("phase %q: type must be \"prompt\" or \"command\", got %q", p.Name, p.Type)
 		}
 
 		if p.Gate != nil {

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -283,6 +283,45 @@ phases:
 			wantErr: `invalid retry_delay "not-a-duration"`,
 		},
 		{
+			name:         "command phase valid via yaml",
+			workflowName: "test-workflow",
+			yaml: `name: test-workflow
+phases:
+  - name: build
+    type: command
+    run: "go build ./..."
+`,
+			checkFunc: func(t *testing.T, s *Workflow) {
+				t.Helper()
+				if s.Phases[0].Type != "command" {
+					t.Fatalf("Type = %q, want command", s.Phases[0].Type)
+				}
+				if s.Phases[0].Run != "go build ./..." {
+					t.Fatalf("Run = %q, want 'go build ./...'", s.Phases[0].Run)
+				}
+			},
+		},
+		{
+			name:         "command phase missing run via yaml",
+			workflowName: "test-workflow",
+			yaml: `name: test-workflow
+phases:
+  - name: build
+    type: command
+`,
+			wantErr: "run is required for command phase",
+		},
+		{
+			name:         "unknown phase type via yaml",
+			workflowName: "test-workflow",
+			yaml: `name: test-workflow
+phases:
+  - name: notify
+    type: webhook
+`,
+			wantErr: "type must be",
+		},
+		{
 			name:         "max_turns zero",
 			workflowName: "test-workflow",
 			yaml: `name: test-workflow
@@ -751,6 +790,73 @@ func TestValidate(t *testing.T) {
 				Name: "test",
 				Phases: []Phase{
 					{Name: "step2", PromptFile: "prompt.md", MaxTurns: 5},
+				},
+			},
+			prompts: []string{"prompt.md"},
+		},
+		{
+			name:             "command phase valid",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "build", Type: "command", Run: "go build ./..."},
+				},
+			},
+		},
+		{
+			name:             "command phase missing run",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "build", Type: "command"},
+				},
+			},
+			wantErr: "run is required for command phase",
+		},
+		{
+			name:             "command phase empty run",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "build", Type: "command", Run: "   "},
+				},
+			},
+			wantErr: "run is required for command phase",
+		},
+		{
+			name:             "unknown phase type",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "notify", Type: "webhook"},
+				},
+			},
+			wantErr: "type must be",
+		},
+		{
+			name:             "command phase with gate",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{
+						Name: "build", Type: "command", Run: "make build",
+						Gate: &Gate{Type: "command", Run: "make test"},
+					},
+				},
+			},
+		},
+		{
+			name:             "prompt phase default",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "step1", PromptFile: "prompt.md", MaxTurns: 5},
 				},
 			},
 			prompts: []string{"prompt.md"},


### PR DESCRIPTION
## Summary
- Add `type` and `run` fields to `Phase` struct, supporting `"command"` phases that execute shell commands instead of invoking an LLM
- Command phases support template variables, gates, no-op detection, and output persistence just like prompt phases
- Add `gate.RunCommand` function (unlike `RunCommandGate`, non-zero exit IS an error)
- Runner conditionally branches between command execution and LLM invocation based on phase type

## Test plan
- [x] `TestValidate` table: command phase valid, missing run, empty run, unknown type, command phase with gate, prompt phase default
- [x] `TestLoad` table: command phase valid via YAML, missing run via YAML, unknown type via YAML
- [x] `TestRunCommandSuccess` and `TestRunCommandNonZeroExit` for `gate.RunCommand`
- [x] `TestDrainCommandPhase` -- command phase executes and completes
- [x] `TestDrainCommandPhaseFailure` -- non-zero exit fails the vessel
- [x] `TestDrainCommandPhaseWithGate` -- command phase + gate + LLM phase works end-to-end
- [x] `TestDrainCommandPhaseWithNoOp` -- command phase output triggers no-op early completion
- [x] All existing tests pass (`go test ./...` -- 22 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)