### PR TITLE
feat: add github-pr-events and github-merge source types

### DIFF
--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -63,8 +63,8 @@ func buildSourceMap(cfg *config.Config, q *queue.Queue, cmdRunner source.Command
 			tasks := make(map[string]source.GitHubTask, len(srcCfg.Tasks))
 			for name, t := range srcCfg.Tasks {
 				tasks[name] = source.GitHubTask{
-					Labels: t.Labels,
-					Workflow:  t.Workflow,
+					Labels:   t.Labels,
+					Workflow: t.Workflow,
 				}
 			}
 			gh := &source.GitHub{
@@ -76,15 +76,68 @@ func buildSourceMap(cfg *config.Config, q *queue.Queue, cmdRunner source.Command
 			}
 			sources[gh.Name()] = gh
 		}
+		if srcCfg.Type == "github-pr" {
+			tasks := make(map[string]source.GitHubTask, len(srcCfg.Tasks))
+			for name, t := range srcCfg.Tasks {
+				tasks[name] = source.GitHubTask{
+					Labels:   t.Labels,
+					Workflow: t.Workflow,
+				}
+			}
+			pr := &source.GitHubPR{
+				Repo:      srcCfg.Repo,
+				Tasks:     tasks,
+				Exclude:   srcCfg.Exclude,
+				Queue:     q,
+				CmdRunner: cmdRunner,
+			}
+			sources[pr.Name()] = pr
+		}
+		if srcCfg.Type == "github-pr-events" {
+			prEventsTasks := make(map[string]source.PREventsTask, len(srcCfg.Tasks))
+			for name, t := range srcCfg.Tasks {
+				pet := source.PREventsTask{Workflow: t.Workflow}
+				if t.On != nil {
+					pet.Labels = t.On.Labels
+					pet.ReviewSubmitted = t.On.ReviewSubmitted
+					pet.ChecksFailed = t.On.ChecksFailed
+					pet.Commented = t.On.Commented
+				}
+				prEventsTasks[name] = pet
+			}
+			pre := &source.GitHubPREvents{
+				Repo:      srcCfg.Repo,
+				Tasks:     prEventsTasks,
+				Exclude:   srcCfg.Exclude,
+				Queue:     q,
+				CmdRunner: cmdRunner,
+			}
+			sources[pre.Name()] = pre
+		}
+		if srcCfg.Type == "github-merge" {
+			mergeTasks := make(map[string]source.MergeTask, len(srcCfg.Tasks))
+			for name, t := range srcCfg.Tasks {
+				mergeTasks[name] = source.MergeTask{Workflow: t.Workflow}
+			}
+			m := &source.GitHubMerge{
+				Repo:      srcCfg.Repo,
+				Tasks:     mergeTasks,
+				Queue:     q,
+				CmdRunner: cmdRunner,
+			}
+			sources[m.Name()] = m
+		}
 	}
 	return sources
 }
 
 func buildReporter(cfg *config.Config, cmdRunner reporter.Runner) *reporter.Reporter {
-	// Find the first GitHub source repo for reporting
 	for _, srcCfg := range cfg.Sources {
-		if srcCfg.Type == "github" && srcCfg.Repo != "" {
-			return &reporter.Reporter{Runner: cmdRunner, Repo: srcCfg.Repo}
+		switch srcCfg.Type {
+		case "github", "github-pr", "github-pr-events", "github-merge":
+			if srcCfg.Repo != "" {
+				return &reporter.Reporter{Runner: cmdRunner, Repo: srcCfg.Repo}
+			}
 		}
 	}
 	return nil

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -35,9 +35,18 @@ type SourceConfig struct {
 	Tasks   map[string]Task `yaml:"tasks,omitempty"`
 }
 
+// PREventsConfig defines which PR events trigger a workflow.
+type PREventsConfig struct {
+	Labels          []string `yaml:"labels,omitempty"`
+	ReviewSubmitted bool     `yaml:"review_submitted,omitempty"`
+	ChecksFailed    bool     `yaml:"checks_failed,omitempty"`
+	Commented       bool     `yaml:"commented,omitempty"`
+}
+
 type Task struct {
-	Labels   []string `yaml:"labels,omitempty"`
-	Workflow string   `yaml:"workflow"`
+	Labels   []string        `yaml:"labels,omitempty"`
+	Workflow string          `yaml:"workflow"`
+	On       *PREventsConfig `yaml:"on,omitempty"`
 }
 
 type ClaudeConfig struct {
@@ -183,8 +192,18 @@ func (c *Config) Validate() error {
 			if err := validateGitHubSource(name, src); err != nil {
 				return err
 			}
+		case "github-pr-events":
+			if err := validateGitHubPREventsSource(name, src); err != nil {
+				return err
+			}
+		case "github-merge":
+			if err := validateGitHubMergeSource(name, src); err != nil {
+				return err
+			}
 		case "":
 			return fmt.Errorf("source %q must specify a type", name)
+		default:
+			return fmt.Errorf("source %q: unknown type %q", name, src.Type)
 		}
 	}
 
@@ -239,6 +258,52 @@ func validateGitHubSource(name string, src SourceConfig) error {
 		if len(task.Labels) == 0 {
 			return fmt.Errorf("source %q task %q: must include at least one labels entry", name, tname)
 		}
+		if strings.TrimSpace(task.Workflow) == "" {
+			return fmt.Errorf("source %q task %q: must include a workflow", name, tname)
+		}
+	}
+	return nil
+}
+
+func validateGitHubPREventsSource(name string, src SourceConfig) error {
+	repo := strings.TrimSpace(src.Repo)
+	if repo == "" {
+		return fmt.Errorf("source %q (github-pr-events): repo is required", name)
+	}
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return fmt.Errorf("source %q (github-pr-events): repo must be in owner/name format", name)
+	}
+	if len(src.Tasks) == 0 {
+		return fmt.Errorf("source %q (github-pr-events): at least one task is required", name)
+	}
+	for tname, task := range src.Tasks {
+		if strings.TrimSpace(task.Workflow) == "" {
+			return fmt.Errorf("source %q task %q: must include a workflow", name, tname)
+		}
+		if task.On == nil {
+			return fmt.Errorf("source %q task %q: on is required for github-pr-events source", name, tname)
+		}
+		if len(task.On.Labels) == 0 && !task.On.ReviewSubmitted && !task.On.ChecksFailed && !task.On.Commented {
+			return fmt.Errorf("source %q task %q: at least one trigger must be configured in on (labels, review_submitted, checks_failed, or commented)", name, tname)
+		}
+	}
+	return nil
+}
+
+func validateGitHubMergeSource(name string, src SourceConfig) error {
+	repo := strings.TrimSpace(src.Repo)
+	if repo == "" {
+		return fmt.Errorf("source %q (github-merge): repo is required", name)
+	}
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return fmt.Errorf("source %q (github-merge): repo must be in owner/name format", name)
+	}
+	if len(src.Tasks) == 0 {
+		return fmt.Errorf("source %q (github-merge): at least one task is required", name)
+	}
+	for tname, task := range src.Tasks {
 		if strings.TrimSpace(task.Workflow) == "" {
 			return fmt.Errorf("source %q task %q: must include a workflow", name, tname)
 		}

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -731,6 +731,235 @@ claude:
 	}
 }
 
+func TestValidateGitHubPREventsAllTriggers(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"respond": {
+						Workflow: "respond-to-pr",
+						On: &PREventsConfig{
+							Labels:          []string{"needs-response"},
+							ReviewSubmitted: true,
+							ChecksFailed:    true,
+							Commented:       true,
+						},
+					},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	if err != nil {
+		t.Fatalf("expected valid github-pr-events config, got: %v", err)
+	}
+}
+
+func TestValidateGitHubPREventsLabelsOnly(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"respond": {
+						Workflow: "respond-to-pr",
+						On: &PREventsConfig{
+							Labels: []string{"needs-response"},
+						},
+					},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	if err != nil {
+		t.Fatalf("expected valid github-pr-events config with labels only, got: %v", err)
+	}
+}
+
+func TestValidateGitHubPREventsNoOnConfig(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"respond": {
+						Workflow: "respond-to-pr",
+					},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "on is required for github-pr-events source")
+}
+
+func TestValidateGitHubPREventsEmptyOn(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"respond": {
+						Workflow: "respond-to-pr",
+						On:       &PREventsConfig{},
+					},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "at least one trigger must be configured")
+}
+
+func TestValidateGitHubPREventsMissingRepo(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "",
+				Tasks: map[string]Task{
+					"respond": {
+						Workflow: "respond-to-pr",
+						On:       &PREventsConfig{ReviewSubmitted: true},
+					},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "repo is required")
+}
+
+func TestValidateGitHubPREventsMissingWorkflow(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"respond": {
+						On: &PREventsConfig{ReviewSubmitted: true},
+					},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "must include a workflow")
+}
+
+func TestValidateGitHubMergeValid(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"merge": {
+				Type: "github-merge",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"post-merge": {Workflow: "post-merge-check"},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	if err != nil {
+		t.Fatalf("expected valid github-merge config, got: %v", err)
+	}
+}
+
+func TestValidateGitHubMergeMissingRepo(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"merge": {
+				Type: "github-merge",
+				Repo: "",
+				Tasks: map[string]Task{
+					"post-merge": {Workflow: "post-merge-check"},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "repo is required")
+}
+
+func TestValidateGitHubMergeMissingWorkflow(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"merge": {
+				Type: "github-merge",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"post-merge": {},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "must include a workflow")
+}
+
+func TestValidateUnknownSourceType(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"custom": {
+				Type: "gitlab",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"task": {Workflow: "fix-bug"},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "unknown type")
+}
+
 func TestLoadLLMAbsentDefaultsClaude(t *testing.T) {
 	path := writeConfigFile(t, `sources:
   github:

--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -354,6 +354,22 @@ func compactVessels(vessels []Vessel) ([]Vessel, int) {
 	return compacted, removed
 }
 
+// HasRefAny reports whether any vessel (in any state) has the given ref.
+// Unlike HasRef, this checks terminal states too, preventing re-processing
+// of already-handled events.
+func (q *Queue) HasRefAny(ref string) bool {
+	vessels, err := q.List()
+	if err != nil {
+		return false
+	}
+	for _, vessel := range vessels {
+		if vessel.Ref == ref {
+			return true
+		}
+	}
+	return false
+}
+
 func (q *Queue) HasRef(ref string) bool {
 	vessels, err := q.List()
 	if err != nil {

--- a/cli/internal/queue/queue_test.go
+++ b/cli/internal/queue/queue_test.go
@@ -277,6 +277,59 @@ func TestCancelNotFound(t *testing.T) {
 	}
 }
 
+func TestHasRefAny(t *testing.T) {
+	ref := "https://github.com/example/repo/issues/42"
+
+	// HasRefAny should find refs in all states, not just active ones.
+	tests := []struct {
+		name        string
+		transitions []VesselState
+		want        bool
+	}{
+		{"pending", nil, true},
+		{"running", []VesselState{StateRunning}, true},
+		{"waiting", []VesselState{StateRunning, StateWaiting}, true},
+		{"completed", []VesselState{StateRunning, StateCompleted}, true},
+		{"failed", []VesselState{StateRunning, StateFailed}, true},
+		{"cancelled", []VesselState{StateCancelled}, true},
+		{"timed_out", []VesselState{StateRunning, StateWaiting, StateTimedOut}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, _ := newTestQueue(t)
+			vessel := testVessel(42)
+			if _, err := q.Enqueue(vessel); err != nil {
+				t.Fatalf("enqueue: %v", err)
+			}
+			for _, s := range tt.transitions {
+				if err := q.Update(vessel.ID, s, ""); err != nil {
+					t.Fatalf("update to %s: %v", s, err)
+				}
+			}
+			got := q.HasRefAny(ref)
+			if got != tt.want {
+				t.Fatalf("HasRefAny(%q) = %v in state %s, want %v", ref, got, tt.name, tt.want)
+			}
+
+			// Contrast with HasRef for terminal states
+			hasRef := q.HasRef(ref)
+			switch tt.name {
+			case "completed", "failed", "cancelled", "timed_out":
+				if hasRef {
+					t.Fatalf("HasRef should return false for terminal state %s", tt.name)
+				}
+			}
+		})
+	}
+
+	// HasRefAny for unknown ref should return false
+	q, _ := newTestQueue(t)
+	if q.HasRefAny("https://github.com/example/repo/issues/999") {
+		t.Fatal("expected HasRefAny to be false for unknown ref")
+	}
+}
+
 func TestHasRef(t *testing.T) {
 	q, _ := newTestQueue(t)
 	if _, err := q.Enqueue(testVessel(42)); err != nil {

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -86,6 +86,23 @@ func (s *Scanner) buildSources() []source.Source {
 				Queue:     s.Queue,
 				CmdRunner: s.CmdRunner,
 			})
+		case "github-pr-events":
+			prEventsTasks := convertPREventsTasks(srcCfg.Tasks)
+			sources = append(sources, &source.GitHubPREvents{
+				Repo:      srcCfg.Repo,
+				Tasks:     prEventsTasks,
+				Exclude:   srcCfg.Exclude,
+				Queue:     s.Queue,
+				CmdRunner: s.CmdRunner,
+			})
+		case "github-merge":
+			mergeTasks := convertMergeTasks(srcCfg.Tasks)
+			sources = append(sources, &source.GitHubMerge{
+				Repo:      srcCfg.Repo,
+				Tasks:     mergeTasks,
+				Queue:     s.Queue,
+				CmdRunner: s.CmdRunner,
+			})
 		}
 	}
 	return sources
@@ -96,6 +113,33 @@ func convertTasks(cfgTasks map[string]config.Task) map[string]source.GitHubTask 
 	for name, t := range cfgTasks {
 		tasks[name] = source.GitHubTask{
 			Labels:   t.Labels,
+			Workflow: t.Workflow,
+		}
+	}
+	return tasks
+}
+
+func convertPREventsTasks(cfgTasks map[string]config.Task) map[string]source.PREventsTask {
+	tasks := make(map[string]source.PREventsTask, len(cfgTasks))
+	for name, t := range cfgTasks {
+		pet := source.PREventsTask{
+			Workflow: t.Workflow,
+		}
+		if t.On != nil {
+			pet.Labels = t.On.Labels
+			pet.ReviewSubmitted = t.On.ReviewSubmitted
+			pet.ChecksFailed = t.On.ChecksFailed
+			pet.Commented = t.On.Commented
+		}
+		tasks[name] = pet
+	}
+	return tasks
+}
+
+func convertMergeTasks(cfgTasks map[string]config.Task) map[string]source.MergeTask {
+	tasks := make(map[string]source.MergeTask, len(cfgTasks))
+	for name, t := range cfgTasks {
+		tasks[name] = source.MergeTask{
 			Workflow: t.Workflow,
 		}
 	}

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -503,3 +503,118 @@ func TestScanEmptyIssuesList(t *testing.T) {
 		t.Errorf("expected 0 added, got %d", result.Added)
 	}
 }
+
+// ghPR mirrors the GitHub PR JSON structure for test helpers.
+type ghPR struct {
+	Number      int    `json:"number"`
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+	HeadRefName string `json:"headRefName"`
+	Labels      []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+}
+
+func TestScanGitHubPREvents(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		StateDir:    dir,
+		Claude:      config.ClaudeConfig{Command: "claude"},
+		Sources: map[string]config.SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "owner/repo",
+				Tasks: map[string]config.Task{
+					"respond": {
+						Workflow: "respond-to-pr",
+						On: &config.PREventsConfig{
+							Labels: []string{"needs-response"},
+						},
+					},
+				},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "needs review", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix-bug",
+			Labels: []struct{ Name string `json:"name"` }{{Name: "needs-response"}}},
+	}
+	prData, _ := json.Marshal(prs)
+	r.set(prData, "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+
+	s := New(cfg, q, r)
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Added != 1 {
+		t.Errorf("expected 1 added, got %d", result.Added)
+	}
+	vessels, _ := q.List()
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel in queue, got %d", len(vessels))
+	}
+	if vessels[0].Source != "github-pr-events" {
+		t.Errorf("expected source github-pr-events, got %q", vessels[0].Source)
+	}
+}
+
+type ghMergedPR struct {
+	Number      int    `json:"number"`
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+	MergeCommit struct {
+		Oid string `json:"oid"`
+	} `json:"mergeCommit"`
+}
+
+func TestScanGitHubMerge(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		StateDir:    dir,
+		Claude:      config.ClaudeConfig{Command: "claude"},
+		Sources: map[string]config.SourceConfig{
+			"merge": {
+				Type: "github-merge",
+				Repo: "owner/repo",
+				Tasks: map[string]config.Task{
+					"post-merge": {Workflow: "post-merge-check"},
+				},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghMergedPR{
+		{Number: 10, Title: "merged fix", URL: "https://github.com/owner/repo/pull/10",
+			MergeCommit: struct{ Oid string `json:"oid"` }{Oid: "abc123def456"}},
+	}
+	prData, _ := json.Marshal(prs)
+	r.set(prData, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit", "--limit", "20")
+
+	s := New(cfg, q, r)
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Added != 1 {
+		t.Errorf("expected 1 added, got %d", result.Added)
+	}
+	vessels, _ := q.List()
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel in queue, got %d", len(vessels))
+	}
+	if vessels[0].Source != "github-merge" {
+		t.Errorf("expected source github-merge, got %q", vessels[0].Source)
+	}
+}

--- a/cli/internal/source/github_merge.go
+++ b/cli/internal/source/github_merge.go
@@ -1,0 +1,102 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+// MergeTask defines a workflow triggered by a merge.
+type MergeTask struct {
+	Workflow string
+}
+
+// GitHubMerge scans for recently merged pull requests.
+type GitHubMerge struct {
+	Repo      string
+	Tasks     map[string]MergeTask
+	Queue     *queue.Queue
+	CmdRunner CommandRunner
+}
+
+type ghMergedPR struct {
+	Number      int    `json:"number"`
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+	MergeCommit struct {
+		Oid string `json:"oid"`
+	} `json:"mergeCommit"`
+}
+
+func (g *GitHubMerge) Name() string { return "github-merge" }
+
+func (g *GitHubMerge) Scan(ctx context.Context) ([]queue.Vessel, error) {
+	out, err := g.CmdRunner.Run(ctx, "gh", "pr", "list",
+		"--repo", g.Repo,
+		"--state", "merged",
+		"--json", "number,title,url,mergeCommit",
+		"--limit", "20",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("gh pr list (merged): %w", err)
+	}
+
+	var prs []ghMergedPR
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("parse gh pr list output: %w", err)
+	}
+
+	var vessels []queue.Vessel
+	seen := make(map[int]bool)
+
+	for _, pr := range prs {
+		if seen[pr.Number] {
+			continue
+		}
+		seen[pr.Number] = true
+
+		// Use merge commit OID in ref to prevent re-processing after compaction
+		ref := fmt.Sprintf("%s#merge-%s", pr.URL, pr.MergeCommit.Oid)
+		if g.Queue.HasRefAny(ref) {
+			continue
+		}
+
+		for _, task := range g.Tasks {
+			vessels = append(vessels, queue.Vessel{
+				ID:       fmt.Sprintf("merge-%d-%s", pr.Number, shortMergeHash(pr.MergeCommit.Oid)),
+				Source:   "github-merge",
+				Ref:      ref,
+				Workflow: task.Workflow,
+				Meta: map[string]string{
+					"pr_num":       strconv.Itoa(pr.Number),
+					"merge_commit": pr.MergeCommit.Oid,
+				},
+				State:     queue.StatePending,
+				CreatedAt: time.Now().UTC(),
+			})
+		}
+	}
+	return vessels, nil
+}
+
+func (g *GitHubMerge) OnStart(ctx context.Context, vessel queue.Vessel) error {
+	return nil
+}
+
+func (g *GitHubMerge) BranchName(vessel queue.Vessel) string {
+	prNum := vessel.Meta["pr_num"]
+	slug := slugify(vessel.Ref)
+	return fmt.Sprintf("merge/pr-%s-%s", prNum, slug)
+}
+
+// shortMergeHash returns the first 8 characters of a commit SHA.
+func shortMergeHash(oid string) string {
+	if len(oid) > 8 {
+		return oid[:8]
+	}
+	return oid
+}

--- a/cli/internal/source/github_merge_test.go
+++ b/cli/internal/source/github_merge_test.go
@@ -1,0 +1,259 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+func mergedPRJSON(prs []ghMergedPR) []byte {
+	b, _ := json.Marshal(prs)
+	return b
+}
+
+func TestGitHubMergeScanFindsMergedPRs(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghMergedPR{
+		{Number: 10, Title: "merged fix", URL: "https://github.com/owner/repo/pull/10",
+			MergeCommit: struct{ Oid string `json:"oid"` }{Oid: "abc123def456"}},
+		{Number: 20, Title: "merged feature", URL: "https://github.com/owner/repo/pull/20",
+			MergeCommit: struct{ Oid string `json:"oid"` }{Oid: "789abcdef012"}},
+	}
+	r.set(mergedPRJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit", "--limit", "20")
+
+	src := &GitHubMerge{
+		Repo: "owner/repo",
+		Tasks: map[string]MergeTask{
+			"post-merge": {Workflow: "post-merge-check"},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 2 {
+		t.Fatalf("expected 2 vessels, got %d", len(vessels))
+	}
+	for _, v := range vessels {
+		if v.Source != "github-merge" {
+			t.Errorf("expected source github-merge, got %q", v.Source)
+		}
+		if v.Meta["pr_num"] == "" {
+			t.Error("expected Meta[pr_num] to be set")
+		}
+		if v.Meta["merge_commit"] == "" {
+			t.Error("expected Meta[merge_commit] to be set")
+		}
+		if v.Workflow != "post-merge-check" {
+			t.Errorf("expected workflow post-merge-check, got %q", v.Workflow)
+		}
+		if !strings.HasPrefix(v.ID, "merge-") {
+			t.Errorf("expected ID to start with merge-, got %q", v.ID)
+		}
+	}
+}
+
+func TestGitHubMergeScanAlreadyProcessed(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+
+	// Pre-enqueue a merge event and mark it completed
+	ref := "https://github.com/owner/repo/pull/10#merge-abc123def456"
+	_, _ = q.Enqueue(queue.Vessel{
+		ID: "merge-10-abc123de", Source: "github-merge",
+		Ref: ref, Workflow: "post-merge-check",
+		State: queue.StatePending,
+	})
+	_, _ = q.Dequeue()
+	_ = q.Update("merge-10-abc123de", queue.StateCompleted, "")
+
+	r := newMock()
+	prs := []ghMergedPR{
+		{Number: 10, Title: "merged fix", URL: "https://github.com/owner/repo/pull/10",
+			MergeCommit: struct{ Oid string `json:"oid"` }{Oid: "abc123def456"}},
+	}
+	r.set(mergedPRJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit", "--limit", "20")
+
+	src := &GitHubMerge{
+		Repo: "owner/repo",
+		Tasks: map[string]MergeTask{
+			"post-merge": {Workflow: "post-merge-check"},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Errorf("expected 0 vessels (already processed via HasRefAny), got %d", len(vessels))
+	}
+}
+
+func TestGitHubMergeScanMultipleTasks(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghMergedPR{
+		{Number: 10, Title: "merged fix", URL: "https://github.com/owner/repo/pull/10",
+			MergeCommit: struct{ Oid string `json:"oid"` }{Oid: "abc123def456"}},
+	}
+	r.set(mergedPRJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit", "--limit", "20")
+
+	src := &GitHubMerge{
+		Repo: "owner/repo",
+		Tasks: map[string]MergeTask{
+			"deploy":     {Workflow: "deploy"},
+			"post-merge": {Workflow: "post-merge-check"},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 2 {
+		t.Fatalf("expected 2 vessels (one per task), got %d", len(vessels))
+	}
+	workflows := make(map[string]bool)
+	for _, v := range vessels {
+		workflows[v.Workflow] = true
+	}
+	if !workflows["deploy"] || !workflows["post-merge-check"] {
+		t.Errorf("expected both workflows, got: %v", workflows)
+	}
+}
+
+func TestGitHubMergeVesselIDUsesCommitHash(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghMergedPR{
+		{Number: 42, Title: "test", URL: "https://github.com/owner/repo/pull/42",
+			MergeCommit: struct{ Oid string `json:"oid"` }{Oid: "deadbeefcafe1234"}},
+	}
+	r.set(mergedPRJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit", "--limit", "20")
+
+	src := &GitHubMerge{
+		Repo: "owner/repo",
+		Tasks: map[string]MergeTask{
+			"task": {Workflow: "wf"},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	if vessels[0].ID != "merge-42-deadbeef" {
+		t.Errorf("expected ID merge-42-deadbeef, got %q", vessels[0].ID)
+	}
+}
+
+func TestGitHubMergeBranchName(t *testing.T) {
+	src := &GitHubMerge{Repo: "owner/repo"}
+	vessel := queue.Vessel{
+		ID:   "merge-42-deadbeef",
+		Ref:  "https://github.com/owner/repo/pull/42#merge-deadbeefcafe1234",
+		Meta: map[string]string{"pr_num": "42", "merge_commit": "deadbeefcafe1234"},
+	}
+	branch := src.BranchName(vessel)
+	if !strings.HasPrefix(branch, "merge/pr-42-") {
+		t.Errorf("expected branch to start with merge/pr-42-, got %q", branch)
+	}
+}
+
+func TestGitHubMergeOnStart(t *testing.T) {
+	src := &GitHubMerge{Repo: "owner/repo"}
+	vessel := queue.Vessel{
+		ID:   "merge-10-abc",
+		Meta: map[string]string{"pr_num": "10"},
+	}
+	err := src.OnStart(context.Background(), vessel)
+	if err != nil {
+		t.Fatalf("expected OnStart to be a no-op, got: %v", err)
+	}
+}
+
+func TestGitHubMergeName(t *testing.T) {
+	src := &GitHubMerge{}
+	if src.Name() != "github-merge" {
+		t.Errorf("expected name github-merge, got %q", src.Name())
+	}
+}
+
+func TestGitHubMergeScanGHFailure(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	r.setErr(errTest, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit", "--limit", "20")
+
+	src := &GitHubMerge{
+		Repo: "owner/repo",
+		Tasks: map[string]MergeTask{
+			"post-merge": {Workflow: "post-merge-check"},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	_, err := src.Scan(context.Background())
+	if err == nil {
+		t.Fatal("expected error from gh failure, got nil")
+	}
+}
+
+func TestGitHubMergeScanMalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	r.set([]byte(`{not valid`), "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit", "--limit", "20")
+
+	src := &GitHubMerge{
+		Repo: "owner/repo",
+		Tasks: map[string]MergeTask{
+			"post-merge": {Workflow: "post-merge-check"},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	_, err := src.Scan(context.Background())
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestShortMergeHash(t *testing.T) {
+	if got := shortMergeHash("deadbeefcafe1234"); got != "deadbeef" {
+		t.Errorf("expected deadbeef, got %q", got)
+	}
+	if got := shortMergeHash("short"); got != "short" {
+		t.Errorf("expected short, got %q", got)
+	}
+	if got := shortMergeHash("12345678"); got != "12345678" {
+		t.Errorf("expected 12345678, got %q", got)
+	}
+}

--- a/cli/internal/source/github_pr_events.go
+++ b/cli/internal/source/github_pr_events.go
@@ -1,0 +1,265 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+// PREventsTask defines triggers for the PR events source.
+type PREventsTask struct {
+	Workflow        string
+	Labels          []string
+	ReviewSubmitted bool
+	ChecksFailed    bool
+	Commented       bool
+}
+
+// GitHubPREvents scans GitHub pull requests for events and produces vessels.
+type GitHubPREvents struct {
+	Repo      string
+	Tasks     map[string]PREventsTask
+	Exclude   []string
+	Queue     *queue.Queue
+	CmdRunner CommandRunner
+}
+
+func (g *GitHubPREvents) Name() string { return "github-pr-events" }
+
+func (g *GitHubPREvents) Scan(ctx context.Context) ([]queue.Vessel, error) {
+	// Get open PRs (recently updated, limit 20)
+	out, err := g.CmdRunner.Run(ctx, "gh", "pr", "list",
+		"--repo", g.Repo,
+		"--state", "open",
+		"--json", "number,title,url,labels,headRefName",
+		"--limit", "20",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("gh pr list: %w", err)
+	}
+
+	var prs []ghPR
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("parse gh pr list output: %w", err)
+	}
+
+	excludeSet := make(map[string]bool, len(g.Exclude))
+	for _, ex := range g.Exclude {
+		excludeSet[ex] = true
+	}
+
+	var vessels []queue.Vessel
+
+	for _, pr := range prs {
+		if g.hasExcludedLabel(pr, excludeSet) {
+			continue
+		}
+
+		for _, task := range g.Tasks {
+			// Check label triggers
+			if len(task.Labels) > 0 {
+				for _, triggerLabel := range task.Labels {
+					if prHasLabel(pr, triggerLabel) {
+						ref := fmt.Sprintf("%s#label-%s", pr.URL, triggerLabel)
+						if !g.Queue.HasRefAny(ref) {
+							vessels = append(vessels, g.makeVessel(pr, task.Workflow, ref, "label"))
+						}
+					}
+				}
+			}
+
+			// Check review_submitted trigger
+			if task.ReviewSubmitted {
+				reviewVessels, err := g.scanReviews(ctx, pr, task.Workflow)
+				if err != nil {
+					// Log and continue — don't block other PRs
+					continue
+				}
+				vessels = append(vessels, reviewVessels...)
+			}
+
+			// Check checks_failed trigger
+			if task.ChecksFailed {
+				checksVessels, err := g.scanCheckFailures(ctx, pr, task.Workflow)
+				if err != nil {
+					continue
+				}
+				vessels = append(vessels, checksVessels...)
+			}
+
+			// Check commented trigger
+			if task.Commented {
+				commentVessels, err := g.scanComments(ctx, pr, task.Workflow)
+				if err != nil {
+					continue
+				}
+				vessels = append(vessels, commentVessels...)
+			}
+		}
+	}
+
+	return vessels, nil
+}
+
+func (g *GitHubPREvents) scanReviews(ctx context.Context, pr ghPR, workflow string) ([]queue.Vessel, error) {
+	out, err := g.CmdRunner.Run(ctx, "gh", "api",
+		fmt.Sprintf("repos/%s/pulls/%d/reviews", g.Repo, pr.Number),
+		"--jq", ".[].id",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var vessels []queue.Vessel
+	for _, idStr := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		idStr = strings.TrimSpace(idStr)
+		if idStr == "" {
+			continue
+		}
+		ref := fmt.Sprintf("%s#review-%s", pr.URL, idStr)
+		if !g.Queue.HasRefAny(ref) {
+			vessels = append(vessels, g.makeVessel(pr, workflow, ref, "review"))
+		}
+	}
+	return vessels, nil
+}
+
+func (g *GitHubPREvents) scanCheckFailures(ctx context.Context, pr ghPR, workflow string) ([]queue.Vessel, error) {
+	out, err := g.CmdRunner.Run(ctx, "gh", "pr", "checks",
+		strconv.Itoa(pr.Number),
+		"--repo", g.Repo,
+		"--json", "name,state",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var checks []struct {
+		Name  string `json:"name"`
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(out, &checks); err != nil {
+		return nil, err
+	}
+
+	// Only trigger if there are failed checks
+	hasFailed := false
+	for _, c := range checks {
+		if c.State == "FAILURE" || c.State == "ERROR" {
+			hasFailed = true
+			break
+		}
+	}
+	if !hasFailed {
+		return nil, nil
+	}
+
+	// Use PR URL + head SHA as ref to deduplicate per commit
+	// Get head SHA
+	headOut, err := g.CmdRunner.Run(ctx, "gh", "pr", "view",
+		strconv.Itoa(pr.Number),
+		"--repo", g.Repo,
+		"--json", "headRefOid",
+	)
+	if err != nil {
+		return nil, err
+	}
+	var headInfo struct {
+		HeadRefOid string `json:"headRefOid"`
+	}
+	if err := json.Unmarshal(headOut, &headInfo); err != nil {
+		return nil, err
+	}
+
+	ref := fmt.Sprintf("%s#checks-failed-%s", pr.URL, headInfo.HeadRefOid)
+	if g.Queue.HasRefAny(ref) {
+		return nil, nil
+	}
+
+	return []queue.Vessel{g.makeVessel(pr, workflow, ref, "checks_failed")}, nil
+}
+
+func (g *GitHubPREvents) scanComments(ctx context.Context, pr ghPR, workflow string) ([]queue.Vessel, error) {
+	out, err := g.CmdRunner.Run(ctx, "gh", "api",
+		fmt.Sprintf("repos/%s/issues/%d/comments", g.Repo, pr.Number),
+		"--jq", ".[].id",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var vessels []queue.Vessel
+	for _, idStr := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		idStr = strings.TrimSpace(idStr)
+		if idStr == "" {
+			continue
+		}
+		ref := fmt.Sprintf("%s#comment-%s", pr.URL, idStr)
+		if !g.Queue.HasRefAny(ref) {
+			vessels = append(vessels, g.makeVessel(pr, workflow, ref, "comment"))
+		}
+	}
+	return vessels, nil
+}
+
+func (g *GitHubPREvents) makeVessel(pr ghPR, workflow, ref, eventType string) queue.Vessel {
+	return queue.Vessel{
+		ID:       fmt.Sprintf("pr-%d-%s-%s", pr.Number, eventType, shortHash(ref)),
+		Source:   "github-pr-events",
+		Ref:      ref,
+		Workflow: workflow,
+		Meta: map[string]string{
+			"pr_num":         strconv.Itoa(pr.Number),
+			"event_type":     eventType,
+			"pr_head_branch": pr.HeadRefName,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	}
+}
+
+func (g *GitHubPREvents) OnStart(ctx context.Context, vessel queue.Vessel) error {
+	// No default label changes for PR event vessels
+	return nil
+}
+
+func (g *GitHubPREvents) BranchName(vessel queue.Vessel) string {
+	prNum := vessel.Meta["pr_num"]
+	eventType := vessel.Meta["event_type"]
+	slug := slugify(vessel.Ref)
+	return fmt.Sprintf("pr-event/%s-%s-%s", prNum, eventType, slug)
+}
+
+func (g *GitHubPREvents) hasExcludedLabel(pr ghPR, excluded map[string]bool) bool {
+	for _, l := range pr.Labels {
+		if excluded[l.Name] {
+			return true
+		}
+	}
+	return false
+}
+
+func prHasLabel(pr ghPR, label string) bool {
+	for _, l := range pr.Labels {
+		if l.Name == label {
+			return true
+		}
+	}
+	return false
+}
+
+// shortHash returns first 8 chars of a simple hash of s for vessel ID uniqueness.
+func shortHash(s string) string {
+	// Simple deterministic hash using FNV
+	h := uint32(2166136261)
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= 16777619
+	}
+	return fmt.Sprintf("%08x", h)
+}

--- a/cli/internal/source/github_pr_events_test.go
+++ b/cli/internal/source/github_pr_events_test.go
@@ -1,0 +1,428 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+func TestGitHubPREventsScanLabelTrigger(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "needs review", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix-bug",
+			Labels: []struct{ Name string `json:"name"` }{{Name: "needs-response"}}},
+		{Number: 20, Title: "no label", URL: "https://github.com/owner/repo/pull/20", HeadRefName: "add-feature",
+			Labels: []struct{ Name string `json:"name"` }{{Name: "other"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"respond": {Workflow: "respond-to-pr", Labels: []string{"needs-response"}},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	v := vessels[0]
+	if v.Source != "github-pr-events" {
+		t.Errorf("expected source github-pr-events, got %q", v.Source)
+	}
+	if v.Meta["event_type"] != "label" {
+		t.Errorf("expected event_type label, got %q", v.Meta["event_type"])
+	}
+	if v.Meta["pr_num"] != "10" {
+		t.Errorf("expected pr_num 10, got %q", v.Meta["pr_num"])
+	}
+	if !strings.Contains(v.Ref, "#label-needs-response") {
+		t.Errorf("expected ref to contain #label-needs-response, got %q", v.Ref)
+	}
+	if v.Workflow != "respond-to-pr" {
+		t.Errorf("expected workflow respond-to-pr, got %q", v.Workflow)
+	}
+}
+
+func TestGitHubPREventsScanReviewTrigger(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "has reviews", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix-bug"},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+	r.set([]byte("111\n222\n"), "gh", "api", "repos/owner/repo/pulls/10/reviews", "--jq", ".[].id")
+
+	src := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review": {Workflow: "handle-review", ReviewSubmitted: true},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 2 {
+		t.Fatalf("expected 2 vessels (one per review), got %d", len(vessels))
+	}
+	for _, v := range vessels {
+		if v.Meta["event_type"] != "review" {
+			t.Errorf("expected event_type review, got %q", v.Meta["event_type"])
+		}
+	}
+}
+
+func TestGitHubPREventsScanChecksFailed(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "failing checks", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix-bug"},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+
+	checks := []struct {
+		Name  string `json:"name"`
+		State string `json:"state"`
+	}{
+		{Name: "lint", State: "SUCCESS"},
+		{Name: "test", State: "FAILURE"},
+	}
+	checksJSON, _ := json.Marshal(checks)
+	r.set(checksJSON, "gh", "pr", "checks", "10", "--repo", "owner/repo", "--json", "name,state")
+	r.set([]byte(`{"headRefOid":"abc123def456"}`), "gh", "pr", "view", "10", "--repo", "owner/repo", "--json", "headRefOid")
+
+	src := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"fix-checks": {Workflow: "fix-checks", ChecksFailed: true},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	v := vessels[0]
+	if v.Meta["event_type"] != "checks_failed" {
+		t.Errorf("expected event_type checks_failed, got %q", v.Meta["event_type"])
+	}
+	if !strings.Contains(v.Ref, "#checks-failed-abc123def456") {
+		t.Errorf("expected ref to contain #checks-failed-abc123def456, got %q", v.Ref)
+	}
+}
+
+func TestGitHubPREventsScanChecksAllPassing(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "passing checks", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix-bug"},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+
+	checks := []struct {
+		Name  string `json:"name"`
+		State string `json:"state"`
+	}{
+		{Name: "lint", State: "SUCCESS"},
+		{Name: "test", State: "SUCCESS"},
+	}
+	checksJSON, _ := json.Marshal(checks)
+	r.set(checksJSON, "gh", "pr", "checks", "10", "--repo", "owner/repo", "--json", "name,state")
+
+	src := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"fix-checks": {Workflow: "fix-checks", ChecksFailed: true},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels (checks passing), got %d", len(vessels))
+	}
+}
+
+func TestGitHubPREventsScanCommentTrigger(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "has comments", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix-bug"},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+	r.set([]byte("501\n502\n"), "gh", "api", "repos/owner/repo/issues/10/comments", "--jq", ".[].id")
+
+	src := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"respond": {Workflow: "respond-to-comment", Commented: true},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 2 {
+		t.Fatalf("expected 2 vessels (one per comment), got %d", len(vessels))
+	}
+	for _, v := range vessels {
+		if v.Meta["event_type"] != "comment" {
+			t.Errorf("expected event_type comment, got %q", v.Meta["event_type"])
+		}
+	}
+}
+
+func TestGitHubPREventsScanExcludedLabel(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "excluded", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix-bug",
+			Labels: []struct{ Name string `json:"name"` }{{Name: "needs-response"}, {Name: "no-bot"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"respond": {Workflow: "respond-to-pr", Labels: []string{"needs-response"}},
+		},
+		Exclude:   []string{"no-bot"},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Errorf("expected 0 vessels (excluded), got %d", len(vessels))
+	}
+}
+
+func TestGitHubPREventsScanAlreadyProcessed(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+
+	// Pre-enqueue a label event and mark it completed
+	ref := "https://github.com/owner/repo/pull/10#label-needs-response"
+	_, _ = q.Enqueue(queue.Vessel{
+		ID: "pr-10-label-abc", Source: "github-pr-events",
+		Ref: ref, Workflow: "respond-to-pr",
+		State: queue.StatePending,
+	})
+	// Transition to completed
+	_, _ = q.Dequeue()
+	_ = q.Update("pr-10-label-abc", queue.StateCompleted, "")
+
+	r := newMock()
+	prs := []ghPR{
+		{Number: 10, Title: "needs review", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix-bug",
+			Labels: []struct{ Name string `json:"name"` }{{Name: "needs-response"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"respond": {Workflow: "respond-to-pr", Labels: []string{"needs-response"}},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Errorf("expected 0 vessels (already processed via HasRefAny), got %d", len(vessels))
+	}
+}
+
+func TestGitHubPREventsVesselID(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 42, Title: "test", URL: "https://github.com/owner/repo/pull/42", HeadRefName: "fix",
+			Labels: []struct{ Name string `json:"name"` }{{Name: "trigger"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"task": {Workflow: "wf", Labels: []string{"trigger"}},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	if !strings.HasPrefix(vessels[0].ID, "pr-42-label-") {
+		t.Errorf("expected ID to start with pr-42-label-, got %q", vessels[0].ID)
+	}
+}
+
+func TestGitHubPREventsBranchName(t *testing.T) {
+	src := &GitHubPREvents{Repo: "owner/repo"}
+	vessel := queue.Vessel{
+		ID:   "pr-42-label-abc",
+		Ref:  "https://github.com/owner/repo/pull/42#label-needs-response",
+		Meta: map[string]string{"pr_num": "42", "event_type": "label"},
+	}
+	branch := src.BranchName(vessel)
+	if !strings.HasPrefix(branch, "pr-event/42-label-") {
+		t.Errorf("expected branch to start with pr-event/42-label-, got %q", branch)
+	}
+}
+
+func TestGitHubPREventsOnStart(t *testing.T) {
+	src := &GitHubPREvents{Repo: "owner/repo"}
+	vessel := queue.Vessel{
+		ID:   "pr-10-label-abc",
+		Meta: map[string]string{"pr_num": "10"},
+	}
+	err := src.OnStart(context.Background(), vessel)
+	if err != nil {
+		t.Fatalf("expected OnStart to be a no-op, got: %v", err)
+	}
+}
+
+func TestGitHubPREventsName(t *testing.T) {
+	src := &GitHubPREvents{}
+	if src.Name() != "github-pr-events" {
+		t.Errorf("expected name github-pr-events, got %q", src.Name())
+	}
+}
+
+func TestGitHubPREventsScanGHFailure(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	r.setErr(errTest, "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"respond": {Workflow: "respond-to-pr", Labels: []string{"trigger"}},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	_, err := src.Scan(context.Background())
+	if err == nil {
+		t.Fatal("expected error from gh failure, got nil")
+	}
+}
+
+func TestShortHash(t *testing.T) {
+	// shortHash should be deterministic
+	h1 := shortHash("test-input")
+	h2 := shortHash("test-input")
+	if h1 != h2 {
+		t.Fatalf("shortHash is not deterministic: %q != %q", h1, h2)
+	}
+	if len(h1) != 8 {
+		t.Fatalf("expected 8 char hash, got %d: %q", len(h1), h1)
+	}
+
+	// Different inputs should produce different hashes
+	h3 := shortHash("different-input")
+	if h1 == h3 {
+		t.Fatal("expected different inputs to produce different hashes")
+	}
+}
+
+func TestPrHasLabel(t *testing.T) {
+	pr := ghPR{
+		Labels: []struct{ Name string `json:"name"` }{
+			{Name: "bug"}, {Name: "review-me"},
+		},
+	}
+	if !prHasLabel(pr, "bug") {
+		t.Error("expected prHasLabel to find 'bug'")
+	}
+	if prHasLabel(pr, "missing") {
+		t.Error("expected prHasLabel to not find 'missing'")
+	}
+}
+
+func TestGitHubPREventsScanReviewAPIError(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "test", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix"},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+	r.setErr(fmt.Errorf("api error"), "gh", "api", "repos/owner/repo/pulls/10/reviews", "--jq", ".[].id")
+
+	src := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review": {Workflow: "handle-review", ReviewSubmitted: true},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	// Should not error — review API errors are swallowed per PR
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Errorf("expected 0 vessels when review API fails, got %d", len(vessels))
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `github-pr-events` source type that monitors open PRs for label additions, review submissions, check failures, and new comments
- Adds `github-merge` source type that monitors recently merged PRs for post-merge workflows
- Adds `Queue.HasRefAny` method that checks all vessel states (including terminal) for deduplication, preventing re-processing of already-handled events
- Wires both sources into scanner, drain, and reporter with full config validation

## Test plan
- [x] Config validation tests for github-pr-events (all triggers, labels only, missing on, empty on, missing repo, missing workflow)
- [x] Config validation tests for github-merge (valid, missing repo, missing workflow)
- [x] Unknown source type validation test
- [x] Queue.HasRefAny tests for all vessel states (pending, running, waiting, completed, failed, cancelled, timed_out)
- [x] GitHubPREvents scan tests (label trigger, review trigger, checks_failed trigger, commented trigger, excluded labels, already processed, API errors)
- [x] GitHubMerge scan tests (find merged PRs, already processed, multiple tasks, vessel ID format, gh error handling)
- [x] Scanner integration tests for both new source types
- [x] All existing tests pass (`go test ./...` - 22 packages OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)