### PR TITLE
feat: add command/script phase type for deterministic workflow phases

### DIFF
--- a/cli/internal/gate/gate.go
+++ b/cli/internal/gate/gate.go
@@ -32,6 +32,13 @@ func RunCommandGate(ctx context.Context, r Runner, dir string, command string) (
 	return string(output), true, nil
 }
 
+// RunCommand executes a shell command in the given directory and returns its
+// output. Unlike RunCommandGate, a non-zero exit code IS returned as an error.
+func RunCommand(ctx context.Context, r Runner, dir string, command string) (string, error) {
+	output, err := r.RunOutput(ctx, "sh", "-c", fmt.Sprintf("cd %s && %s", shellQuote(dir), command))
+	return string(output), err
+}
+
 // ghLabelsResponse is the JSON shape returned by `gh issue view --json labels`.
 type ghLabelsResponse struct {
 	Labels []struct {

--- a/cli/internal/gate/gate_test.go
+++ b/cli/internal/gate/gate_test.go
@@ -83,6 +83,33 @@ func TestRunCommandGateShellQuotesDir(t *testing.T) {
 	}
 }
 
+// --- RunCommand tests ---
+
+func TestRunCommandSuccess(t *testing.T) {
+	r := &mockRunner{output: []byte("build complete\n")}
+	out, err := RunCommand(context.Background(), r, "/tmp/work", "make build")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "build complete\n" {
+		t.Errorf("expected output %q, got %q", "build complete\n", out)
+	}
+}
+
+func TestRunCommandFailure(t *testing.T) {
+	r := &mockRunner{
+		output: []byte("compilation error\n"),
+		err:    &exitError{code: 1},
+	}
+	out, err := RunCommand(context.Background(), r, "/tmp/work", "make build")
+	if err == nil {
+		t.Fatal("expected error for non-zero exit, got nil")
+	}
+	if out != "compilation error\n" {
+		t.Errorf("expected output %q, got %q", "compilation error\n", out)
+	}
+}
+
 // --- CheckLabel tests ---
 
 func TestCheckLabelPresent(t *testing.T) {

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -272,42 +272,57 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 				},
 			}
 
-			// Read prompt template
-			promptContent, err := os.ReadFile(p.PromptFile)
-			if err != nil {
-				r.failVessel(vessel.ID, fmt.Sprintf("read prompt file %s: %v", p.PromptFile, err))
-				if err := src.OnFail(ctx, vessel); err != nil {
-					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-				}
-				return "failed"
-			}
-
-			// Render prompt
-			rendered, err := phase.RenderPrompt(string(promptContent), td)
-			if err != nil {
-				r.failVessel(vessel.ID, fmt.Sprintf("render prompt for phase %s: %v", p.Name, err))
-				if err := src.OnFail(ctx, vessel); err != nil {
-					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-				}
-				return "failed"
-			}
-
-			// Write prompt to file for debugging
+			// Create phases dir early
 			phasesDir := filepath.Join(r.Config.StateDir, "phases", vessel.ID)
 			os.MkdirAll(phasesDir, 0o755)
-			promptPath := filepath.Join(phasesDir, p.Name+".prompt")
-			if wErr := os.WriteFile(promptPath, []byte(rendered), 0o644); wErr != nil {
-				log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
+
+			var output []byte
+			var runErr error
+
+			if p.Type == "command" {
+				// Command phase: render and execute shell command
+				rendered, err := phase.RenderPrompt(p.Run, td)
+				if err != nil {
+					r.failVessel(vessel.ID, fmt.Sprintf("render command for phase %s: %v", p.Name, err))
+					if err := src.OnFail(ctx, vessel); err != nil {
+						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+					}
+					return "failed"
+				}
+				if wErr := os.WriteFile(filepath.Join(phasesDir, p.Name+".command"), []byte(rendered), 0o644); wErr != nil {
+					log.Printf("warn: write command file: %v", wErr)
+				}
+				cmdOut, cmdErr := gate.RunCommand(ctx, r.Runner, worktreePath, rendered)
+				output = []byte(cmdOut)
+				runErr = cmdErr
+			} else {
+				// LLM phase: existing code
+				promptContent, err := os.ReadFile(p.PromptFile)
+				if err != nil {
+					r.failVessel(vessel.ID, fmt.Sprintf("read prompt file %s: %v", p.PromptFile, err))
+					if err := src.OnFail(ctx, vessel); err != nil {
+						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+					}
+					return "failed"
+				}
+				rendered, err := phase.RenderPrompt(string(promptContent), td)
+				if err != nil {
+					r.failVessel(vessel.ID, fmt.Sprintf("render prompt for phase %s: %v", p.Name, err))
+					if err := src.OnFail(ctx, vessel); err != nil {
+						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+					}
+					return "failed"
+				}
+				promptPath := filepath.Join(phasesDir, p.Name+".prompt")
+				if wErr := os.WriteFile(promptPath, []byte(rendered), 0o644); wErr != nil {
+					log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
+				}
+				provider := resolveProvider(r.Config, sk, &p)
+				cmd, args := buildProviderPhaseArgs(r.Config, sk, &p, harnessContent, provider)
+				output, runErr = r.Runner.RunPhase(ctx, worktreePath, strings.NewReader(rendered), cmd, args...)
 			}
 
-			// Resolve provider and build args
-			provider := resolveProvider(r.Config, sk, &p)
-			cmd, args := buildProviderPhaseArgs(r.Config, sk, &p, harnessContent, provider)
-
-			// Run phase via stdin
-			output, runErr := r.Runner.RunPhase(ctx, worktreePath, strings.NewReader(rendered), cmd, args...)
-
-			// Write phase output
+			// Shared: Write phase output
 			outputPath := filepath.Join(phasesDir, p.Name+".output")
 			if wErr := os.WriteFile(outputPath, output, 0o644); wErr != nil {
 				log.Printf("warn: write output file %s: %v", outputPath, wErr)

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -281,13 +281,19 @@ func writeWorkflowFile(t *testing.T, dir, name string, phases []testPhase) {
 
 	var phaseYAML strings.Builder
 	for _, p := range phases {
-		promptPath := filepath.Join(dir, ".xylem", "prompts", name, p.name+".md")
-		os.MkdirAll(filepath.Dir(promptPath), 0o755)
-		os.WriteFile(promptPath, []byte(p.promptContent), 0o644)
-
 		phaseYAML.WriteString(fmt.Sprintf("  - name: %s\n", p.name))
-		phaseYAML.WriteString(fmt.Sprintf("    prompt_file: %s\n", promptPath))
-		phaseYAML.WriteString(fmt.Sprintf("    max_turns: %d\n", p.maxTurns))
+
+		if p.phaseType == "command" {
+			phaseYAML.WriteString("    type: command\n")
+			phaseYAML.WriteString(fmt.Sprintf("    run: %q\n", p.run))
+		} else {
+			promptPath := filepath.Join(dir, ".xylem", "prompts", name, p.name+".md")
+			os.MkdirAll(filepath.Dir(promptPath), 0o755)
+			os.WriteFile(promptPath, []byte(p.promptContent), 0o644)
+
+			phaseYAML.WriteString(fmt.Sprintf("    prompt_file: %s\n", promptPath))
+			phaseYAML.WriteString(fmt.Sprintf("    max_turns: %d\n", p.maxTurns))
+		}
 		if p.noopMatch != "" {
 			phaseYAML.WriteString("    noop:\n")
 			phaseYAML.WriteString(fmt.Sprintf("      match: %q\n", p.noopMatch))
@@ -411,6 +417,8 @@ type testPhase struct {
 	noopMatch     string
 	gate          string
 	allowedTools  string
+	phaseType     string // "command" or "" for prompt (default)
+	run           string // shell command for type=command
 }
 
 // --- Tests ---
@@ -1994,3 +2002,202 @@ func TestBuildPromptOnlyCmdArgsHeadlessDedup(t *testing.T) {
 }
 
 func strPtrRunner(s string) *string { return &s }
+
+func TestDrainCommandPhase(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fix-bug"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{name: "build", phaseType: "command", run: "echo building"},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{
+		gateOutput: []byte("build complete\n"),
+		gateErr:    nil,
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Completed != 1 {
+		t.Errorf("expected 1 completed, got %d", result.Completed)
+	}
+
+	// Command phases go through RunOutput (like gates), not RunPhase
+	if len(cmdRunner.phaseCalls) != 0 {
+		t.Errorf("expected 0 RunPhase calls for command phase, got %d", len(cmdRunner.phaseCalls))
+	}
+
+	// Verify output file was written
+	outputPath := filepath.Join(dir, ".xylem", "phases", "issue-1", "build.output")
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
+		t.Errorf("expected output file %s to exist", outputPath)
+	}
+
+	// Verify command file was written
+	commandPath := filepath.Join(dir, ".xylem", "phases", "issue-1", "build.command")
+	if _, err := os.Stat(commandPath); os.IsNotExist(err) {
+		t.Errorf("expected command file %s to exist", commandPath)
+	}
+
+	vessels, _ := q.List()
+	if vessels[0].State != queue.StateCompleted {
+		t.Errorf("expected vessel completed, got %s", vessels[0].State)
+	}
+}
+
+func TestDrainCommandPhaseFailure(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fix-bug"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{name: "build", phaseType: "command", run: "make build"},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{
+		gateOutput: []byte("compilation failed\n"),
+		gateErr:    &mockExitError{code: 1},
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Failed != 1 {
+		t.Errorf("expected 1 failed, got %d", result.Failed)
+	}
+
+	vessels, _ := q.List()
+	if vessels[0].State != queue.StateFailed {
+		t.Errorf("expected vessel failed, got %s", vessels[0].State)
+	}
+}
+
+func TestDrainCommandPhaseWithGate(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fix-bug"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{
+			name: "build", phaseType: "command", run: "make build",
+			gate: "      type: command\n      run: \"make test\"",
+		},
+		{name: "pr", promptContent: "Create PR", maxTurns: 3},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	// Track call index to distinguish command phase from gate
+	callIdx := int32(0)
+	cmdRunner := &mockCmdRunner{
+		gateCallResults: []gateCallResult{
+			{output: []byte("build ok\n"), err: nil},   // command phase execution
+			{output: []byte("tests pass\n"), err: nil},  // gate execution
+		},
+	}
+	_ = callIdx // suppress unused
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Completed != 1 {
+		t.Errorf("expected 1 completed, got %d", result.Completed)
+	}
+
+	// Second phase (pr) should have been invoked via RunPhase
+	if len(cmdRunner.phaseCalls) != 1 {
+		t.Errorf("expected 1 RunPhase call (for pr phase), got %d", len(cmdRunner.phaseCalls))
+	}
+
+	vessels, _ := q.List()
+	if vessels[0].State != queue.StateCompleted {
+		t.Errorf("expected vessel completed, got %s", vessels[0].State)
+	}
+}
+
+func TestDrainCommandPhaseWithNoOp(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fix-bug"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{
+			name: "check", phaseType: "command", run: "make check",
+			noopMatch: "XYLEM_NOOP",
+		},
+		{name: "implement", promptContent: "Implement", maxTurns: 10},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{
+		gateOutput: []byte("Already up to date.\n\nXYLEM_NOOP\n"),
+		gateErr:    nil,
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Completed != 1 {
+		t.Fatalf("expected 1 completed, got %d", result.Completed)
+	}
+
+	// No RunPhase calls should have been made (command phase + noop skips remaining)
+	if len(cmdRunner.phaseCalls) != 0 {
+		t.Fatalf("expected 0 RunPhase calls (noop should skip implement phase), got %d", len(cmdRunner.phaseCalls))
+	}
+
+	vessels, _ := q.List()
+	if vessels[0].State != queue.StateCompleted {
+		t.Errorf("expected vessel completed, got %s", vessels[0].State)
+	}
+	if vessels[0].CurrentPhase != 1 {
+		t.Errorf("expected CurrentPhase 1, got %d", vessels[0].CurrentPhase)
+	}
+}

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -2046,11 +2046,25 @@ func TestDrainCommandPhase(t *testing.T) {
 	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
 		t.Errorf("expected output file %s to exist", outputPath)
 	}
+	outputData, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if !strings.Contains(string(outputData), "build complete") {
+		t.Errorf("output file content = %q, want to contain 'build complete'", string(outputData))
+	}
 
 	// Verify command file was written
 	commandPath := filepath.Join(dir, ".xylem", "phases", "issue-1", "build.command")
 	if _, err := os.Stat(commandPath); os.IsNotExist(err) {
 		t.Errorf("expected command file %s to exist", commandPath)
+	}
+	commandData, err := os.ReadFile(commandPath)
+	if err != nil {
+		t.Fatalf("read command file: %v", err)
+	}
+	if !strings.Contains(string(commandData), "echo building") {
+		t.Errorf("command file content = %q, want to contain 'echo building'", string(commandData))
 	}
 
 	vessels, _ := q.List()
@@ -2117,15 +2131,12 @@ func TestDrainCommandPhaseWithGate(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(oldWd)
 
-	// Track call index to distinguish command phase from gate
-	callIdx := int32(0)
 	cmdRunner := &mockCmdRunner{
 		gateCallResults: []gateCallResult{
 			{output: []byte("build ok\n"), err: nil},   // command phase execution
 			{output: []byte("tests pass\n"), err: nil},  // gate execution
 		},
 	}
-	_ = callIdx // suppress unused
 	wt := &mockWorktree{}
 	r := New(cfg, q, wt, cmdRunner)
 	r.Sources = map[string]source.Source{
@@ -2138,6 +2149,11 @@ func TestDrainCommandPhaseWithGate(t *testing.T) {
 	}
 	if result.Completed != 1 {
 		t.Errorf("expected 1 completed, got %d", result.Completed)
+	}
+
+	// Verify both command phase and gate were called via RunOutput
+	if cmdRunner.gateCallCount != 2 {
+		t.Errorf("expected 2 RunOutput calls (command + gate), got %d", cmdRunner.gateCallCount)
 	}
 
 	// Second phase (pr) should have been invoked via RunPhase

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -28,6 +28,8 @@ type Workflow struct {
 // Phase represents a single step in a workflow's execution pipeline.
 type Phase struct {
 	Name         string  `yaml:"name"`
+	Type         string  `yaml:"type,omitempty"`          // "prompt" (default) or "command"
+	Run          string  `yaml:"run,omitempty"`            // shell command for type=command, supports template variables
 	PromptFile   string  `yaml:"prompt_file"`
 	MaxTurns     int     `yaml:"max_turns"`
 	LLM          *string `yaml:"llm,omitempty"`
@@ -109,16 +111,25 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 			return fmt.Errorf("phase name %q is invalid; must start with a lowercase letter and contain only lowercase letters, digits, and underscores", p.Name)
 		}
 
-		if p.PromptFile == "" {
-			return fmt.Errorf("phase %q: prompt_file is required", p.Name)
-		}
+		switch p.Type {
+		case "", "prompt":
+			if p.PromptFile == "" {
+				return fmt.Errorf("phase %q: prompt_file is required", p.Name)
+			}
 
-		if _, err := os.Stat(p.PromptFile); err != nil {
-			return fmt.Errorf("phase %q: prompt_file not found: %s", p.Name, p.PromptFile)
-		}
+			if _, err := os.Stat(p.PromptFile); err != nil {
+				return fmt.Errorf("phase %q: prompt_file not found: %s", p.Name, p.PromptFile)
+			}
 
-		if p.MaxTurns <= 0 {
-			return fmt.Errorf("phase %q: max_turns must be greater than 0", p.Name)
+			if p.MaxTurns <= 0 {
+				return fmt.Errorf("phase %q: max_turns must be greater than 0", p.Name)
+			}
+		case "command":
+			if strings.TrimSpace(p.Run) == "" {
+				return fmt.Errorf("phase %q: run is required for command phase", p.Name)
+			}
+		default:
+			return fmt.Errorf("phase %q: type must be \"prompt\" or \"command\", got %q", p.Name, p.Type)
 		}
 
 		if p.Gate != nil {

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -755,6 +755,70 @@ func TestValidate(t *testing.T) {
 			},
 			prompts: []string{"prompt.md"},
 		},
+		{
+			name:             "command phase valid",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "build", Type: "command", Run: "echo hello"},
+				},
+			},
+		},
+		{
+			name:             "command phase missing run",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "build", Type: "command"},
+				},
+			},
+			wantErr: "run is required",
+		},
+		{
+			name:             "command phase empty run",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "build", Type: "command", Run: "   "},
+				},
+			},
+			wantErr: "run is required",
+		},
+		{
+			name:             "unknown phase type",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "build", Type: "webhook"},
+				},
+			},
+			wantErr: "type must be",
+		},
+		{
+			name:             "command phase with gate",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "build", Type: "command", Run: "make build", Gate: &Gate{Type: "command", Run: "make test"}},
+				},
+			},
+		},
+		{
+			name:             "prompt phase default",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "step1", PromptFile: "prompt.md", MaxTurns: 5},
+				},
+			},
+			prompts: []string{"prompt.md"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Adds a new `type: command` phase type to workflows that executes a shell command instead of invoking an LLM
- Command phases support template variable interpolation (same as prompt templates: `{{.Issue.Title}}`, `{{.PreviousOutputs.phase_name}}`, etc.)
- Command phases integrate with existing gates, noop detection, and lifecycle hooks

## Test plan
- [x] `TestValidate` covers command phase valid/invalid cases (missing run, empty run, unknown type, with gate, default prompt type)
- [x] `TestRunCommandSuccess` and `TestRunCommandFailure` verify the new `gate.RunCommand` function
- [x] `TestDrainCommandPhase` verifies successful command phase execution
- [x] `TestDrainCommandPhaseFailure` verifies non-zero exit fails the vessel
- [x] `TestDrainCommandPhaseWithGate` verifies command phase + gate integration
- [x] `TestDrainCommandPhaseWithNoOp` verifies noop detection works for command phases
- [x] Full test suite passes: `cd cli && go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)