### PR TITLE
feat: add github-pr-events and github-merge source types

### DIFF
--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -59,7 +59,8 @@ func cmdDrain(cfg *config.Config, q *queue.Queue, wt *worktree.Manager, dryRun b
 func buildSourceMap(cfg *config.Config, q *queue.Queue, cmdRunner source.CommandRunner) map[string]source.Source {
 	sources := make(map[string]source.Source)
 	for _, srcCfg := range cfg.Sources {
-		if srcCfg.Type == "github" {
+		switch srcCfg.Type {
+		case "github":
 			tasks := make(map[string]source.GitHubTask, len(srcCfg.Tasks))
 			for name, t := range srcCfg.Tasks {
 				tasks[name] = source.GitHubTaskFromConfig(t)
@@ -72,16 +73,55 @@ func buildSourceMap(cfg *config.Config, q *queue.Queue, cmdRunner source.Command
 				CmdRunner: cmdRunner,
 			}
 			sources[gh.Name()] = gh
+		case "github-pr-events":
+			prEventsTasks := make(map[string]source.PREventsTask, len(srcCfg.Tasks))
+			for name, t := range srcCfg.Tasks {
+				task := source.PREventsTask{
+					Workflow: t.Workflow,
+				}
+				if t.On != nil {
+					task.Labels = t.On.Labels
+					task.ReviewSubmitted = t.On.ReviewSubmitted
+					task.ChecksFailed = t.On.ChecksFailed
+					task.Commented = t.On.Commented
+				}
+				prEventsTasks[name] = task
+			}
+			pre := &source.GitHubPREvents{
+				Repo:      srcCfg.Repo,
+				Tasks:     prEventsTasks,
+				Exclude:   srcCfg.Exclude,
+				Queue:     q,
+				CmdRunner: cmdRunner,
+			}
+			sources[pre.Name()] = pre
+		case "github-merge":
+			mergeTasks := make(map[string]source.MergeTask, len(srcCfg.Tasks))
+			for name, t := range srcCfg.Tasks {
+				mergeTasks[name] = source.MergeTask{
+					Workflow: t.Workflow,
+				}
+			}
+			gm := &source.GitHubMerge{
+				Repo:      srcCfg.Repo,
+				Tasks:     mergeTasks,
+				Queue:     q,
+				CmdRunner: cmdRunner,
+			}
+			sources[gm.Name()] = gm
 		}
 	}
 	return sources
 }
 
 func buildReporter(cfg *config.Config, cmdRunner reporter.Runner) *reporter.Reporter {
-	// Find the first GitHub source repo for reporting
+	// Find the first GitHub-based source repo for reporting
 	for _, srcCfg := range cfg.Sources {
-		if srcCfg.Type == "github" && srcCfg.Repo != "" {
-			return &reporter.Reporter{Runner: cmdRunner, Repo: srcCfg.Repo}
+		switch srcCfg.Type {
+		case "github", "github-pr", "github-pr-events", "github-merge":
+			if srcCfg.Repo != "" {
+				return &reporter.Reporter{Runner: cmdRunner, Repo: srcCfg.Repo}
+			}
 		}
 	}
 	return nil

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -43,10 +43,19 @@ type StatusLabels struct {
 	TimedOut  string `yaml:"timed_out,omitempty"`
 }
 
+// PREventsConfig defines which PR events trigger a workflow.
+type PREventsConfig struct {
+	Labels          []string `yaml:"labels,omitempty"`
+	ReviewSubmitted bool     `yaml:"review_submitted,omitempty"`
+	ChecksFailed    bool     `yaml:"checks_failed,omitempty"`
+	Commented       bool     `yaml:"commented,omitempty"`
+}
+
 type Task struct {
-	Labels       []string      `yaml:"labels,omitempty"`
-	Workflow     string        `yaml:"workflow"`
-	StatusLabels *StatusLabels `yaml:"status_labels,omitempty"`
+	Labels       []string        `yaml:"labels,omitempty"`
+	Workflow     string          `yaml:"workflow"`
+	StatusLabels *StatusLabels   `yaml:"status_labels,omitempty"`
+	On           *PREventsConfig `yaml:"on,omitempty"`
 }
 
 type ClaudeConfig struct {
@@ -192,8 +201,18 @@ func (c *Config) Validate() error {
 			if err := validateGitHubSource(name, src); err != nil {
 				return err
 			}
+		case "github-pr-events":
+			if err := validateGitHubPREventsSource(name, src); err != nil {
+				return err
+			}
+		case "github-merge":
+			if err := validateGitHubMergeSource(name, src); err != nil {
+				return err
+			}
 		case "":
 			return fmt.Errorf("source %q must specify a type", name)
+		default:
+			return fmt.Errorf("source %q: unknown type %q", name, src.Type)
 		}
 	}
 
@@ -248,6 +267,52 @@ func validateGitHubSource(name string, src SourceConfig) error {
 		if len(task.Labels) == 0 {
 			return fmt.Errorf("source %q task %q: must include at least one labels entry", name, tname)
 		}
+		if strings.TrimSpace(task.Workflow) == "" {
+			return fmt.Errorf("source %q task %q: must include a workflow", name, tname)
+		}
+	}
+	return nil
+}
+
+func validateGitHubPREventsSource(name string, src SourceConfig) error {
+	repo := strings.TrimSpace(src.Repo)
+	if repo == "" {
+		return fmt.Errorf("source %q (github-pr-events): repo is required", name)
+	}
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return fmt.Errorf("source %q (github-pr-events): repo must be in owner/name format", name)
+	}
+	if len(src.Tasks) == 0 {
+		return fmt.Errorf("source %q (github-pr-events): at least one task is required", name)
+	}
+	for tname, task := range src.Tasks {
+		if strings.TrimSpace(task.Workflow) == "" {
+			return fmt.Errorf("source %q task %q: must include a workflow", name, tname)
+		}
+		if task.On == nil {
+			return fmt.Errorf("source %q task %q: must include an 'on' block with at least one trigger", name, tname)
+		}
+		if len(task.On.Labels) == 0 && !task.On.ReviewSubmitted && !task.On.ChecksFailed && !task.On.Commented {
+			return fmt.Errorf("source %q task %q: 'on' block must specify at least one trigger (labels, review_submitted, checks_failed, or commented)", name, tname)
+		}
+	}
+	return nil
+}
+
+func validateGitHubMergeSource(name string, src SourceConfig) error {
+	repo := strings.TrimSpace(src.Repo)
+	if repo == "" {
+		return fmt.Errorf("source %q (github-merge): repo is required", name)
+	}
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return fmt.Errorf("source %q (github-merge): repo must be in owner/name format", name)
+	}
+	if len(src.Tasks) == 0 {
+		return fmt.Errorf("source %q (github-merge): at least one task is required", name)
+	}
+	for tname, task := range src.Tasks {
 		if strings.TrimSpace(task.Workflow) == "" {
 			return fmt.Errorf("source %q task %q: must include a workflow", name, tname)
 		}

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -840,3 +840,155 @@ claude:
 		t.Fatalf("LLM = %q, want empty (defaults to claude at runtime)", cfg.LLM)
 	}
 }
+
+func TestValidateGitHubPREventsValid(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"review": {
+						Workflow: "handle-review",
+						On: &PREventsConfig{
+							Labels:          []string{"needs-review"},
+							ReviewSubmitted: true,
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid config, got: %v", err)
+	}
+}
+
+func TestValidateGitHubPREventsMissingOn(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"review": {Workflow: "handle-review"},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "'on' block")
+}
+
+func TestValidateGitHubPREventsEmptyTriggers(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"review": {
+						Workflow: "handle-review",
+						On:       &PREventsConfig{},
+					},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "at least one trigger")
+}
+
+func TestValidateGitHubPREventsMissingRepo(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "",
+				Tasks: map[string]Task{
+					"review": {
+						Workflow: "handle-review",
+						On:       &PREventsConfig{ReviewSubmitted: true},
+					},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "repo is required")
+}
+
+func TestValidateGitHubMergeValid(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"merge": {
+				Type: "github-merge",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"deploy": {Workflow: "post-merge"},
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid config, got: %v", err)
+	}
+}
+
+func TestValidateGitHubMergeMissingRepo(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"merge": {
+				Type:  "github-merge",
+				Repo:  "",
+				Tasks: map[string]Task{"deploy": {Workflow: "post-merge"}},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "repo is required")
+}
+
+func TestValidateUnknownSourceType(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude"},
+		Sources: map[string]SourceConfig{
+			"unknown": {
+				Type: "bitbucket",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"test": {Workflow: "test-wf"},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "unknown type")
+}

--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -371,6 +371,20 @@ func (q *Queue) HasRef(ref string) bool {
 	return false
 }
 
+// HasRefAny reports whether any vessel (in any state) has the given ref.
+func (q *Queue) HasRefAny(ref string) bool {
+	vessels, err := q.List()
+	if err != nil {
+		return false
+	}
+	for _, vessel := range vessels {
+		if vessel.Ref == ref {
+			return true
+		}
+	}
+	return false
+}
+
 func (q *Queue) withLock(fn func() error) error {
 	lock := flock.New(q.lockPath)
 	if err := lock.Lock(); err != nil {

--- a/cli/internal/queue/queue_test.go
+++ b/cli/internal/queue/queue_test.go
@@ -354,6 +354,74 @@ func TestHasRefActiveStates(t *testing.T) {
 	}
 }
 
+func TestHasRefAny(t *testing.T) {
+	q, _ := newTestQueue(t)
+	vessel := testVessel(42)
+	if _, err := q.Enqueue(vessel); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	if !q.HasRefAny("https://github.com/example/repo/issues/42") {
+		t.Fatal("expected HasRefAny to be true for enqueued ref")
+	}
+	if q.HasRefAny("https://github.com/example/repo/issues/99") {
+		t.Fatal("expected HasRefAny to be false for unknown ref")
+	}
+}
+
+func TestHasRefAnyFindsTerminalStates(t *testing.T) {
+	tests := []struct {
+		state       VesselState
+		transitions []VesselState
+	}{
+		{StateCompleted, []VesselState{StateRunning, StateCompleted}},
+		{StateFailed, []VesselState{StateRunning, StateFailed}},
+		{StateTimedOut, []VesselState{StateRunning, StateWaiting, StateTimedOut}},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			q, _ := newTestQueue(t)
+			vessel := testVessel(42)
+			if _, err := q.Enqueue(vessel); err != nil {
+				t.Fatalf("enqueue: %v", err)
+			}
+			for _, s := range tt.transitions {
+				if err := q.Update(vessel.ID, s, ""); err != nil {
+					t.Fatalf("update to %s: %v", s, err)
+				}
+			}
+			// HasRefAny should still find vessels in terminal states
+			if !q.HasRefAny("https://github.com/example/repo/issues/42") {
+				t.Fatalf("expected HasRefAny to find %s vessel", tt.state)
+			}
+			// HasRef should NOT find vessels in terminal states
+			if q.HasRef("https://github.com/example/repo/issues/42") {
+				t.Fatalf("expected HasRef to NOT find %s vessel", tt.state)
+			}
+		})
+	}
+}
+
+func TestHasRefAnyCancelled(t *testing.T) {
+	q, _ := newTestQueue(t)
+	vessel := testVessel(42)
+	if _, err := q.Enqueue(vessel); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if err := q.Cancel(vessel.ID); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+
+	// HasRefAny should find cancelled vessels too
+	if !q.HasRefAny("https://github.com/example/repo/issues/42") {
+		t.Fatal("expected HasRefAny to find cancelled vessel")
+	}
+	// HasRef should NOT find cancelled vessels
+	if q.HasRef("https://github.com/example/repo/issues/42") {
+		t.Fatal("expected HasRef to NOT find cancelled vessel")
+	}
+}
+
 func TestEnqueueIdempotentDuplicateRef(t *testing.T) {
 	q, _ := newTestQueue(t)
 	vessel := testVessel(42)

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -72,9 +72,9 @@ func (s *Scanner) Scan(ctx context.Context) (ScanResult, error) {
 func (s *Scanner) buildSources() []source.Source {
 	var sources []source.Source
 	for _, srcCfg := range s.Config.Sources {
-		tasks := convertTasks(srcCfg.Tasks)
 		switch srcCfg.Type {
 		case "github":
+			tasks := convertTasks(srcCfg.Tasks)
 			sources = append(sources, &source.GitHub{
 				Repo:      srcCfg.Repo,
 				Tasks:     tasks,
@@ -83,10 +83,28 @@ func (s *Scanner) buildSources() []source.Source {
 				CmdRunner: s.CmdRunner,
 			})
 		case "github-pr":
+			tasks := convertTasks(srcCfg.Tasks)
 			sources = append(sources, &source.GitHubPR{
 				Repo:      srcCfg.Repo,
 				Tasks:     tasks,
 				Exclude:   srcCfg.Exclude,
+				Queue:     s.Queue,
+				CmdRunner: s.CmdRunner,
+			})
+		case "github-pr-events":
+			prEventsTasks := convertPREventsTasks(srcCfg.Tasks)
+			sources = append(sources, &source.GitHubPREvents{
+				Repo:      srcCfg.Repo,
+				Tasks:     prEventsTasks,
+				Exclude:   srcCfg.Exclude,
+				Queue:     s.Queue,
+				CmdRunner: s.CmdRunner,
+			})
+		case "github-merge":
+			mergeTasks := convertMergeTasks(srcCfg.Tasks)
+			sources = append(sources, &source.GitHubMerge{
+				Repo:      srcCfg.Repo,
+				Tasks:     mergeTasks,
 				Queue:     s.Queue,
 				CmdRunner: s.CmdRunner,
 			})
@@ -99,6 +117,33 @@ func convertTasks(cfgTasks map[string]config.Task) map[string]source.GitHubTask 
 	tasks := make(map[string]source.GitHubTask, len(cfgTasks))
 	for name, t := range cfgTasks {
 		tasks[name] = source.GitHubTaskFromConfig(t)
+	}
+	return tasks
+}
+
+func convertPREventsTasks(cfgTasks map[string]config.Task) map[string]source.PREventsTask {
+	tasks := make(map[string]source.PREventsTask, len(cfgTasks))
+	for name, t := range cfgTasks {
+		task := source.PREventsTask{
+			Workflow: t.Workflow,
+		}
+		if t.On != nil {
+			task.Labels = t.On.Labels
+			task.ReviewSubmitted = t.On.ReviewSubmitted
+			task.ChecksFailed = t.On.ChecksFailed
+			task.Commented = t.On.Commented
+		}
+		tasks[name] = task
+	}
+	return tasks
+}
+
+func convertMergeTasks(cfgTasks map[string]config.Task) map[string]source.MergeTask {
+	tasks := make(map[string]source.MergeTask, len(cfgTasks))
+	for name, t := range cfgTasks {
+		tasks[name] = source.MergeTask{
+			Workflow: t.Workflow,
+		}
 	}
 	return tasks
 }

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -586,3 +586,147 @@ func TestScanEmptyIssuesList(t *testing.T) {
 		t.Errorf("expected 0 added, got %d", result.Added)
 	}
 }
+
+// ghPRForScanner mirrors the GitHub PR JSON structure for test helpers.
+type ghPRForScanner struct {
+	Number      int    `json:"number"`
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+	HeadRefName string `json:"headRefName"`
+	Labels      []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+}
+
+func prJSON(prs []ghPRForScanner) []byte {
+	b, _ := json.Marshal(prs)
+	return b
+}
+
+func TestScanPREvents(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		StateDir:    dir,
+		Claude:      config.ClaudeConfig{Command: "claude"},
+		Sources: map[string]config.SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "owner/repo",
+				Tasks: map[string]config.Task{
+					"review": {
+						Workflow: "handle-review",
+						On: &config.PREventsConfig{
+							Labels: []string{"needs-review"},
+						},
+					},
+				},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPRForScanner{
+		{
+			Number:      10,
+			Title:       "test PR",
+			URL:         "https://github.com/owner/repo/pull/10",
+			HeadRefName: "feature-branch",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "needs-review"}},
+		},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+
+	s := New(cfg, q, r)
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Added != 1 {
+		t.Errorf("expected 1 added, got %d", result.Added)
+	}
+	vessels, _ := q.List()
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel in queue, got %d", len(vessels))
+	}
+	if vessels[0].Source != "github-pr-events" {
+		t.Errorf("expected source github-pr-events, got %q", vessels[0].Source)
+	}
+	if vessels[0].Workflow != "handle-review" {
+		t.Errorf("expected workflow handle-review, got %q", vessels[0].Workflow)
+	}
+}
+
+type ghMergeCommitForScanner struct {
+	OID string `json:"oid"`
+}
+
+type ghMergedPRForScanner struct {
+	Number      int                     `json:"number"`
+	Title       string                  `json:"title"`
+	URL         string                  `json:"url"`
+	MergeCommit ghMergeCommitForScanner `json:"mergeCommit"`
+	HeadRefName string                  `json:"headRefName"`
+}
+
+func mergedPRJSON(prs []ghMergedPRForScanner) []byte {
+	b, _ := json.Marshal(prs)
+	return b
+}
+
+func TestScanMerge(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		StateDir:    dir,
+		Claude:      config.ClaudeConfig{Command: "claude"},
+		Sources: map[string]config.SourceConfig{
+			"merge": {
+				Type: "github-merge",
+				Repo: "owner/repo",
+				Tasks: map[string]config.Task{
+					"deploy": {Workflow: "post-merge"},
+				},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghMergedPRForScanner{
+		{
+			Number:      20,
+			Title:       "merged PR",
+			URL:         "https://github.com/owner/repo/pull/20",
+			MergeCommit: ghMergeCommitForScanner{OID: "abcdef1234567890"},
+			HeadRefName: "feature-x",
+		},
+	}
+	r.set(mergedPRJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+
+	s := New(cfg, q, r)
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Added != 1 {
+		t.Errorf("expected 1 added, got %d", result.Added)
+	}
+	vessels, _ := q.List()
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel in queue, got %d", len(vessels))
+	}
+	if vessels[0].Source != "github-merge" {
+		t.Errorf("expected source github-merge, got %q", vessels[0].Source)
+	}
+	if vessels[0].Workflow != "post-merge" {
+		t.Errorf("expected workflow post-merge, got %q", vessels[0].Workflow)
+	}
+}

--- a/cli/internal/source/github_merge.go
+++ b/cli/internal/source/github_merge.go
@@ -1,0 +1,101 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+// MergeTask defines a task triggered by merged PRs.
+type MergeTask struct {
+	Workflow string
+}
+
+// GitHubMerge scans for merged PRs and produces vessels.
+type GitHubMerge struct {
+	Repo      string
+	Tasks     map[string]MergeTask
+	Queue     *queue.Queue
+	CmdRunner CommandRunner
+}
+
+type ghMergeCommit struct {
+	OID string `json:"oid"`
+}
+
+type ghMergedPR struct {
+	Number      int            `json:"number"`
+	Title       string         `json:"title"`
+	URL         string         `json:"url"`
+	MergeCommit ghMergeCommit  `json:"mergeCommit"`
+	HeadRefName string         `json:"headRefName"`
+}
+
+func (g *GitHubMerge) Name() string { return "github-merge" }
+
+func (g *GitHubMerge) Scan(ctx context.Context) ([]queue.Vessel, error) {
+	args := []string{
+		"pr", "list",
+		"--repo", g.Repo,
+		"--state", "merged",
+		"--json", "number,title,url,mergeCommit,headRefName",
+		"--limit", "20",
+	}
+	out, err := g.CmdRunner.Run(ctx, "gh", args...)
+	if err != nil {
+		return nil, fmt.Errorf("gh pr list (merged): %w", err)
+	}
+
+	var prs []ghMergedPR
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("parse gh pr list output: %w", err)
+	}
+
+	var vessels []queue.Vessel
+
+	for _, pr := range prs {
+		oid := strings.TrimSpace(pr.MergeCommit.OID)
+		if oid == "" {
+			continue
+		}
+
+		for _, task := range g.Tasks {
+			ref := fmt.Sprintf("%s#merge-%s", pr.URL, oid)
+			if g.Queue.HasRefAny(ref) {
+				continue
+			}
+			vessels = append(vessels, queue.Vessel{
+				ID:       fmt.Sprintf("merge-pr-%d-%s", pr.Number, oid[:minLen(len(oid), 8)]),
+				Source:   "github-merge",
+				Ref:      ref,
+				Workflow: task.Workflow,
+				Meta: map[string]string{
+					"pr_num":         strconv.Itoa(pr.Number),
+					"event_type":     "merge",
+					"pr_head_branch": pr.HeadRefName,
+				},
+				State:     queue.StatePending,
+				CreatedAt: time.Now().UTC(),
+			})
+		}
+	}
+
+	return vessels, nil
+}
+
+func (g *GitHubMerge) OnEnqueue(_ context.Context, _ queue.Vessel) error  { return nil }
+func (g *GitHubMerge) OnStart(_ context.Context, _ queue.Vessel) error    { return nil }
+func (g *GitHubMerge) OnComplete(_ context.Context, _ queue.Vessel) error { return nil }
+func (g *GitHubMerge) OnFail(_ context.Context, _ queue.Vessel) error     { return nil }
+func (g *GitHubMerge) OnTimedOut(_ context.Context, _ queue.Vessel) error { return nil }
+
+func (g *GitHubMerge) BranchName(vessel queue.Vessel) string {
+	prNum := vessel.Meta["pr_num"]
+	slug := slugify(vessel.Ref)
+	return fmt.Sprintf("merge/pr-%s-%s", prNum, slug)
+}

--- a/cli/internal/source/github_merge_test.go
+++ b/cli/internal/source/github_merge_test.go
@@ -1,0 +1,239 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+func TestMergeName(t *testing.T) {
+	g := &GitHubMerge{}
+	if g.Name() != "github-merge" {
+		t.Fatalf("Name() = %q, want github-merge", g.Name())
+	}
+}
+
+func TestMergeScan(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghMergedPR{
+		{
+			Number:         20,
+			Title:          "merged PR",
+			URL:            "https://github.com/owner/repo/pull/20",
+			MergeCommit: ghMergeCommit{OID: "abcdef1234567890"},
+			HeadRefName:    "feature-x",
+		},
+	}
+	prBytes, _ := json.Marshal(prs)
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+
+	g := &GitHubMerge{
+		Repo: "owner/repo",
+		Tasks: map[string]MergeTask{
+			"deploy": {Workflow: "post-merge"},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	v := vessels[0]
+	if v.Source != "github-merge" {
+		t.Errorf("Source = %q, want github-merge", v.Source)
+	}
+	if !strings.Contains(v.Ref, "#merge-abcdef1234567890") {
+		t.Errorf("Ref = %q, want to contain #merge-abcdef1234567890", v.Ref)
+	}
+	if v.Meta["pr_num"] != "20" {
+		t.Errorf("Meta[pr_num] = %q, want 20", v.Meta["pr_num"])
+	}
+	if v.Meta["event_type"] != "merge" {
+		t.Errorf("Meta[event_type] = %q, want merge", v.Meta["event_type"])
+	}
+	if v.Meta["pr_head_branch"] != "feature-x" {
+		t.Errorf("Meta[pr_head_branch] = %q, want feature-x", v.Meta["pr_head_branch"])
+	}
+	if v.Workflow != "post-merge" {
+		t.Errorf("Workflow = %q, want post-merge", v.Workflow)
+	}
+}
+
+func TestMergeScanDedup(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghMergedPR{
+		{Number: 20, Title: "merged PR", URL: "https://github.com/owner/repo/pull/20", MergeCommit: ghMergeCommit{OID: "abcdef1234567890"}, HeadRefName: "feature-x"},
+	}
+	prBytes, _ := json.Marshal(prs)
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+
+	// Pre-enqueue the same merge ref
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:     "merge-pr-20-abcdef12",
+		Source: "github-merge",
+		Ref:    "https://github.com/owner/repo/pull/20#merge-abcdef1234567890",
+		State:  queue.StatePending,
+	})
+
+	g := &GitHubMerge{
+		Repo:  "owner/repo",
+		Tasks: map[string]MergeTask{"deploy": {Workflow: "post-merge"}},
+		Queue: q, CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels (already queued), got %d", len(vessels))
+	}
+}
+
+func TestMergeScanDedupCompleted(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghMergedPR{
+		{Number: 20, Title: "merged PR", URL: "https://github.com/owner/repo/pull/20", MergeCommit: ghMergeCommit{OID: "abcdef1234567890"}, HeadRefName: "feature-x"},
+	}
+	prBytes, _ := json.Marshal(prs)
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+
+	// Pre-enqueue and complete the same merge ref
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:     "merge-pr-20-abcdef12",
+		Source: "github-merge",
+		Ref:    "https://github.com/owner/repo/pull/20#merge-abcdef1234567890",
+		State:  queue.StatePending,
+	})
+	_, _ = q.Dequeue()
+	_ = q.Update("merge-pr-20-abcdef12", queue.StateCompleted, "")
+
+	g := &GitHubMerge{
+		Repo:  "owner/repo",
+		Tasks: map[string]MergeTask{"deploy": {Workflow: "post-merge"}},
+		Queue: q, CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels (completed ref blocks re-processing), got %d", len(vessels))
+	}
+}
+
+func TestMergeBranchName(t *testing.T) {
+	g := &GitHubMerge{}
+	vessel := queue.Vessel{
+		Ref: "https://github.com/owner/repo/pull/20#merge-abcdef1234567890",
+		Meta: map[string]string{
+			"pr_num": "20",
+		},
+	}
+	got := g.BranchName(vessel)
+	if !strings.HasPrefix(got, "merge/pr-20-") {
+		t.Errorf("BranchName = %q, want prefix merge/pr-20-", got)
+	}
+}
+
+func TestMergeOnStartNoOp(t *testing.T) {
+	g := &GitHubMerge{}
+	if err := g.OnStart(context.Background(), queue.Vessel{}); err != nil {
+		t.Fatalf("OnStart should be no-op, got: %v", err)
+	}
+}
+
+func TestMergeOnEnqueueNoOp(t *testing.T) {
+	g := &GitHubMerge{}
+	if err := g.OnEnqueue(context.Background(), queue.Vessel{}); err != nil {
+		t.Fatalf("OnEnqueue should be no-op, got: %v", err)
+	}
+}
+
+func TestMergeOnCompleteNoOp(t *testing.T) {
+	g := &GitHubMerge{}
+	if err := g.OnComplete(context.Background(), queue.Vessel{}); err != nil {
+		t.Fatalf("OnComplete should be no-op, got: %v", err)
+	}
+}
+
+func TestMergeOnFailNoOp(t *testing.T) {
+	g := &GitHubMerge{}
+	if err := g.OnFail(context.Background(), queue.Vessel{}); err != nil {
+		t.Fatalf("OnFail should be no-op, got: %v", err)
+	}
+}
+
+func TestMergeOnTimedOutNoOp(t *testing.T) {
+	g := &GitHubMerge{}
+	if err := g.OnTimedOut(context.Background(), queue.Vessel{}); err != nil {
+		t.Fatalf("OnTimedOut should be no-op, got: %v", err)
+	}
+}
+
+func TestMergeScanGHError(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	r.setErr(fmt.Errorf("network error"), "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+
+	g := &GitHubMerge{
+		Repo:      "owner/repo",
+		Tasks:     map[string]MergeTask{"deploy": {Workflow: "post-merge"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	_, err := g.Scan(context.Background())
+	if err == nil {
+		t.Fatal("expected error from gh failure, got nil")
+	}
+}
+
+func TestMergeScanEmptyOIDSkipped(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghMergedPR{
+		{Number: 30, Title: "no OID", URL: "https://github.com/owner/repo/pull/30", MergeCommit: ghMergeCommit{OID: ""}, HeadRefName: "branch-30"},
+	}
+	prBytes, _ := json.Marshal(prs)
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+
+	g := &GitHubMerge{
+		Repo:      "owner/repo",
+		Tasks:     map[string]MergeTask{"deploy": {Workflow: "post-merge"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels (empty OID), got %d", len(vessels))
+	}
+}

--- a/cli/internal/source/github_pr_events.go
+++ b/cli/internal/source/github_pr_events.go
@@ -1,0 +1,299 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+// PREventsTask defines a task triggered by PR events.
+type PREventsTask struct {
+	Workflow        string
+	Labels          []string
+	ReviewSubmitted bool
+	ChecksFailed    bool
+	Commented       bool
+}
+
+// GitHubPREvents scans GitHub PRs for specific events and produces vessels.
+type GitHubPREvents struct {
+	Repo      string
+	Tasks     map[string]PREventsTask
+	Exclude   []string
+	Queue     *queue.Queue
+	CmdRunner CommandRunner
+}
+
+func (g *GitHubPREvents) Name() string { return "github-pr-events" }
+
+func (g *GitHubPREvents) Scan(ctx context.Context) ([]queue.Vessel, error) {
+	excludeSet := make(map[string]bool, len(g.Exclude))
+	for _, ex := range g.Exclude {
+		excludeSet[ex] = true
+	}
+
+	// List open PRs
+	args := []string{
+		"pr", "list",
+		"--repo", g.Repo,
+		"--state", "open",
+		"--json", "number,title,url,labels,headRefName",
+		"--limit", "50",
+	}
+	out, err := g.CmdRunner.Run(ctx, "gh", args...)
+	if err != nil {
+		return nil, fmt.Errorf("gh pr list: %w", err)
+	}
+
+	var prs []ghPR
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("parse gh pr list output: %w", err)
+	}
+
+	var vessels []queue.Vessel
+
+	for _, pr := range prs {
+		if g.hasExcludedLabel(pr, excludeSet) {
+			continue
+		}
+
+		for _, task := range g.Tasks {
+			// Label triggers
+			if len(task.Labels) > 0 {
+				prLabels := make(map[string]bool, len(pr.Labels))
+				for _, l := range pr.Labels {
+					prLabels[l.Name] = true
+				}
+				for _, triggerLabel := range task.Labels {
+					if prLabels[triggerLabel] {
+						ref := fmt.Sprintf("%s#label-%s", pr.URL, triggerLabel)
+						if !g.Queue.HasRefAny(ref) {
+							vessels = append(vessels, queue.Vessel{
+								ID:       fmt.Sprintf("pr-%d-label-%s", pr.Number, triggerLabel),
+								Source:   "github-pr-events",
+								Ref:      ref,
+								Workflow: task.Workflow,
+								Meta: map[string]string{
+									"pr_num":         strconv.Itoa(pr.Number),
+									"event_type":     "label",
+									"pr_head_branch": pr.HeadRefName,
+								},
+								State:     queue.StatePending,
+								CreatedAt: time.Now().UTC(),
+							})
+						}
+					}
+				}
+			}
+
+			// Review submitted trigger
+			if task.ReviewSubmitted {
+				v, err := g.scanReviews(ctx, pr, task)
+				if err != nil {
+					return vessels, err
+				}
+				vessels = append(vessels, v...)
+			}
+
+			// Checks failed trigger
+			if task.ChecksFailed {
+				v, err := g.scanChecksFailed(ctx, pr, task)
+				if err != nil {
+					return vessels, err
+				}
+				vessels = append(vessels, v...)
+			}
+
+			// Comment trigger
+			if task.Commented {
+				v, err := g.scanComments(ctx, pr, task)
+				if err != nil {
+					return vessels, err
+				}
+				vessels = append(vessels, v...)
+			}
+		}
+	}
+
+	return vessels, nil
+}
+
+func (g *GitHubPREvents) scanReviews(ctx context.Context, pr ghPR, task PREventsTask) ([]queue.Vessel, error) {
+	args := []string{
+		"api",
+		fmt.Sprintf("repos/%s/pulls/%d/reviews", g.Repo, pr.Number),
+		"--jq", ".[].id",
+	}
+	out, err := g.CmdRunner.Run(ctx, "gh", args...)
+	if err != nil {
+		return nil, nil // non-fatal: skip reviews on error
+	}
+
+	var vessels []queue.Vessel
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		reviewID := strings.TrimSpace(line)
+		if reviewID == "" {
+			continue
+		}
+		ref := fmt.Sprintf("%s#review-%s", pr.URL, reviewID)
+		if !g.Queue.HasRefAny(ref) {
+			vessels = append(vessels, queue.Vessel{
+				ID:       fmt.Sprintf("pr-%d-review-%s", pr.Number, reviewID),
+				Source:   "github-pr-events",
+				Ref:      ref,
+				Workflow: task.Workflow,
+				Meta: map[string]string{
+					"pr_num":         strconv.Itoa(pr.Number),
+					"event_type":     "review_submitted",
+					"pr_head_branch": pr.HeadRefName,
+				},
+				State:     queue.StatePending,
+				CreatedAt: time.Now().UTC(),
+			})
+		}
+	}
+	return vessels, nil
+}
+
+type ghCheck struct {
+	Name  string `json:"name"`
+	State string `json:"state"`
+}
+
+func (g *GitHubPREvents) scanChecksFailed(ctx context.Context, pr ghPR, task PREventsTask) ([]queue.Vessel, error) {
+	args := []string{
+		"pr", "checks", strconv.Itoa(pr.Number),
+		"--repo", g.Repo,
+		"--json", "name,state",
+	}
+	out, err := g.CmdRunner.Run(ctx, "gh", args...)
+	if err != nil {
+		return nil, nil // non-fatal
+	}
+
+	var checks []ghCheck
+	if err := json.Unmarshal(out, &checks); err != nil {
+		return nil, nil // non-fatal
+	}
+
+	hasFailed := false
+	for _, c := range checks {
+		if c.State == "FAILURE" || c.State == "ERROR" {
+			hasFailed = true
+			break
+		}
+	}
+
+	if !hasFailed {
+		return nil, nil
+	}
+
+	// Use head SHA via gh pr view for dedup
+	shaArgs := []string{
+		"pr", "view", strconv.Itoa(pr.Number),
+		"--repo", g.Repo,
+		"--json", "headRefOid",
+		"--jq", ".headRefOid",
+	}
+	shaOut, err := g.CmdRunner.Run(ctx, "gh", shaArgs...)
+	if err != nil {
+		return nil, nil // non-fatal
+	}
+
+	sha := strings.TrimSpace(string(shaOut))
+	if sha == "" {
+		return nil, nil
+	}
+
+	ref := fmt.Sprintf("%s#checks-failed-%s", pr.URL, sha)
+	if g.Queue.HasRefAny(ref) {
+		return nil, nil
+	}
+
+	return []queue.Vessel{
+		{
+			ID:       fmt.Sprintf("pr-%d-checks-failed-%s", pr.Number, sha[:minLen(len(sha), 8)]),
+			Source:   "github-pr-events",
+			Ref:      ref,
+			Workflow: task.Workflow,
+			Meta: map[string]string{
+				"pr_num":         strconv.Itoa(pr.Number),
+				"event_type":     "checks_failed",
+				"pr_head_branch": pr.HeadRefName,
+			},
+			State:     queue.StatePending,
+			CreatedAt: time.Now().UTC(),
+		},
+	}, nil
+}
+
+func (g *GitHubPREvents) scanComments(ctx context.Context, pr ghPR, task PREventsTask) ([]queue.Vessel, error) {
+	args := []string{
+		"api",
+		fmt.Sprintf("repos/%s/issues/%d/comments", g.Repo, pr.Number),
+		"--jq", ".[].id",
+	}
+	out, err := g.CmdRunner.Run(ctx, "gh", args...)
+	if err != nil {
+		return nil, nil // non-fatal
+	}
+
+	var vessels []queue.Vessel
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		commentID := strings.TrimSpace(line)
+		if commentID == "" {
+			continue
+		}
+		ref := fmt.Sprintf("%s#comment-%s", pr.URL, commentID)
+		if !g.Queue.HasRefAny(ref) {
+			vessels = append(vessels, queue.Vessel{
+				ID:       fmt.Sprintf("pr-%d-comment-%s", pr.Number, commentID),
+				Source:   "github-pr-events",
+				Ref:      ref,
+				Workflow: task.Workflow,
+				Meta: map[string]string{
+					"pr_num":         strconv.Itoa(pr.Number),
+					"event_type":     "commented",
+					"pr_head_branch": pr.HeadRefName,
+				},
+				State:     queue.StatePending,
+				CreatedAt: time.Now().UTC(),
+			})
+		}
+	}
+	return vessels, nil
+}
+
+func (g *GitHubPREvents) OnEnqueue(_ context.Context, _ queue.Vessel) error  { return nil }
+func (g *GitHubPREvents) OnStart(_ context.Context, _ queue.Vessel) error    { return nil }
+func (g *GitHubPREvents) OnComplete(_ context.Context, _ queue.Vessel) error { return nil }
+func (g *GitHubPREvents) OnFail(_ context.Context, _ queue.Vessel) error     { return nil }
+func (g *GitHubPREvents) OnTimedOut(_ context.Context, _ queue.Vessel) error { return nil }
+
+func (g *GitHubPREvents) BranchName(vessel queue.Vessel) string {
+	prNum := vessel.Meta["pr_num"]
+	eventType := vessel.Meta["event_type"]
+	slug := slugify(vessel.Ref)
+	return fmt.Sprintf("event/pr-%s-%s-%s", prNum, eventType, slug)
+}
+
+func (g *GitHubPREvents) hasExcludedLabel(pr ghPR, excluded map[string]bool) bool {
+	for _, l := range pr.Labels {
+		if excluded[l.Name] {
+			return true
+		}
+	}
+	return false
+}
+
+func minLen(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cli/internal/source/github_pr_events_test.go
+++ b/cli/internal/source/github_pr_events_test.go
@@ -1,0 +1,444 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+func prEventsListJSON(prs []ghPR) []byte {
+	b, _ := json.Marshal(prs)
+	return b
+}
+
+func TestPREventsName(t *testing.T) {
+	g := &GitHubPREvents{}
+	if g.Name() != "github-pr-events" {
+		t.Fatalf("Name() = %q, want github-pr-events", g.Name())
+	}
+}
+
+func TestPREventsScanLabels(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{
+			Number:      10,
+			Title:       "test PR",
+			URL:         "https://github.com/owner/repo/pull/10",
+			HeadRefName: "feature-branch",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "needs-review"}},
+		},
+	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review": {
+				Workflow: "handle-review",
+				Labels:   []string{"needs-review"},
+			},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	v := vessels[0]
+	if v.Source != "github-pr-events" {
+		t.Errorf("Source = %q, want github-pr-events", v.Source)
+	}
+	if !strings.Contains(v.Ref, "#label-needs-review") {
+		t.Errorf("Ref = %q, want to contain #label-needs-review", v.Ref)
+	}
+	if v.Meta["pr_num"] != "10" {
+		t.Errorf("Meta[pr_num] = %q, want 10", v.Meta["pr_num"])
+	}
+	if v.Meta["event_type"] != "label" {
+		t.Errorf("Meta[event_type] = %q, want label", v.Meta["event_type"])
+	}
+	if v.Meta["pr_head_branch"] != "feature-branch" {
+		t.Errorf("Meta[pr_head_branch] = %q, want feature-branch", v.Meta["pr_head_branch"])
+	}
+}
+
+func TestPREventsScanReviewSubmitted(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 5, Title: "PR 5", URL: "https://github.com/owner/repo/pull/5", HeadRefName: "branch-5"},
+	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+	r.set([]byte("1001\n1002\n"), "gh", "api", "repos/owner/repo/pulls/5/reviews", "--jq", ".[].id")
+
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"reviews": {
+				Workflow:        "handle-review",
+				ReviewSubmitted: true,
+			},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 2 {
+		t.Fatalf("expected 2 vessels (one per review), got %d", len(vessels))
+	}
+	for _, v := range vessels {
+		if v.Meta["event_type"] != "review_submitted" {
+			t.Errorf("Meta[event_type] = %q, want review_submitted", v.Meta["event_type"])
+		}
+	}
+}
+
+func TestPREventsScanChecksFailed(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 7, Title: "PR 7", URL: "https://github.com/owner/repo/pull/7", HeadRefName: "branch-7"},
+	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+
+	checks := []ghCheck{
+		{Name: "lint", State: "SUCCESS"},
+		{Name: "test", State: "FAILURE"},
+	}
+	checksJSON, _ := json.Marshal(checks)
+	r.set(checksJSON, "gh", "pr", "checks", "7", "--repo", "owner/repo", "--json", "name,state")
+	r.set([]byte("abc12345def"), "gh", "pr", "view", "7", "--repo", "owner/repo", "--json", "headRefOid", "--jq", ".headRefOid")
+
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"fix-checks": {
+				Workflow:     "fix-ci",
+				ChecksFailed: true,
+			},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	v := vessels[0]
+	if v.Meta["event_type"] != "checks_failed" {
+		t.Errorf("Meta[event_type] = %q, want checks_failed", v.Meta["event_type"])
+	}
+	if !strings.Contains(v.Ref, "#checks-failed-abc12345def") {
+		t.Errorf("Ref = %q, want to contain #checks-failed-abc12345def", v.Ref)
+	}
+}
+
+func TestPREventsScanChecksNoFailure(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 7, Title: "PR 7", URL: "https://github.com/owner/repo/pull/7", HeadRefName: "branch-7"},
+	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+
+	checks := []ghCheck{
+		{Name: "lint", State: "SUCCESS"},
+		{Name: "test", State: "SUCCESS"},
+	}
+	checksJSON, _ := json.Marshal(checks)
+	r.set(checksJSON, "gh", "pr", "checks", "7", "--repo", "owner/repo", "--json", "name,state")
+
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"fix-checks": {
+				Workflow:     "fix-ci",
+				ChecksFailed: true,
+			},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels (no failures), got %d", len(vessels))
+	}
+}
+
+func TestPREventsScanCommented(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 3, Title: "PR 3", URL: "https://github.com/owner/repo/pull/3", HeadRefName: "branch-3"},
+	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+	r.set([]byte("5001\n5002\n5003\n"), "gh", "api", "repos/owner/repo/issues/3/comments", "--jq", ".[].id")
+
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"comments": {
+				Workflow:  "respond-comment",
+				Commented: true,
+			},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 3 {
+		t.Fatalf("expected 3 vessels (one per comment), got %d", len(vessels))
+	}
+	for _, v := range vessels {
+		if v.Meta["event_type"] != "commented" {
+			t.Errorf("Meta[event_type] = %q, want commented", v.Meta["event_type"])
+		}
+	}
+}
+
+func TestPREventsScanExcluded(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{
+			Number: 1, Title: "excluded PR",
+			URL:         "https://github.com/owner/repo/pull/1",
+			HeadRefName: "branch-1",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "needs-review"}, {Name: "wontfix"}},
+		},
+	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+
+	g := &GitHubPREvents{
+		Repo:    "owner/repo",
+		Exclude: []string{"wontfix"},
+		Tasks: map[string]PREventsTask{
+			"review": {
+				Workflow: "handle-review",
+				Labels:   []string{"needs-review"},
+			},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels (excluded), got %d", len(vessels))
+	}
+}
+
+func TestPREventsScanDedup(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{
+			Number: 10, Title: "test PR",
+			URL:         "https://github.com/owner/repo/pull/10",
+			HeadRefName: "feature-branch",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "needs-review"}},
+		},
+	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+
+	// Pre-enqueue a vessel with matching ref
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:     "pr-10-label-needs-review",
+		Source: "github-pr-events",
+		Ref:    "https://github.com/owner/repo/pull/10#label-needs-review",
+		State:  queue.StatePending,
+	})
+
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review": {
+				Workflow: "handle-review",
+				Labels:   []string{"needs-review"},
+			},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels (already queued), got %d", len(vessels))
+	}
+}
+
+func TestPREventsScanDedupCompletedRef(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{
+			Number: 10, Title: "test PR",
+			URL:         "https://github.com/owner/repo/pull/10",
+			HeadRefName: "feature-branch",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "needs-review"}},
+		},
+	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+
+	// Pre-enqueue and complete a vessel with matching ref
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:     "pr-10-label-needs-review",
+		Source: "github-pr-events",
+		Ref:    "https://github.com/owner/repo/pull/10#label-needs-review",
+		State:  queue.StatePending,
+	})
+	_, _ = q.Dequeue()
+	_ = q.Update("pr-10-label-needs-review", queue.StateCompleted, "")
+
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review": {
+				Workflow: "handle-review",
+				Labels:   []string{"needs-review"},
+			},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	// HasRefAny should still find completed vessels, so no new vessel is created
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels (completed ref blocks re-processing), got %d", len(vessels))
+	}
+}
+
+func TestPREventsBranchName(t *testing.T) {
+	g := &GitHubPREvents{}
+	vessel := queue.Vessel{
+		Ref: "https://github.com/owner/repo/pull/10#label-needs-review",
+		Meta: map[string]string{
+			"pr_num":     "10",
+			"event_type": "label",
+		},
+	}
+	got := g.BranchName(vessel)
+	if !strings.HasPrefix(got, "event/pr-10-label-") {
+		t.Errorf("BranchName = %q, want prefix event/pr-10-label-", got)
+	}
+}
+
+func TestPREventsOnStartNoOp(t *testing.T) {
+	g := &GitHubPREvents{}
+	err := g.OnStart(context.Background(), queue.Vessel{})
+	if err != nil {
+		t.Fatalf("OnStart should be no-op, got: %v", err)
+	}
+}
+
+func TestPREventsOnEnqueueNoOp(t *testing.T) {
+	g := &GitHubPREvents{}
+	if err := g.OnEnqueue(context.Background(), queue.Vessel{}); err != nil {
+		t.Fatalf("OnEnqueue should be no-op, got: %v", err)
+	}
+}
+
+func TestPREventsOnCompleteNoOp(t *testing.T) {
+	g := &GitHubPREvents{}
+	if err := g.OnComplete(context.Background(), queue.Vessel{}); err != nil {
+		t.Fatalf("OnComplete should be no-op, got: %v", err)
+	}
+}
+
+func TestPREventsOnFailNoOp(t *testing.T) {
+	g := &GitHubPREvents{}
+	if err := g.OnFail(context.Background(), queue.Vessel{}); err != nil {
+		t.Fatalf("OnFail should be no-op, got: %v", err)
+	}
+}
+
+func TestPREventsOnTimedOutNoOp(t *testing.T) {
+	g := &GitHubPREvents{}
+	if err := g.OnTimedOut(context.Background(), queue.Vessel{}); err != nil {
+		t.Fatalf("OnTimedOut should be no-op, got: %v", err)
+	}
+}
+
+func TestPREventsScanGHError(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	r.setErr(fmt.Errorf("network error"), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review": {Workflow: "handle-review", Labels: []string{"needs-review"}},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	_, err := g.Scan(context.Background())
+	if err == nil {
+		t.Fatal("expected error from gh failure, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `github-pr-events` source type that monitors open PRs for events (labels added, reviews submitted, checks failed, comments) and creates deduplicated vessels per event
- Add `github-merge` source type that monitors merged PRs and creates vessels using merge commit OID for deduplication
- Add `Queue.HasRefAny()` method to match refs across all vessel states (including terminal), used by event sources to prevent re-processing
- Add config validation for new source types including `PREventsConfig` struct and `on` trigger requirements
- Wire new sources into scanner `buildSources`, drain `buildSourceMap`, and `buildReporter`

## Test plan
- [x] Config validation: valid pr-events, missing `on`, empty triggers, missing repo
- [x] Config validation: valid merge, missing repo, unknown source type
- [x] Queue: HasRefAny finds refs in all states including terminal (contrasted with HasRef)
- [x] PR events source: label, review, checks-failed, comment triggers all produce correct vessels
- [x] PR events source: exclusion, dedup (pending + completed), branch name, lifecycle no-ops
- [x] Merge source: scan, dedup (pending + completed), empty OID skip, branch name, lifecycle no-ops
- [x] Scanner integration: new source types produce vessels via full scan flow
- [x] All existing tests continue to pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)