### PR TITLE
feat: integrate new source types into runner and drain

### DIFF
--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -73,6 +73,19 @@ func buildSourceMap(cfg *config.Config, q *queue.Queue, cmdRunner source.Command
 				CmdRunner: cmdRunner,
 			}
 			sources[gh.Name()] = gh
+		case "github-pr":
+			tasks := make(map[string]source.GitHubTask, len(srcCfg.Tasks))
+			for name, t := range srcCfg.Tasks {
+				tasks[name] = source.GitHubTaskFromConfig(t)
+			}
+			pr := &source.GitHubPR{
+				Repo:      srcCfg.Repo,
+				Tasks:     tasks,
+				Exclude:   srcCfg.Exclude,
+				Queue:     q,
+				CmdRunner: cmdRunner,
+			}
+			sources[pr.Name()] = pr
 		case "github-pr-events":
 			prEventsTasks := make(map[string]source.PREventsTask, len(srcCfg.Tasks))
 			for name, t := range srcCfg.Tasks {

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -591,7 +591,7 @@ func (r *Runner) fetchIssueData(ctx context.Context, vessel *queue.Vessel) phase
 	switch vessel.Source {
 	case "github-issue":
 		return r.fetchGitHubData(ctx, vessel, "issue", "issue")
-	case "github-pr":
+	case "github-pr", "github-pr-events", "github-merge":
 		return r.fetchGitHubData(ctx, vessel, "pr", "pr")
 	default:
 		return phase.IssueData{}
@@ -714,6 +714,10 @@ func (r *Runner) resolveRepo(vessel queue.Vessel) string {
 	case *source.GitHub:
 		return s.Repo
 	case *source.GitHubPR:
+		return s.Repo
+	case *source.GitHubPREvents:
+		return s.Repo
+	case *source.GitHubMerge:
 		return s.Repo
 	default:
 		return ""

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -2217,3 +2217,85 @@ func TestDrainCommandPhaseWithNoOp(t *testing.T) {
 		t.Errorf("expected CurrentPhase 1, got %d", vessels[0].CurrentPhase)
 	}
 }
+
+func TestDrainPREventsVessel(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	// Enqueue a PR-events vessel (review submitted)
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:       "pr-10-review-abc123",
+		Source:   "github-pr-events",
+		Ref:      "https://github.com/owner/repo/pull/10#review-1001",
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"pr_num":         "10",
+			"event_type":     "review_submitted",
+			"pr_head_branch": "feature-branch",
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{name: "respond", promptContent: "Respond to review on {{.Issue.Title}}", maxTurns: 5},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	// Mock the gh pr view call that fetchIssueData triggers
+	prViewJSON := `{"title":"Test PR","body":"PR body","url":"https://github.com/owner/repo/pull/10","labels":[{"name":"needs-review"}]}`
+	cmdRunner := &mockCmdRunner{
+		outputData: []byte(prViewJSON),
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-pr-events": &source.GitHubPREvents{Repo: "owner/repo"},
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Completed != 1 {
+		t.Errorf("expected 1 completed, got %d", result.Completed)
+	}
+
+	// Verify that the prompt included the PR title from fetchIssueData
+	if len(cmdRunner.phaseCalls) != 1 {
+		t.Fatalf("expected 1 phase call, got %d", len(cmdRunner.phaseCalls))
+	}
+	if !strings.Contains(cmdRunner.phaseCalls[0].prompt, "Test PR") {
+		t.Errorf("expected prompt to contain PR title 'Test PR', got: %s", cmdRunner.phaseCalls[0].prompt)
+	}
+}
+
+func TestResolveRepoNewSources(t *testing.T) {
+	r := &Runner{
+		Sources: map[string]source.Source{
+			"github-pr-events": &source.GitHubPREvents{Repo: "owner/events-repo"},
+			"github-merge":     &source.GitHubMerge{Repo: "owner/merge-repo"},
+		},
+	}
+
+	tests := []struct {
+		source string
+		want   string
+	}{
+		{"github-pr-events", "owner/events-repo"},
+		{"github-merge", "owner/merge-repo"},
+		{"unknown", ""},
+	}
+
+	for _, tt := range tests {
+		got := r.resolveRepo(queue.Vessel{Source: tt.source})
+		if got != tt.want {
+			t.Errorf("resolveRepo(%q) = %q, want %q", tt.source, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `github-pr-events` and `github-merge` to `fetchIssueData` so PR data is fetched and available in prompt templates for these vessel types
- Add `GitHubPREvents` and `GitHubMerge` to `resolveRepo` so the runner can find the repo for reporter comments and label gate checks
- Add missing `github-pr` case to `buildSourceMap` in drain.go (pre-existing gap)

## Test plan
- [x] `TestDrainPREventsVessel` — verifies PR event vessels get PR data fetched and rendered in prompts
- [x] `TestResolveRepoNewSources` — verifies resolveRepo returns correct repo for both new source types
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)