### PR TITLE
feat: reject duplicate DependsOn entries in workflow validation

### DIFF
--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -36,7 +36,8 @@ type Phase struct {
 	Model        *string `yaml:"model,omitempty"`
 	NoOp         *NoOp   `yaml:"noop,omitempty"`
 	Gate         *Gate   `yaml:"gate,omitempty"`
-	AllowedTools *string `yaml:"allowed_tools,omitempty"`
+	AllowedTools *string  `yaml:"allowed_tools,omitempty"`
+	DependsOn    []string `yaml:"depends_on,omitempty"`
 }
 
 // NoOp defines an early-success completion rule for a phase.
@@ -96,6 +97,12 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 		return err
 	}
 
+	// Collect all phase names upfront for dependency reference validation.
+	allNames := make(map[string]bool, len(s.Phases))
+	for _, p := range s.Phases {
+		allNames[p.Name] = true
+	}
+
 	seen := make(map[string]bool, len(s.Phases))
 	for _, p := range s.Phases {
 		if p.Name == "" {
@@ -151,8 +158,92 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 		if err := validateLLM(p.LLM, fmt.Sprintf("phase %q", p.Name)); err != nil {
 			return err
 		}
+
+		seenDeps := make(map[string]bool, len(p.DependsOn))
+		for _, dep := range p.DependsOn {
+			if seenDeps[dep] {
+				return fmt.Errorf("phase %q: depends_on contains duplicate entry %q", p.Name, dep)
+			}
+			seenDeps[dep] = true
+			if dep == p.Name {
+				return fmt.Errorf("phase %q: depends_on contains self-reference", p.Name)
+			}
+			if !allNames[dep] {
+				return fmt.Errorf("phase %q: depends_on references unknown phase %q", p.Name, dep)
+			}
+		}
 	}
 
+	if err := validateDependencyCycles(s.Phases); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// HasDependencies returns true if any phase declares explicit depends_on.
+func (s *Workflow) HasDependencies() bool {
+	for _, p := range s.Phases {
+		if len(p.DependsOn) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// validateDependencyCycles checks for cycles in the phase dependency graph.
+func validateDependencyCycles(phases []Phase) error {
+	hasDeps := false
+	for _, p := range phases {
+		if len(p.DependsOn) > 0 {
+			hasDeps = true
+			break
+		}
+	}
+	if !hasDeps {
+		return nil
+	}
+
+	// Build adjacency list: edge from dep -> phase (dep must complete before phase).
+	adj := make(map[string][]string, len(phases))
+	for _, p := range phases {
+		adj[p.Name] = nil // ensure all nodes present
+	}
+	for _, p := range phases {
+		for _, dep := range p.DependsOn {
+			adj[dep] = append(adj[dep], p.Name)
+		}
+	}
+
+	const (
+		white = 0 // unvisited
+		gray  = 1 // in current path
+		black = 2 // fully explored
+	)
+	color := make(map[string]int, len(phases))
+
+	var dfs func(string) bool
+	dfs = func(u string) bool {
+		color[u] = gray
+		for _, v := range adj[u] {
+			if color[v] == gray {
+				return true
+			}
+			if color[v] == white && dfs(v) {
+				return true
+			}
+		}
+		color[u] = black
+		return false
+	}
+
+	for _, p := range phases {
+		if color[p.Name] == white {
+			if dfs(p.Name) {
+				return fmt.Errorf("depends_on creates a cycle in the phase graph")
+			}
+		}
+	}
 	return nil
 }
 

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -319,6 +319,145 @@ phases:
 			prompts: []string{"prompts/analyze.md"},
 			wantErr: `workflow name "wrong-name" does not match filename "fix-bug.yaml"`,
 		},
+		{
+			name: "valid depends_on",
+			yaml: `name: fix-bug
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+  - name: implement
+    prompt_file: prompts/implement.md
+    max_turns: 20
+    depends_on:
+      - analyze
+`,
+			prompts: []string{"prompts/analyze.md", "prompts/implement.md"},
+			checkFunc: func(t *testing.T, s *Workflow) {
+				t.Helper()
+				if len(s.Phases[1].DependsOn) != 1 || s.Phases[1].DependsOn[0] != "analyze" {
+					t.Fatalf("DependsOn = %v, want [analyze]", s.Phases[1].DependsOn)
+				}
+				if !s.HasDependencies() {
+					t.Fatal("HasDependencies() = false, want true")
+				}
+			},
+		},
+		{
+			name: "depends_on self-reference",
+			yaml: `name: fix-bug
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+    depends_on:
+      - analyze
+`,
+			prompts: []string{"prompts/analyze.md"},
+			wantErr: "depends_on contains self-reference",
+		},
+		{
+			name: "depends_on unknown phase",
+			yaml: `name: fix-bug
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+    depends_on:
+      - nonexistent
+`,
+			prompts: []string{"prompts/analyze.md"},
+			wantErr: `depends_on references unknown phase "nonexistent"`,
+		},
+		{
+			name: "depends_on duplicate entry",
+			yaml: `name: fix-bug
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+  - name: implement
+    prompt_file: prompts/implement.md
+    max_turns: 20
+    depends_on:
+      - analyze
+      - analyze
+`,
+			prompts: []string{"prompts/analyze.md", "prompts/implement.md"},
+			wantErr: `depends_on contains duplicate entry "analyze"`,
+		},
+		{
+			name: "depends_on cycle",
+			yaml: `name: fix-bug
+phases:
+  - name: alpha
+    prompt_file: prompts/alpha.md
+    max_turns: 10
+    depends_on:
+      - beta
+  - name: beta
+    prompt_file: prompts/beta.md
+    max_turns: 10
+    depends_on:
+      - alpha
+`,
+			prompts: []string{"prompts/alpha.md", "prompts/beta.md"},
+			wantErr: "depends_on creates a cycle",
+		},
+		{
+			name: "parallel phases with shared dependency",
+			yaml: `name: fix-bug
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+  - name: implement_a
+    prompt_file: prompts/implement_a.md
+    max_turns: 20
+    depends_on:
+      - analyze
+  - name: implement_b
+    prompt_file: prompts/implement_b.md
+    max_turns: 20
+    depends_on:
+      - analyze
+  - name: merge
+    prompt_file: prompts/merge.md
+    max_turns: 5
+    depends_on:
+      - implement_a
+      - implement_b
+`,
+			prompts: []string{"prompts/analyze.md", "prompts/implement_a.md", "prompts/implement_b.md", "prompts/merge.md"},
+			checkFunc: func(t *testing.T, s *Workflow) {
+				t.Helper()
+				if len(s.Phases) != 4 {
+					t.Fatalf("len(Phases) = %d, want 4", len(s.Phases))
+				}
+				if len(s.Phases[3].DependsOn) != 2 {
+					t.Fatalf("merge DependsOn = %v, want [implement_a, implement_b]", s.Phases[3].DependsOn)
+				}
+			},
+		},
+		{
+			name: "no depends_on means HasDependencies false",
+			yaml: `name: fix-bug
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+  - name: implement
+    prompt_file: prompts/implement.md
+    max_turns: 20
+`,
+			prompts: []string{"prompts/analyze.md", "prompts/implement.md"},
+			checkFunc: func(t *testing.T, s *Workflow) {
+				t.Helper()
+				if s.HasDependencies() {
+					t.Fatal("HasDependencies() = true, want false")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -818,6 +957,55 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			prompts: []string{"prompt.md"},
+		},
+		{
+			name:             "depends_on duplicate entry",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "analyze", PromptFile: "a.md", MaxTurns: 5},
+					{Name: "implement", PromptFile: "b.md", MaxTurns: 5, DependsOn: []string{"analyze", "analyze"}},
+				},
+			},
+			prompts: []string{"a.md", "b.md"},
+			wantErr: `depends_on contains duplicate entry "analyze"`,
+		},
+		{
+			name:             "depends_on self-reference",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "step1", PromptFile: "prompt.md", MaxTurns: 5, DependsOn: []string{"step1"}},
+				},
+			},
+			prompts: []string{"prompt.md"},
+			wantErr: "depends_on contains self-reference",
+		},
+		{
+			name:             "depends_on unknown phase",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "step1", PromptFile: "prompt.md", MaxTurns: 5, DependsOn: []string{"missing"}},
+				},
+			},
+			prompts: []string{"prompt.md"},
+			wantErr: `depends_on references unknown phase "missing"`,
+		},
+		{
+			name:             "valid depends_on",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{Name: "analyze", PromptFile: "a.md", MaxTurns: 5},
+					{Name: "implement", PromptFile: "b.md", MaxTurns: 5, DependsOn: []string{"analyze"}},
+				},
+			},
+			prompts: []string{"a.md", "b.md"},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Adds `DependsOn` field to `Phase` struct for DAG-based phase execution ordering
- Validates `depends_on` entries: rejects self-references, unknown phase names, duplicate entries, and dependency cycles
- Adds `HasDependencies()` method and `validateDependencyCycles()` for graph-level validation
- Includes comprehensive tests in both `TestLoad` (YAML round-trip) and `TestValidate` (struct-based) tables

## Test plan
- [x] All existing workflow tests pass (`go test -race ./internal/workflow/...`)
- [x] Full test suite passes (`go test ./...` -- 22 packages)
- [x] New test cases cover: valid depends_on, self-reference, unknown phase, duplicate entry, cycle detection, parallel phases with shared dependency, HasDependencies false case

🤖 Generated with [Claude Code](https://claude.com/claude-code)