### PR TITLE
feat: wire orchestrator into runner with parallel phase execution

### DIFF
--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/gate"
+	"github.com/nicholls-inc/xylem/cli/internal/orchestrator"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
@@ -238,10 +239,16 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) string {
 	// Read harness file
 	harnessContent := r.readHarness()
 
+	// Orchestrator-driven execution for workflows with explicit phase dependencies.
+	// This enables parallel phase execution within waves and context firewalls.
+	if sk.HasDependencies() {
+		return r.runVesselOrchestrated(ctx, vessel, sk, issueData, harnessContent, worktreePath, src)
+	}
+
 	// Rebuild previousOutputs from .xylem/phases/<id>/*.output (for resume)
 	previousOutputs := r.rebuildPreviousOutputs(vessel.ID, sk)
 
-	// Execute phases
+	// Execute phases sequentially (no explicit dependencies)
 	var phaseResults []reporter.PhaseResult
 	for i := vessel.CurrentPhase; i < len(sk.Phases); i++ {
 		p := sk.Phases[i]
@@ -568,6 +575,322 @@ func (r *Runner) completeVessel(ctx context.Context, vessel queue.Vessel, worktr
 	}
 
 	return "completed"
+}
+
+// runVesselOrchestrated executes a workflow with explicit phase dependencies
+// using the orchestrator for tracking and wave-based parallel execution.
+// Phases within the same wave (no dependencies between them) run concurrently.
+// Context firewalls ensure each phase only sees outputs from its declared dependencies.
+func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel, wf *workflow.Workflow, issueData phase.IssueData, harnessContent, worktreePath string, src source.Source) string {
+	graph, err := buildPhaseGraph(wf)
+	if err != nil {
+		r.failVessel(vessel.ID, fmt.Sprintf("build phase graph: %v", err))
+		if err := src.OnFail(ctx, vessel); err != nil {
+			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+		}
+		return "failed"
+	}
+
+	// Rebuild previous outputs for resume.
+	allOutputs := r.rebuildPreviousOutputs(vessel.ID, wf)
+
+	// Mark already-completed phases in orchestrator.
+	for phaseName, output := range allOutputs {
+		_ = graph.orch.UpdateAgent(phaseName, orchestrator.StatusCompleted, 0, 0, "")
+		_ = graph.orch.SetResult(orchestrator.SubAgentResult{
+			AgentID: phaseName,
+			Summary: output,
+			Success: true,
+		})
+	}
+
+	var allPhaseResults []reporter.PhaseResult
+
+	for _, wave := range graph.waves {
+		// Filter out already-completed phases.
+		var pending []int
+		for _, idx := range wave {
+			if _, done := allOutputs[wf.Phases[idx].Name]; !done {
+				pending = append(pending, idx)
+			}
+		}
+		if len(pending) == 0 {
+			continue
+		}
+
+		// Execute wave: single phase runs inline, multiple phases run concurrently.
+		type waveResult struct {
+			phaseIdx int
+			output   string
+			status   string // "completed", "no-op", "failed", "waiting"
+			duration time.Duration
+			gateOut  string
+		}
+
+		results := make([]waveResult, len(pending))
+
+		if len(pending) == 1 {
+			// Single phase: run inline (no goroutine overhead).
+			idx := pending[0]
+			depOutputs := graph.dependencyOutputs(idx, allOutputs)
+			res := r.runSinglePhase(ctx, vessel, wf, idx, depOutputs, issueData, harnessContent, worktreePath, src)
+			results[0] = waveResult{phaseIdx: idx, output: res.output, status: res.status, duration: res.duration, gateOut: res.gateOut}
+		} else {
+			// Multiple phases: run concurrently.
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+			for ri, idx := range pending {
+				wg.Add(1)
+				go func(ri, idx int) {
+					defer wg.Done()
+					mu.Lock()
+					depOutputs := graph.dependencyOutputs(idx, allOutputs)
+					mu.Unlock()
+
+					// Mark running in orchestrator.
+					mu.Lock()
+					_ = graph.orch.UpdateAgent(wf.Phases[idx].Name, orchestrator.StatusRunning, 0, 0, "")
+					mu.Unlock()
+
+					res := r.runSinglePhase(ctx, vessel, wf, idx, depOutputs, issueData, harnessContent, worktreePath, src)
+
+					mu.Lock()
+					results[ri] = waveResult{phaseIdx: idx, output: res.output, status: res.status, duration: res.duration, gateOut: res.gateOut}
+					mu.Unlock()
+				}(ri, idx)
+			}
+			wg.Wait()
+		}
+
+		// Process wave results: update orchestrator, collect outputs.
+		for _, res := range results {
+			p := wf.Phases[res.phaseIdx]
+
+			switch res.status {
+			case "completed", "no-op":
+				_ = graph.orch.UpdateAgent(p.Name, orchestrator.StatusCompleted, 0, res.duration, "")
+				_ = graph.orch.SetResult(orchestrator.SubAgentResult{
+					AgentID: p.Name,
+					Summary: res.output,
+					Success: true,
+				})
+				allOutputs[p.Name] = res.output
+			case "failed":
+				_ = graph.orch.UpdateAgent(p.Name, orchestrator.StatusFailed, 0, res.duration, res.gateOut)
+				// Fail-fast: stop processing.
+				return "failed"
+			case "waiting":
+				return "waiting"
+			}
+
+			allPhaseResults = append(allPhaseResults, reporter.PhaseResult{
+				Name:     p.Name,
+				Duration: res.duration,
+				Status:   res.status,
+			})
+
+			if res.status == "no-op" {
+				log.Printf("%sphase %q triggered no-op; completing workflow early", vesselLabel(vessel), p.Name)
+				if err := src.OnComplete(ctx, vessel); err != nil {
+					log.Printf("warn: OnComplete hook for vessel %s: %v", vessel.ID, err)
+				}
+				return r.completeVessel(ctx, vessel, worktreePath, allPhaseResults)
+			}
+		}
+	}
+
+	// All waves complete.
+	log.Printf("%scompleted all phases (orchestrated, %d waves)", vesselLabel(vessel), len(graph.waves))
+	if err := src.OnComplete(ctx, vessel); err != nil {
+		log.Printf("warn: OnComplete hook for vessel %s: %v", vessel.ID, err)
+	}
+	return r.completeVessel(ctx, vessel, worktreePath, allPhaseResults)
+}
+
+// singlePhaseResult holds the outcome of executing one phase including its gate.
+type singlePhaseResult struct {
+	output   string
+	status   string // "completed", "no-op", "failed", "waiting"
+	duration time.Duration
+	gateOut  string
+}
+
+// runSinglePhase executes a single workflow phase (prompt or command), including
+// gate evaluation and retries. It returns the outcome without mutating the
+// vessel's queue state directly (the caller handles that).
+func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *workflow.Workflow, phaseIdx int, previousOutputs map[string]string, issueData phase.IssueData, harnessContent, worktreePath string, src source.Source) singlePhaseResult {
+	p := wf.Phases[phaseIdx]
+	gateResult := ""
+	gateRetries := 0
+	if p.Gate != nil && p.Gate.Type == "command" && p.Gate.Retries > 0 {
+		gateRetries = p.Gate.Retries
+	}
+
+	phaseStart := time.Now()
+
+	for {
+		log.Printf("%sphase %q starting (orchestrated)", vesselLabel(vessel), p.Name)
+
+		td := phase.TemplateData{
+			Issue: issueData,
+			Phase: phase.PhaseData{
+				Name:  p.Name,
+				Index: phaseIdx,
+			},
+			PreviousOutputs: previousOutputs,
+			GateResult:      gateResult,
+			Vessel: phase.VesselData{
+				ID:     vessel.ID,
+				Source: vessel.Source,
+			},
+		}
+
+		phasesDir := filepath.Join(r.Config.StateDir, "phases", vessel.ID)
+		os.MkdirAll(phasesDir, 0o755)
+
+		var output []byte
+		var runErr error
+
+		if p.Type == "command" {
+			rendered, err := phase.RenderPrompt(p.Run, td)
+			if err != nil {
+				r.failVessel(vessel.ID, fmt.Sprintf("render command for phase %s: %v", p.Name, err))
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
+				return singlePhaseResult{status: "failed", duration: time.Since(phaseStart)}
+			}
+			if wErr := os.WriteFile(filepath.Join(phasesDir, p.Name+".command"), []byte(rendered), 0o644); wErr != nil {
+				log.Printf("warn: write command file: %v", wErr)
+			}
+			cmdOut, cmdErr := gate.RunCommand(ctx, r.Runner, worktreePath, rendered)
+			output = []byte(cmdOut)
+			runErr = cmdErr
+		} else {
+			promptContent, err := os.ReadFile(p.PromptFile)
+			if err != nil {
+				r.failVessel(vessel.ID, fmt.Sprintf("read prompt file %s: %v", p.PromptFile, err))
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
+				return singlePhaseResult{status: "failed", duration: time.Since(phaseStart)}
+			}
+			rendered, err := phase.RenderPrompt(string(promptContent), td)
+			if err != nil {
+				r.failVessel(vessel.ID, fmt.Sprintf("render prompt for phase %s: %v", p.Name, err))
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
+				return singlePhaseResult{status: "failed", duration: time.Since(phaseStart)}
+			}
+			promptPath := filepath.Join(phasesDir, p.Name+".prompt")
+			if wErr := os.WriteFile(promptPath, []byte(rendered), 0o644); wErr != nil {
+				log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
+			}
+			provider := resolveProvider(r.Config, wf, &p)
+			cmd, args := buildProviderPhaseArgs(r.Config, wf, &p, harnessContent, provider)
+			output, runErr = r.Runner.RunPhase(ctx, worktreePath, strings.NewReader(rendered), cmd, args...)
+		}
+
+		// Write output file.
+		outputPath := filepath.Join(phasesDir, p.Name+".output")
+		if wErr := os.WriteFile(outputPath, output, 0o644); wErr != nil {
+			log.Printf("warn: write output file %s: %v", outputPath, wErr)
+		}
+		fmt.Printf("Phase %s complete: %s\n", p.Name, outputPath)
+
+		if runErr != nil {
+			log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
+			vessel.FailedPhase = p.Name
+			r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, runErr))
+			if err := src.OnFail(ctx, vessel); err != nil {
+				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+			}
+			issueNum := r.parseIssueNum(vessel)
+			if issueNum > 0 && r.Reporter != nil {
+				r.Reporter.VesselFailed(ctx, issueNum, p.Name, runErr.Error(), "")
+			}
+			return singlePhaseResult{status: "failed", duration: time.Since(phaseStart)}
+		}
+
+		// Report phase completion.
+		issueNum := r.parseIssueNum(vessel)
+		if phaseMatchedNoOp(&p, string(output)) {
+			if issueNum > 0 && r.Reporter != nil {
+				r.Reporter.PhaseComplete(ctx, issueNum, p.Name, time.Since(phaseStart), string(output))
+			}
+			return singlePhaseResult{output: string(output), status: "no-op", duration: time.Since(phaseStart)}
+		}
+
+		if issueNum > 0 && r.Reporter != nil {
+			r.Reporter.PhaseComplete(ctx, issueNum, p.Name, time.Since(phaseStart), string(output))
+		}
+
+		// Handle gate.
+		if p.Gate == nil {
+			return singlePhaseResult{output: string(output), status: "completed", duration: time.Since(phaseStart)}
+		}
+
+		switch p.Gate.Type {
+		case "command":
+			gateOut, passed, gateErr := gate.RunCommandGate(ctx, r.Runner, worktreePath, p.Gate.Run)
+			if gateErr != nil {
+				r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate error: %v", p.Name, gateErr))
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
+				return singlePhaseResult{status: "failed", duration: time.Since(phaseStart), gateOut: gateOut}
+			}
+			if passed {
+				log.Printf("%sgate passed for phase %q", vesselLabel(vessel), p.Name)
+				return singlePhaseResult{output: string(output), status: "completed", duration: time.Since(phaseStart)}
+			}
+
+			// Gate failed — retry or fail.
+			retryDelay := 10 * time.Second
+			if p.Gate.RetryDelay != "" {
+				if parsed, pErr := time.ParseDuration(p.Gate.RetryDelay); pErr == nil {
+					retryDelay = parsed
+				}
+			}
+			if gateRetries <= 0 {
+				log.Printf("%sgate failed for phase %q, retries exhausted", vesselLabel(vessel), p.Name)
+				vessel.FailedPhase = p.Name
+				vessel.GateOutput = gateOut
+				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: gate failed, retries exhausted", p.Name))
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
+				if issueNum > 0 && r.Reporter != nil {
+					r.Reporter.VesselFailed(ctx, issueNum, p.Name, "gate failed, retries exhausted", gateOut)
+				}
+				return singlePhaseResult{status: "failed", duration: time.Since(phaseStart), gateOut: gateOut}
+			}
+			gateRetries--
+			log.Printf("%sgate failed for phase %q, retries remaining=%d", vesselLabel(vessel), p.Name, gateRetries)
+			gateResult = fmt.Sprintf("The following gate check failed after the previous phase. Fix the issues and try again:\n\n%s", gateOut)
+			time.Sleep(retryDelay)
+			continue // re-run phase
+
+		case "label":
+			log.Printf("%swaiting for label %q after phase %q", vesselLabel(vessel), p.Gate.WaitFor, p.Name)
+			vessel.WaitingFor = p.Gate.WaitFor
+			now := time.Now().UTC()
+			vessel.WaitingSince = &now
+			vessel.State = queue.StateWaiting
+			vessel.CurrentPhase = phaseIdx + 1
+			if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
+				log.Printf("warn: persist waiting state for %s: %v", vessel.ID, updateErr)
+			}
+			if updateErr := r.Queue.Update(vessel.ID, queue.StateWaiting, ""); updateErr != nil {
+				log.Printf("warn: failed to set vessel %s to waiting: %v", vessel.ID, updateErr)
+			}
+			return singlePhaseResult{output: string(output), status: "waiting", duration: time.Since(phaseStart)}
+		}
+
+		// Unknown gate type: treat as passed.
+		return singlePhaseResult{output: string(output), status: "completed", duration: time.Since(phaseStart)}
+	}
 }
 
 func phaseMatchedNoOp(p *workflow.Phase, output string) bool {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -23,6 +24,7 @@ import (
 // --- Mock types ---
 
 type mockCmdRunner struct {
+	mu           sync.Mutex // protects phaseCalls and outputArgs
 	processErr   error
 	outputErr    error
 	outputData   []byte
@@ -52,7 +54,9 @@ type phaseCall struct {
 }
 
 func (m *mockCmdRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	m.mu.Lock()
 	m.outputArgs = append(m.outputArgs, append([]string{name}, args...))
+	m.mu.Unlock()
 	// Detect gate commands by matching the exact shape produced by gate.RunCommandGate:
 	// RunOutput("sh", "-c", "cd <dir> && <cmd>")
 	isGate := false
@@ -83,12 +87,14 @@ func (m *mockCmdRunner) RunProcess(_ context.Context, _ string, _ string, _ ...s
 
 func (m *mockCmdRunner) RunPhase(_ context.Context, dir string, stdin io.Reader, name string, args ...string) ([]byte, error) {
 	prompt, _ := io.ReadAll(stdin)
+	m.mu.Lock()
 	m.phaseCalls = append(m.phaseCalls, phaseCall{
 		dir:    dir,
 		prompt: string(prompt),
 		name:   name,
 		args:   args,
 	})
+	m.mu.Unlock()
 	atomic.AddInt32(&m.started, 1)
 
 	// Return canned output based on prompt content
@@ -156,6 +162,7 @@ func (c *countingCmdRunner) RunPhase(_ context.Context, _ string, stdin io.Reade
 }
 
 type mockWorktree struct {
+	mu           sync.Mutex
 	createErr    error
 	path         string
 	removeErr    error
@@ -164,6 +171,8 @@ type mockWorktree struct {
 }
 
 func (m *mockWorktree) Create(_ context.Context, branchName string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.createErr != nil {
 		return "", m.createErr
 	}
@@ -174,6 +183,8 @@ func (m *mockWorktree) Create(_ context.Context, branchName string) (string, err
 }
 
 func (m *mockWorktree) Remove(_ context.Context, worktreePath string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.removeCalled = true
 	m.removePath = worktreePath
 	return m.removeErr
@@ -304,6 +315,12 @@ func writeWorkflowFile(t *testing.T, dir, name string, phases []testPhase) {
 		if p.allowedTools != "" {
 			phaseYAML.WriteString(fmt.Sprintf("    allowed_tools: %q\n", p.allowedTools))
 		}
+		if len(p.dependsOn) > 0 {
+			phaseYAML.WriteString("    depends_on:\n")
+			for _, dep := range p.dependsOn {
+				phaseYAML.WriteString(fmt.Sprintf("      - %s\n", dep))
+			}
+		}
 	}
 
 	workflowContent := fmt.Sprintf("name: %s\nphases:\n%s", name, phaseYAML.String())
@@ -417,8 +434,9 @@ type testPhase struct {
 	noopMatch     string
 	gate          string
 	allowedTools  string
-	phaseType     string // "command" or "" for prompt (default)
-	run           string // shell command for type=command
+	phaseType     string   // "command" or "" for prompt (default)
+	run           string   // shell command for type=command
+	dependsOn     []string // explicit phase dependencies
 }
 
 // --- Tests ---
@@ -2297,5 +2315,303 @@ func TestResolveRepoNewSources(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("resolveRepo(%q) = %q, want %q", tt.source, got, tt.want)
 		}
+	}
+}
+
+// --- Orchestrated (parallel) execution tests ---
+
+func TestDrainOrchestratedDiamondWorkflow(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "diamond"))
+
+	// Diamond: analyze -> implement_a + implement_b -> merge
+	writeWorkflowFile(t, dir, "diamond", []testPhase{
+		{name: "analyze", promptContent: "Analyze issue", maxTurns: 5},
+		{name: "implement_a", promptContent: "Implement A: {{.PreviousOutputs.analyze}}", maxTurns: 10, dependsOn: []string{"analyze"}},
+		{name: "implement_b", promptContent: "Implement B: {{.PreviousOutputs.analyze}}", maxTurns: 10, dependsOn: []string{"analyze"}},
+		{name: "merge", promptContent: "Merge: {{.PreviousOutputs.implement_a}} {{.PreviousOutputs.implement_b}}", maxTurns: 5, dependsOn: []string{"implement_a", "implement_b"}},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Completed != 1 {
+		t.Errorf("expected 1 completed, got %d (failed=%d)", result.Completed, result.Failed)
+	}
+
+	// All 4 phases should have been executed.
+	if len(cmdRunner.phaseCalls) != 4 {
+		t.Errorf("expected 4 phase calls, got %d", len(cmdRunner.phaseCalls))
+	}
+
+	// Verify output files were written.
+	for _, name := range []string{"analyze", "implement_a", "implement_b", "merge"} {
+		path := filepath.Join(cfg.StateDir, "phases", "issue-1", name+".output")
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("expected output file for phase %q", name)
+		}
+	}
+}
+
+func TestDrainOrchestratedContextFirewall(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "firewall"))
+
+	// Phase b depends on a, phase c depends on a.
+	// Phase c should NOT see b's output in PreviousOutputs.
+	writeWorkflowFile(t, dir, "firewall", []testPhase{
+		{name: "a", promptContent: "Phase A", maxTurns: 5},
+		{name: "b", promptContent: "Phase B with dep: {{.PreviousOutputs.a}}", maxTurns: 5, dependsOn: []string{"a"}},
+		{name: "c", promptContent: "Phase C with dep: {{.PreviousOutputs.a}} absent: {{.PreviousOutputs.b}}", maxTurns: 5, dependsOn: []string{"a"}},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Phase A": []byte("output-A"),
+			"Phase B": []byte("output-B"),
+			"Phase C": []byte("output-C"),
+		},
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Completed != 1 {
+		t.Errorf("expected 1 completed, got %d (failed=%d)", result.Completed, result.Failed)
+	}
+
+	// Check that phase c's prompt was rendered with a's output but not b's.
+	// The template {{.PreviousOutputs.b}} should render as empty (context firewall).
+	for _, call := range cmdRunner.phaseCalls {
+		if strings.Contains(call.prompt, "Phase C") {
+			if strings.Contains(call.prompt, "output-B") {
+				t.Error("context firewall violated: phase c saw phase b's output")
+			}
+			// Phase c should see "output-A" from its dependency on a.
+			if !strings.Contains(call.prompt, "output-A") {
+				t.Error("phase c should see phase a's output via depends_on")
+			}
+		}
+	}
+}
+
+func TestDrainOrchestratedPhaseFailure(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fail-test"))
+
+	writeWorkflowFile(t, dir, "fail-test", []testPhase{
+		{name: "a", promptContent: "Phase A", maxTurns: 5},
+		{name: "b", promptContent: "Phase B", maxTurns: 5, dependsOn: []string{"a"}},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{
+		phaseErr: errors.New("claude crashed"),
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Failed != 1 {
+		t.Errorf("expected 1 failed, got failed=%d completed=%d", result.Failed, result.Completed)
+	}
+	// Phase b should NOT have been called since a failed.
+	if len(cmdRunner.phaseCalls) != 1 {
+		t.Errorf("expected 1 phase call (only a), got %d", len(cmdRunner.phaseCalls))
+	}
+}
+
+func TestDrainOrchestratedNoOp(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "noop-test"))
+
+	writeWorkflowFile(t, dir, "noop-test", []testPhase{
+		{name: "analyze", promptContent: "Analyze", maxTurns: 5, noopMatch: "XYLEM_NOOP"},
+		{name: "implement", promptContent: "Implement", maxTurns: 10, dependsOn: []string{"analyze"}},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Analyze": []byte("Nothing to do XYLEM_NOOP"),
+		},
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Completed != 1 {
+		t.Errorf("expected 1 completed (noop), got completed=%d failed=%d", result.Completed, result.Failed)
+	}
+	// Only analyze should have been called (noop stops workflow).
+	if len(cmdRunner.phaseCalls) != 1 {
+		t.Errorf("expected 1 phase call (noop), got %d", len(cmdRunner.phaseCalls))
+	}
+}
+
+func TestDrainOrchestratedWithGate(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "gate-test"))
+
+	writeWorkflowFile(t, dir, "gate-test", []testPhase{
+		{name: "implement", promptContent: "Implement", maxTurns: 10,
+			gate: "      type: command\n      run: \"go test ./...\""},
+		{name: "pr", promptContent: "Create PR: {{.PreviousOutputs.implement}}", maxTurns: 5, dependsOn: []string{"implement"}},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	// Gate passes (exit code 0 from RunOutput for gate commands).
+	cmdRunner := &mockCmdRunner{
+		gateOutput: []byte("ok"),
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Completed != 1 {
+		t.Errorf("expected 1 completed, got completed=%d failed=%d", result.Completed, result.Failed)
+	}
+	// Both phases should have executed.
+	if len(cmdRunner.phaseCalls) != 2 {
+		t.Errorf("expected 2 phase calls, got %d", len(cmdRunner.phaseCalls))
+	}
+}
+
+// perPhaseCmdRunner returns per-phase errors based on prompt content.
+// Phases whose prompt contains a key in failOn return the corresponding error.
+type perPhaseCmdRunner struct {
+	mu     sync.Mutex
+	failOn map[string]error // prompt substring -> error
+	calls  []phaseCall
+}
+
+func (m *perPhaseCmdRunner) RunOutput(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (m *perPhaseCmdRunner) RunProcess(_ context.Context, _ string, _ string, _ ...string) error {
+	return nil
+}
+
+func (m *perPhaseCmdRunner) RunPhase(_ context.Context, dir string, stdin io.Reader, name string, args ...string) ([]byte, error) {
+	prompt, _ := io.ReadAll(stdin)
+	m.mu.Lock()
+	m.calls = append(m.calls, phaseCall{dir: dir, prompt: string(prompt), name: name, args: args})
+	m.mu.Unlock()
+
+	for key, err := range m.failOn {
+		if bytes.Contains(prompt, []byte(key)) {
+			return []byte("failed output"), err
+		}
+	}
+	return []byte("mock output"), nil
+}
+
+// TestDrainOrchestratedParallelFailureNoRace verifies that two phases in the
+// same wave can both fail without a data race on vessel fields. Run with
+// `go test -race` to confirm.
+func TestDrainOrchestratedParallelFailureNoRace(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "parallel-fail"))
+
+	// root -> a, root -> b: a and b are in the same wave and run concurrently.
+	writeWorkflowFile(t, dir, "parallel-fail", []testPhase{
+		{name: "root", promptContent: "Root phase", maxTurns: 5},
+		{name: "a", promptContent: "Phase A", maxTurns: 5, dependsOn: []string{"root"}},
+		{name: "b", promptContent: "Phase B", maxTurns: 5, dependsOn: []string{"root"}},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	// root succeeds; a and b both fail. Since a and b are in the same wave,
+	// they run concurrently and both write to their local vessel copy.
+	// Before the fix (vessel passed by pointer), this was a data race.
+	cmdRunner := &perPhaseCmdRunner{
+		failOn: map[string]error{
+			"Phase A": errors.New("phase A crashed"),
+			"Phase B": errors.New("phase B crashed"),
+		},
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Failed != 1 {
+		t.Errorf("expected 1 failed vessel, got failed=%d completed=%d", result.Failed, result.Completed)
 	}
 }

--- a/cli/internal/runner/schedule.go
+++ b/cli/internal/runner/schedule.go
@@ -1,0 +1,150 @@
+package runner
+
+import (
+	"fmt"
+
+	"github.com/nicholls-inc/xylem/cli/internal/orchestrator"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
+)
+
+// phaseGraph holds the orchestrator topology and computed execution waves
+// for a workflow. Waves are groups of phase indices that can execute concurrently;
+// within each wave, all dependencies are satisfied by prior waves.
+type phaseGraph struct {
+	orch  *orchestrator.Orchestrator
+	waves [][]int // each element is a list of phase indices
+	// deps maps each phase index to the set of phase names it depends on.
+	// When the workflow has no explicit depends_on, this encodes the implicit
+	// sequential chain (each phase depends on its predecessor).
+	deps map[int]map[string]struct{}
+	// parallel is true when the workflow declares explicit depends_on on any phase,
+	// meaning waves may contain more than one phase.
+	parallel bool
+}
+
+// buildPhaseGraph creates an orchestrator topology from a workflow and computes
+// execution waves via level-based topological sort (Kahn's algorithm).
+//
+// When no phase declares depends_on, phases are chained sequentially and
+// parallel is false. When any phase declares depends_on, the explicit
+// dependency graph is used and parallel is true.
+func buildPhaseGraph(wf *workflow.Workflow) (*phaseGraph, error) {
+	n := len(wf.Phases)
+	nameToIdx := make(map[string]int, n)
+	for i, p := range wf.Phases {
+		nameToIdx[p.Name] = i
+	}
+
+	hasExplicit := wf.HasDependencies()
+
+	// Build successor list and in-degree for topological sort.
+	successors := make([][]int, n)
+	inDegree := make([]int, n)
+	deps := make(map[int]map[string]struct{}, n)
+
+	if hasExplicit {
+		for i, p := range wf.Phases {
+			if len(p.DependsOn) > 0 {
+				deps[i] = make(map[string]struct{}, len(p.DependsOn))
+				for _, dep := range p.DependsOn {
+					j := nameToIdx[dep]
+					successors[j] = append(successors[j], i)
+					inDegree[i]++
+					deps[i][dep] = struct{}{}
+				}
+			}
+		}
+	} else {
+		// Implicit sequential chain: phase i depends on phase i-1.
+		for i := 1; i < n; i++ {
+			successors[i-1] = append(successors[i-1], i)
+			inDegree[i] = 1
+			deps[i] = map[string]struct{}{wf.Phases[i-1].Name: {}}
+		}
+	}
+
+	// Kahn's algorithm: level-based topological sort.
+	var waves [][]int
+	done := make([]bool, n)
+
+	for {
+		var wave []int
+		for i := 0; i < n; i++ {
+			if !done[i] && inDegree[i] == 0 {
+				wave = append(wave, i)
+			}
+		}
+		if len(wave) == 0 {
+			break
+		}
+		waves = append(waves, wave)
+		for _, i := range wave {
+			done[i] = true
+			for _, j := range successors[i] {
+				inDegree[j]--
+			}
+		}
+	}
+
+	// Build orchestrator topology.
+	orch := orchestrator.NewOrchestrator(orchestrator.OrchestratorConfig{
+		FailurePolicy: "fail-fast",
+	})
+
+	for _, p := range wf.Phases {
+		if err := orch.AddAgent(p.Name, p.Name); err != nil {
+			return nil, fmt.Errorf("add phase %q to orchestrator: %w", p.Name, err)
+		}
+	}
+
+	for _, p := range wf.Phases {
+		for _, dep := range p.DependsOn {
+			if err := orch.AddEdge(dep, p.Name, "depends"); err != nil {
+				return nil, fmt.Errorf("add dependency edge %s -> %s: %w", dep, p.Name, err)
+			}
+		}
+	}
+	// For implicit sequential, add edges too.
+	if !hasExplicit && n > 1 {
+		for i := 0; i < n-1; i++ {
+			if err := orch.AddEdge(wf.Phases[i].Name, wf.Phases[i+1].Name, "sequential"); err != nil {
+				return nil, fmt.Errorf("add sequential edge: %w", err)
+			}
+		}
+	}
+
+	return &phaseGraph{
+		orch:     orch,
+		waves:    waves,
+		deps:     deps,
+		parallel: hasExplicit,
+	}, nil
+}
+
+// dependencyOutputs returns the subset of allOutputs that the phase at phaseIdx
+// is allowed to see. When the workflow uses explicit depends_on (parallel mode),
+// only outputs from declared dependencies are included — this is the context
+// firewall. In sequential mode, all previous outputs are visible for backward
+// compatibility.
+func (g *phaseGraph) dependencyOutputs(phaseIdx int, allOutputs map[string]string) map[string]string {
+	if !g.parallel {
+		// Sequential mode: all outputs visible (backward compat).
+		out := make(map[string]string, len(allOutputs))
+		for k, v := range allOutputs {
+			out[k] = v
+		}
+		return out
+	}
+
+	depSet := g.deps[phaseIdx]
+	if len(depSet) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(depSet))
+	for dep := range depSet {
+		if v, ok := allOutputs[dep]; ok {
+			out[dep] = v
+		}
+	}
+	return out
+}

--- a/cli/internal/runner/schedule_test.go
+++ b/cli/internal/runner/schedule_test.go
@@ -1,0 +1,180 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
+)
+
+func TestBuildPhaseGraph_Sequential(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name: "test",
+		Phases: []workflow.Phase{
+			{Name: "a"},
+			{Name: "b"},
+			{Name: "c"},
+		},
+	}
+
+	g, err := buildPhaseGraph(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if g.parallel {
+		t.Error("expected parallel=false for sequential workflow")
+	}
+
+	// Sequential: 3 waves, one phase each.
+	if len(g.waves) != 3 {
+		t.Fatalf("expected 3 waves, got %d", len(g.waves))
+	}
+	for i, wave := range g.waves {
+		if len(wave) != 1 || wave[0] != i {
+			t.Errorf("wave %d = %v, want [%d]", i, wave, i)
+		}
+	}
+}
+
+func TestBuildPhaseGraph_DiamondDependency(t *testing.T) {
+	// Diamond: A -> B, A -> C, B+C -> D
+	wf := &workflow.Workflow{
+		Name: "test",
+		Phases: []workflow.Phase{
+			{Name: "a"},
+			{Name: "b", DependsOn: []string{"a"}},
+			{Name: "c", DependsOn: []string{"a"}},
+			{Name: "d", DependsOn: []string{"b", "c"}},
+		},
+	}
+
+	g, err := buildPhaseGraph(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !g.parallel {
+		t.Error("expected parallel=true for workflow with depends_on")
+	}
+
+	// Wave 0: [a], Wave 1: [b, c], Wave 2: [d]
+	if len(g.waves) != 3 {
+		t.Fatalf("expected 3 waves, got %d: %v", len(g.waves), g.waves)
+	}
+	if len(g.waves[0]) != 1 || g.waves[0][0] != 0 {
+		t.Errorf("wave 0 = %v, want [0]", g.waves[0])
+	}
+	if len(g.waves[1]) != 2 {
+		t.Errorf("wave 1 = %v, want 2 phases", g.waves[1])
+	}
+	if len(g.waves[2]) != 1 || g.waves[2][0] != 3 {
+		t.Errorf("wave 2 = %v, want [3]", g.waves[2])
+	}
+}
+
+func TestBuildPhaseGraph_FullyParallel(t *testing.T) {
+	// All phases have no dependencies — they should all be in wave 0.
+	wf := &workflow.Workflow{
+		Name: "test",
+		Phases: []workflow.Phase{
+			{Name: "a", DependsOn: []string{}},
+			{Name: "b", DependsOn: []string{}},
+			{Name: "c", DependsOn: []string{}},
+		},
+	}
+
+	// HasDependencies is false when all DependsOn are empty slices.
+	// This means sequential mode (backward compat).
+	if wf.HasDependencies() {
+		t.Fatal("HasDependencies() should be false for empty DependsOn slices")
+	}
+}
+
+func TestBuildPhaseGraph_SinglePhase(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:   "test",
+		Phases: []workflow.Phase{{Name: "only"}},
+	}
+
+	g, err := buildPhaseGraph(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(g.waves) != 1 || len(g.waves[0]) != 1 {
+		t.Errorf("expected 1 wave with 1 phase, got %v", g.waves)
+	}
+}
+
+func TestDependencyOutputs_Sequential(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name: "test",
+		Phases: []workflow.Phase{
+			{Name: "a"},
+			{Name: "b"},
+		},
+	}
+
+	g, err := buildPhaseGraph(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	allOutputs := map[string]string{
+		"a": "output-a",
+	}
+
+	// In sequential mode, phase b sees all outputs.
+	out := g.dependencyOutputs(1, allOutputs)
+	if out["a"] != "output-a" {
+		t.Errorf("sequential mode: expected output-a, got %q", out["a"])
+	}
+}
+
+func TestDependencyOutputs_ContextFirewall(t *testing.T) {
+	// Diamond: A -> B, A -> C, B+C -> D
+	wf := &workflow.Workflow{
+		Name: "test",
+		Phases: []workflow.Phase{
+			{Name: "a"},
+			{Name: "b", DependsOn: []string{"a"}},
+			{Name: "c", DependsOn: []string{"a"}},
+			{Name: "d", DependsOn: []string{"b", "c"}},
+		},
+	}
+
+	g, err := buildPhaseGraph(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	allOutputs := map[string]string{
+		"a": "output-a",
+		"b": "output-b",
+		"c": "output-c",
+	}
+
+	// Phase b (index 1) should only see output from a.
+	outB := g.dependencyOutputs(1, allOutputs)
+	if len(outB) != 1 || outB["a"] != "output-a" {
+		t.Errorf("phase b outputs = %v, want {a: output-a}", outB)
+	}
+
+	// Phase d (index 3) should only see outputs from b and c (not a).
+	outD := g.dependencyOutputs(3, allOutputs)
+	if len(outD) != 2 {
+		t.Errorf("phase d outputs = %v, want 2 entries", outD)
+	}
+	if outD["b"] != "output-b" || outD["c"] != "output-c" {
+		t.Errorf("phase d outputs = %v, want {b: output-b, c: output-c}", outD)
+	}
+	if _, hasA := outD["a"]; hasA {
+		t.Error("phase d should NOT see output from a (context firewall)")
+	}
+
+	// Phase a (index 0) should see nothing (no deps).
+	outA := g.dependencyOutputs(0, allOutputs)
+	if len(outA) != 0 {
+		t.Errorf("phase a outputs = %v, want empty", outA)
+	}
+}

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -27,15 +27,15 @@ type Workflow struct {
 
 // Phase represents a single step in a workflow's execution pipeline.
 type Phase struct {
-	Name         string  `yaml:"name"`
-	Type         string  `yaml:"type,omitempty"`          // "prompt" (default) or "command"
-	Run          string  `yaml:"run,omitempty"`            // shell command for type=command, supports template variables
-	PromptFile   string  `yaml:"prompt_file"`
-	MaxTurns     int     `yaml:"max_turns"`
-	LLM          *string `yaml:"llm,omitempty"`
-	Model        *string `yaml:"model,omitempty"`
-	NoOp         *NoOp   `yaml:"noop,omitempty"`
-	Gate         *Gate   `yaml:"gate,omitempty"`
+	Name         string   `yaml:"name"`
+	Type         string   `yaml:"type,omitempty"`          // "prompt" (default) or "command"
+	Run          string   `yaml:"run,omitempty"`            // shell command for type=command, supports template variables
+	PromptFile   string   `yaml:"prompt_file"`
+	MaxTurns     int      `yaml:"max_turns"`
+	LLM          *string  `yaml:"llm,omitempty"`
+	Model        *string  `yaml:"model,omitempty"`
+	NoOp         *NoOp    `yaml:"noop,omitempty"`
+	Gate         *Gate    `yaml:"gate,omitempty"`
 	AllowedTools *string  `yaml:"allowed_tools,omitempty"`
 	DependsOn    []string `yaml:"depends_on,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Wire orchestrator into runner for wave-based parallel phase execution with context firewalls between phases
- Fix vessel data race in `runSinglePhase` by passing vessel by value instead of pointer, preventing concurrent goroutines from writing to shared `FailedPhase`/`GateOutput` fields
- Clean up unused loop variable in `schedule.go`
- Add `TestDrainOrchestratedParallelFailureNoRace` test that exercises concurrent phase failure under `-race`

## Test plan
- [x] `go test -race ./internal/runner/...` passes (1.6s, no races detected)
- [x] `go test -race ./...` passes (all 22 packages)
- [x] New test `TestDrainOrchestratedParallelFailureNoRace` confirms two goroutines failing in the same wave do not race on vessel fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)