### PR TITLE
docs: add ADR directory with three initial architecture decision records

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,8 @@
 
 This document describes the internal architecture of xylem for contributors working on the codebase. It covers the system's two-layer design, core abstractions, data flow, isolation model, and testing approach.
 
+Architecture decisions are recorded in [docs/decisions/](decisions/).
+
 ## High-level overview
 
 xylem is a two-layer system:
@@ -361,7 +363,7 @@ Every vessel runs in its own git worktree. This provides filesystem isolation be
 
 **Worktree lifecycle:**
 
-1. **Create** -- `git fetch origin <default-branch>` then `git worktree add .claude/worktrees/<branch> -b <branch> origin/<default-branch>`. The worktree starts from a clean copy of the default branch.
+1. **Create** -- `git fetch origin <default-branch>` then `git worktree add .claude/worktrees/<branch> -B <branch> origin/<default-branch>`. The worktree starts from a clean copy of the default branch.
 
 2. **Config copy** -- `.claude/settings.json`, `.claude/settings.local.json`, and `.claude/rules/` are copied from the main repo into the worktree so provider-backed prompt phases have the correct tool permissions and rules.
 

--- a/docs/decisions/001-jsonl-queue.md
+++ b/docs/decisions/001-jsonl-queue.md
@@ -1,0 +1,37 @@
+# ADR-001: JSONL Queue Storage
+
+**Status:** Accepted
+
+## Context
+
+xylem needs a persistent, crash-safe work queue to hold `Vessel` records across daemon restarts. The queue must support concurrent readers (e.g., status checks) and exclusive writers (e.g., enqueue, dequeue, update). Candidates considered:
+
+- **SQLite / embedded relational DB** — full ACID guarantees, rich query support, binary format
+- **JSONL file with file-level locking** — simple text format, human-readable, no embedded DB dependency
+
+The workload is low-throughput: tens to low hundreds of vessels, infrequent writes, occasional compaction.
+
+## Decision
+
+Vessels are persisted in a single JSONL file at `<state_dir>/queue.jsonl`. File-level locking uses `gofrs/flock` with a `.lock` sidecar file. Two lock helpers provide appropriate access levels:
+
+- `withLock` — exclusive write lock for all mutation operations
+- `withRLock` — shared read lock for read-only operations (e.g., `List`)
+
+Every write operation follows a full-rewrite pattern: `readAllVessels()` → modify in-memory slice → `writeAllVessels()` via `os.WriteFile`. There is no append-only mode; each write replaces the entire file.
+
+## Rationale
+
+- **Simplest correct solution** for the expected workload. No daemon process, no query planner, no schema migrations.
+- **Human-readable** — operators can inspect and manually repair the queue with any text editor.
+- **No embedded DB dependency** — avoids cgo (SQLite) or a Go-native DB binary embedded in the CLI.
+- **File-level locking** prevents corruption without requiring a long-running server process. `gofrs/flock` is cross-platform and supports both exclusive and shared locking.
+- **`os.WriteFile` atomicity** — on most filesystems, overwriting a file is atomic at the OS level for small files, which is sufficient for this use case.
+
+## Consequences
+
+- **Positive:** Simple to reason about, easy to inspect, zero external dependencies beyond `gofrs/flock`.
+- **Positive:** The full-rewrite pattern means any operation that reads-then-writes sees a consistent snapshot under the exclusive lock.
+- **Negative:** Full rewrite on every write does not scale to thousands of vessels or high write frequency. A high-throughput workload would require replacement with an append-only log or embedded DB.
+- **Negative:** JSONL is not indexed; `List` and lookup operations are O(n) scans.
+- **Negative:** Compaction (`Compact`) must also take an exclusive lock and rewrite the file, which blocks all other writers during cleanup.

--- a/docs/decisions/002-worktree-isolation.md
+++ b/docs/decisions/002-worktree-isolation.md
@@ -1,0 +1,44 @@
+# ADR-002: Git Worktree Isolation
+
+**Status:** Accepted
+
+## Context
+
+Concurrent vessels must not interfere with each other on the filesystem. Each vessel works on a distinct task (a GitHub issue, a manual job) and needs its own branch and working directory. Options considered:
+
+- **Containers / VMs** — full process and network isolation, but heavyweight and requires Docker or similar
+- **Separate repository clones** — full filesystem isolation, but slow to create and wastes disk
+- **Git worktrees** — lightweight, native git feature; each worktree shares the object store but has its own working tree and HEAD
+
+## Decision
+
+Each vessel is assigned a dedicated git worktree at `.claude/worktrees/<branchName>` relative to the repository root. The worktree is created by:
+
+1. `git fetch origin <default-branch>` — ensures the branch point is current
+2. `git worktree add .claude/worktrees/<branch> -B <branch> origin/<defaultBranch>` — creates the worktree on a new branch
+
+Branch names follow the pattern `fix/issue-<N>-<slug>` or `feat/issue-<N>-<slug>` for GitHub sources, and `task/<id>-<slug>` for Manual sources.
+
+At creation time, `copyClaudeConfig()` copies the following files from the parent `.claude/` directory into the worktree's `.claude/` directory:
+
+- `settings.json`
+- `settings.local.json`
+- `rules/` (directory, copied allowlist-based)
+
+The directories `worktrees/`, `conversations/`, and `projects/` are skipped to avoid recursive or session-specific state leaking into the worktree.
+
+## Rationale
+
+- **Native git** — no process or container overhead; `git worktree` is a stable, first-class git feature.
+- **Branch-per-vessel** — each vessel produces a clean, reviewable branch with a meaningful name derived from the issue.
+- **Config copy** — copying provider tool permission files (`settings.json`, `rules/`) at creation ensures the Claude session inside the worktree has the same allowed-tools configuration as the parent, without coupling the worktree to a mutable parent config.
+- **Shared object store** — worktrees share the parent repository's object store, so fetch operations are fast and disk usage is minimal.
+
+## Consequences
+
+- **Positive:** Lightweight and fast to create compared to full clones.
+- **Positive:** Each vessel works on its own branch; merging is a standard git pull request flow.
+- **Positive:** Config copy at creation time gives each vessel a stable, independent snapshot of tool permissions.
+- **Negative:** Isolation is **filesystem-only**. There is no process isolation, no network isolation, and no resource limits. Concurrent vessels share the same OS process environment, CPU, memory, and network.
+- **Negative:** Worktree cleanup requires explicit action: `git worktree remove --force` followed by branch deletion. Stale worktrees accumulate if cleanup is skipped. Cleanup is governed by the `cleanup_after` setting (default: 7 days).
+- **Negative:** The `.claude/worktrees/` path is baked into the worktree location convention; moving or renaming the parent repository requires recreating worktrees.

--- a/docs/decisions/003-harness-cli-separation.md
+++ b/docs/decisions/003-harness-cli-separation.md
@@ -1,0 +1,37 @@
+# ADR-003: Harness/CLI Package Separation
+
+**Status:** Accepted
+
+## Context
+
+The `cli/internal/` directory contains two distinct groups of packages that co-exist in the same Go module:
+
+**CLI packages** (the control plane):
+`queue`, `runner`, `scanner`, `source`, `workflow`, `gate`, `phase`, `worktree`, `reporter`, `config`, and `cmd/xylem`
+
+**Harness packages** (standalone agent library):
+`orchestrator`, `mission`, `memory`, `signal`, `evaluator`, `cost`, `ctxmgr`, `intermediary`, `bootstrap`, `catalog`, `observability`
+
+The harness packages implement multi-agent orchestration primitives (topologies, task decomposition, typed memory, behavioral signals, cost tracking, context management, intent validation, tool catalogs, observability). They were built alongside the CLI but are conceptually independent composable libraries.
+
+The question was whether to couple these groups — for example, having `runner` delegate directly to `orchestrator` for phase execution — or to maintain a hard import boundary between them.
+
+## Decision
+
+Zero cross-imports between the CLI group and the harness group. CLI packages may not import harness packages, and harness packages may not import CLI packages. This boundary is enforced by convention; no automated tooling guard is configured.
+
+## Rationale
+
+- **Separate evolvability** — the harness packages have their own abstractions, interfaces, and test suites. Coupling them to the CLI's `Vessel`, `Workflow`, or `Phase` types would make both groups harder to evolve independently.
+- **No accidental coupling** — keeping the boundary explicit prevents the gradual accumulation of import edges that would eventually make it impossible to extract the harness into a separate module or repository.
+- **Future migration path** — a future version of `runner` could delegate phase execution to `orchestrator` at the boundary (e.g., via a thin adapter or configuration), rather than requiring a big-bang refactor that interleaves the two call graphs.
+- **Composability** — harness packages are designed to be usable independently of xylem's CLI. Importing CLI types would break this property.
+
+## Consequences
+
+- **Positive:** Each group can be understood, tested, and modified in isolation.
+- **Positive:** Harness packages remain suitable for extraction into a standalone module if needed.
+- **Positive:** Contributors working only on the CLI do not need to understand the harness internals, and vice versa.
+- **Negative:** Some primitives (e.g., context handling, error types) may be duplicated across the two groups rather than shared.
+- **Negative:** The boundary is enforced only by convention. Without a tooling guard (e.g., `go-import-boss`, `depguard`, or a CI `grep`-based check), a contributor can accidentally violate it without immediate feedback.
+- **Negative:** Integrating the harness into the runner in the future will require designing an explicit adapter layer at the boundary rather than direct function calls.


### PR DESCRIPTION
## Summary

- Creates `docs/decisions/` with three seed ADRs covering the core architectural decisions in the codebase
- Adds a discoverability link near the top of `docs/architecture.md`
- Also corrects `-b` → `-B` in the worktree creation command documented in the isolation model section (matches the actual implementation)

## ADRs added

| File | Decision |
|------|----------|
| `docs/decisions/001-jsonl-queue.md` | JSONL file with `gofrs/flock` over SQLite/embedded DB; full-rewrite-on-write pattern; rationale and scalability tradeoffs |
| `docs/decisions/002-worktree-isolation.md` | Git worktrees at `.claude/worktrees/<branch>`; filesystem-only isolation; config copy at creation; cleanup lifecycle |
| `docs/decisions/003-harness-cli-separation.md` | Zero cross-imports between CLI packages and harness packages; convention-enforced boundary; future migration path |

Each ADR follows the standard structure: Status, Context, Decision, Rationale, Consequences.

Closes https://github.com/nicholls-inc/xylem/issues/54

🤖 Generated with [Claude Code](https://claude.com/claude-code)