### PR TITLE
docs: smoke scenarios for harness impl spec workstreams 1-4

### DIFF
--- a/docs/design/smoke-scenarios-unit-1.md
+++ b/docs/design/smoke-scenarios-unit-1.md
@@ -1,0 +1,526 @@
+# Smoke Scenarios: Workstream 1 — Protect Control Surfaces and Mediate High-Risk Actions
+
+**Spec ref:** `docs/design/xylem-harness-impl-spec.md` sections 2–4
+**Date:** 2026-03-31
+**Scope:** Config schema extensions (§2), protected surface verification (§3), policy enforcement (§4)
+
+---
+
+> **Numbering:** S1–S32 follow the ordered list in the task brief. Scenarios S29–S32 cover config helper methods and validation that logically belong with §2 but were assigned higher numbers in the brief — they appear in §2 here for reading coherence.
+
+## Section 2 — Config schema extensions
+
+### S1: Config loads with full harness section
+
+**Spec ref:** Section 2.1, 2.5
+
+**Preconditions:** A `.xylem.yml` file containing all new top-level sections — `harness`, `observability`, and `cost` — as shown in the full YAML example in §2.5.
+
+**Action:** Call `config.Load(".xylem.yml")`.
+
+**Expected outcome:** Returns a non-nil `*Config` with no error. `cfg.Harness.AuditLog` equals `".xylem/audit.jsonl"`. `cfg.Harness.ProtectedSurfaces.Paths` contains four entries. `cfg.Harness.Policy.Rules` contains four entries. `cfg.Observability.Enabled` is non-nil and `*cfg.Observability.Enabled` is `true`. `cfg.Observability.SampleRate` equals `1.0`. `cfg.Cost.Budget` is non-nil with `MaxCostUSD == 10.0` and `MaxTokens == 1000000`.
+
+**Verification:** Assert no error returned; assert each field value using direct struct access.
+
+---
+
+### S2: Config loads with no harness section (defaults activate)
+
+**Spec ref:** Section 2.2, 2.3, 2.5
+
+**Preconditions:** An existing valid `.xylem.yml` with no `harness`, `observability`, or `cost` keys.
+
+**Action:** Call `config.Load(".xylem.yml")`.
+
+**Expected outcome:** Returns a non-nil `*Config` with no error. `cfg.EffectiveProtectedSurfaces()` returns the four-element `DefaultProtectedSurfaces` slice. `cfg.EffectiveAuditLogPath()` returns `"audit.jsonl"`. `cfg.ObservabilityEnabled()` returns `true`. `cfg.ObservabilitySampleRate()` returns `1.0`. `cfg.VesselBudget()` returns `nil`. `cfg.BuildIntermediaryPolicies()` returns a single-element slice containing the default policy named `"default"`.
+
+**Verification:** Assert no error; call each helper method and compare return values.
+
+---
+
+### S3: Config with `paths: ["none"]` disables surface protection
+
+**Spec ref:** Section 2.2 (`EffectiveProtectedSurfaces`)
+
+**Preconditions:** A `.xylem.yml` with:
+```yaml
+harness:
+  protected_surfaces:
+    paths: ["none"]
+```
+
+**Action:** Call `config.Load(".xylem.yml")`, then call `cfg.EffectiveProtectedSurfaces()`.
+
+**Expected outcome:** Load returns no error. `EffectiveProtectedSurfaces()` returns `nil` — not `[]string{}` and not the defaults. The function must return the untyped nil, not an empty allocated slice.
+
+**Verification:** Assert `result == nil` (Go nil slice equality, not just `len == 0`).
+
+---
+
+### S4: Config validation rejects invalid glob patterns in protected_surfaces
+
+**Spec ref:** Section 2.4 (`validateHarness`)
+
+**Preconditions:** A `.xylem.yml` with:
+```yaml
+harness:
+  protected_surfaces:
+    paths:
+      - "[invalid-glob"
+```
+
+**Action:** Call `config.Load(".xylem.yml")`.
+
+**Expected outcome:** Returns a non-nil error. The error message contains `"harness.protected_surfaces.paths"` and `"invalid glob"` and the pattern `"[invalid-glob"`.
+
+**Verification:** Assert `err != nil`; assert `strings.Contains(err.Error(), "harness.protected_surfaces.paths")`.
+
+---
+
+### S5: Config validation rejects unknown policy effect values
+
+**Spec ref:** Section 2.4 (`validateHarness`)
+
+**Preconditions:** A `.xylem.yml` with:
+```yaml
+harness:
+  policy:
+    rules:
+      - action: "file_write"
+        resource: "*"
+        effect: "approve_maybe"
+```
+
+**Action:** Call `config.Load(".xylem.yml")`.
+
+**Expected outcome:** Returns a non-nil error. The error message references `"harness.policy.rules[0]"`, the string `"invalid effect"`, and the value `"approve_maybe"`.
+
+**Verification:** Assert `err != nil`; assert `strings.Contains(err.Error(), "invalid effect")` and `strings.Contains(err.Error(), "approve_maybe")`.
+
+---
+
+### S6: Default policy denies file_write to `.xylem/HARNESS.md`
+
+**Spec ref:** Section 2.3 (`DefaultPolicy`)
+
+**Preconditions:** A `Config` with no policy rules configured (so `BuildIntermediaryPolicies()` returns the default policy).
+
+**Action:** Call `cfg.BuildIntermediaryPolicies()`, construct an `Intermediary` from the result, then call `Evaluate` with intent `{Action: "file_write", Resource: ".xylem/HARNESS.md", AgentID: "vessel-001"}`.
+
+**Expected outcome:** `PolicyResult.Effect` equals `intermediary.Deny`. `PolicyResult.MatchedRule` is non-nil with `Action == "file_write"` and `Resource == ".xylem/HARNESS.md"`.
+
+**Verification:** Assert `result.Effect == intermediary.Deny`.
+
+---
+
+### S7: Default policy requires approval for git_push
+
+**Spec ref:** Section 2.3 (`DefaultPolicy`)
+
+**Preconditions:** A `Config` with no policy rules configured (default policy active).
+
+**Action:** Construct an `Intermediary` from `cfg.BuildIntermediaryPolicies()`, call `Evaluate` with intent `{Action: "git_push", Resource: "main", AgentID: "vessel-002"}`.
+
+**Expected outcome:** `PolicyResult.Effect` equals `intermediary.RequireApproval`.
+
+**Verification:** Assert `result.Effect == intermediary.RequireApproval`.
+
+---
+
+### S8: Default policy allows general phase_execute actions
+
+**Spec ref:** Section 2.3 (`DefaultPolicy`)
+
+**Preconditions:** A `Config` with no policy rules configured (default policy active).
+
+**Action:** Construct an `Intermediary` from `cfg.BuildIntermediaryPolicies()`, call `Evaluate` with intent `{Action: "phase_execute", Resource: "lint", AgentID: "vessel-003"}`.
+
+**Expected outcome:** `PolicyResult.Effect` equals `intermediary.Allow`. The matched rule has `Action == "*"` and `Resource == "*"`.
+
+**Verification:** Assert `result.Effect == intermediary.Allow`.
+
+---
+
+### S29: ObservabilityConfig defaults apply when section is absent
+
+**Spec ref:** Section 2.2 (`ObservabilityEnabled`, `ObservabilitySampleRate`)
+
+**Preconditions:** A `Config` with `Observability` as its zero value (no YAML section provided).
+
+**Action:** Call `cfg.ObservabilityEnabled()` and `cfg.ObservabilitySampleRate()`.
+
+**Expected outcome:** `ObservabilityEnabled()` returns `true` (nil pointer treated as enabled). `ObservabilitySampleRate()` returns `1.0` (zero value for `SampleRate` triggers the default).
+
+**Verification:** Assert both return values directly.
+
+---
+
+### S30: CostConfig with budget fields loads correctly
+
+**Spec ref:** Section 2.1, 2.2 (`VesselBudget`)
+
+**Preconditions:** A `Config` with:
+```yaml
+cost:
+  budget:
+    max_cost_usd: 5.0
+    max_tokens: 500000
+```
+
+**Action:** Call `config.Load(".xylem.yml")`, then call `cfg.VesselBudget()`.
+
+**Expected outcome:** `VesselBudget()` returns a non-nil `*cost.Budget` with `CostLimitUSD == 5.0` and `TokenLimit == 500000`.
+
+**Verification:** Assert non-nil return; assert both numeric fields.
+
+---
+
+### S31: Validation rejects negative sample_rate
+
+**Spec ref:** Section 2.4 (`validateObservability`)
+
+**Preconditions:** A `.xylem.yml` with:
+```yaml
+observability:
+  sample_rate: -0.5
+```
+
+**Action:** Call `config.Load(".xylem.yml")`.
+
+**Expected outcome:** Returns a non-nil error containing `"observability.sample_rate"`.
+
+**Verification:** Assert `err != nil`; assert `strings.Contains(err.Error(), "observability.sample_rate")`.
+
+---
+
+### S32: Validation rejects negative max_cost_usd
+
+**Spec ref:** Section 2.4 (`validateCost`)
+
+**Preconditions:** A `.xylem.yml` with:
+```yaml
+cost:
+  budget:
+    max_cost_usd: -1.0
+```
+
+**Action:** Call `config.Load(".xylem.yml")`.
+
+**Expected outcome:** Returns a non-nil error containing `"cost.budget.max_cost_usd"`.
+
+**Verification:** Assert `err != nil`; assert `strings.Contains(err.Error(), "cost.budget.max_cost_usd")`.
+
+---
+
+## Section 3 — Protected surface verification
+
+### S9: TakeSnapshot on empty directory returns empty snapshot
+
+**Spec ref:** Section 3.2 (`TakeSnapshot`)
+
+**Preconditions:** A temporary empty directory created via `t.TempDir()`. Patterns: `[".xylem/HARNESS.md", ".xylem.yml"]`.
+
+**Action:** Call `surface.TakeSnapshot(dir, patterns)` where `dir` is the temp directory path.
+
+**Expected outcome:** Returns an empty `Snapshot` with no error. `snapshot.Files` is nil or an empty slice (len == 0). No error is returned because missing files for a pattern are silently skipped.
+
+**Verification:** Assert `err == nil`; assert `len(snapshot.Files) == 0`.
+
+---
+
+### S10: TakeSnapshot matches globs and hashes correctly
+
+**Spec ref:** Section 3.2 (`TakeSnapshot`)
+
+**Preconditions:** A temporary directory created via `t.TempDir()` containing:
+- `.xylem/HARNESS.md` with content `"harness content"`
+- `.xylem.yml` with content `"config content"`
+- `src/main.go` with content `"package main"` (not matched by patterns)
+
+Patterns: `[".xylem/HARNESS.md", ".xylem.yml"]`.
+
+**Action:** Call `surface.TakeSnapshot(dir, patterns)` where `dir` is the temp directory path.
+
+**Expected outcome:** Returns a `Snapshot` with exactly two entries. Each entry has a non-empty `Hash` field. The hash for `.xylem/HARNESS.md` equals the lowercase hex-encoded SHA256 of `"harness content"`. `src/main.go` is not included. No error is returned.
+
+**Verification:** Assert `len(snapshot.Files) == 2`; compute expected SHA256 hashes in test and compare.
+
+---
+
+### S11: TakeSnapshot is deterministic (two calls return identical results)
+
+**Spec ref:** Section 3.2 (`TakeSnapshot`), §1.2 decision 1
+
+**Preconditions:** A temporary directory created via `t.TempDir()` containing `.xylem.yml` with content `"stable content"`. Patterns: `[".xylem.yml"]`.
+
+**Action:** Call `surface.TakeSnapshot(dir, patterns)` twice without modifying any files between calls.
+
+**Expected outcome:** Both calls return identical `Snapshot` values: same number of files, same paths, same hashes. No error on either call.
+
+**Verification:** Assert `reflect.DeepEqual(snap1, snap2)`.
+
+---
+
+### S12: TakeSnapshot sorts results by path
+
+**Spec ref:** Section 3.2 (`TakeSnapshot`, "Invariant: sorted by Path")
+
+**Preconditions:** A temporary directory created via `t.TempDir()` containing:
+- `.xylem/workflows/fix-bug.yaml`
+- `.xylem/workflows/implement-feature.yaml`
+- `.xylem.yml`
+
+Patterns: `[".xylem/workflows/*.yaml", ".xylem.yml"]`.
+
+**Action:** Call `surface.TakeSnapshot(dir, patterns)` where `dir` is the temp directory path.
+
+**Expected outcome:** `snapshot.Files` is sorted in lexicographic ascending order by `Path`. The invariant is that entries are always sorted — regardless of filesystem traversal order.
+
+**Verification:** Assert each `snapshot.Files[i].Path <= snapshot.Files[i+1].Path` for all consecutive pairs.
+
+---
+
+### S13: Compare detects no violations for identical snapshots
+
+**Spec ref:** Section 3.2 (`Compare`)
+
+**Preconditions:** Two identical `Snapshot` values:
+```go
+snap := surface.Snapshot{Files: []surface.FileHash{{Path: ".xylem.yml", Hash: "abc123"}}}
+```
+
+**Action:** Call `surface.Compare(snap, snap)`.
+
+**Expected outcome:** Returns an empty (nil or zero-length) `[]Violation`. No panics.
+
+**Verification:** Assert `len(violations) == 0`.
+
+---
+
+### S14: Compare detects a modified file (changed hash)
+
+**Spec ref:** Section 3.2 (`Compare`)
+
+**Preconditions:**
+```go
+before := surface.Snapshot{Files: []surface.FileHash{{Path: ".xylem.yml", Hash: "aaa"}}}
+after  := surface.Snapshot{Files: []surface.FileHash{{Path: ".xylem.yml", Hash: "bbb"}}}
+```
+
+**Action:** Call `surface.Compare(before, after)`.
+
+**Expected outcome:** Returns a single `Violation` with `Path == ".xylem.yml"`, `Before == "aaa"`, `After == "bbb"`.
+
+**Verification:** Assert `len(violations) == 1`; assert all three fields of `violations[0]`.
+
+---
+
+### S15: Compare detects a deleted file
+
+**Spec ref:** Section 3.2 (`Compare`)
+
+**Preconditions:**
+```go
+before := surface.Snapshot{Files: []surface.FileHash{{Path: ".xylem/HARNESS.md", Hash: "ddd"}}}
+after  := surface.Snapshot{Files: []surface.FileHash{}}
+```
+
+**Action:** Call `surface.Compare(before, after)`.
+
+**Expected outcome:** Returns a single `Violation` with `Path == ".xylem/HARNESS.md"`, `Before == "ddd"`, `After == "deleted"`.
+
+**Verification:** Assert `violations[0].After == "deleted"`.
+
+---
+
+### S16: Compare detects a created file (new file in after)
+
+**Spec ref:** Section 3.2 (`Compare`)
+
+**Preconditions:**
+```go
+before := surface.Snapshot{Files: []surface.FileHash{}}
+after  := surface.Snapshot{Files: []surface.FileHash{{Path: ".xylem/workflows/new.yaml", Hash: "eee"}}}
+```
+
+**Action:** Call `surface.Compare(before, after)`.
+
+**Expected outcome:** Returns a single `Violation` with `Path == ".xylem/workflows/new.yaml"`, `Before == "absent"`, `After == "eee"`.
+
+**Verification:** Assert `violations[0].Before == "absent"`.
+
+---
+
+## Section 4 — Policy enforcement
+
+### S17: Runner with nil Intermediary skips policy check
+
+**Spec ref:** Section 4.3
+
+**Preconditions:** A `Runner` with `Intermediary == nil`. A vessel with one prompt-type phase. Use a stub `CommandRunner` that records calls and returns empty output successfully.
+
+**Action:** Execute the vessel through `runVessel` (or the equivalent orchestrated path).
+
+**Expected outcome:** The vessel completes without error. The stub `CommandRunner` was called, confirming phase execution proceeded normally. No policy-related error message appears in the vessel failure state.
+
+**Verification:** Assert vessel final state is `completed`; assert stub was invoked.
+
+---
+
+### S18: Runner policy denies a phase — vessel fails with "denied by policy"
+
+**Spec ref:** Section 4.3 (policy check block)
+
+**Preconditions:** A `Runner` with an `Intermediary` configured with a single rule: `{Action: "*", Resource: "*", Effect: intermediary.Deny}`. A vessel with one prompt-type phase named `"solve"`.
+
+**Action:** Execute the vessel.
+
+**Expected outcome:** The vessel transitions to `failed` state. The failure message contains `"denied by policy"` and the phase name `"solve"`. The stub `CommandRunner` is never called (no phase execution occurred).
+
+**Verification:** Assert vessel state is `failed`; assert failure message contains `"denied by policy"` and `"solve"`; assert stub was not invoked.
+
+---
+
+### S19: Runner policy require_approval — vessel fails with approval message
+
+**Spec ref:** Section 4.3 (policy check block), §1.2 decision 3
+
+**Preconditions:** A `Runner` with an `Intermediary` whose policy maps the phase's action to `RequireApproval`. A vessel with one prompt-type phase named `"deploy"`.
+
+**Action:** Execute the vessel.
+
+**Expected outcome:** The vessel transitions to `failed` state. The failure message contains `"requires approval"` and `"deploy"` and some indication that automatic approval is not yet supported.
+
+**Verification:** Assert vessel state is `failed`; assert failure message contains `"requires approval"` and `"automatic approval not yet supported"`.
+
+---
+
+### S20: Surface pre-snapshot is taken before phase execution
+
+**Spec ref:** Section 4.3 (surface pre-snapshot block)
+
+**Preconditions:** A `Runner` with a non-empty `EffectiveProtectedSurfaces()` list. A vessel with a prompt-type phase. A stub `CommandRunner` that records when it is called. The worktree directory contains a `.xylem.yml` file.
+
+**Action:** Execute the vessel using a stub `CommandRunner` that records its invocation timestamp and a test-double snapshot function (or a real temp directory that the snapshot reads before the stub runs).
+
+**Expected outcome:** `surface.TakeSnapshot` is called and returns a non-empty snapshot before the `CommandRunner` records its invocation. The pre-snapshot is taken even when the policy check passes.
+
+**Verification:** In the test double, assert that the snapshot timestamp (or call-order index) precedes the CommandRunner invocation index.
+
+---
+
+### S21: Surface post-verification detects mutation — vessel fails
+
+**Spec ref:** Section 4.3 (surface post-verification block)
+
+**Preconditions:** A `Runner` configured with protected surface patterns. A stub `CommandRunner` that, when invoked for a phase, modifies `.xylem.yml` in the worktree (simulating an agent that mutated a protected file). The worktree contains `.xylem.yml` initially.
+
+**Action:** Execute the vessel.
+
+**Expected outcome:** The vessel transitions to `failed` state. The failure message contains `"violated protected surfaces"` and the path `.xylem.yml`.
+
+**Verification:** Assert vessel state is `failed`; assert failure message contains `"violated protected surfaces"` and `".xylem.yml"`.
+
+---
+
+### S22: Audit log records policy decisions
+
+**Spec ref:** Section 4.3 (audit log append inside policy check block)
+
+**Preconditions:** A `Runner` with an `Intermediary` and a configured `AuditLog` pointing to a temporary JSONL file. A vessel with one prompt-type phase.
+
+**Action:** Execute the vessel. Use a policy that allows the phase so the audit entry is always written regardless of the phase outcome.
+
+**Expected outcome:** After the vessel completes (or fails), the audit log JSONL file contains at least one entry. The entry has `intent.action` set to `"phase_execute"`, `intent.agent_id` equal to the vessel ID, and `decision` set to `"allow"`.
+
+**Verification:** Call `auditLog.Entries()`, assert `len(entries) >= 1`, assert field values on `entries[0]`.
+
+---
+
+### S23: Audit log records surface violations
+
+**Spec ref:** Section 4.3 (audit log append inside surface violation block)
+
+**Preconditions:** A `Runner` with a configured `AuditLog` and protected surface patterns. A stub `CommandRunner` that mutates `.xylem.yml` during phase execution. Policy allows the phase to run.
+
+**Action:** Execute the vessel.
+
+**Expected outcome:** After the vessel fails, the audit log contains an entry with `intent.action == "file_write"`, `intent.resource == ".xylem.yml"`, and `decision == "deny"`.
+
+**Verification:** Call `auditLog.Entries()`, find the `file_write` entry, assert all three fields.
+
+---
+
+### S24: phaseActionType returns "external_command" for command phases
+
+**Spec ref:** Section 4.4 (`phaseActionType`)
+
+**Preconditions:** A `workflow.Phase` with `Type == "command"`.
+
+**Action:** Call `phaseActionType(phase)`.
+
+**Expected outcome:** Returns the string `"external_command"`.
+
+**Verification:** Assert `result == "external_command"`.
+
+---
+
+### S25: phaseActionType returns "phase_execute" for prompt phases
+
+**Spec ref:** Section 4.4 (`phaseActionType`)
+
+**Preconditions:** A `workflow.Phase` with `Type == ""` (the zero value, representing a prompt phase).
+
+**Action:** Call `phaseActionType(phase)`.
+
+**Expected outcome:** Returns the string `"phase_execute"`.
+
+**Verification:** Assert `result == "phase_execute"`.
+
+---
+
+### S26: formatViolations produces human-readable output
+
+**Spec ref:** Section 4.4 (`formatViolations`)
+
+**Preconditions:**
+```go
+violations := []surface.Violation{
+    {Path: ".xylem.yml",       Before: "abc", After: "xyz"},
+    {Path: ".xylem/HARNESS.md", Before: "111", After: "deleted"},
+}
+```
+
+**Action:** Call `formatViolations(violations)`.
+
+**Expected outcome:** Returns a string containing both paths, their before/after values, and a separator between the two violations. Example acceptable output: `".xylem.yml (before: abc, after: xyz); .xylem/HARNESS.md (before: 111, after: deleted)"`.
+
+**Verification:** Assert the returned string contains `".xylem.yml"`, `"before: abc"`, `"after: xyz"`, `".xylem/HARNESS.md"`, and `"deleted"`.
+
+---
+
+### S27: CLI wiring in drain.go creates Intermediary from config
+
+**Spec ref:** Section 4.2 (drain.go `cmdDrain`)
+
+**Preconditions:** A valid `.xylem.yml` with no harness section (defaults apply). The `drain` command is invoked (or the runner is constructed as `cmdDrain` would construct it).
+
+**Action:** Inspect the `Runner` struct after `cmdDrain` constructs it, before `r.Drain()` is called.
+
+**Expected outcome:** `r.Intermediary` is non-nil. `r.AuditLog` is non-nil. The audit log path is `filepath.Join(cfg.StateDir, "audit.jsonl")` (the default). The intermediary's policies include the default policy with at least the `file_write` deny rule for `.xylem/HARNESS.md`.
+
+**Verification:** In a unit test that stubs the queue and CommandRunner, assert `r.Intermediary != nil` and `r.AuditLog != nil` after construction.
+
+---
+
+### S28: CLI wiring in daemon.go creates Intermediary from config
+
+**Spec ref:** Section 4.2 (daemon.go `runDrain`)
+
+**Preconditions:** A valid `.xylem.yml` with no harness section (defaults apply). The `runDrain` function is invoked (or the runner is constructed as it would be).
+
+**Action:** Inspect the `Runner` struct after `runDrain` constructs it.
+
+**Expected outcome:** `r.Intermediary` is non-nil. `r.AuditLog` is non-nil. Both match the same construction logic as `cmdDrain` — same policy set, same audit log path derivation.
+
+**Verification:** In a unit test or integration test, assert `r.Intermediary != nil` and `r.AuditLog != nil` after `runDrain` runs setup (before the drain loop).

--- a/docs/design/smoke-scenarios-unit-2.md
+++ b/docs/design/smoke-scenarios-unit-2.md
@@ -1,0 +1,456 @@
+# Smoke Scenarios: Unit 2 — Observability and Cost
+
+Workstream 3 of the xylem harness implementation spec.
+Covers spec sections 5 (observability integration) and 6 (cost estimation and budget enforcement).
+
+---
+
+## Section 5: Observability integration
+
+### S1: VesselSpanAttributes includes id, source, and workflow
+
+**Spec ref:** Section 5.3
+
+**Preconditions:** `observability/vessel.go` exists with `VesselSpanAttributes` implemented.
+
+**Action:** Call `VesselSpanAttributes("vessel-123", "github", "fix-bug", "refs/pull/42/head")`.
+
+**Expected outcome:** Returns a slice of four `SpanAttribute` values: `xylem.vessel.id = "vessel-123"`, `xylem.vessel.source = "github"`, `xylem.vessel.workflow = "fix-bug"`, `xylem.vessel.ref = "refs/pull/42/head"`.
+
+**Verification:** Unit test asserting length == 4 and key/value pairs match the spec exactly.
+
+---
+
+### S2: VesselSpanAttributes omits ref when empty
+
+**Spec ref:** Section 5.3
+
+**Preconditions:** `VesselSpanAttributes` implemented.
+
+**Action:** Call `VesselSpanAttributes("vessel-456", "manual", "implement-feature", "")`.
+
+**Expected outcome:** Returns a slice of exactly three `SpanAttribute` values. No attribute with key `xylem.vessel.ref` is present.
+
+**Verification:** Unit test asserting length == 3 and no element has Key == `"xylem.vessel.ref"`.
+
+---
+
+### S3: PhaseSpanAttributes includes name, index, type, provider, and model
+
+**Spec ref:** Section 5.3
+
+**Preconditions:** `PhaseSpanAttributes` implemented.
+
+**Action:** Call `PhaseSpanAttributes("analyse", 0, "prompt", "anthropic", "claude-sonnet-4-20250514")`.
+
+**Expected outcome:** Returns a slice of five `SpanAttribute` values: `xylem.phase.name = "analyse"`, `xylem.phase.index = "0"`, `xylem.phase.type = "prompt"`, `xylem.phase.provider = "anthropic"`, `xylem.phase.model = "claude-sonnet-4-20250514"`. The index field is stringified, not numeric.
+
+**Verification:** Unit test asserting length == 5 and all five key/value pairs are present with correct string values.
+
+---
+
+### S4: PhaseResultAttributes formats tokens and cost as strings
+
+**Spec ref:** Section 5.3
+
+**Preconditions:** `PhaseResultAttributes` implemented.
+
+**Action:** Call `PhaseResultAttributes(1200, 300, 0.0081, 4500)`.
+
+**Expected outcome:** Returns four `SpanAttribute` values: `xylem.phase.input_tokens_est = "1200"`, `xylem.phase.output_tokens_est = "300"`, `xylem.phase.cost_usd_est = "0.008100"` (six decimal places via `%.6f`), `xylem.phase.duration_ms = "4500"`.
+
+**Verification:** Unit test asserting exact string formatting, including the six-decimal-place cost.
+
+---
+
+### S5: GateSpanAttributes formats boolean and int as strings
+
+**Spec ref:** Section 5.3
+
+**Preconditions:** `GateSpanAttributes` implemented.
+
+**Action:** Call `GateSpanAttributes("command", true, 2)`.
+
+**Expected outcome:** Returns three `SpanAttribute` values: `xylem.gate.type = "command"`, `xylem.gate.passed = "true"`, `xylem.gate.retry_attempt = "2"`.
+
+**Verification:** Unit test asserting the boolean is rendered as the lowercase string `"true"` (not `"1"` or `"True"`) and the retry count is a decimal string.
+
+---
+
+### S6: Tracer initialization with default config uses stdout exporter
+
+**Spec ref:** Section 5.4
+
+**Preconditions:** `NewTracer` implemented; `TracerConfig` with empty `Endpoint`.
+
+**Action:** Call `NewTracer(DefaultTracerConfig())`.
+
+**Expected outcome:** Returns a non-nil `*Tracer` and nil error. No network connection is attempted. Subsequent `StartSpan` calls emit JSON-formatted span output to stdout.
+
+**Verification:** Unit test calling `NewTracer` with empty endpoint, asserting no error returned and tracer is not nil.
+
+---
+
+### S7: Tracer initialization with OTLP endpoint uses gRPC exporter
+
+**Spec ref:** Section 5.4
+
+**Preconditions:** `NewTracer` implemented.
+
+**Action:** Call `NewTracer(TracerConfig{ServiceName: "xylem", Endpoint: "localhost:4317", Insecure: true, SampleRate: 1.0})`.
+
+**Expected outcome:** Returns a non-nil `*Tracer` and nil error (the OTLP exporter is created in lazy mode and does not attempt a connection at construction time). The returned tracer is wired to the `localhost:4317` endpoint.
+
+**Verification:** Unit test asserting non-nil tracer and nil error; confirm the implementation does not block on a missing collector at init time.
+
+---
+
+### S8: Tracer initialization failure logs warning and continues without tracing
+
+**Spec ref:** Section 5.4
+
+**Preconditions:** Tracer initialization code in `drain.go` / `daemon.go` that wraps `NewTracer` in a log-and-continue pattern.
+
+**Action:** Simulate `NewTracer` returning an error (e.g., by providing a malformed endpoint string that the OTLP library rejects at construction time).
+
+**Expected outcome:** The drain command logs a warning message containing `"warn: failed to initialize tracer:"` and proceeds to create the runner with `r.Tracer = nil`. The drain run does not abort.
+
+**Verification:** Integration test or log-capture test asserting the warning is logged and no fatal/panic occurs.
+
+---
+
+### S9: nil Tracer skips all span creation without panicking
+
+**Spec ref:** Sections 5.5 and 5.6
+
+**Preconditions:** `Runner` with `Tracer` field set to nil. A pending vessel exists in the queue.
+
+**Action:** Call `runner.Drain(ctx)` with at least one pending vessel and `r.Tracer == nil`.
+
+**Expected outcome:** The vessel executes normally — phases run, output is persisted, state transitions occur. No nil pointer dereference panic occurs anywhere in the span-creation code paths.
+
+**Verification:** Existing drain tests with a nil tracer (the default) pass without modification. No additional guard is needed — the `if r.Tracer != nil` checks in the spec fully cover this.
+
+---
+
+### S10: drain_run span wraps the entire Drain() call
+
+**Spec ref:** Section 5.5
+
+**Preconditions:** `Runner` with a non-nil `Tracer`. Queue contains two pending vessels.
+
+**Action:** Call `runner.Drain(ctx)` to completion.
+
+**Expected outcome:** Exactly one span named `"drain_run"` appears in the trace output. It carries attributes `xylem.drain.concurrency` and `xylem.drain.timeout`. Its start time precedes all vessel spans and its end time follows all vessel spans.
+
+**Verification:** Capture stdout trace output from a test with a stdout exporter. Assert one root span named `"drain_run"` with the two expected attributes, and that its time range encloses all child spans.
+
+---
+
+### S11: vessel span is a child of drain_run span
+
+**Spec ref:** Section 5.5
+
+**Preconditions:** `Runner` with a non-nil `Tracer`. Queue contains one pending vessel.
+
+**Action:** Call `runner.Drain(ctx)` to completion.
+
+**Expected outcome:** The trace output contains a span named `"vessel:<vessel-id>"` whose parent span ID matches the `drain_run` span. The vessel span carries the four vessel attributes (`xylem.vessel.id`, `xylem.vessel.source`, `xylem.vessel.workflow`, and optionally `xylem.vessel.ref`).
+
+**Verification:** Parse the stdout JSON trace output and assert the vessel span's `parentSpanID` == `drain_run` span's `spanID`.
+
+---
+
+### S12: phase span is a child of vessel span
+
+**Spec ref:** Section 5.6
+
+**Preconditions:** `Runner` with non-nil `Tracer`. Vessel has a single-phase workflow.
+
+**Action:** Run one vessel to completion through `Drain`.
+
+**Expected outcome:** The trace output contains a span named `"phase:<phase-name>"` whose parent span ID matches the vessel span's span ID.
+
+**Verification:** Parse stdout trace JSON and assert parent-child relationship between vessel span and phase span.
+
+---
+
+### S13: gate span is a child of phase span
+
+**Spec ref:** Section 5.6
+
+**Preconditions:** `Runner` with non-nil `Tracer`. Vessel workflow has a phase with a `command`-type gate.
+
+**Action:** Run one vessel through the gate evaluation path.
+
+**Expected outcome:** The trace output contains a span named `"gate:command"` whose parent span ID matches the enclosing phase span. The gate span carries attributes `xylem.gate.type`, `xylem.gate.passed`, and `xylem.gate.retry_attempt`.
+
+**Verification:** Parse stdout trace JSON and assert parent-child relationship and gate attribute presence.
+
+---
+
+### S14: Phase span gets result attributes added after execution
+
+**Spec ref:** Section 5.6
+
+**Preconditions:** `Runner` with non-nil `Tracer`. Prompt-type phase that produces non-empty output.
+
+**Action:** Run one vessel with a prompt-type phase.
+
+**Expected outcome:** The phase span in the trace output contains all four result attributes: `xylem.phase.input_tokens_est`, `xylem.phase.output_tokens_est`, `xylem.phase.cost_usd_est`, and `xylem.phase.duration_ms`. The cost attribute is formatted to six decimal places.
+
+**Verification:** Parse stdout trace JSON for the phase span and assert all four result attributes are present and non-empty.
+
+---
+
+### S15: Phase span records error on phase failure
+
+**Spec ref:** Section 5.6
+
+**Preconditions:** `Runner` with non-nil `Tracer`. Phase is configured to fail (e.g., command phase returns non-zero exit code).
+
+**Action:** Run a vessel whose phase fails.
+
+**Expected outcome:** The phase span in the trace output contains an OTel error event (the span's `RecordError` was called with the failure error). The span's status is set to error.
+
+**Verification:** Parse stdout trace JSON for the phase span and assert an event of type `"exception"` or equivalent OTel error annotation is present.
+
+---
+
+### S16: Phase span always ends even when phase fails
+
+**Spec ref:** Section 5.6
+
+**Preconditions:** `Runner` with non-nil `Tracer`. Phase is configured to fail.
+
+**Action:** Run a vessel whose phase fails and observe the trace output after `Drain` returns.
+
+**Expected outcome:** The phase span appears in the trace output with a valid end time (it is not missing, which would indicate a span that was started but never ended). The `drain_run` and vessel spans also end cleanly.
+
+**Verification:** After `Shutdown` is called on the tracer, count the spans in stdout output. Every started span (drain_run, vessel, phase) must appear as a completed span.
+
+---
+
+## Section 6: Cost estimation and budget enforcement
+
+### S17: EstimateTokens returns len/4 for a known string
+
+**Spec ref:** Section 6.1
+
+**Preconditions:** `cost/estimate.go` exists with `EstimateTokens` implemented.
+
+**Action:** Call `EstimateTokens("Hello, world! This is a test string.")` where the string length is 36 characters.
+
+**Expected outcome:** Returns `9` (36 / 4 = 9).
+
+**Verification:** Unit test asserting `EstimateTokens("Hello, world! This is a test string.") == 9`.
+
+---
+
+### S18: EstimateTokens returns 0 for empty string
+
+**Spec ref:** Section 6.1
+
+**Preconditions:** `EstimateTokens` implemented.
+
+**Action:** Call `EstimateTokens("")`.
+
+**Expected outcome:** Returns `0`. No panic or error.
+
+**Verification:** Unit test asserting `EstimateTokens("") == 0`.
+
+---
+
+### S19: EstimateCost with known pricing produces correct arithmetic
+
+**Spec ref:** Section 6.1
+
+**Preconditions:** `EstimateCost` and `ModelPricing` implemented.
+
+**Action:** Call `EstimateCost(1_000_000, 500_000, &ModelPricing{InputPer1M: 3.00, OutputPer1M: 15.00})`.
+
+**Expected outcome:** Returns `10.5` (1M input tokens * $3.00/1M + 500K output tokens * $15.00/1M = $3.00 + $7.50 = $10.50).
+
+**Verification:** Unit test asserting the return value equals `10.5` within floating-point tolerance.
+
+---
+
+### S20: EstimateCost with nil pricing returns 0
+
+**Spec ref:** Section 6.1
+
+**Preconditions:** `EstimateCost` implemented.
+
+**Action:** Call `EstimateCost(5000, 1000, nil)`.
+
+**Expected outcome:** Returns `0`. No panic.
+
+**Verification:** Unit test asserting `EstimateCost(5000, 1000, nil) == 0.0`.
+
+---
+
+### S21: LookupPricing exact match returns correct pricing
+
+**Spec ref:** Section 6.1
+
+**Preconditions:** `LookupPricing` implemented with `DefaultPricingTable` containing `"claude-sonnet-4"`.
+
+**Action:** Call `LookupPricing("claude-sonnet-4")`.
+
+**Expected outcome:** Returns a non-nil `*ModelPricing` with `InputPer1M == 3.00` and `OutputPer1M == 15.00`.
+
+**Verification:** Unit test asserting non-nil return and correct pricing values.
+
+---
+
+### S22: LookupPricing falls back to prefix match for versioned model name
+
+**Spec ref:** Section 6.1
+
+**Preconditions:** `LookupPricing` implemented. `DefaultPricingTable` contains `"claude-sonnet-4"` but not `"claude-sonnet-4-20250514"`.
+
+**Action:** Call `LookupPricing("claude-sonnet-4-20250514")`.
+
+**Expected outcome:** Returns a non-nil `*ModelPricing` with `InputPer1M == 3.00` and `OutputPer1M == 15.00` (matched via prefix `"claude-sonnet-4"`).
+
+**Verification:** Unit test asserting non-nil return and pricing values match the `"claude-sonnet-4"` entry.
+
+---
+
+### S23: LookupPricing longest prefix wins when multiple prefixes match
+
+**Spec ref:** Section 6.1
+
+**Preconditions:** `LookupPricing` implemented. `DefaultPricingTable` contains both `"claude-haiku-3"` and `"claude-haiku-4"`. The model being looked up starts with both.
+
+**Action:** Call `LookupPricing("claude-haiku-4-5")` where `DefaultPricingTable` has `"claude-haiku-3"` (`InputPer1M: 0.25`) and `"claude-haiku-4"` (`InputPer1M: 0.80`).
+
+**Expected outcome:** Returns pricing for `"claude-haiku-4"` (`InputPer1M == 0.80`), not for `"claude-haiku-3"` (`InputPer1M == 0.25`), because `"claude-haiku-4"` is the longer matching prefix.
+
+**Verification:** Unit test asserting `InputPer1M == 0.80` in the returned pricing.
+
+---
+
+### S24: LookupPricing returns nil for unrecognised model
+
+**Spec ref:** Section 6.1
+
+**Preconditions:** `LookupPricing` implemented.
+
+**Action:** Call `LookupPricing("gpt-4o")`.
+
+**Expected outcome:** Returns `nil`.
+
+**Verification:** Unit test asserting `LookupPricing("gpt-4o") == nil`.
+
+---
+
+### S25: Per-vessel Tracker is created fresh for each vessel
+
+**Spec ref:** Section 6.2
+
+**Preconditions:** `Runner` configured. Two pending vessels in the queue. `r.Config.VesselBudget()` returns a non-nil budget.
+
+**Action:** Call `runner.Drain(ctx)` to process both vessels sequentially.
+
+**Expected outcome:** Each vessel accumulates cost independently. Spending on vessel A does not carry over to vessel B's tracker. If vessel A's total cost is $0.05, vessel B starts at $0.00.
+
+**Verification:** Test with two sequential vessels and a tight cost budget that vessel A would exceed only after two phases — assert that vessel B starts fresh (its first phase does not immediately exceed the budget).
+
+---
+
+### S26: Cost recorded after each prompt-type phase
+
+**Spec ref:** Section 6.2
+
+**Preconditions:** `Runner` with a vessel running a two-phase prompt workflow. Each phase produces non-empty rendered input and output.
+
+**Action:** Run the vessel to completion.
+
+**Expected outcome:** The vessel's tracker has exactly two `UsageRecord` entries (one per prompt-type phase). Each record has non-zero `InputTokens`, non-zero `OutputTokens`, and a non-zero `CostUSD` (when using a model that has a pricing entry in `DefaultPricingTable`).
+
+**Verification:** Expose the tracker state for test assertions or check the TotalTokens() is > 0 after both phases complete.
+
+---
+
+### S27: Command-type phases do not generate cost records
+
+**Spec ref:** Section 6.2
+
+**Preconditions:** `Runner` with a vessel running a workflow containing one prompt phase and one command phase.
+
+**Action:** Run the vessel to completion.
+
+**Expected outcome:** The vessel's tracker has exactly one `UsageRecord` entry (from the prompt phase only). `TotalTokens()` reflects only the prompt phase's tokens.
+
+**Verification:** Assert `vesselTracker.TotalTokens()` equals the estimated tokens from the prompt phase's input/output, not double that amount.
+
+---
+
+### S28: Budget enforcement fails vessel when budget is exceeded
+
+**Spec ref:** Section 6.3
+
+**Preconditions:** `Runner` configured with a vessel budget of `CostLimitUSD: 0.0001` (very tight). Vessel has a three-phase prompt workflow where the first phase's estimated cost alone exceeds the limit.
+
+**Action:** Run the vessel through `Drain`.
+
+**Expected outcome:** The vessel enters the `failed` state after the first phase completes and the budget check fires. The failure reason stored on the vessel contains the string `"budget exceeded"`, the estimated cost value, and the estimated token count.
+
+**Verification:** After drain completes, query the vessel's final state from the queue and assert `Status == "failed"` and the error message contains `"budget exceeded"`.
+
+---
+
+### S29: nil budget means no enforcement
+
+**Spec ref:** Section 6.3
+
+**Preconditions:** `Runner` where `r.Config.VesselBudget()` returns nil. Vessel has a prompt workflow that would be expensive.
+
+**Action:** Run the vessel to completion.
+
+**Expected outcome:** The vessel completes all phases successfully regardless of cost. `BudgetExceeded()` is never called in an enforcing way. No failure state is reached due to cost.
+
+**Verification:** Assert the vessel reaches `completed` status and no `"budget exceeded"` message appears in the vessel's failure reason or drain logs.
+
+---
+
+### S30: Tracer wired in drain.go after config load
+
+**Spec ref:** Section 5.4
+
+**Preconditions:** `cli/cmd/drain.go` (or equivalent) contains the tracer initialization block after config loading.
+
+**Action:** Run `xylem drain` with observability enabled in `.xylem.yml` (endpoint set to empty string for stdout mode).
+
+**Expected outcome:** Span output appears on stdout during the drain run. The runner's `Tracer` field is non-nil for the duration of the drain call. `tracer.Shutdown` is deferred and fires when the command exits (all spans are flushed).
+
+**Verification:** Run the CLI with a test vessel and a stdout-mode tracer config; confirm span JSON appears in stdout and includes a `"drain_run"` span.
+
+---
+
+### S31: Tracer wired in daemon.go runDrain
+
+**Spec ref:** Section 5.4
+
+**Preconditions:** `cli/cmd/daemon.go` contains the same tracer initialization block inside `runDrain`, after intermediary wiring.
+
+**Action:** Run `xylem daemon` briefly (or call `runDrain` directly in a test) with observability enabled.
+
+**Expected outcome:** Each invocation of `runDrain` initializes a fresh tracer and defers its shutdown. Spans appear in trace output for each drain cycle and are flushed before the next cycle begins.
+
+**Verification:** Confirm the tracer initialization and shutdown code path is exercised in the daemon's drain loop — no drain cycle runs with a stale or shutdown tracer.
+
+---
+
+### S32: Tracer shutdown deferred in both drain and daemon paths
+
+**Spec ref:** Section 5.4
+
+**Preconditions:** Both `drain.go` and `daemon.go` implement the `defer tracer.Shutdown(context.Background())` pattern.
+
+**Action:** Run `xylem drain` with two pending vessels and interrupt it cleanly (context cancellation).
+
+**Expected outcome:** Even on early exit, the deferred `Shutdown` call fires and flushes any pending spans to the exporter. No spans are lost in the stdout output — all started spans appear as completed entries.
+
+**Verification:** Count spans in stdout output after an interrupted drain. Assert all started spans (drain_run + one vessel span per dequeued vessel) appear as completed entries in the flushed output.

--- a/docs/design/smoke-scenarios-unit-3.md
+++ b/docs/design/smoke-scenarios-unit-3.md
@@ -1,0 +1,362 @@
+# Smoke Scenarios — Unit 3: Per-vessel summary artifact
+
+These scenarios cover the observable behaviour of the per-vessel summary artifact
+described in spec section 7 of `xylem-harness-impl-spec.md`.
+
+---
+
+### S1: Summary file written on vessel completion
+
+**Spec ref:** Section 7.1, 7.3
+
+**Preconditions:** A vessel with ID `vessel-abc123`, workflow `fix-bug`, source
+`github`, and two phases completes successfully. State dir is `/tmp/xylem-state`.
+
+**Action:** `completeVessel` is called after all phases finish.
+
+**Expected outcome:** A file exists at
+`/tmp/xylem-state/phases/vessel-abc123/summary.json`. The file is non-empty and
+parses as valid JSON with top-level field `"vessel_id": "vessel-abc123"` and
+`"state": "completed"`.
+
+**Verification:** `os.Stat` the path; `json.Unmarshal` into `VesselSummary` and
+assert `VesselID == "vessel-abc123"` and `State == "completed"`.
+
+---
+
+### S2: Summary file written on vessel failure (partial summary)
+
+**Spec ref:** Section 7.3 (failure paths)
+
+**Preconditions:** A vessel with ID `vessel-def456` has completed its first
+phase. The runner fails before the second phase runs (e.g. worktree creation
+fails). State dir is `/tmp/xylem-state`.
+
+**Action:** The failure path calls `buildSummary("failed")` and
+`SaveVesselSummary` with only the first phase in the accumulator.
+
+**Expected outcome:** A file exists at
+`/tmp/xylem-state/phases/vessel-def456/summary.json`. It parses as valid JSON
+with `"state": "failed"`. The `"phases"` array contains exactly one entry
+reflecting the completed first phase.
+
+**Verification:** Parse the file; assert `State == "failed"` and
+`len(Phases) == 1`.
+
+---
+
+### S3: Summary contains the disclaimer note
+
+**Spec ref:** Section 7.1 (`summaryDisclaimer` constant, `SaveVesselSummary`)
+
+**Preconditions:** Any vessel completes or fails, triggering `SaveVesselSummary`.
+
+**Action:** `SaveVesselSummary` writes the summary to disk.
+
+**Expected outcome:** The written JSON has a `"note"` field equal to `"Token
+counts and costs are estimates (len/4 heuristic + static pricing). Not
+provider-reported values."`.
+
+**Verification:** Read `summary.json`, parse, and assert
+`Note == summaryDisclaimer`.
+
+---
+
+### S4: Summary JSON is pretty-printed
+
+**Spec ref:** Section 7.1 (`json.MarshalIndent`)
+
+**Preconditions:** A vessel with any ID completes. State dir is
+`/tmp/xylem-state`.
+
+**Action:** `SaveVesselSummary` is called.
+
+**Expected outcome:** The raw bytes of `summary.json` contain newlines and
+two-space indentation. The first line is `{` and the second line starts with
+`  "`.
+
+**Verification:** Read the raw file bytes; check that `bytes.Contains(data, []byte("\n  "))` is true.
+
+---
+
+### S5: PhaseSummary records "completed" status for a successful phase
+
+**Spec ref:** Section 7.1 (`PhaseSummary.Status`)
+
+**Preconditions:** A vessel runs a single phase named `"implement"` that
+finishes without error.
+
+**Action:** `addPhase` is called with a `PhaseSummary{Status: "completed"}`;
+`buildSummary` is then called.
+
+**Expected outcome:** The resulting `VesselSummary.Phases[0].Status` is
+`"completed"` and `Phases[0].Error` is empty.
+
+**Verification:** Assert `summary.Phases[0].Status == "completed"` and
+`summary.Phases[0].Error == ""`.
+
+---
+
+### S6: PhaseSummary records "failed" status for a failed phase
+
+**Spec ref:** Section 7.1 (`PhaseSummary.Status`, `PhaseSummary.Error`)
+
+**Preconditions:** A vessel phase named `"test"` fails with error message
+`"exit status 1"`.
+
+**Action:** `addPhase` is called with
+`PhaseSummary{Status: "failed", Error: "exit status 1"}`; `buildSummary` is then
+called.
+
+**Expected outcome:** `Phases[0].Status == "failed"` and
+`Phases[0].Error == "exit status 1"`.
+
+**Verification:** Assert both fields on the returned summary.
+
+---
+
+### S7: PhaseSummary records "no-op" status for an early-completion phase
+
+**Spec ref:** Section 7.1 (`PhaseSummary.Status`)
+
+**Preconditions:** A vessel has a phase that was previously completed and is
+skipped on resume (already present in phase outputs).
+
+**Action:** `addPhase` is called with `PhaseSummary{Status: "no-op"}`;
+`buildSummary` is called.
+
+**Expected outcome:** `Phases[0].Status == "no-op"`. Token and cost fields for
+that phase are zero (the phase did no work).
+
+**Verification:** Assert `Phases[0].Status == "no-op"`,
+`Phases[0].InputTokensEst == 0`, and `Phases[0].CostUSDEst == 0.0`.
+
+---
+
+### S8: vesselRunState.addPhase accumulates phases in insertion order
+
+**Spec ref:** Section 7.2 (`vesselRunState.addPhase`)
+
+**Preconditions:** A `vesselRunState` is created with no phases.
+
+**Action:** `addPhase` is called three times with phases named `"plan"`,
+`"implement"`, `"test"` in that order.
+
+**Expected outcome:** After the third call, `vrs.phases` has length 3 and the
+names appear in insertion order: `phases[0].Name == "plan"`,
+`phases[1].Name == "implement"`, `phases[2].Name == "test"`.
+
+**Verification:** Inspect `vrs.phases` directly in a unit test; assert order and
+length.
+
+---
+
+### S9: buildSummary computes TotalTokensEst as sum of phase token fields
+
+**Spec ref:** Section 7.2 (`buildSummary`)
+
+**Preconditions:** A `vesselRunState` has two phases:
+- Phase A: `InputTokensEst=100`, `OutputTokensEst=50`
+- Phase B: `InputTokensEst=200`, `OutputTokensEst=80`
+
+**Action:** `buildSummary("completed")` is called.
+
+**Expected outcome:** The returned summary has
+`TotalInputTokensEst == 300`, `TotalOutputTokensEst == 130`,
+and `TotalTokensEst == 430`.
+
+**Verification:** Assert all three total fields on the returned `*VesselSummary`.
+
+---
+
+### S10: buildSummary computes TotalCostUSDEst as sum of phase costs
+
+**Spec ref:** Section 7.2 (`buildSummary`)
+
+**Preconditions:** A `vesselRunState` has two phases:
+- Phase A: `CostUSDEst=0.0012`
+- Phase B: `CostUSDEst=0.0034`
+
+**Action:** `buildSummary("completed")` is called.
+
+**Expected outcome:** `TotalCostUSDEst` is approximately `0.0046` (sum of both
+phases, within floating-point tolerance).
+
+**Verification:** Assert `math.Abs(summary.TotalCostUSDEst - 0.0046) < 1e-9`.
+
+---
+
+### S11: buildSummary sets DurationMS from startedAt to call time
+
+**Spec ref:** Section 7.2 (`buildSummary`)
+
+**Preconditions:** A `vesselRunState` is created with `startedAt` set to a fixed
+time `T` in the past.
+
+**Action:** `buildSummary("completed")` is called.
+
+**Expected outcome:** The returned summary has `DurationMS > 0`,
+`StartedAt == T`, and `EndedAt` is after `T`.
+
+**Verification:** Assert `summary.DurationMS > 0` and
+`summary.EndedAt.After(summary.StartedAt)`.
+
+---
+
+### S12: buildSummary reads BudgetExceeded from the costTracker
+
+**Spec ref:** Section 7.2 (`buildSummary`, `cost.Tracker.BudgetExceeded`)
+
+**Preconditions:** A `vesselRunState` holds a `costTracker` that has exceeded its
+budget (i.e. `BudgetExceeded()` returns `true`).
+
+**Action:** `buildSummary("completed")` is called.
+
+**Expected outcome:** The returned `VesselSummary.BudgetExceeded` is `true`.
+
+**Verification:** Assert `summary.BudgetExceeded == true`.
+
+---
+
+### S13: SaveVesselSummary creates the phases/<vessel-id> directory if absent
+
+**Spec ref:** Section 7.1 (`SaveVesselSummary`, `os.MkdirAll`)
+
+**Preconditions:** The directory `<state_dir>/phases/vessel-new999` does not
+exist.
+
+**Action:** `SaveVesselSummary(stateDir, &VesselSummary{VesselID: "vessel-new999", ...})` is called.
+
+**Expected outcome:** The call returns `nil`. The directory
+`<state_dir>/phases/vessel-new999` exists and contains `summary.json`.
+
+**Verification:** `os.Stat` the directory and file; assert both exist with no
+error.
+
+---
+
+### S14: SaveVesselSummary failure is non-fatal — caller continues
+
+**Spec ref:** Section 7.3 (`SaveVesselSummary` non-fatal note)
+
+**Preconditions:** The state directory path points to a location where directory
+creation will fail (e.g. `/dev/null/phases` on Linux, or a path inside a
+read-only mount) so that `os.MkdirAll` returns an error.
+
+**Action:** `SaveVesselSummary` is called from a failure path in `runVessel`.
+
+**Expected outcome:** `runVessel` does not panic or return an error to the queue.
+The vessel state is updated to `failed` in the queue as normal. A warning is
+written to the log (`log.Printf("warn: save vessel summary: ..."`)).
+
+**Verification:** Assert `Queue.Update` was called with `StateFailed`; assert no
+panic; capture log output and verify the `"warn: save vessel summary"` line is
+present.
+
+---
+
+### S15: completeVessel updated signature accepts vesselRunState
+
+**Spec ref:** Section 7.3 (updated `completeVessel` signature)
+
+**Preconditions:** A `vesselRunState` has been populated with two completed
+phases during a run of `runVessel`.
+
+**Action:** `completeVessel(ctx, vessel, worktreePath, phaseResults, vrs, nil)`
+is called (nil claims).
+
+**Expected outcome:** The call compiles and returns `"completed"`. No nil-pointer
+panic occurs when `claims` is nil.
+
+**Verification:** Unit test calls the updated signature; asserts return value is
+`"completed"` and that `summary.json` is written to the state dir.
+
+---
+
+### S16: completeVessel saves summary after existing completion logic
+
+**Spec ref:** Section 7.3 (ordering — summary saved after queue update)
+
+**Preconditions:** A vessel completes the sequential phase loop. Queue and
+Reporter stubs are in place.
+
+**Action:** `completeVessel` is called.
+
+**Expected outcome:** After `completeVessel` returns, the vessel state in the
+queue is `StateCompleted` and `summary.json` exists with `"state": "completed"`.
+
+**Verification:** Read the queue and assert vessel state is `completed`; parse
+`summary.json` and assert its `state` field is `"completed"`.
+
+---
+
+### S17: completeVessel saves evidence manifest when claims are present
+
+**Spec ref:** Section 7.3 (evidence manifest block)
+
+**Preconditions:** `completeVessel` is called with a non-empty `claims` slice
+(e.g. one `evidence.Claim` for the `"implement"` phase).
+
+**Action:** `completeVessel` executes the evidence manifest block.
+
+**Expected outcome:** A file `<state_dir>/phases/<vessel-id>/evidence-manifest.json`
+is created. It is valid JSON. `summary.EvidenceManifestPath` is
+`"phases/<vessel-id>/evidence-manifest.json"` (the relative path).
+
+**Verification:** `os.Stat` the manifest file; parse it; assert
+`summary.EvidenceManifestPath` is set to the expected relative path.
+
+---
+
+### S18: EvidenceManifestPath is empty in summary when no claims provided
+
+**Spec ref:** Section 7.3 (`EvidenceManifestPath` omitempty)
+
+**Preconditions:** `completeVessel` is called with an empty or nil `claims`
+slice.
+
+**Action:** `completeVessel` skips the evidence manifest block.
+
+**Expected outcome:** The `evidence-manifest.json` file is not created.
+`summary.EvidenceManifestPath` is empty string, which means it is omitted from
+the JSON output (`omitempty`).
+
+**Verification:** Assert the manifest file does not exist; parse `summary.json`
+and confirm the `"evidence_manifest_path"` key is absent.
+
+---
+
+### S19: Failure path builds summary with state "failed" and calls SaveVesselSummary
+
+**Spec ref:** Section 7.3 (failure paths)
+
+**Preconditions:** A vessel is running phase 2 of 3. Phase 2's gate fails with
+retries exhausted.
+
+**Action:** The gate-failure branch in `runVessel` executes:
+`summary := vrs.buildSummary("failed"); _ = SaveVesselSummary(...)`.
+
+**Expected outcome:** `summary.json` is written for the vessel. Parsing it shows
+`"state": "failed"`. The `phases` array contains the entries recorded before
+the failure (phase 1 completed, phase 2 added with `Status: "failed"`).
+
+**Verification:** Trigger the gate-failure path in a test; read the written
+`summary.json`; assert state and phase count.
+
+---
+
+### S20: BudgetMaxCostUSD and BudgetMaxTokens appear in summary when budget is configured
+
+**Spec ref:** Section 7.1 (`BudgetMaxCostUSD`, `BudgetMaxTokens` omitempty)
+
+**Preconditions:** The runner is configured with a budget of `max_cost_usd: 1.00`
+and `max_tokens: 50000`. The `VesselSummary` is populated with these values
+before calling `SaveVesselSummary`.
+
+**Action:** `SaveVesselSummary` writes the summary.
+
+**Expected outcome:** The written JSON contains both
+`"budget_max_cost_usd": 1.0` and `"budget_max_tokens": 50000`.
+
+**Verification:** Parse `summary.json`; assert `*BudgetMaxCostUSD == 1.0` and
+`*BudgetMaxTokens == 50000`.

--- a/docs/design/smoke-scenarios-unit-4.md
+++ b/docs/design/smoke-scenarios-unit-4.md
@@ -1,0 +1,232 @@
+# Smoke scenarios — Workstream 4: Verification evidence model
+
+Spec reference: `docs/design/xylem-harness-impl-spec.md` section 8
+
+---
+
+### S1: Level.Valid() accepts all named levels including Untyped
+**Spec ref:** Section 8.1
+**Preconditions:** `cli/internal/evidence` package exists with `Level` type and `Valid()` method.
+**Action:** Call `Valid()` on each of the five recognised constants: `Proved`, `MechanicallyChecked`, `BehaviorallyChecked`, `ObservedInSitu`, and `Untyped` (the empty string).
+**Expected outcome:** All five calls return `true`.
+**Verification:** Unit test asserts `true` for each level, including the zero-value empty string.
+
+---
+
+### S2: Level.Valid() rejects arbitrary strings
+**Spec ref:** Section 8.1
+**Preconditions:** `Level` type and `Valid()` method exist.
+**Action:** Call `Valid()` on unrecognised strings such as `"high"`, `"none"`, `"PROVED"` (wrong case), and `"mechanically-checked"` (wrong separator).
+**Expected outcome:** All calls return `false`.
+**Verification:** Unit test asserts `false` for each input; case-sensitivity and separator format are confirmed to matter.
+
+---
+
+### S3: Level.Rank() ordering — Proved is strongest, Untyped is weakest
+**Spec ref:** Section 8.1
+**Preconditions:** `Rank()` method exists on `Level`.
+**Action:** Call `Rank()` on all five levels and compare results.
+**Expected outcome:** `Proved.Rank()` (4) > `MechanicallyChecked.Rank()` (3) > `BehaviorallyChecked.Rank()` (2) > `ObservedInSitu.Rank()` (1) > `Untyped.Rank()` (0).
+**Verification:** Unit test asserts strict ordering and the exact integer values for all five levels.
+
+---
+
+### S4: Manifest.BuildSummary counts total, passed, and failed claims
+**Spec ref:** Section 8.1
+**Preconditions:** `Manifest` and `BuildSummary()` exist.
+**Action:** Create a `Manifest` with three claims: two with `Passed: true` and one with `Passed: false`. Call `BuildSummary()`.
+**Expected outcome:** `manifest.Summary.Total == 3`, `manifest.Summary.Passed == 2`, `manifest.Summary.Failed == 1`.
+**Verification:** Unit test reads the three fields from `manifest.Summary` after the call.
+
+---
+
+### S5: Manifest.BuildSummary groups claims by level
+**Spec ref:** Section 8.1
+**Preconditions:** `BuildSummary()` populates `Summary.ByLevel`.
+**Action:** Create a `Manifest` with four claims: two at `BehaviorallyChecked`, one at `MechanicallyChecked`, one at `Untyped`. Call `BuildSummary()`.
+**Expected outcome:** `Summary.ByLevel["behaviorally_checked"] == 2`, `Summary.ByLevel["mechanically_checked"] == 1`, `Summary.ByLevel[""] == 1`. No entry exists for levels with zero claims.
+**Verification:** Unit test checks the map entries; confirms absent keys are not present rather than set to zero.
+
+---
+
+### S6: Manifest.StrongestLevel returns highest-ranked passing claim level
+**Spec ref:** Section 8.1
+**Preconditions:** `StrongestLevel()` method exists.
+**Action:** Create a `Manifest` with three passing claims at levels `ObservedInSitu`, `BehaviorallyChecked`, and `MechanicallyChecked`. Call `StrongestLevel()`.
+**Expected outcome:** Returns `MechanicallyChecked`.
+**Verification:** Unit test asserts the returned level equals `MechanicallyChecked`.
+
+---
+
+### S7: Manifest.StrongestLevel returns Untyped when no claims passed
+**Spec ref:** Section 8.1
+**Preconditions:** `StrongestLevel()` method exists.
+**Action:** Call `StrongestLevel()` on a manifest whose claims all have `Passed: false` (including a claim at `Proved`). Also call it on a manifest with no claims at all.
+**Expected outcome:** Returns `Untyped` (empty string) in both cases.
+**Verification:** Unit test asserts the returned value equals `evidence.Untyped` for each case.
+
+---
+
+### S8: SaveManifest writes JSON to the expected path
+**Spec ref:** Section 8.1
+**Preconditions:** `SaveManifest` function exists; a temporary directory is available as `stateDir`.
+**Action:** Call `SaveManifest(stateDir, "vessel-abc123", manifest)` where `manifest` has one claim.
+**Expected outcome:** A file is created at `<stateDir>/phases/vessel-abc123/evidence-manifest.json`. The file contains valid JSON with `vessel_id`, `claims`, and `summary` keys.
+**Verification:** Unit test checks the file exists at the exact path and that `json.Unmarshal` succeeds with the correct `VesselID`.
+
+---
+
+### S9: SaveManifest calls BuildSummary before writing
+**Spec ref:** Section 8.1
+**Preconditions:** `SaveManifest` and `BuildSummary` exist.
+**Action:** Create a `Manifest` with two claims (one passed, one failed) but do not call `BuildSummary()` first. Call `SaveManifest(stateDir, "vessel-xyz", manifest)`.
+**Expected outcome:** The written JSON file contains a `summary` block with `total: 2`, `passed: 1`, `failed: 1` — populated automatically by `SaveManifest`.
+**Verification:** Unit test reads back the file, unmarshals it, and asserts the summary fields are populated without a prior manual call to `BuildSummary`.
+
+---
+
+### S10: LoadManifest round-trips correctly
+**Spec ref:** Section 8.1
+**Preconditions:** `SaveManifest` and `LoadManifest` both exist.
+**Action:** Build a `Manifest` with vessel ID `"vessel-roundtrip"`, workflow `"fix-bug"`, and two claims. Save it with `SaveManifest`. Then load it with `LoadManifest(stateDir, "vessel-roundtrip")`.
+**Expected outcome:** The loaded manifest has identical `VesselID`, `Workflow`, and `Claims` slice (same claim text, level, checker, passed status). The `Summary` is also populated.
+**Verification:** Unit test performs a field-by-field comparison of the saved and loaded values.
+
+---
+
+### S11: Gate without evidence metadata loads cleanly with nil Evidence field
+**Spec ref:** Section 8.2
+**Preconditions:** `GateEvidence` struct is added to `workflow.go`; `Gate` has an `Evidence *GateEvidence` field tagged `yaml:"evidence,omitempty"`.
+**Action:** Load a valid workflow YAML file whose gate specifies only `type: command` and `run: "go test ./..."` with no `evidence:` section.
+**Expected outcome:** `workflow.Phases[0].Gate.Evidence` is `nil`. The gate validates and loads without error.
+**Verification:** Unit test checks `gate.Evidence == nil` and that `workflow.Load` returns no error.
+
+---
+
+### S12: Gate with valid evidence metadata parses correctly
+**Spec ref:** Section 8.2
+**Preconditions:** `GateEvidence` struct and `Gate.Evidence` field exist.
+**Action:** Load a workflow YAML whose gate contains:
+```yaml
+evidence:
+  claim: "All tests pass"
+  level: behaviorally_checked
+  checker: "go test"
+  trust_boundary: "Package-level only"
+```
+**Expected outcome:** `gate.Evidence.Claim == "All tests pass"`, `gate.Evidence.Level == "behaviorally_checked"`, `gate.Evidence.Checker == "go test"`, `gate.Evidence.TrustBoundary == "Package-level only"`.
+**Verification:** Unit test asserts each field value on the parsed struct.
+
+---
+
+### S13: Gate with invalid evidence level is rejected by validateGate
+**Spec ref:** Section 8.2
+**Preconditions:** `validateGate` checks evidence level validity.
+**Action:** Attempt to load a workflow YAML whose gate has `evidence.level: "high"` (not a recognised level).
+**Expected outcome:** `workflow.Load` returns a non-nil error whose message includes the invalid level string `"high"` and guidance about valid values.
+**Verification:** Unit test asserts the error is non-nil and contains `"high"` in the message.
+
+---
+
+### S14: Gate with partial evidence (claim and level only) parses without error
+**Spec ref:** Section 8.2
+**Preconditions:** All `GateEvidence` fields are optional except the level is validated when present.
+**Action:** Load a workflow YAML whose gate has:
+```yaml
+evidence:
+  claim: "Tests pass"
+  level: mechanically_checked
+```
+with no `checker` or `trust_boundary` fields.
+**Expected outcome:** The workflow loads without error. `gate.Evidence.Checker` is an empty string and `gate.Evidence.TrustBoundary` is an empty string.
+**Verification:** Unit test asserts no error and the two unpopulated fields are empty strings.
+
+---
+
+### S15: buildGateClaim with evidence metadata produces a typed claim
+**Spec ref:** Section 8.3
+**Preconditions:** `buildGateClaim` helper exists in `runner.go`.
+**Action:** Call `buildGateClaim` with a `Phase` whose gate has `Evidence` set to `{Claim: "All tests pass", Level: "behaviorally_checked", Checker: "go test", TrustBoundary: "Package-level only"}`, and `passed = true`.
+**Expected outcome:** The returned `Claim` has `Claim == "All tests pass"`, `Level == evidence.BehaviorallyChecked`, `Checker == "go test"`, `TrustBoundary == "Package-level only"`, `Passed == true`.
+**Verification:** Unit test asserts all five fields on the returned struct.
+
+---
+
+### S16: buildGateClaim without evidence metadata produces an Untyped claim
+**Spec ref:** Section 8.3
+**Preconditions:** `buildGateClaim` exists.
+**Action:** Call `buildGateClaim` with a `Phase` whose gate has `Evidence == nil` and `passed = true`.
+**Expected outcome:** The returned `Claim` has `Level == evidence.Untyped` (empty string), `TrustBoundary == "No trust boundary declared"`, and `Claim` is a generated string containing the phase name (e.g. `"Gate passed for phase \"implement\""`).
+**Verification:** Unit test asserts `Level` is `""`, `TrustBoundary` matches exactly, and `Claim` contains the phase name.
+
+---
+
+### S17: buildGateClaim sets Checker from gate Run command when no evidence
+**Spec ref:** Section 8.3
+**Preconditions:** `buildGateClaim` exists.
+**Action:** Call `buildGateClaim` with a `Phase` whose gate has `Run: "cd cli && go test ./..."` and `Evidence == nil`.
+**Expected outcome:** The returned `Claim.Checker` equals `"cd cli && go test ./..."`.
+**Verification:** Unit test asserts `claim.Checker == "cd cli && go test ./..."`.
+
+---
+
+### S18: Evidence claims are accumulated across multiple phases
+**Spec ref:** Section 8.3
+**Preconditions:** Runner accumulates claims in a `[]evidence.Claim` slice during vessel execution.
+**Action:** Execute a vessel through two phases, each with a passing gate that has distinct evidence metadata.
+**Expected outcome:** After both phases complete, the manifest saved to disk contains exactly two claims — one for each phase — with the correct `Phase` field identifying each.
+**Verification:** Load the manifest from `<stateDir>/phases/<vesselID>/evidence-manifest.json` and assert `len(manifest.Claims) == 2` with correct phase names.
+
+---
+
+### S19: Gate failure produces no claim but preserves claims from prior phases
+**Spec ref:** Section 8.3
+**Preconditions:** Runner accumulates claims only after a gate passes; a gate failure stops vessel execution.
+**Action:** Execute a vessel through three phases where phases 1 and 2 pass their gates but phase 3 fails its gate.
+**Expected outcome:** The manifest saved at vessel completion contains exactly two claims (for phases 1 and 2). No claim exists for phase 3 because claims are only appended on gate pass. The vessel status is `failed`.
+**Verification:** Load the manifest and assert `len(manifest.Claims) == 2`, with no claim whose `Phase` field equals the third phase's name.
+
+---
+
+### S20: VesselCompleted with nil manifest produces output identical to current behaviour
+**Spec ref:** Section 8.4
+**Preconditions:** `VesselCompleted` signature updated to accept `*evidence.Manifest` as a fourth parameter.
+**Action:** Call `VesselCompleted(ctx, 42, phases, nil)` with a normal phases slice.
+**Expected outcome:** The comment body is identical to what the current implementation produces — phase table with Name/Duration/Status columns and a Total line. No "Verification evidence" section appears.
+**Verification:** Unit test for the nil-manifest case asserts the output string does not contain `"Verification evidence"` and matches the format produced by the pre-evidence implementation.
+
+---
+
+### S21: VesselCompleted with evidence renders a table with the correct columns
+**Spec ref:** Section 8.4
+**Preconditions:** `VesselCompleted` accepts a non-nil `*evidence.Manifest`; `formatEvidenceSection` is implemented.
+**Action:** Call `VesselCompleted(ctx, 42, phases, manifest)` where `manifest` contains one claim: `{Claim: "All tests pass", Level: "behaviorally_checked", Checker: "go test", Passed: true}`.
+**Expected outcome:** The comment body contains a `### Verification evidence` heading, followed by a markdown table with columns `Claim`, `Level`, `Checker`, and `Result`. The single row contains `All tests pass`, `behaviorally_checked`, `go test`, and a checkmark symbol.
+**Verification:** Unit test asserts all four column headers and the row values are present in the rendered string.
+
+---
+
+### S22: VesselCompleted renders checkmark for passed claims and X for failed
+**Spec ref:** Section 8.4
+**Preconditions:** `formatEvidenceSection` renders per-claim result symbols.
+**Action:** Call `VesselCompleted` with a manifest containing two claims — one with `Passed: true` and one with `Passed: false`.
+**Expected outcome:** The evidence table row for the passing claim contains `:white_check_mark:`. The row for the failing claim contains `:x:` (or the equivalent rendered symbol). Each is on a separate row.
+**Verification:** Unit test asserts both symbols appear in the rendered string and are on separate lines corresponding to their respective claims.
+
+---
+
+### S23: VesselCompleted renders trust boundaries in a collapsible details block
+**Spec ref:** Section 8.4
+**Preconditions:** `formatEvidenceSection` emits a `<details>` block for trust boundaries.
+**Action:** Call `VesselCompleted` with a manifest containing one claim: `{Claim: "All tests pass", TrustBoundary: "Package-level only", Passed: true}`.
+**Expected outcome:** The comment body contains `<details>`, `<summary>Trust boundaries</summary>`, and a bullet item `**All tests pass** — Package-level only` inside the block.
+**Verification:** Unit test asserts the `<details>` tag, the summary text, and the formatted trust boundary bullet are all present in the output.
+
+---
+
+### S24: Existing VesselCompleted tests pass nil as the manifest parameter
+**Spec ref:** Section 8.4
+**Preconditions:** Existing tests in `reporter_test.go` (e.g. `TestVesselCompleted`, `TestVesselCompletedNoOp`) call `VesselCompleted` with the old three-argument signature.
+**Action:** Update all call sites in `reporter_test.go` to pass `nil` as the new fourth `*evidence.Manifest` argument. Run `go test ./internal/reporter/...`.
+**Expected outcome:** All existing reporter tests pass without modification to their assertions. No test output changes — the nil manifest case is backward-compatible.
+**Verification:** `go test ./internal/reporter/...` exits with status 0 and no test failures.


### PR DESCRIPTION
## Summary

- Adds smoke scenarios for all four workstreams of the xylem harness implementation spec (sections 5–8)
- S1–S24 for Workstream 4 (verification evidence model): covers `Level.Valid/Rank`, `Manifest.BuildSummary/StrongestLevel`, `SaveManifest/LoadManifest`, `Gate` YAML evidence extension, `buildGateClaim` helper, runner claim accumulation, and `VesselCompleted` reporter rendering

## Test plan

- [ ] All Go tests pass (`cd cli && go test ./...`) — confirmed clean before commit
- [ ] Docs-only change: no source files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)