### PR TITLE
feat: fingerprint issues to skip re-enqueue of unchanged failed vessels

### DIFF
--- a/cli/cmd/xylem/scan_test.go
+++ b/cli/cmd/xylem/scan_test.go
@@ -73,6 +73,7 @@ func makeScanConfig(dir string) *config.Config {
 type ghIssueJSON struct {
 	Number int    `json:"number"`
 	Title  string `json:"title"`
+	Body   string `json:"body"`
 	URL    string `json:"url"`
 	Labels []struct {
 		Name string `json:"name"`
@@ -91,7 +92,7 @@ func stubScanCommands(r *mockScanRunner, cfg *config.Config, issues []ghIssueJSO
 	ghSrc := cfg.Sources["github"]
 	for _, task := range ghSrc.Tasks {
 		r.set(issuesJSON(issues), "gh", "search", "issues", "--repo", ghSrc.Repo,
-			"--state", "open", "--json", "number,title,url,labels",
+			"--state", "open", "--json", "number,title,body,url,labels",
 			"--limit", "20", "--label", task.Labels[0])
 	}
 	// Stub branch checks and PR checks for each issue
@@ -208,7 +209,7 @@ func TestScanPausedOutput(t *testing.T) {
 	// Stub the gh search command (paused scan short-circuits before this,
 	// but the mock would error on unstubbed commands)
 	r.set([]byte("[]"), "gh", "search", "issues", "--repo", "owner/repo",
-		"--state", "open", "--json", "number,title,url,labels",
+		"--state", "open", "--json", "number,title,body,url,labels",
 		"--limit", "20", "--label", "bug")
 
 	out := captureStdout(func() {
@@ -231,7 +232,7 @@ func TestScanDryRunEmpty(t *testing.T) {
 
 	// Stub the gh search to return empty array
 	r.set([]byte("[]"), "gh", "search", "issues", "--repo", "owner/repo",
-		"--state", "open", "--json", "number,title,url,labels",
+		"--state", "open", "--json", "number,title,body,url,labels",
 		"--limit", "20", "--label", "bug")
 
 	old := os.Stdout
@@ -264,7 +265,7 @@ func TestScanError(t *testing.T) {
 	// Stub gh search to return an error
 	r.setErr(errors.New("gh: not authenticated"),
 		"gh", "search", "issues", "--repo", "owner/repo",
-		"--state", "open", "--json", "number,title,url,labels",
+		"--state", "open", "--json", "number,title,body,url,labels",
 		"--limit", "20", "--label", "bug")
 
 	err := cmdScan(cfg, q, r, false)

--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -39,10 +39,10 @@ var validTransitions = map[VesselState]map[VesselState]bool{
 		StateCancelled: true,
 		StateWaiting:   true, // label gate pauses vessel
 	},
-	StateWaiting: {            // label gate pause state
-		StateRunning:   true,  // label gate passed, resume
-		StateTimedOut:  true,  // label gate timed out
-		StateCancelled: true,  // manually cancelled while waiting
+	StateWaiting: { // label gate pause state
+		StateRunning:   true, // label gate passed, resume
+		StateTimedOut:  true, // label gate timed out
+		StateCancelled: true, // manually cancelled while waiting
 	},
 	StateFailed: {
 		StatePending: true, // allow retry
@@ -65,7 +65,7 @@ type Vessel struct {
 	ID        string            `json:"id"`
 	Source    string            `json:"source"`
 	Ref       string            `json:"ref,omitempty"`
-	Workflow     string            `json:"workflow,omitempty"`
+	Workflow  string            `json:"workflow,omitempty"`
 	Prompt    string            `json:"prompt,omitempty"`
 	Meta      map[string]string `json:"meta,omitempty"`
 	State     VesselState       `json:"state"`
@@ -233,6 +233,27 @@ func (q *Queue) FindByID(id string) (*Vessel, error) {
 			}
 		}
 		return fmt.Errorf("vessel %s not found", id)
+	})
+	return found, err
+}
+
+// FindLatestByRef returns the most recent vessel with the given ref.
+func (q *Queue) FindLatestByRef(ref string) (*Vessel, error) {
+	var found *Vessel
+	err := q.withRLock(func() error {
+		vessels, readErr := q.readAllVessels()
+		if readErr != nil {
+			return readErr
+		}
+		for i := len(vessels) - 1; i >= 0; i-- {
+			if vessels[i].Ref != ref {
+				continue
+			}
+			v := vessels[i]
+			found = &v
+			return nil
+		}
+		return fmt.Errorf("vessel with ref %s not found", ref)
 	})
 	return found, err
 }
@@ -422,9 +443,9 @@ func (q *Queue) readAllVessels() ([]Vessel, error) {
 	defer f.Close()
 
 	var (
-		vessels     = make([]Vessel, 0)
-		lineNum  int
-		skipped  int
+		vessels = make([]Vessel, 0)
+		lineNum int
+		skipped int
 	)
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {

--- a/cli/internal/queue/queue_test.go
+++ b/cli/internal/queue/queue_test.go
@@ -31,12 +31,12 @@ func newTestQueue(t *testing.T) (*Queue, string) {
 
 func testVessel(issue int) Vessel {
 	return Vessel{
-		ID:     fmt.Sprintf("issue-%d", issue),
-		Source: "github-issue",
-		Ref:    fmt.Sprintf("https://github.com/example/repo/issues/%d", issue),
+		ID:        fmt.Sprintf("issue-%d", issue),
+		Source:    "github-issue",
+		Ref:       fmt.Sprintf("https://github.com/example/repo/issues/%d", issue),
 		Workflow:  "fix-bug",
-		Meta:   map[string]string{"issue_num": fmt.Sprintf("%d", issue)},
-		State:  StatePending,
+		Meta:      map[string]string{"issue_num": fmt.Sprintf("%d", issue)},
+		State:     StatePending,
 		CreatedAt: time.Now().UTC(),
 	}
 }
@@ -1099,7 +1099,7 @@ func TestV2VesselFields(t *testing.T) {
 		ID:           "v2-test-1",
 		Source:       "github-issue",
 		Ref:          "https://github.com/example/repo/issues/99",
-		Workflow:        "fix-bug",
+		Workflow:     "fix-bug",
 		State:        StatePending,
 		CreatedAt:    now,
 		CurrentPhase: 2,
@@ -1289,6 +1289,48 @@ func TestFindByID(t *testing.T) {
 		_, err := q.FindByID("does-not-exist")
 		if err == nil {
 			t.Fatal("expected error for non-existent vessel")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Fatalf("expected not-found error, got: %v", err)
+		}
+	})
+}
+
+func TestFindLatestByRef(t *testing.T) {
+	t.Run("returns latest vessel for ref", func(t *testing.T) {
+		q, _ := newTestQueue(t)
+		vessel := testVessel(701)
+		if _, err := q.Enqueue(vessel); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		if _, err := q.Dequeue(); err != nil {
+			t.Fatalf("dequeue: %v", err)
+		}
+		if err := q.Update(vessel.ID, StateFailed, "boom"); err != nil {
+			t.Fatalf("update failed: %v", err)
+		}
+		retry := vessel
+		retry.ID = "issue-701-retry-1"
+		retry.State = StatePending
+		retry.CreatedAt = time.Now().UTC()
+		if _, err := q.Enqueue(retry); err != nil {
+			t.Fatalf("enqueue retry: %v", err)
+		}
+
+		got, err := q.FindLatestByRef(vessel.Ref)
+		if err != nil {
+			t.Fatalf("FindLatestByRef: %v", err)
+		}
+		if got.ID != retry.ID {
+			t.Fatalf("expected latest id %s, got %s", retry.ID, got.ID)
+		}
+	})
+
+	t.Run("missing ref returns error", func(t *testing.T) {
+		q, _ := newTestQueue(t)
+		_, err := q.FindLatestByRef("https://github.com/example/repo/issues/999")
+		if err == nil {
+			t.Fatal("expected error for missing ref")
 		}
 		if !strings.Contains(err.Error(), "not found") {
 			t.Fatalf("expected not-found error, got: %v", err)
@@ -1646,4 +1688,3 @@ func TestCompactDryRun(t *testing.T) {
 		t.Fatalf("dry run modified the file: before=%d lines, after=%d lines", len(linesBefore), len(linesAfter))
 	}
 }
-

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -2,13 +2,16 @@ package scanner
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
@@ -52,6 +55,7 @@ func (m *mockRunner) Run(_ context.Context, name string, args ...string) ([]byte
 type ghIssue struct {
 	Number int    `json:"number"`
 	Title  string `json:"title"`
+	Body   string `json:"body"`
 	URL    string `json:"url"`
 	Labels []struct {
 		Name string `json:"name"`
@@ -88,6 +92,17 @@ func issueJSON(issues []ghIssue) []byte {
 	return b
 }
 
+func scanFingerprint(title, body string, labels []string) string {
+	sorted := append([]string(nil), labels...)
+	sort.Strings(sorted)
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		title,
+		body,
+		strings.Join(sorted, ","),
+	}, "\n")))
+	return fmt.Sprintf("%x", sum)
+}
+
 func TestScanFindsIssues(t *testing.T) {
 	dir := t.TempDir()
 	queueFile := filepath.Join(dir, "queue.jsonl")
@@ -103,7 +118,7 @@ func TestScanFindsIssues(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s := New(cfg, q, r)
 	result, err := s.Scan(context.Background())
@@ -145,7 +160,7 @@ func TestScanExcludedLabel(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}, {Name: "wontfix"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s := New(cfg, q, r)
 	result, err := s.Scan(context.Background())
@@ -168,7 +183,7 @@ func TestScanAlreadyQueued(t *testing.T) {
 	_, _ = q.Enqueue(queue.Vessel{
 		ID: "issue-1", Source: "github-issue",
 		Ref: "https://github.com/owner/repo/issues/1", Workflow: "fix-bug",
-		Meta: map[string]string{"issue_num": "1"},
+		Meta:  map[string]string{"issue_num": "1"},
 		State: queue.StatePending, CreatedAt: queue.Vessel{}.CreatedAt,
 	})
 
@@ -177,7 +192,7 @@ func TestScanAlreadyQueued(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s := New(cfg, q, r)
 	result, err := s.Scan(context.Background())
@@ -200,7 +215,7 @@ func TestScanExistingBranch(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	r.set([]byte("abc123\trefs/heads/fix/issue-42-something"), "git", "ls-remote", "--heads", "origin", "fix/issue-42-*")
 
 	s := New(cfg, q, r)
@@ -224,7 +239,7 @@ func TestScanExistingPR(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	r.set([]byte(`[{"number":99,"headRefName":"fix/issue-55-null-fix"}]`),
 		"gh", "pr", "list", "--repo", "owner/repo", "--search", "head:fix/issue-55-", "--state", "open", "--json", "number,headRefName", "--limit", "5")
 
@@ -235,6 +250,116 @@ func TestScanExistingPR(t *testing.T) {
 	}
 	if result.Added != 0 {
 		t.Errorf("expected 0 added (open PR exists), got %d", result.Added)
+	}
+}
+
+func TestScanSkipsUnchangedFailedIssue(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{
+		{Number: 1, Title: "same title", Body: "same body", URL: "https://github.com/owner/repo/issues/1", Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}}},
+	}
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	for _, prefix := range []string{"fix", "feat"} {
+		r.set([]byte(""), "git", "ls-remote", "--heads", "origin", fmt.Sprintf("%s/issue-%d-*", prefix, 1))
+		r.set([]byte("[]"), "gh", "pr", "list", "--repo", "owner/repo", "--search", fmt.Sprintf("head:%s/issue-%d-", prefix, 1), "--state", "open", "--json", "number,headRefName", "--limit", "5")
+	}
+
+	fingerprint := scanFingerprint("same title", "same body", []string{"bug"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "issue-1",
+		Source:   "github-issue",
+		Ref:      "https://github.com/owner/repo/issues/1",
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "1",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("enqueue seed: %v", err)
+	}
+	if _, err := q.Dequeue(); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if err := q.Update("issue-1", queue.StateFailed, "boom"); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	s := New(cfg, q, r)
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Added != 0 {
+		t.Fatalf("expected unchanged failed issue to be skipped, added=%d", result.Added)
+	}
+}
+
+func TestScanReenqueuesChangedFailedIssue(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{
+		{Number: 1, Title: "same title", Body: "updated body", URL: "https://github.com/owner/repo/issues/1", Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}}},
+	}
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	for _, prefix := range []string{"fix", "feat"} {
+		r.set([]byte(""), "git", "ls-remote", "--heads", "origin", fmt.Sprintf("%s/issue-%d-*", prefix, 1))
+		r.set([]byte("[]"), "gh", "pr", "list", "--repo", "owner/repo", "--search", fmt.Sprintf("head:%s/issue-%d-", prefix, 1), "--state", "open", "--json", "number,headRefName", "--limit", "5")
+	}
+
+	oldFingerprint := scanFingerprint("same title", "same body", []string{"bug"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "issue-1",
+		Source:   "github-issue",
+		Ref:      "https://github.com/owner/repo/issues/1",
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "1",
+			"source_input_fingerprint": oldFingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("enqueue seed: %v", err)
+	}
+	if _, err := q.Dequeue(); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if err := q.Update("issue-1", queue.StateFailed, "boom"); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	s := New(cfg, q, r)
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Added != 1 {
+		t.Fatalf("expected changed failed issue to be re-enqueued, added=%d", result.Added)
+	}
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("list queue: %v", err)
+	}
+	if len(vessels) != 2 {
+		t.Fatalf("expected 2 queue entries, got %d", len(vessels))
+	}
+	if vessels[1].Meta["source_input_fingerprint"] == oldFingerprint {
+		t.Fatal("expected updated fingerprint for changed issue input")
 	}
 }
 
@@ -249,7 +374,7 @@ func TestScanPRFalsePositiveIgnored(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	r.set([]byte(`[{"number":200,"headRefName":"chore/priority-1-ci-fix"}]`),
 		"gh", "pr", "list", "--repo", "owner/repo", "--search", "head:fix/issue-1-", "--state", "open", "--json", "number,headRefName", "--limit", "5")
 	r.set([]byte(`[]`),
@@ -287,8 +412,8 @@ func TestScanCrossTaskDedupDeterministic(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}, {Name: "urgent"}}},
 	}
-	r.set(issueJSON(sharedIssue), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
-	r.set(issueJSON(sharedIssue), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "urgent")
+	r.set(issueJSON(sharedIssue), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(sharedIssue), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "urgent")
 
 	for i := 0; i < 5; i++ {
 		qFile := filepath.Join(dir, fmt.Sprintf("queue-%d.jsonl", i))
@@ -335,7 +460,7 @@ func TestScanGHFailure(t *testing.T) {
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
 	r := newMock()
 
-	r.setErr(errors.New("network error"), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+	r.setErr(errors.New("network error"), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s := New(cfg, q, r)
 	_, err := s.Scan(context.Background())
@@ -373,8 +498,8 @@ func TestScanMultipleTasks(t *testing.T) {
 		}{{Name: "low-effort"}}},
 	}
 
-	r.set(issueJSON(bugIssues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
-	r.set(issueJSON(featureIssues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "low-effort")
+	r.set(issueJSON(bugIssues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(featureIssues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "low-effort")
 
 	s := New(cfg, q, r)
 	result, err := s.Scan(context.Background())
@@ -400,7 +525,7 @@ func TestScanGHReturnsMalformedJSON(t *testing.T) {
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
 	r := newMock()
 
-	r.set([]byte(`{not valid json`), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+	r.set([]byte(`{not valid json`), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s := New(cfg, q, r)
 	_, err := s.Scan(context.Background())
@@ -420,7 +545,7 @@ func TestHasOpenPRMalformedJSONIgnored(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	r.set([]byte(`not json at all`),
 		"gh", "pr", "list", "--repo", "owner/repo", "--search", "head:fix/issue-77-", "--state", "open", "--json", "number,headRefName", "--limit", "5")
 	r.set([]byte(`not json`),
@@ -447,7 +572,7 @@ func TestHasOpenPRGHErrorIgnored(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	r.setErr(errors.New("gh auth error"),
 		"gh", "pr", "list", "--repo", "owner/repo", "--search", "head:fix/issue-88-", "--state", "open", "--json", "number,headRefName", "--limit", "5")
 	r.setErr(errors.New("gh auth error"),
@@ -474,7 +599,7 @@ func TestScanExistingBranchFeatPrefix(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	r.set([]byte(""), "git", "ls-remote", "--heads", "origin", "fix/issue-99-*")
 	r.set([]byte("abc123\trefs/heads/feat/issue-99-add-feature"), "git", "ls-remote", "--heads", "origin", "feat/issue-99-*")
 
@@ -515,7 +640,7 @@ func TestScanAppliesQueuedLabel(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s := New(cfg, q, r)
 	result, err := s.Scan(context.Background())
@@ -551,7 +676,7 @@ func TestScanNoQueuedLabelWhenNotConfigured(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s := New(cfg, q, r)
 	result, err := s.Scan(context.Background())

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -2,8 +2,10 @@ package source
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -30,6 +32,7 @@ type GitHub struct {
 type ghIssue struct {
 	Number int    `json:"number"`
 	Title  string `json:"title"`
+	Body   string `json:"body"`
 	URL    string `json:"url"`
 	Labels []struct {
 		Name string `json:"name"`
@@ -53,7 +56,7 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 				"search", "issues",
 				"--repo", g.Repo,
 				"--state", "open",
-				"--json", "number,title,url,labels",
+				"--json", "number,title,body,url,labels",
 				"--limit", "20",
 				"--label", label,
 			}
@@ -72,15 +75,21 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 				if seen[issue.Number] {
 					continue
 				}
+				fingerprint := githubSourceFingerprint(issue.Title, issue.Body, issueLabelNames(issue.Labels))
 				if g.hasExcludedLabel(issue, excludeSet) ||
 					g.Queue.HasRef(issue.URL) ||
+					g.hasMatchingFailedFingerprint(issue.URL, fingerprint) ||
 					g.hasBranch(ctx, issue.Number) ||
 					g.hasOpenPR(ctx, issue.Number) {
 					continue
 				}
 				seen[issue.Number] = true
 				meta := map[string]string{
-					"issue_num": strconv.Itoa(issue.Number),
+					"issue_num":                strconv.Itoa(issue.Number),
+					"issue_title":              issue.Title,
+					"issue_body":               issue.Body,
+					"issue_labels":             strings.Join(issueLabelNames(issue.Labels), ","),
+					"source_input_fingerprint": fingerprint,
 				}
 				sl := task.StatusLabels
 				if sl != nil {
@@ -184,6 +193,35 @@ func (g *GitHub) hasExcludedLabel(issue ghIssue, excluded map[string]bool) bool 
 		}
 	}
 	return false
+}
+
+func (g *GitHub) hasMatchingFailedFingerprint(ref, fingerprint string) bool {
+	latest, err := g.Queue.FindLatestByRef(ref)
+	if err != nil || latest == nil {
+		return false
+	}
+	return latest.State == queue.StateFailed && latest.Meta["source_input_fingerprint"] == fingerprint
+}
+
+func issueLabelNames(labels []struct {
+	Name string `json:"name"`
+}) []string {
+	names := make([]string, 0, len(labels))
+	for _, l := range labels {
+		names = append(names, l.Name)
+	}
+	return names
+}
+
+func githubSourceFingerprint(title, body string, labels []string) string {
+	sorted := append([]string(nil), labels...)
+	sort.Strings(sorted)
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		title,
+		body,
+		strings.Join(sorted, ","),
+	}, "\n")))
+	return fmt.Sprintf("%x", sum)
 }
 
 // branchPrefixes lists the branch name prefixes xylem uses when creating

--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -23,6 +23,7 @@ type GitHubPR struct {
 type ghPR struct {
 	Number      int    `json:"number"`
 	Title       string `json:"title"`
+	Body        string `json:"body"`
 	URL         string `json:"url"`
 	HeadRefName string `json:"headRefName"`
 	Labels      []struct {
@@ -48,7 +49,7 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 				"--repo", g.Repo,
 				"--state", "open",
 				"--label", label,
-				"--json", "number,title,url,labels,headRefName",
+				"--json", "number,title,body,url,labels,headRefName",
 				"--limit", "20",
 			}
 
@@ -66,14 +67,20 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 				if seen[pr.Number] {
 					continue
 				}
+				fingerprint := githubSourceFingerprint(pr.Title, pr.Body, issueLabelNames(pr.Labels))
 				if g.hasExcludedLabel(pr, excludeSet) ||
 					g.Queue.HasRef(pr.URL) ||
+					g.hasMatchingFailedFingerprint(pr.URL, fingerprint) ||
 					g.hasBranch(ctx, pr.Number) {
 					continue
 				}
 				seen[pr.Number] = true
 				meta := map[string]string{
-					"pr_num": strconv.Itoa(pr.Number),
+					"pr_num":                   strconv.Itoa(pr.Number),
+					"pr_title":                 pr.Title,
+					"pr_body":                  pr.Body,
+					"pr_labels":                strings.Join(issueLabelNames(pr.Labels), ","),
+					"source_input_fingerprint": fingerprint,
 				}
 				sl := task.StatusLabels
 				if sl != nil {
@@ -182,4 +189,12 @@ func (g *GitHubPR) hasBranch(ctx context.Context, prNum int) bool {
 		return true
 	}
 	return false
+}
+
+func (g *GitHubPR) hasMatchingFailedFingerprint(ref, fingerprint string) bool {
+	latest, err := g.Queue.FindLatestByRef(ref)
+	if err != nil || latest == nil {
+		return false
+	}
+	return latest.State == queue.StateFailed && latest.Meta["source_input_fingerprint"] == fingerprint
 }

--- a/cli/internal/source/github_pr_test.go
+++ b/cli/internal/source/github_pr_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
@@ -55,11 +56,15 @@ func TestGitHubPRScanFindsPRs(t *testing.T) {
 
 	prs := []ghPR{
 		{Number: 10, Title: "fix readme", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix-readme",
-			Labels: []struct{ Name string `json:"name"` }{{Name: "review-me"}}},
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
 		{Number: 20, Title: "add tests", URL: "https://github.com/owner/repo/pull/20", HeadRefName: "add-tests",
-			Labels: []struct{ Name string `json:"name"` }{{Name: "review-me"}}},
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo:      "owner/repo",
@@ -99,9 +104,11 @@ func TestGitHubPRScanExcludedLabel(t *testing.T) {
 
 	prs := []ghPR{
 		{Number: 10, Title: "excluded pr", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "excluded",
-			Labels: []struct{ Name string `json:"name"` }{{Name: "review-me"}, {Name: "wontfix"}}},
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}, {Name: "wontfix"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo:      "owner/repo",
@@ -126,16 +133,18 @@ func TestGitHubPRScanAlreadyQueued(t *testing.T) {
 	_, _ = q.Enqueue(queue.Vessel{
 		ID: "pr-10", Source: "github-pr",
 		Ref: "https://github.com/owner/repo/pull/10", Workflow: "review-pr",
-		Meta: map[string]string{"pr_num": "10"},
+		Meta:  map[string]string{"pr_num": "10"},
 		State: queue.StatePending,
 	})
 	r := newMock()
 
 	prs := []ghPR{
 		{Number: 10, Title: "already queued", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix",
-			Labels: []struct{ Name string `json:"name"` }{{Name: "review-me"}}},
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo:      "owner/repo",
@@ -160,9 +169,11 @@ func TestGitHubPRScanExistingBranch(t *testing.T) {
 
 	prs := []ghPR{
 		{Number: 42, Title: "has branch", URL: "https://github.com/owner/repo/pull/42", HeadRefName: "fix",
-			Labels: []struct{ Name string `json:"name"` }{{Name: "review-me"}}},
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
 	r.set([]byte("abc123\trefs/heads/review/pr-42-something"), "git", "ls-remote", "--heads", "origin", "review/pr-42-*")
 
 	src := &GitHubPR{
@@ -188,10 +199,12 @@ func TestGitHubPRScanDeduplicates(t *testing.T) {
 
 	prs := []ghPR{
 		{Number: 10, Title: "dup pr", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix",
-			Labels: []struct{ Name string `json:"name"` }{{Name: "review-me"}, {Name: "urgent"}}},
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}, {Name: "urgent"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,url,labels,headRefName", "--limit", "20")
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "urgent", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "urgent", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo: "owner/repo",
@@ -217,7 +230,7 @@ func TestGitHubPRScanGHFailure(t *testing.T) {
 	q := queue.New(dir + "/queue.jsonl")
 	r := newMock()
 
-	r.setErr(errTest, "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+	r.setErr(errTest, "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo:      "owner/repo",
@@ -237,7 +250,7 @@ func TestGitHubPRScanMalformedJSON(t *testing.T) {
 	q := queue.New(dir + "/queue.jsonl")
 	r := newMock()
 
-	r.set([]byte(`{not valid`), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,url,labels,headRefName", "--limit", "20")
+	r.set([]byte(`{not valid`), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo:      "owner/repo",
@@ -249,6 +262,113 @@ func TestGitHubPRScanMalformedJSON(t *testing.T) {
 	_, err := src.Scan(context.Background())
 	if err == nil {
 		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestGitHubPRScanSkipsUnchangedFailedVessel(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "same title", Body: "same body", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+
+	fingerprint := githubSourceFingerprint("same title", "same body", []string{"review-me"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "pr-10",
+		Source:   "github-pr",
+		Ref:      "https://github.com/owner/repo/pull/10",
+		Workflow: "review-pr",
+		Meta: map[string]string{
+			"pr_num":                   "10",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("enqueue failed vessel seed: %v", err)
+	}
+	if _, err := q.Dequeue(); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if err := q.Update("pr-10", queue.StateFailed, "boom"); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected unchanged failed PR to be skipped, got %d vessels", len(vessels))
+	}
+}
+
+func TestGitHubPRScanReenqueuesChangedFailedVessel(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "same title", Body: "updated body", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+
+	oldFingerprint := githubSourceFingerprint("same title", "same body", []string{"review-me"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "pr-10",
+		Source:   "github-pr",
+		Ref:      "https://github.com/owner/repo/pull/10",
+		Workflow: "review-pr",
+		Meta: map[string]string{
+			"pr_num":                   "10",
+			"source_input_fingerprint": oldFingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("enqueue failed vessel seed: %v", err)
+	}
+	if _, err := q.Dequeue(); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if err := q.Update("pr-10", queue.StateFailed, "boom"); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected changed failed PR to be re-enqueued, got %d vessels", len(vessels))
+	}
+	if vessels[0].Meta["source_input_fingerprint"] == oldFingerprint {
+		t.Fatal("expected updated fingerprint for changed PR input")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `body` to GitHub issue scan queries (`number,title,body,url,labels`) so issue content is available to vessels
- Computes a SHA-256 fingerprint of `title + body + sorted labels` stored in vessel meta as `source_input_fingerprint`
- Scanner skips re-enqueueing a failed vessel when the fingerprint matches the previous attempt, and re-enqueues with a fresh fingerprint when the issue content has changed
- Adds `Queue.FindLatestByRef` to look up the most recent vessel for a given issue URL

## Test plan

- [ ] `TestScanSkipsUnchangedFailedIssue` — unchanged failed issue is not re-enqueued
- [ ] `TestScanReenqueuesChangedFailedIssue` — changed issue body triggers re-enqueue with updated fingerprint
- [ ] `TestFindLatestByRef` — returns most recent vessel for a ref; errors on missing ref
- [ ] All existing scanner and scan command tests pass with updated `--json` flag including `body`

🤖 Generated with [Claude Code](https://claude.com/claude-code)