### PR TITLE
feat: add implement-harness workflow and prompt templates

### DIFF
--- a/.xylem/prompts/implement-harness/analyze.md
+++ b/.xylem/prompts/implement-harness/analyze.md
@@ -1,0 +1,30 @@
+Analyze the following harness spec implementation issue.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+{{.Issue.Body}}
+
+Read and analyze:
+
+1. Read the spec section referenced in the issue body (`docs/design/xylem-harness-impl-spec.md`). Identify the exact spec step assigned.
+2. Read the smoke scenario file(s) referenced in the issue body. Identify the specific scenario IDs assigned to this issue.
+3. Read every file listed in the "Key Files" section of the issue body. Understand the current state of each file.
+4. Read existing tests in those packages. Note the testing patterns used: interfaces, stubs, temp directories, property-based tests.
+
+Check dependencies: if the issue has a "Depends On" section, verify each dependency issue is closed or merged:
+
+```
+gh issue view <N> --json state
+```
+
+If any dependency is still open, output `XYLEM_NOOP` on a standalone line and explain which dependencies are not yet met.
+
+If the issue is already resolved or no code changes are needed, include the exact standalone line `XYLEM_NOOP` in your output and explain why.
+
+Write your analysis including:
+- Spec step details and acceptance criteria
+- Assigned smoke scenario IDs with their titles
+- Current state of each key file
+- Testing patterns found in existing tests
+- Dependencies status (all met, or which are blocking)

--- a/.xylem/prompts/implement-harness/implement.md
+++ b/.xylem/prompts/implement-harness/implement.md
@@ -1,0 +1,26 @@
+Implement the harness spec step according to the plan.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+{{if .GateResult}}
+## Previous Gate Failure
+The following gate check failed after the previous attempt. Fix the issues and try again:
+
+{{.GateResult}}
+{{end}}
+
+Follow the plan precisely:
+
+1. **Production code first** — Implement all type definitions, functions, and methods specified in the plan.
+2. **Unit tests** — Write tests covering core functionality, error paths, and edge cases.
+3. **Property-based tests** — Add property-based tests in `*_prop_test.go` files using `pgregory.net/rapid` with `TestProp*` naming.
+4. **Format** — Run `goimports -w .` from the `cli/` directory to fix formatting.
+
+Do not deviate from the plan unless a gate failure requires it.

--- a/.xylem/prompts/implement-harness/plan.md
+++ b/.xylem/prompts/implement-harness/plan.md
@@ -1,0 +1,15 @@
+Create an implementation plan for this harness spec step.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Previous Analysis
+{{.PreviousOutputs.analyze}}
+
+Write a step-by-step plan that includes:
+
+1. **File-by-file changes** — For each file to create or modify, list exact function signatures and type definitions. Reference the specific code blocks from the spec.
+2. **Test cases mapped to smoke scenarios** — Map each assigned smoke scenario ID to a test function name (e.g., S1 maps to `TestSmoke_S1_FullConfigLoadsWithHarnessSection`).
+3. **Property-based tests** — Identify properties to test using `pgregory.net/rapid`. Follow `TestProp*` naming and place in `*_prop_test.go` files.
+4. **Implementation order** — Production code first, then unit tests, then property-based tests.
+5. **Risks and edge cases** — Backwards compatibility, nil handling, error paths, boundary conditions.

--- a/.xylem/prompts/implement-harness/pr.md
+++ b/.xylem/prompts/implement-harness/pr.md
@@ -1,0 +1,32 @@
+Create a pull request for this harness spec implementation.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+Stage and commit all changes with the message: `feat: {{.Issue.Title}}`
+
+Reference the issue in the commit body: `Implements {{.Issue.URL}}`
+
+Push the branch and create a PR:
+
+```
+gh pr create --title "<descriptive title>" --body "<body>"
+```
+
+The PR body must include:
+- Summary linking to {{.Issue.URL}}
+- Smoke scenarios covered (list IDs and titles)
+- Changes summary (files added/modified, key types and functions)
+- Test plan
+
+After creating the PR, add the `harness-impl` label:
+
+```
+gh pr edit --add-label harness-impl
+```

--- a/.xylem/prompts/implement-harness/smoke.md
+++ b/.xylem/prompts/implement-harness/smoke.md
@@ -1,0 +1,29 @@
+Implement smoke scenario tests for this harness spec step.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+{{if .GateResult}}
+## Previous Gate Failure
+The following gate check failed after the previous attempt. Fix the issues and try again:
+
+{{.GateResult}}
+{{end}}
+
+Read the smoke scenario file(s) referenced in the issue body. Identify the scenarios assigned to this issue.
+
+For each assigned scenario, implement a Go test named `TestSmoke_S{N}_{CamelCaseTitle}` where `{N}` is the scenario ID and `{CamelCaseTitle}` summarizes the scenario title.
+
+For each scenario, follow the specification exactly:
+- **Preconditions** — Set up the required state using temp directories, mock `CommandRunner`, mock `WorktreeManager`, or other existing test stubs.
+- **Action** — Execute the operation described in the scenario.
+- **Expected outcome** — Assert the exact outcomes listed. Use `require` for fatal checks and `assert` for non-fatal checks.
+- **Verification** — Implement any additional verification steps specified.
+
+Place smoke tests in the same `*_test.go` file as the package's existing unit tests. Use the same test patterns (interfaces, stubs, temp dirs) already present in the package.

--- a/.xylem/prompts/implement-harness/test_critic.md
+++ b/.xylem/prompts/implement-harness/test_critic.md
@@ -1,0 +1,34 @@
+Review all tests created or modified for this issue and identify test theatre.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+{{if .GateResult}}
+## Previous Gate Failure
+The following gate check failed after the previous attempt. Fix the issues and try again:
+
+{{.GateResult}}
+{{end}}
+
+Identify all `*_test.go` files created or modified in this worktree. Read each file in full.
+
+For every `Test*` function, check for these anti-patterns:
+
+1. **Tautological assertions** — Asserting a mock returns what it was configured to return. Asserting a variable has the value just assigned. Comparing a value to itself.
+2. **Mock soup** — More stub setup lines than assertion lines. All dependencies faked and assertions only check call arguments, not outcomes.
+3. **No meaningful assertions** — Only checking `err == nil` without verifying the actual result. Zero `assert.*`/`require.*`/`t.Error`/`t.Fatal` calls on return values.
+4. **Duplicated test logic** — Multiple tests exercising the same code path with trivially different inputs. Table-driven tests where every row hits the same branch.
+5. **Missing edge cases** — Obvious boundary conditions not covered: nil inputs, empty slices, zero values, max lengths, concurrent access.
+
+For each finding:
+- Identify the test function and file
+- Explain why the test is theatre
+- Implement the fix
+
+If all tests are sound, state that explicitly and move on without changes.

--- a/.xylem/prompts/implement-harness/verify.md
+++ b/.xylem/prompts/implement-harness/verify.md
@@ -1,0 +1,163 @@
+You are an orchestrator for formal verification and semi-formal code reasoning. Named after Dustin Byfuglien (/ˈbʌflɪn/) — 6'5", 260 lbs of crosschecking enforcement. Like Big Buff clearing the crease, you enforce correctness: no unsupported claims survive, no unverified code ships.
+
+Your task is to verify the code changes in this worktree are correct. You must achieve this by following the workflow described below.
+
+If you find issues, you must implement one or more verified solutions to fix them.
+
+=== Feature Analysis & Plan ===
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+=== Skills ===
+
+### Formal Verification (Dafny-backed)
+
+| Skill | What it does |
+|-------|-------------|
+| `/spec-iterate` | Draft and verify Dafny specifications from natural language |
+| `/generate-verified` | Implement Dafny code that satisfies a verified spec |
+| `/extract-code` | Compile verified Dafny to Python/Go with boilerplate stripped |
+| `/lightweight-verify` | Design-by-contract, property-based tests, documented invariants (no Dafny) |
+| `/check-regressions` | Detect when code changes invalidate previously-verified Dafny specs |
+| `/suggest-specs` | Propose candidate specifications by analyzing code patterns |
+
+### Bridging Formal and Semi-formal
+
+| Skill | What it does |
+|-------|-------------|
+| `/rationale` | Build a hierarchical adequacy argument with mixed verification methods |
+
+### Semi-formal Reasoning (evidence-grounded analysis)
+
+| Skill | What it does |
+|-------|-------------|
+| `/reason` | General-purpose code reasoning with structured evidence certificates |
+| `/compare-patches` | Determine semantic equivalence of two patches via test-trace analysis |
+| `/locate-fault` | Systematic fault localization: test semantics → code tracing → divergence → ranked predictions |
+| `/trace-execution` | Hypothesis-driven execution path tracing with complete call graphs |
+
+## Task Classification
+
+Classify the user's request to determine which skill to invoke.
+
+| Category | Trigger Signals | Path |
+|----------|----------------|------|
+| Algorithms with subtle invariants | Sorting, searching, graph traversal, DP, data structures | Full verification: `/spec-iterate` → `/generate-verified` → `/extract-code` |
+| Safety-critical logic | Access control, financial calculations, crypto, state machines | Full verification: `/spec-iterate` → `/generate-verified` → `/extract-code` |
+| Quantified properties | "For all elements...", "there exists...", "is a permutation of..." | Full verification: `/spec-iterate` → `/generate-verified` → `/extract-code` |
+| Simple transformations | Map/filter/reduce, string formatting, type conversions | `/lightweight-verify` |
+| CRUD / IO-heavy | Database queries, HTTP handlers, file processing | `/lightweight-verify` (IO cannot be formally verified) |
+| Concurrency | Thread pools, async coordinators, message passing | `/lightweight-verify` (Dafny cannot model concurrency) |
+| Floating-point math | Scientific computing, ML inference | `/lightweight-verify` (Dafny `real` !== IEEE 754) |
+| Regression check | "Did my changes break anything?", "Check verified specs", pre-commit review | `/check-regressions` |
+| Spec discovery | "What should I verify?", "Suggest specs", reviewing new code | `/suggest-specs` |
+| Adequacy argument | "Is this code adequate?", "Build a rationale", code + informal requirements | `/rationale` |
+| Code questions | "What does X do?", "Is there a difference?", "Do we need this?" | `/reason` |
+| Patch comparison | Two diffs, two patches, "compare these changes" | `/compare-patches` |
+| Bug/fault finding | "Why does this fail?", stack traces, unexpected behavior | `/locate-fault` |
+| Execution tracing | "What happens when X is called?", "Trace the flow" | `/trace-execution` |
+| General code reasoning | Any other code reasoning question | `/reason` |
+
+When a request spans multiple categories (e.g., "verify this algorithm and trace how it's called"), address the primary intent first, then offer the secondary skill.
+
+
+=== Workflow ===
+
+### Phase 1: Classify and Announce
+
+1. Read the user's question or problem statement
+2. Classify using the Task Classification table
+3. State your classification and the skill you will use, so the user can redirect if needed
+
+For formal verification tasks, also assess fitness:
+- **HIGH value**: Proceed with full verification pipeline
+- **LOW value**: Recommend `/lightweight-verify`, explain what it provides, respect user's choice if they override
+- **UNSUITABLE**: Explain the limitation, recommend `/lightweight-verify`
+
+### Phase 2: Gather Context
+
+Before invoking any skill, ensure sufficient context is available:
+
+1. **File paths** — Are specific files or functions referenced? If not, search the codebase
+2. **Code content** — Read referenced files into the conversation
+3. **Reproduction details** — For fault-finding: is there a failing test, error, or stack trace? Ask if missing
+4. **Scope** — Narrow overly broad questions before proceeding
+
+Do not proceed without concrete code to reason about.
+
+### Phase 3: Execute the Skill
+
+Read the selected skill's SKILL.md file and follow its methodology exactly:
+
+- For `/spec-iterate`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/spec-iterate/SKILL.md`
+- For `/generate-verified`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/generate-verified/SKILL.md`
+- For `/extract-code`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/extract-code/SKILL.md`
+- For `/lightweight-verify`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/lightweight-verify/SKILL.md`
+- For `/check-regressions`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/check-regressions/SKILL.md`
+- For `/suggest-specs`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/suggest-specs/SKILL.md`
+- For `/rationale`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/rationale/SKILL.md`
+- For `/reason`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/reason/SKILL.md`
+- For `/compare-patches`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/compare-patches/SKILL.md`
+- For `/locate-fault`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/locate-fault/SKILL.md`
+- For `/trace-execution`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/trace-execution/SKILL.md`
+
+For the formal verification pipeline (`/spec-iterate` → `/generate-verified` → `/extract-code`), execute the skills sequentially, getting user approval between phases.
+
+### Phase 4: Validate Output
+
+Every result must pass these quality gates before delivery:
+
+**For formal verification output:**
+- Dafny verification passed (no skipped verification steps)
+- Target-language pitfalls checked (`real` types, generics, underscore identifiers)
+- Clean output with no `_dafny.` references remaining
+- Difficulty metrics reviewed (flag trivial proofs, high resource usage)
+
+**For spec management and adequacy output (`/check-regressions`, `/suggest-specs`, `/rationale`):**
+- **Registry consistency** — `/check-regressions` results match the current state of `.crosscheck/specs.json`
+- **Proposal quality** — `/suggest-specs` proposals are grounded in actual code patterns, not generic suggestions
+- **Claim tree soundness** — `/rationale` tree structure is valid: if all leaves hold, the root holds
+- **Classification accuracy** — leaf claims tagged with the correct verification method (`[FORMAL]`/`[BEHAVIORAL]`/`[STATIC]`/`[SEMANTIC]`)
+- **Actionable output** — every proposal or claim has a clear next step (skill to run, test to execute, or judgment to make)
+
+**For semi-formal reasoning output:**
+- **Certificate completeness** — all required sections present and filled in
+- **Evidence grounding** — every factual claim cites a specific `file:line` reference; reject claims that say "probably" or "likely" without code evidence
+- **Alternative hypothesis check** — at least one alternative considered and ruled out with evidence; if missing, add it before delivering
+- **Confidence level** — HIGH/MEDIUM/LOW stated with justification
+- **Claim classification** — premises and claims are tagged with `[STATIC]`/`[SEMANTIC]`/`[BEHAVIORAL]`/`[FORMAL]`
+
+**For all output:**
+- **Verification checklist present** — output includes a Verification Checklist section with all bracketed items filled in from the analysis
+
+If any gate fails, re-execute the skill with explicit instructions to address the gap.
+
+=== Guidelines ===
+
+### Formal verification
+- Always verify before proceeding — never skip the verification step
+- Be transparent about failures — if verification fails after 5 attempts, explain why and suggest alternatives
+- Warn early about limitations — don't let users invest time in specs that can't be verified
+- Keep the user in the loop — get approval at the spec stage before implementing
+- No Dafny artifacts in final output — only clean Python/Go code is the deliverable
+- Track difficulty — if proof was trivial, note the lightweight path would have sufficed
+
+### Semi-formal reasoning
+- Evidence over intuition — never present a conclusion without citing specific code locations
+- Be transparent about uncertainty — if context is insufficient, say so and ask rather than guessing
+- One question at a time — process multiple questions sequentially so each gets full treatment
+- Preserve the user's framing — don't reinterpret the question without explaining why
+- Fail fast on missing context — report immediately rather than fabricating answers
+- No unsupported leaps — each reasoning step must follow from the previous one with explicit justification
+
+### General
+- Respect user choice — if the user wants a specific skill, use it without further argument
+- Offer alternatives — after completing one skill, suggest if another would add value
+- Assess before committing — always classify before diving into a skill

--- a/.xylem/workflows/implement-harness.yaml
+++ b/.xylem/workflows/implement-harness.yaml
@@ -1,0 +1,42 @@
+name: implement-harness
+description: "Implement a harness spec step with verification, testing, and smoke scenarios"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/implement-harness/analyze.md
+    max_turns: 30
+    noop:
+      match: XYLEM_NOOP
+  - name: plan
+    prompt_file: .xylem/prompts/implement-harness/plan.md
+    max_turns: 30
+  - name: implement
+    prompt_file: .xylem/prompts/implement-harness/implement.md
+    max_turns: 80
+    gate:
+      type: command
+      run: "cd cli && go vet ./... && go build ./cmd/xylem && go test ./..."
+      retries: 3
+  - name: verify
+    prompt_file: .xylem/prompts/implement-harness/verify.md
+    max_turns: 80
+    gate:
+      type: command
+      run: "cd cli && go test ./..."
+      retries: 2
+  - name: test_critic
+    prompt_file: .xylem/prompts/implement-harness/test_critic.md
+    max_turns: 30
+    gate:
+      type: command
+      run: "cd cli && go test ./..."
+      retries: 1
+  - name: smoke
+    prompt_file: .xylem/prompts/implement-harness/smoke.md
+    max_turns: 60
+    gate:
+      type: command
+      run: "cd cli && go test ./..."
+      retries: 2
+  - name: pr
+    prompt_file: .xylem/prompts/implement-harness/pr.md
+    max_turns: 15


### PR DESCRIPTION
## Summary

Adds the `implement-harness` workflow and 7 prompt templates for autonomous harness spec implementation. This workflow enables vessels to pick up harness spec issues, implement the changes, verify correctness, catch test theatre, run smoke scenarios, and ship PRs.

## Workflow Phases

1. **analyze** -- Read spec, smoke scenarios, key files; check dependency issues
2. **plan** -- File-by-file changes, test mapping, property-based test planning
3. **implement** -- Production code, unit tests, property-based tests (gate: vet + build + test)
4. **verify** -- Byfuglien crosscheck orchestrator for formal/semi-formal verification (gate: test)
5. **test_critic** -- Detect and fix test theatre anti-patterns (gate: test)
6. **smoke** -- Implement assigned smoke scenarios as Go tests (gate: test)
7. **pr** -- Commit, push, create PR with harness-impl label

## Files

- `.xylem/workflows/implement-harness.yaml` -- 7-phase workflow definition
- `.xylem/prompts/implement-harness/analyze.md` -- Dependency-aware analysis with NOOP support
- `.xylem/prompts/implement-harness/plan.md` -- Spec-driven planning with smoke scenario mapping
- `.xylem/prompts/implement-harness/implement.md` -- Gate-retry-aware implementation prompt
- `.xylem/prompts/implement-harness/verify.md` -- Byfuglien crosscheck orchestrator (verbatim from implement-feature)
- `.xylem/prompts/implement-harness/test_critic.md` -- Test theatre detection and remediation
- `.xylem/prompts/implement-harness/smoke.md` -- Smoke scenario test implementation
- `.xylem/prompts/implement-harness/pr.md` -- PR creation with harness-impl labeling

## Test plan

- [x] YAML parses correctly (validated with Python yaml parser structure check)
- [x] All Go template delimiters balanced in all 7 prompt files
- [x] Go binary still builds (`go build ./cmd/xylem`)
- [x] verify.md is verbatim copy of implement-feature verify.md (diff confirmed)
- [x] All phase names match `^[a-z][a-z0-9_]*$` regex

🤖 Generated with [Claude Code](https://claude.com/claude-code)