### PR TITLE
feat: add fix-pr-checks workflow and prompt templates

### DIFF
--- a/.xylem/prompts/fix-pr-checks/diagnose.md
+++ b/.xylem/prompts/fix-pr-checks/diagnose.md
@@ -1,0 +1,52 @@
+Diagnose failing CI checks on a pull request.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+{{.Issue.Body}}
+
+## Step 1: Check out the PR branch
+
+Run `gh pr checkout {{.Issue.Number}}` to switch to the PR branch.
+
+## Step 2: Guard — verify this is a harness implementation PR
+
+Check whether the PR has the `harness-impl` label:
+
+```
+gh pr view {{.Issue.Number}} --json labels --jq '.labels[].name' | grep -q harness-impl
+```
+
+If the `harness-impl` label is absent, output `XYLEM_NOOP` on its own line and stop. This workflow only applies to harness implementation PRs.
+
+## Step 3: Mutex — prevent concurrent vessels
+
+Check whether the PR already has the `pr-vessel-active` label:
+
+```
+gh pr view {{.Issue.Number}} --json labels --jq '.labels[].name' | grep -q pr-vessel-active
+```
+
+If `pr-vessel-active` is present, another vessel is already working on this PR. Output `XYLEM_NOOP` on its own line and stop.
+
+Otherwise, apply the mutex label immediately:
+
+```
+gh pr edit {{.Issue.Number}} --add-label pr-vessel-active
+```
+
+## Step 4: Read CI check results
+
+Run `gh pr checks {{.Issue.Number}}` to list all CI checks and their statuses.
+
+For each failing check, read its full log output to identify the root cause. Use `gh run view <run-id> --log-failed` or download logs as needed.
+
+## Step 5: Write diagnosis
+
+Produce a structured diagnosis listing each failure:
+
+- **Check name**: The name of the failing CI check
+- **Root cause**: What caused the failure, with evidence from the logs
+- **Planned fix**: The specific change needed to resolve it
+
+Do not modify any files. This is a read-only diagnostic phase.

--- a/.xylem/prompts/fix-pr-checks/fix.md
+++ b/.xylem/prompts/fix-pr-checks/fix.md
@@ -1,0 +1,40 @@
+Fix the failing CI checks identified in the diagnosis.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Diagnosis
+{{.PreviousOutputs.diagnose}}
+
+{{if .GateResult}}
+## Previous Gate Failure
+The following gate check failed after the previous attempt. Fix the issues and try again:
+
+{{.GateResult}}
+{{end}}
+
+## Fix procedure
+
+Work through the failures identified in the diagnosis. Apply fixes in this order:
+
+### 1. Fix formatting
+
+Run `cd cli && goimports -w .` to fix all import ordering and formatting issues.
+
+### 2. Fix compilation errors
+
+Run `cd cli && go vet ./...` and `cd cli && go build ./cmd/xylem` to surface any remaining compilation or static analysis errors. Fix each one.
+
+### 3. Fix failing tests
+
+Run `cd cli && go test ./...` to identify failing tests. Read each failing test to understand what it expects, then fix the code or test as appropriate.
+
+### 4. Verify full CI locally
+
+Run the complete CI gate command to confirm everything passes:
+
+```
+cd cli && goimports -l . | grep -c . | xargs test 0 -eq && go vet ./... && go build ./cmd/xylem && go test ./...
+```
+
+If any step still fails, fix the issue and re-run until the full command succeeds.

--- a/.xylem/prompts/fix-pr-checks/push.md
+++ b/.xylem/prompts/fix-pr-checks/push.md
@@ -1,0 +1,44 @@
+Push the CI fixes and update the pull request.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Diagnosis
+{{.PreviousOutputs.diagnose}}
+
+## Fixes Applied
+{{.PreviousOutputs.fix}}
+
+## Step 1: Commit and push
+
+Stage and commit all changes:
+
+```
+git add -A && git commit -m "fix: resolve CI failures on #{{.Issue.Number}}"
+```
+
+Push to the remote branch:
+
+```
+git push
+```
+
+## Step 2: Post a summary comment
+
+Post a comment on the PR summarizing what was fixed. Reference the diagnosis and the specific changes made:
+
+```
+gh pr comment {{.Issue.Number}} --body "## CI Fixes Applied
+
+<summarize the failures that were found and the fixes applied, referencing the diagnosis>
+
+All CI checks should now pass."
+```
+
+## Step 3: Remove the mutex label
+
+Release the vessel mutex so future runs can process this PR if needed:
+
+```
+gh pr edit {{.Issue.Number}} --remove-label pr-vessel-active
+```

--- a/.xylem/workflows/fix-pr-checks.yaml
+++ b/.xylem/workflows/fix-pr-checks.yaml
@@ -1,0 +1,18 @@
+name: fix-pr-checks
+description: "Diagnose and fix failing CI checks on a PR"
+phases:
+  - name: diagnose
+    prompt_file: .xylem/prompts/fix-pr-checks/diagnose.md
+    max_turns: 30
+    noop:
+      match: XYLEM_NOOP
+  - name: fix
+    prompt_file: .xylem/prompts/fix-pr-checks/fix.md
+    max_turns: 60
+    gate:
+      type: command
+      run: "cd cli && goimports -l . | grep -c . | xargs test 0 -eq && go vet ./... && go build ./cmd/xylem && go test ./..."
+      retries: 3
+  - name: push
+    prompt_file: .xylem/prompts/fix-pr-checks/push.md
+    max_turns: 10


### PR DESCRIPTION
## Summary
- Add `fix-pr-checks` workflow with three phases: diagnose, fix, push
- Add prompt templates for each phase with guard (harness-impl label), mutex (pr-vessel-active label), and full CI gate
- Diagnose phase reads CI check logs and writes structured failure analysis
- Fix phase applies formatting, compilation, and test fixes with 3 gate retries
- Push phase commits, pushes, comments on PR, and releases the mutex label

## Test plan
- [x] YAML parses correctly (verified with structural check)
- [x] All Go template delimiters are balanced across all 3 prompts
- [x] Go binary builds successfully (`go build ./cmd/xylem`)
- [x] Existing workflow tests pass (`go test ./internal/workflow/`)
- [x] Pre-commit hooks pass (YAML check, end-of-file, trailing whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)