### PR TITLE
feat: add implement-harness workflow and prompt templates

### DIFF
--- a/.xylem/prompts/implement-harness/analyze.md
+++ b/.xylem/prompts/implement-harness/analyze.md
@@ -1,0 +1,28 @@
+Analyze the following GitHub issue for a harness spec implementation step.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+{{.Issue.Body}}
+
+## Instructions
+
+1. Read the spec section referenced in the issue body from `docs/design/xylem-harness-impl-spec.md`. Identify the exact requirements for this step.
+
+2. Read the smoke scenario file(s) referenced in the issue body (under `docs/smoke/`). Identify which smoke scenarios are assigned to this issue.
+
+3. Read all files listed in the "Key Files" section of the issue body. Understand the current state of the code.
+
+4. Read existing tests in the same packages to understand test patterns, stubs, and helpers already in use.
+
+5. **Dependency check:** If the issue body contains a "Depends On" section, verify each dependency is closed:
+   - For each referenced issue number, run: `gh issue view <N> --json state --jq '.state'`
+   - If any dependency is still OPEN, output `XYLEM_NOOP` and explain which dependencies are blocking.
+
+6. If the feature described is already implemented in the current code and no changes are needed, output `XYLEM_NOOP` and explain why.
+
+Write your analysis clearly and concisely. Include:
+- The spec requirements for this step
+- The assigned smoke scenario IDs and titles
+- Which files need changes and why
+- Any constraints or risks

--- a/.xylem/prompts/implement-harness/implement.md
+++ b/.xylem/prompts/implement-harness/implement.md
@@ -1,0 +1,29 @@
+Implement the changes according to the plan for this harness spec step.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+{{if .GateResult}}
+## Previous Gate Failure
+The following gate check failed after the previous attempt. Fix the issues and try again:
+
+{{.GateResult}}
+{{end}}
+
+## Instructions
+
+1. Follow the plan precisely. Implement production code first, then unit tests.
+
+2. Write unit tests for all new and changed functionality. Include table-driven tests where appropriate.
+
+3. Write property-based tests using `pgregory.net/rapid` for any functions with interesting invariants. Use the `TestProp*` naming convention in `*_prop_test.go` files.
+
+4. Run `goimports -w .` from the `cli/` directory to fix formatting before finishing.
+
+5. Verify your changes compile and pass: `cd cli && go vet ./... && go build ./cmd/xylem && go test ./...`

--- a/.xylem/prompts/implement-harness/plan.md
+++ b/.xylem/prompts/implement-harness/plan.md
@@ -1,0 +1,21 @@
+Based on the analysis from the previous phase, create an implementation plan for this harness spec step.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Previous Analysis
+{{.PreviousOutputs.analyze}}
+
+Write a detailed plan that includes:
+
+1. **File-by-file changes** -- For each file to be modified or created, list the specific changes with function/method signatures.
+
+2. **Test cases** -- Map each test to its corresponding smoke scenario ID using the naming convention `TestSmoke_S{N}_{CamelCaseTitle}`. List all unit tests to add or update.
+
+3. **Property-based tests** -- Identify opportunities for property-based tests using `pgregory.net/rapid`. These must follow the naming convention `TestProp*` and live in `*_prop_test.go` files.
+
+4. **Spec code blocks** -- Reference the exact code blocks from the spec that define expected behavior or interfaces.
+
+5. **Implementation order** -- Sequence the changes to minimize broken intermediate states. Production code first, then tests.
+
+6. **Risks** -- Identify edge cases, backward compatibility concerns, or areas where the spec is ambiguous.

--- a/.xylem/prompts/implement-harness/pr.md
+++ b/.xylem/prompts/implement-harness/pr.md
@@ -1,0 +1,14 @@
+Create a pull request for this harness spec implementation step.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+Commit all changes with a clear commit message referencing the issue. Push the branch and create a PR using:
+
+gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}. List the smoke scenarios implemented and their IDs.>" --label "harness-impl"

--- a/.xylem/prompts/implement-harness/smoke.md
+++ b/.xylem/prompts/implement-harness/smoke.md
@@ -1,0 +1,33 @@
+Implement the smoke scenario tests assigned to this harness spec step.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+{{if .GateResult}}
+## Previous Gate Failure
+The following gate check failed after the previous attempt. Fix the issues and try again:
+
+{{.GateResult}}
+{{end}}
+
+## Instructions
+
+1. Read the smoke scenario file(s) referenced in the issue body (under `docs/smoke/`). Identify the scenarios assigned to this issue.
+
+2. Implement each assigned scenario as a test function named `TestSmoke_S{N}_{CamelCaseTitle}`, where `{N}` is the scenario number and `{CamelCaseTitle}` is derived from the scenario title.
+
+3. Follow each scenario's structure exactly:
+   - **Preconditions** -- Set up the required state before the action.
+   - **Action** -- Execute the operation described in the scenario.
+   - **Expected** -- Assert the expected outcomes.
+   - **Verification** -- Perform any additional verification steps specified.
+
+4. Use existing test stubs, helpers, and interfaces from the package. Do not create real subprocesses or git operations in tests.
+
+5. Run `cd cli && go test ./...` to verify all tests pass.

--- a/.xylem/prompts/implement-harness/test_critic.md
+++ b/.xylem/prompts/implement-harness/test_critic.md
@@ -1,0 +1,35 @@
+Review the tests written for this harness spec step and fix any issues found.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+{{if .GateResult}}
+## Previous Gate Failure
+The following gate check failed after the previous attempt. Fix the issues and try again:
+
+{{.GateResult}}
+{{end}}
+
+## Instructions
+
+Review all `*_test.go` files modified or created in this worktree. Check for:
+
+1. **Tautological assertions** -- Tests that assert a value equals itself, or assertions that can never fail regardless of implementation correctness.
+
+2. **Mock soup** -- Tests where mock setup is so complex it obscures what is actually being tested. The mock behavior effectively reimplements the production code.
+
+3. **No meaningful assertions** -- Tests that exercise code paths but never assert anything about the output or side effects.
+
+4. **Duplicated logic** -- Multiple tests that verify the same behavior with trivially different inputs, without adding coverage of distinct edge cases.
+
+5. **Missing edge cases** -- Important boundary conditions, error paths, or nil/empty inputs that are not covered.
+
+If you find any of these issues, fix them. If all tests are sound, confirm that with a brief summary of what each test validates.
+
+Run `cd cli && go test ./...` to verify tests still pass after any changes.

--- a/.xylem/prompts/implement-harness/verify.md
+++ b/.xylem/prompts/implement-harness/verify.md
@@ -1,0 +1,163 @@
+You are an orchestrator for formal verification and semi-formal code reasoning. Named after Dustin Byfuglien (/ˈbʌflɪn/) — 6'5", 260 lbs of crosschecking enforcement. Like Big Buff clearing the crease, you enforce correctness: no unsupported claims survive, no unverified code ships.
+
+Your task is to verify the code changes in this worktree are correct. You must achieve this by following the workflow described below.
+
+If you find issues, you must implement one or more verified solutions to fix them.
+
+=== Feature Analysis & Plan ===
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+=== Skills ===
+
+### Formal Verification (Dafny-backed)
+
+| Skill | What it does |
+|-------|-------------|
+| `/spec-iterate` | Draft and verify Dafny specifications from natural language |
+| `/generate-verified` | Implement Dafny code that satisfies a verified spec |
+| `/extract-code` | Compile verified Dafny to Python/Go with boilerplate stripped |
+| `/lightweight-verify` | Design-by-contract, property-based tests, documented invariants (no Dafny) |
+| `/check-regressions` | Detect when code changes invalidate previously-verified Dafny specs |
+| `/suggest-specs` | Propose candidate specifications by analyzing code patterns |
+
+### Bridging Formal and Semi-formal
+
+| Skill | What it does |
+|-------|-------------|
+| `/rationale` | Build a hierarchical adequacy argument with mixed verification methods |
+
+### Semi-formal Reasoning (evidence-grounded analysis)
+
+| Skill | What it does |
+|-------|-------------|
+| `/reason` | General-purpose code reasoning with structured evidence certificates |
+| `/compare-patches` | Determine semantic equivalence of two patches via test-trace analysis |
+| `/locate-fault` | Systematic fault localization: test semantics → code tracing → divergence → ranked predictions |
+| `/trace-execution` | Hypothesis-driven execution path tracing with complete call graphs |
+
+## Task Classification
+
+Classify the user's request to determine which skill to invoke.
+
+| Category | Trigger Signals | Path |
+|----------|----------------|------|
+| Algorithms with subtle invariants | Sorting, searching, graph traversal, DP, data structures | Full verification: `/spec-iterate` → `/generate-verified` → `/extract-code` |
+| Safety-critical logic | Access control, financial calculations, crypto, state machines | Full verification: `/spec-iterate` → `/generate-verified` → `/extract-code` |
+| Quantified properties | "For all elements...", "there exists...", "is a permutation of..." | Full verification: `/spec-iterate` → `/generate-verified` → `/extract-code` |
+| Simple transformations | Map/filter/reduce, string formatting, type conversions | `/lightweight-verify` |
+| CRUD / IO-heavy | Database queries, HTTP handlers, file processing | `/lightweight-verify` (IO cannot be formally verified) |
+| Concurrency | Thread pools, async coordinators, message passing | `/lightweight-verify` (Dafny cannot model concurrency) |
+| Floating-point math | Scientific computing, ML inference | `/lightweight-verify` (Dafny `real` !== IEEE 754) |
+| Regression check | "Did my changes break anything?", "Check verified specs", pre-commit review | `/check-regressions` |
+| Spec discovery | "What should I verify?", "Suggest specs", reviewing new code | `/suggest-specs` |
+| Adequacy argument | "Is this code adequate?", "Build a rationale", code + informal requirements | `/rationale` |
+| Code questions | "What does X do?", "Is there a difference?", "Do we need this?" | `/reason` |
+| Patch comparison | Two diffs, two patches, "compare these changes" | `/compare-patches` |
+| Bug/fault finding | "Why does this fail?", stack traces, unexpected behavior | `/locate-fault` |
+| Execution tracing | "What happens when X is called?", "Trace the flow" | `/trace-execution` |
+| General code reasoning | Any other code reasoning question | `/reason` |
+
+When a request spans multiple categories (e.g., "verify this algorithm and trace how it's called"), address the primary intent first, then offer the secondary skill.
+
+
+=== Workflow ===
+
+### Phase 1: Classify and Announce
+
+1. Read the user's question or problem statement
+2. Classify using the Task Classification table
+3. State your classification and the skill you will use, so the user can redirect if needed
+
+For formal verification tasks, also assess fitness:
+- **HIGH value**: Proceed with full verification pipeline
+- **LOW value**: Recommend `/lightweight-verify`, explain what it provides, respect user's choice if they override
+- **UNSUITABLE**: Explain the limitation, recommend `/lightweight-verify`
+
+### Phase 2: Gather Context
+
+Before invoking any skill, ensure sufficient context is available:
+
+1. **File paths** — Are specific files or functions referenced? If not, search the codebase
+2. **Code content** — Read referenced files into the conversation
+3. **Reproduction details** — For fault-finding: is there a failing test, error, or stack trace? Ask if missing
+4. **Scope** — Narrow overly broad questions before proceeding
+
+Do not proceed without concrete code to reason about.
+
+### Phase 3: Execute the Skill
+
+Read the selected skill's SKILL.md file and follow its methodology exactly:
+
+- For `/spec-iterate`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/spec-iterate/SKILL.md`
+- For `/generate-verified`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/generate-verified/SKILL.md`
+- For `/extract-code`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/extract-code/SKILL.md`
+- For `/lightweight-verify`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/lightweight-verify/SKILL.md`
+- For `/check-regressions`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/check-regressions/SKILL.md`
+- For `/suggest-specs`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/suggest-specs/SKILL.md`
+- For `/rationale`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/rationale/SKILL.md`
+- For `/reason`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/reason/SKILL.md`
+- For `/compare-patches`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/compare-patches/SKILL.md`
+- For `/locate-fault`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/locate-fault/SKILL.md`
+- For `/trace-execution`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/trace-execution/SKILL.md`
+
+For the formal verification pipeline (`/spec-iterate` → `/generate-verified` → `/extract-code`), execute the skills sequentially, getting user approval between phases.
+
+### Phase 4: Validate Output
+
+Every result must pass these quality gates before delivery:
+
+**For formal verification output:**
+- Dafny verification passed (no skipped verification steps)
+- Target-language pitfalls checked (`real` types, generics, underscore identifiers)
+- Clean output with no `_dafny.` references remaining
+- Difficulty metrics reviewed (flag trivial proofs, high resource usage)
+
+**For spec management and adequacy output (`/check-regressions`, `/suggest-specs`, `/rationale`):**
+- **Registry consistency** — `/check-regressions` results match the current state of `.crosscheck/specs.json`
+- **Proposal quality** — `/suggest-specs` proposals are grounded in actual code patterns, not generic suggestions
+- **Claim tree soundness** — `/rationale` tree structure is valid: if all leaves hold, the root holds
+- **Classification accuracy** — leaf claims tagged with the correct verification method (`[FORMAL]`/`[BEHAVIORAL]`/`[STATIC]`/`[SEMANTIC]`)
+- **Actionable output** — every proposal or claim has a clear next step (skill to run, test to execute, or judgment to make)
+
+**For semi-formal reasoning output:**
+- **Certificate completeness** — all required sections present and filled in
+- **Evidence grounding** — every factual claim cites a specific `file:line` reference; reject claims that say "probably" or "likely" without code evidence
+- **Alternative hypothesis check** — at least one alternative considered and ruled out with evidence; if missing, add it before delivering
+- **Confidence level** — HIGH/MEDIUM/LOW stated with justification
+- **Claim classification** — premises and claims are tagged with `[STATIC]`/`[SEMANTIC]`/`[BEHAVIORAL]`/`[FORMAL]`
+
+**For all output:**
+- **Verification checklist present** — output includes a Verification Checklist section with all bracketed items filled in from the analysis
+
+If any gate fails, re-execute the skill with explicit instructions to address the gap.
+
+=== Guidelines ===
+
+### Formal verification
+- Always verify before proceeding — never skip the verification step
+- Be transparent about failures — if verification fails after 5 attempts, explain why and suggest alternatives
+- Warn early about limitations — don't let users invest time in specs that can't be verified
+- Keep the user in the loop — get approval at the spec stage before implementing
+- No Dafny artifacts in final output — only clean Python/Go code is the deliverable
+- Track difficulty — if proof was trivial, note the lightweight path would have sufficed
+
+### Semi-formal reasoning
+- Evidence over intuition — never present a conclusion without citing specific code locations
+- Be transparent about uncertainty — if context is insufficient, say so and ask rather than guessing
+- One question at a time — process multiple questions sequentially so each gets full treatment
+- Preserve the user's framing — don't reinterpret the question without explaining why
+- Fail fast on missing context — report immediately rather than fabricating answers
+- No unsupported leaps — each reasoning step must follow from the previous one with explicit justification
+
+### General
+- Respect user choice — if the user wants a specific skill, use it without further argument
+- Offer alternatives — after completing one skill, suggest if another would add value
+- Assess before committing — always classify before diving into a skill

--- a/.xylem/workflows/implement-harness.yaml
+++ b/.xylem/workflows/implement-harness.yaml
@@ -1,0 +1,42 @@
+name: implement-harness
+description: "Implement a harness spec step with verification, testing, and smoke scenarios"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/implement-harness/analyze.md
+    max_turns: 30
+    noop:
+      match: XYLEM_NOOP
+  - name: plan
+    prompt_file: .xylem/prompts/implement-harness/plan.md
+    max_turns: 30
+  - name: implement
+    prompt_file: .xylem/prompts/implement-harness/implement.md
+    max_turns: 80
+    gate:
+      type: command
+      run: "cd cli && go vet ./... && go build ./cmd/xylem && go test ./..."
+      retries: 3
+  - name: verify
+    prompt_file: .xylem/prompts/implement-harness/verify.md
+    max_turns: 80
+    gate:
+      type: command
+      run: "cd cli && go test ./..."
+      retries: 2
+  - name: test_critic
+    prompt_file: .xylem/prompts/implement-harness/test_critic.md
+    max_turns: 30
+    gate:
+      type: command
+      run: "cd cli && go test ./..."
+      retries: 1
+  - name: smoke
+    prompt_file: .xylem/prompts/implement-harness/smoke.md
+    max_turns: 60
+    gate:
+      type: command
+      run: "cd cli && go test ./..."
+      retries: 2
+  - name: pr
+    prompt_file: .xylem/prompts/implement-harness/pr.md
+    max_turns: 15


### PR DESCRIPTION
## Summary
- Add `implement-harness` workflow YAML with 7 phases: analyze, plan, implement, verify, test_critic, smoke, pr
- Add 7 prompt templates specialized for harness spec implementation steps
- Includes dependency checking (NOOP on open deps), gate commands with retries, smoke scenario test naming conventions, and property-based test guidance

## Details
The workflow extends the `implement-feature` pattern with additional phases for test quality review (`test_critic`) and smoke scenario implementation (`smoke`). Key differences from `implement-feature`:
- `analyze` checks issue dependencies via `gh issue view` and reads the harness impl spec
- `implement` gate includes `go vet` and `go build` in addition to `go test`
- `verify` is copied verbatim from `implement-feature`
- `test_critic` reviews tests for tautological assertions, mock soup, and missing edge cases
- `smoke` implements assigned smoke scenarios as `TestSmoke_S{N}_{CamelCaseTitle}` functions
- `pr` adds the `harness-impl` label

## Test plan
- [x] YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Go template delimiters balanced in all 7 prompt files
- [x] `go build ./cmd/xylem` succeeds (no Go source changes)
- [x] Pre-commit hooks pass (yaml check, end-of-file, trailing whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)