### PR TITLE
feat: add merge-pr and unblock-wave workflows

### DIFF
--- a/.xylem/prompts/merge-pr/check.md
+++ b/.xylem/prompts/merge-pr/check.md
@@ -1,0 +1,27 @@
+Verify that the following pull request is ready to merge.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+PR Number: {{.Issue.Number}}
+
+{{.Issue.Body}}
+
+## Checks
+
+Run all of the following checks and report each result:
+
+1. **CI status** -- Run `gh pr checks {{.Issue.Number}}` and confirm every required check has passed. If any check is failing or pending, record which ones.
+
+2. **Review state** -- Run `gh pr view {{.Issue.Number}} --json reviews --jq '.reviews[] | {state: .state, author: .author.login}'` and check for any `CHANGES_REQUESTED` reviews that have not been followed by an `APPROVED` review from the same author.
+
+3. **Mergeable state** -- Run `gh pr view {{.Issue.Number}} --json mergeable --jq '.mergeable'` and confirm the value is `MERGEABLE`.
+
+## Decision
+
+If ANY check fails, output the exact standalone line:
+
+XYLEM_NOOP
+
+Then explain which checks failed and why the PR cannot be merged yet.
+
+If ALL checks pass, confirm the PR is ready to merge and summarize the passing results.

--- a/.xylem/prompts/unblock-wave/check_deps.md
+++ b/.xylem/prompts/unblock-wave/check_deps.md
@@ -1,0 +1,51 @@
+Check whether a merged PR unblocks any dependent harness issues.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+PR Number: {{.Issue.Number}}
+
+{{.Issue.Body}}
+
+## Guard
+
+First, check if this PR carries the `harness-impl` label:
+
+```
+gh pr view {{.Issue.Number}} --json labels --jq '.labels[].name'
+```
+
+If `harness-impl` is NOT among the labels, this PR is not part of the harness implementation wave. Output the exact standalone line:
+
+XYLEM_NOOP
+
+And stop. No further work is needed.
+
+## Find blocked issues
+
+List all open harness issues that are currently blocked:
+
+```
+gh issue list --repo nicholls-inc/xylem --label harness-impl --label blocked --state open --json number,title,body --limit 100
+```
+
+## Check dependencies
+
+For each blocked issue:
+
+1. Parse the issue body for a "Depends On" section. Dependencies are listed as issue references (e.g., `#42`, `#43`).
+2. For each dependency, check whether it is closed: `gh issue view <N> --repo nicholls-inc/xylem --json state --jq '.state'`
+3. If ALL dependencies are closed, the issue is ready to unblock.
+
+## Unblock ready issues
+
+For each issue where all dependencies are now satisfied:
+
+```
+gh issue edit <N> --repo nicholls-inc/xylem --remove-label blocked --add-label ready-for-work
+```
+
+## Report
+
+Summarize:
+- **Unblocked** -- List issues that were unblocked with their numbers and titles
+- **Still blocked** -- List issues that remain blocked, noting which dependencies are still open

--- a/.xylem/workflows/merge-pr.yaml
+++ b/.xylem/workflows/merge-pr.yaml
@@ -1,0 +1,13 @@
+name: merge-pr
+description: "Merge a PR after verifying all merge criteria are met"
+phases:
+  - name: check
+    prompt_file: .xylem/prompts/merge-pr/check.md
+    max_turns: 10
+    noop:
+      match: XYLEM_NOOP
+  - name: merge
+    type: command
+    run: |
+      PR_NUM=$(gh pr view --json number --jq '.number')
+      gh pr merge $PR_NUM --repo nicholls-inc/xylem --squash --delete-branch

--- a/.xylem/workflows/unblock-wave.yaml
+++ b/.xylem/workflows/unblock-wave.yaml
@@ -1,0 +1,8 @@
+name: unblock-wave
+description: "Check if merged PR satisfies wave dependencies and unblock ready issues"
+phases:
+  - name: check_deps
+    prompt_file: .xylem/prompts/unblock-wave/check_deps.md
+    max_turns: 20
+    noop:
+      match: XYLEM_NOOP


### PR DESCRIPTION
## Summary
- Add `merge-pr` workflow: two-phase (check + merge) workflow that verifies CI status, review state, and mergeable state before squash-merging a PR
- Add `unblock-wave` workflow: single-phase workflow that checks if a merged PR satisfies wave dependencies and unblocks ready harness issues by swapping `blocked` for `ready-for-work` labels

## Test plan
- [x] Both YAML files parse correctly with Python yaml.safe_load
- [x] Go CLI builds successfully (`go build ./cmd/xylem`)
- [x] Phase names match `^[a-z][a-z0-9_]*$` convention
- [x] `type: command` phase in merge-pr has `run:` but no `prompt_file`/`max_turns`
- [x] Prompt templates use correct Go template variables (`{{.Issue.Title}}`, `{{.Issue.URL}}`, etc.)
- [x] XYLEM_NOOP pattern is consistent with existing workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)