### PR TITLE
feat: add vessel-level span attribute helpers

### DIFF
--- a/cli/internal/observability/observability_test.go
+++ b/cli/internal/observability/observability_test.go
@@ -11,6 +11,14 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
+func attrMap(attrs []SpanAttribute) map[string]string {
+	m := make(map[string]string, len(attrs))
+	for _, attr := range attrs {
+		m[attr.Key] = attr.Value
+	}
+	return m
+}
+
 func TestSignalSpanAttributesBasic(t *testing.T) {
 	signals := []SignalData{
 		{Type: "Repetition", Value: 0.75, Level: "Warning"},

--- a/cli/internal/observability/vessel.go
+++ b/cli/internal/observability/vessel.go
@@ -2,49 +2,81 @@ package observability
 
 import "fmt"
 
+// VesselSpanData holds vessel information for attribute extraction.
+type VesselSpanData struct {
+	ID       string `json:"id"`
+	Source   string `json:"source"`
+	Workflow string `json:"workflow"`
+	Ref      string `json:"ref"`
+}
+
 // VesselSpanAttributes returns span attributes for a vessel span.
 // When ref is empty, the xylem.vessel.ref attribute is omitted.
-func VesselSpanAttributes(id, source, workflow, ref string) []SpanAttribute {
+func VesselSpanAttributes(data VesselSpanData) []SpanAttribute {
 	attrs := []SpanAttribute{
-		{Key: "xylem.vessel.id", Value: id},
-		{Key: "xylem.vessel.source", Value: source},
-		{Key: "xylem.vessel.workflow", Value: workflow},
+		{Key: "xylem.vessel.id", Value: data.ID},
+		{Key: "xylem.vessel.source", Value: data.Source},
+		{Key: "xylem.vessel.workflow", Value: data.Workflow},
 	}
-	if ref != "" {
-		attrs = append(attrs, SpanAttribute{Key: "xylem.vessel.ref", Value: ref})
+	if data.Ref != "" {
+		attrs = append(attrs, SpanAttribute{Key: "xylem.vessel.ref", Value: data.Ref})
 	}
 	return attrs
 }
 
+// PhaseSpanData holds phase information for attribute extraction.
+type PhaseSpanData struct {
+	Name     string `json:"name"`
+	Index    int    `json:"index"`
+	Type     string `json:"type"`
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+}
+
 // PhaseSpanAttributes returns span attributes for a phase span.
 // The index is stringified, not stored as a numeric attribute.
-func PhaseSpanAttributes(name string, index int, phaseType, provider, model string) []SpanAttribute {
+func PhaseSpanAttributes(data PhaseSpanData) []SpanAttribute {
 	return []SpanAttribute{
-		{Key: "xylem.phase.name", Value: name},
-		{Key: "xylem.phase.index", Value: fmt.Sprintf("%d", index)},
-		{Key: "xylem.phase.type", Value: phaseType},
-		{Key: "xylem.phase.provider", Value: provider},
-		{Key: "xylem.phase.model", Value: model},
+		{Key: "xylem.phase.name", Value: data.Name},
+		{Key: "xylem.phase.index", Value: fmt.Sprintf("%d", data.Index)},
+		{Key: "xylem.phase.type", Value: data.Type},
+		{Key: "xylem.phase.provider", Value: data.Provider},
+		{Key: "xylem.phase.model", Value: data.Model},
 	}
+}
+
+// PhaseResultData holds phase result information for attribute extraction.
+type PhaseResultData struct {
+	InputTokensEst  int     `json:"input_tokens_est"`
+	OutputTokensEst int     `json:"output_tokens_est"`
+	CostUSDEst      float64 `json:"cost_usd_est"`
+	DurationMS      int64   `json:"duration_ms"`
 }
 
 // PhaseResultAttributes returns span attributes added to a phase span
 // after execution completes. Cost is formatted to six decimal places.
-func PhaseResultAttributes(inputTokensEst, outputTokensEst int, costUSDEst float64, durationMS int64) []SpanAttribute {
+func PhaseResultAttributes(data PhaseResultData) []SpanAttribute {
 	return []SpanAttribute{
-		{Key: "xylem.phase.input_tokens_est", Value: fmt.Sprintf("%d", inputTokensEst)},
-		{Key: "xylem.phase.output_tokens_est", Value: fmt.Sprintf("%d", outputTokensEst)},
-		{Key: "xylem.phase.cost_usd_est", Value: fmt.Sprintf("%.6f", costUSDEst)},
-		{Key: "xylem.phase.duration_ms", Value: fmt.Sprintf("%d", durationMS)},
+		{Key: "xylem.phase.input_tokens_est", Value: fmt.Sprintf("%d", data.InputTokensEst)},
+		{Key: "xylem.phase.output_tokens_est", Value: fmt.Sprintf("%d", data.OutputTokensEst)},
+		{Key: "xylem.phase.cost_usd_est", Value: fmt.Sprintf("%.6f", data.CostUSDEst)},
+		{Key: "xylem.phase.duration_ms", Value: fmt.Sprintf("%d", data.DurationMS)},
 	}
+}
+
+// GateSpanData holds gate information for attribute extraction.
+type GateSpanData struct {
+	Type         string `json:"type"`
+	Passed       bool   `json:"passed"`
+	RetryAttempt int    `json:"retry_attempt"`
 }
 
 // GateSpanAttributes returns span attributes for a gate span.
 // The boolean is rendered as lowercase "true"/"false" via %t.
-func GateSpanAttributes(gateType string, passed bool, retryAttempt int) []SpanAttribute {
+func GateSpanAttributes(data GateSpanData) []SpanAttribute {
 	return []SpanAttribute{
-		{Key: "xylem.gate.type", Value: gateType},
-		{Key: "xylem.gate.passed", Value: fmt.Sprintf("%t", passed)},
-		{Key: "xylem.gate.retry_attempt", Value: fmt.Sprintf("%d", retryAttempt)},
+		{Key: "xylem.gate.type", Value: data.Type},
+		{Key: "xylem.gate.passed", Value: fmt.Sprintf("%t", data.Passed)},
+		{Key: "xylem.gate.retry_attempt", Value: fmt.Sprintf("%d", data.RetryAttempt)},
 	}
 }

--- a/cli/internal/observability/vessel.go
+++ b/cli/internal/observability/vessel.go
@@ -1,0 +1,50 @@
+package observability
+
+import "fmt"
+
+// VesselSpanAttributes returns span attributes for a vessel span.
+// When ref is empty, the xylem.vessel.ref attribute is omitted.
+func VesselSpanAttributes(id, source, workflow, ref string) []SpanAttribute {
+	attrs := []SpanAttribute{
+		{Key: "xylem.vessel.id", Value: id},
+		{Key: "xylem.vessel.source", Value: source},
+		{Key: "xylem.vessel.workflow", Value: workflow},
+	}
+	if ref != "" {
+		attrs = append(attrs, SpanAttribute{Key: "xylem.vessel.ref", Value: ref})
+	}
+	return attrs
+}
+
+// PhaseSpanAttributes returns span attributes for a phase span.
+// The index is stringified, not stored as a numeric attribute.
+func PhaseSpanAttributes(name string, index int, phaseType, provider, model string) []SpanAttribute {
+	return []SpanAttribute{
+		{Key: "xylem.phase.name", Value: name},
+		{Key: "xylem.phase.index", Value: fmt.Sprintf("%d", index)},
+		{Key: "xylem.phase.type", Value: phaseType},
+		{Key: "xylem.phase.provider", Value: provider},
+		{Key: "xylem.phase.model", Value: model},
+	}
+}
+
+// PhaseResultAttributes returns span attributes added to a phase span
+// after execution completes. Cost is formatted to six decimal places.
+func PhaseResultAttributes(inputTokensEst, outputTokensEst int, costUSDEst float64, durationMS int64) []SpanAttribute {
+	return []SpanAttribute{
+		{Key: "xylem.phase.input_tokens_est", Value: fmt.Sprintf("%d", inputTokensEst)},
+		{Key: "xylem.phase.output_tokens_est", Value: fmt.Sprintf("%d", outputTokensEst)},
+		{Key: "xylem.phase.cost_usd_est", Value: fmt.Sprintf("%.6f", costUSDEst)},
+		{Key: "xylem.phase.duration_ms", Value: fmt.Sprintf("%d", durationMS)},
+	}
+}
+
+// GateSpanAttributes returns span attributes for a gate span.
+// The boolean is rendered as lowercase "true"/"false" via %t.
+func GateSpanAttributes(gateType string, passed bool, retryAttempt int) []SpanAttribute {
+	return []SpanAttribute{
+		{Key: "xylem.gate.type", Value: gateType},
+		{Key: "xylem.gate.passed", Value: fmt.Sprintf("%t", passed)},
+		{Key: "xylem.gate.retry_attempt", Value: fmt.Sprintf("%d", retryAttempt)},
+	}
+}

--- a/cli/internal/observability/vessel_prop_test.go
+++ b/cli/internal/observability/vessel_prop_test.go
@@ -26,10 +26,30 @@ func genGateType() *rapid.Generator[string] {
 
 func combinedAttrs() []SpanAttribute {
 	attrs := make([]SpanAttribute, 0, 16)
-	attrs = append(attrs, VesselSpanAttributes("vessel-1", "github", "fix-bug", "refs/pull/1/head")...)
-	attrs = append(attrs, PhaseSpanAttributes("analyse", 1, "prompt", "anthropic", "claude-sonnet")...)
-	attrs = append(attrs, PhaseResultAttributes(10, 20, 1.25, 30)...)
-	attrs = append(attrs, GateSpanAttributes("command", true, 1)...)
+	attrs = append(attrs, VesselSpanAttributes(VesselSpanData{
+		ID:       "vessel-1",
+		Source:   "github",
+		Workflow: "fix-bug",
+		Ref:      "refs/pull/1/head",
+	})...)
+	attrs = append(attrs, PhaseSpanAttributes(PhaseSpanData{
+		Name:     "analyse",
+		Index:    1,
+		Type:     "prompt",
+		Provider: "anthropic",
+		Model:    "claude-sonnet",
+	})...)
+	attrs = append(attrs, PhaseResultAttributes(PhaseResultData{
+		InputTokensEst:  10,
+		OutputTokensEst: 20,
+		CostUSDEst:      1.25,
+		DurationMS:      30,
+	})...)
+	attrs = append(attrs, GateSpanAttributes(GateSpanData{
+		Type:         "command",
+		Passed:       true,
+		RetryAttempt: 1,
+	})...)
 	return attrs
 }
 
@@ -40,7 +60,12 @@ func TestPropVesselAttrsLengthRefPresent(t *testing.T) {
 		workflow := genVesselString().Draw(t, "workflow")
 		ref := genNonEmptyVesselString().Draw(t, "ref")
 
-		attrs := VesselSpanAttributes(id, source, workflow, ref)
+		attrs := VesselSpanAttributes(VesselSpanData{
+			ID:       id,
+			Source:   source,
+			Workflow: workflow,
+			Ref:      ref,
+		})
 		if len(attrs) != 4 {
 			t.Fatalf("expected 4 attributes, got %d", len(attrs))
 		}
@@ -53,7 +78,11 @@ func TestPropVesselAttrsLengthRefAbsent(t *testing.T) {
 		source := genVesselString().Draw(t, "source")
 		workflow := genVesselString().Draw(t, "workflow")
 
-		attrs := VesselSpanAttributes(id, source, workflow, "")
+		attrs := VesselSpanAttributes(VesselSpanData{
+			ID:       id,
+			Source:   source,
+			Workflow: workflow,
+		})
 		if len(attrs) != 3 {
 			t.Fatalf("expected 3 attributes, got %d", len(attrs))
 		}
@@ -62,12 +91,12 @@ func TestPropVesselAttrsLengthRefAbsent(t *testing.T) {
 
 func TestPropVesselAttrsKeysNamespaced(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		attrs := VesselSpanAttributes(
-			genVesselString().Draw(t, "id"),
-			genVesselString().Draw(t, "source"),
-			genVesselString().Draw(t, "workflow"),
-			genVesselString().Draw(t, "ref"),
-		)
+		attrs := VesselSpanAttributes(VesselSpanData{
+			ID:       genVesselString().Draw(t, "id"),
+			Source:   genVesselString().Draw(t, "source"),
+			Workflow: genVesselString().Draw(t, "workflow"),
+			Ref:      genVesselString().Draw(t, "ref"),
+		})
 		for _, attr := range attrs {
 			if !strings.HasPrefix(attr.Key, "xylem.vessel.") {
 				t.Fatalf("key %q does not use xylem.vessel namespace", attr.Key)
@@ -78,13 +107,13 @@ func TestPropVesselAttrsKeysNamespaced(t *testing.T) {
 
 func TestPropPhaseAttrsAlwaysFive(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		attrs := PhaseSpanAttributes(
-			genVesselString().Draw(t, "name"),
-			rapid.IntRange(0, 100).Draw(t, "index"),
-			genPhaseType().Draw(t, "phase_type"),
-			genVesselString().Draw(t, "provider"),
-			genVesselString().Draw(t, "model"),
-		)
+		attrs := PhaseSpanAttributes(PhaseSpanData{
+			Name:     genVesselString().Draw(t, "name"),
+			Index:    rapid.IntRange(0, 100).Draw(t, "index"),
+			Type:     genPhaseType().Draw(t, "phase_type"),
+			Provider: genVesselString().Draw(t, "provider"),
+			Model:    genVesselString().Draw(t, "model"),
+		})
 		if len(attrs) != 5 {
 			t.Fatalf("expected 5 attributes, got %d", len(attrs))
 		}
@@ -94,7 +123,13 @@ func TestPropPhaseAttrsAlwaysFive(t *testing.T) {
 func TestPropPhaseAttrsIndexStringified(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		index := rapid.IntRange(0, 10000).Draw(t, "index")
-		attrs := PhaseSpanAttributes("phase", index, "prompt", "provider", "model")
+		attrs := PhaseSpanAttributes(PhaseSpanData{
+			Name:     "phase",
+			Index:    index,
+			Type:     "prompt",
+			Provider: "provider",
+			Model:    "model",
+		})
 		got, ok := attrMap(attrs)["xylem.phase.index"]
 		if !ok {
 			t.Fatal("xylem.phase.index not found")
@@ -111,12 +146,12 @@ func TestPropPhaseAttrsIndexStringified(t *testing.T) {
 
 func TestPropPhaseResultAttrsAlwaysFour(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		attrs := PhaseResultAttributes(
-			rapid.IntRange(0, 1000000).Draw(t, "input_tokens"),
-			rapid.IntRange(0, 1000000).Draw(t, "output_tokens"),
-			rapid.Float64Range(0.0, 100.0).Draw(t, "cost"),
-			int64(rapid.Int64Range(0, 600000).Draw(t, "duration_ms")),
-		)
+		attrs := PhaseResultAttributes(PhaseResultData{
+			InputTokensEst:  rapid.IntRange(0, 1000000).Draw(t, "input_tokens"),
+			OutputTokensEst: rapid.IntRange(0, 1000000).Draw(t, "output_tokens"),
+			CostUSDEst:      rapid.Float64Range(0.0, 100.0).Draw(t, "cost"),
+			DurationMS:      int64(rapid.Int64Range(0, 600000).Draw(t, "duration_ms")),
+		})
 		if len(attrs) != 4 {
 			t.Fatalf("expected 4 attributes, got %d", len(attrs))
 		}
@@ -125,12 +160,12 @@ func TestPropPhaseResultAttrsAlwaysFour(t *testing.T) {
 
 func TestPropPhaseResultCostSixDecimals(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		attrs := PhaseResultAttributes(
-			rapid.IntRange(0, 100).Draw(t, "input_tokens"),
-			rapid.IntRange(0, 100).Draw(t, "output_tokens"),
-			rapid.Float64Range(0.0, 100.0).Draw(t, "cost"),
-			int64(rapid.Int64Range(0, 1000).Draw(t, "duration_ms")),
-		)
+		attrs := PhaseResultAttributes(PhaseResultData{
+			InputTokensEst:  rapid.IntRange(0, 100).Draw(t, "input_tokens"),
+			OutputTokensEst: rapid.IntRange(0, 100).Draw(t, "output_tokens"),
+			CostUSDEst:      rapid.Float64Range(0.0, 100.0).Draw(t, "cost"),
+			DurationMS:      int64(rapid.Int64Range(0, 1000).Draw(t, "duration_ms")),
+		})
 		cost := attrMap(attrs)["xylem.phase.cost_usd_est"]
 		parts := strings.Split(cost, ".")
 		if len(parts) != 2 {
@@ -144,11 +179,11 @@ func TestPropPhaseResultCostSixDecimals(t *testing.T) {
 
 func TestPropGateAttrsAlwaysThree(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		attrs := GateSpanAttributes(
-			genGateType().Draw(t, "gate_type"),
-			rapid.Bool().Draw(t, "passed"),
-			rapid.IntRange(0, 10).Draw(t, "retry_attempt"),
-		)
+		attrs := GateSpanAttributes(GateSpanData{
+			Type:         genGateType().Draw(t, "gate_type"),
+			Passed:       rapid.Bool().Draw(t, "passed"),
+			RetryAttempt: rapid.IntRange(0, 10).Draw(t, "retry_attempt"),
+		})
 		if len(attrs) != 3 {
 			t.Fatalf("expected 3 attributes, got %d", len(attrs))
 		}
@@ -157,7 +192,10 @@ func TestPropGateAttrsAlwaysThree(t *testing.T) {
 
 func TestPropGatePassedIsLowercaseBool(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		attrs := GateSpanAttributes("command", rapid.Bool().Draw(t, "passed"), 0)
+		attrs := GateSpanAttributes(GateSpanData{
+			Type:   "command",
+			Passed: rapid.Bool().Draw(t, "passed"),
+		})
 		got := attrMap(attrs)["xylem.gate.passed"]
 		if got != "true" && got != "false" {
 			t.Fatalf("expected true or false, got %q", got)
@@ -167,7 +205,6 @@ func TestPropGatePassedIsLowercaseBool(t *testing.T) {
 
 func TestPropAllVesselKeysLowercase(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		_ = t
 		for _, attr := range combinedAttrs() {
 			if attr.Key != strings.ToLower(attr.Key) {
 				t.Fatalf("key %q is not lowercase", attr.Key)
@@ -209,23 +246,63 @@ func TestPropAttributesDeterministic(t *testing.T) {
 
 		checkDeterministic(
 			"VesselSpanAttributes",
-			VesselSpanAttributes(id, source, workflow, ref),
-			VesselSpanAttributes(id, source, workflow, ref),
+			VesselSpanAttributes(VesselSpanData{
+				ID:       id,
+				Source:   source,
+				Workflow: workflow,
+				Ref:      ref,
+			}),
+			VesselSpanAttributes(VesselSpanData{
+				ID:       id,
+				Source:   source,
+				Workflow: workflow,
+				Ref:      ref,
+			}),
 		)
 		checkDeterministic(
 			"PhaseSpanAttributes",
-			PhaseSpanAttributes(name, index, phaseType, provider, model),
-			PhaseSpanAttributes(name, index, phaseType, provider, model),
+			PhaseSpanAttributes(PhaseSpanData{
+				Name:     name,
+				Index:    index,
+				Type:     phaseType,
+				Provider: provider,
+				Model:    model,
+			}),
+			PhaseSpanAttributes(PhaseSpanData{
+				Name:     name,
+				Index:    index,
+				Type:     phaseType,
+				Provider: provider,
+				Model:    model,
+			}),
 		)
 		checkDeterministic(
 			"PhaseResultAttributes",
-			PhaseResultAttributes(inputTokens, outputTokens, cost, duration),
-			PhaseResultAttributes(inputTokens, outputTokens, cost, duration),
+			PhaseResultAttributes(PhaseResultData{
+				InputTokensEst:  inputTokens,
+				OutputTokensEst: outputTokens,
+				CostUSDEst:      cost,
+				DurationMS:      duration,
+			}),
+			PhaseResultAttributes(PhaseResultData{
+				InputTokensEst:  inputTokens,
+				OutputTokensEst: outputTokens,
+				CostUSDEst:      cost,
+				DurationMS:      duration,
+			}),
 		)
 		checkDeterministic(
 			"GateSpanAttributes",
-			GateSpanAttributes(gateType, passed, retryAttempt),
-			GateSpanAttributes(gateType, passed, retryAttempt),
+			GateSpanAttributes(GateSpanData{
+				Type:         gateType,
+				Passed:       passed,
+				RetryAttempt: retryAttempt,
+			}),
+			GateSpanAttributes(GateSpanData{
+				Type:         gateType,
+				Passed:       passed,
+				RetryAttempt: retryAttempt,
+			}),
 		)
 	})
 }

--- a/cli/internal/observability/vessel_prop_test.go
+++ b/cli/internal/observability/vessel_prop_test.go
@@ -1,0 +1,231 @@
+package observability
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func genVesselString() *rapid.Generator[string] {
+	return rapid.StringMatching(`[a-z0-9/_\.-]{0,40}`)
+}
+
+func genNonEmptyVesselString() *rapid.Generator[string] {
+	return rapid.StringMatching(`[a-z0-9/_\.-]{1,40}`)
+}
+
+func genPhaseType() *rapid.Generator[string] {
+	return rapid.SampledFrom([]string{"prompt", "command"})
+}
+
+func genGateType() *rapid.Generator[string] {
+	return rapid.SampledFrom([]string{"command", "label"})
+}
+
+func combinedAttrs() []SpanAttribute {
+	attrs := make([]SpanAttribute, 0, 16)
+	attrs = append(attrs, VesselSpanAttributes("vessel-1", "github", "fix-bug", "refs/pull/1/head")...)
+	attrs = append(attrs, PhaseSpanAttributes("analyse", 1, "prompt", "anthropic", "claude-sonnet")...)
+	attrs = append(attrs, PhaseResultAttributes(10, 20, 1.25, 30)...)
+	attrs = append(attrs, GateSpanAttributes("command", true, 1)...)
+	return attrs
+}
+
+func TestPropVesselAttrsLengthRefPresent(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		id := genVesselString().Draw(t, "id")
+		source := genVesselString().Draw(t, "source")
+		workflow := genVesselString().Draw(t, "workflow")
+		ref := genNonEmptyVesselString().Draw(t, "ref")
+
+		attrs := VesselSpanAttributes(id, source, workflow, ref)
+		if len(attrs) != 4 {
+			t.Fatalf("expected 4 attributes, got %d", len(attrs))
+		}
+	})
+}
+
+func TestPropVesselAttrsLengthRefAbsent(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		id := genVesselString().Draw(t, "id")
+		source := genVesselString().Draw(t, "source")
+		workflow := genVesselString().Draw(t, "workflow")
+
+		attrs := VesselSpanAttributes(id, source, workflow, "")
+		if len(attrs) != 3 {
+			t.Fatalf("expected 3 attributes, got %d", len(attrs))
+		}
+	})
+}
+
+func TestPropVesselAttrsKeysNamespaced(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		attrs := VesselSpanAttributes(
+			genVesselString().Draw(t, "id"),
+			genVesselString().Draw(t, "source"),
+			genVesselString().Draw(t, "workflow"),
+			genVesselString().Draw(t, "ref"),
+		)
+		for _, attr := range attrs {
+			if !strings.HasPrefix(attr.Key, "xylem.vessel.") {
+				t.Fatalf("key %q does not use xylem.vessel namespace", attr.Key)
+			}
+		}
+	})
+}
+
+func TestPropPhaseAttrsAlwaysFive(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		attrs := PhaseSpanAttributes(
+			genVesselString().Draw(t, "name"),
+			rapid.IntRange(0, 100).Draw(t, "index"),
+			genPhaseType().Draw(t, "phase_type"),
+			genVesselString().Draw(t, "provider"),
+			genVesselString().Draw(t, "model"),
+		)
+		if len(attrs) != 5 {
+			t.Fatalf("expected 5 attributes, got %d", len(attrs))
+		}
+	})
+}
+
+func TestPropPhaseAttrsIndexStringified(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		index := rapid.IntRange(0, 10000).Draw(t, "index")
+		attrs := PhaseSpanAttributes("phase", index, "prompt", "provider", "model")
+		got, ok := attrMap(attrs)["xylem.phase.index"]
+		if !ok {
+			t.Fatal("xylem.phase.index not found")
+		}
+		parsed, err := strconv.Atoi(got)
+		if err != nil {
+			t.Fatalf("failed to parse %q: %v", got, err)
+		}
+		if parsed != index {
+			t.Fatalf("parsed index = %d, want %d", parsed, index)
+		}
+	})
+}
+
+func TestPropPhaseResultAttrsAlwaysFour(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		attrs := PhaseResultAttributes(
+			rapid.IntRange(0, 1000000).Draw(t, "input_tokens"),
+			rapid.IntRange(0, 1000000).Draw(t, "output_tokens"),
+			rapid.Float64Range(0.0, 100.0).Draw(t, "cost"),
+			int64(rapid.Int64Range(0, 600000).Draw(t, "duration_ms")),
+		)
+		if len(attrs) != 4 {
+			t.Fatalf("expected 4 attributes, got %d", len(attrs))
+		}
+	})
+}
+
+func TestPropPhaseResultCostSixDecimals(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		attrs := PhaseResultAttributes(
+			rapid.IntRange(0, 100).Draw(t, "input_tokens"),
+			rapid.IntRange(0, 100).Draw(t, "output_tokens"),
+			rapid.Float64Range(0.0, 100.0).Draw(t, "cost"),
+			int64(rapid.Int64Range(0, 1000).Draw(t, "duration_ms")),
+		)
+		cost := attrMap(attrs)["xylem.phase.cost_usd_est"]
+		parts := strings.Split(cost, ".")
+		if len(parts) != 2 {
+			t.Fatalf("expected decimal cost, got %q", cost)
+		}
+		if len(parts[1]) != 6 {
+			t.Fatalf("expected 6 decimal places, got %q", cost)
+		}
+	})
+}
+
+func TestPropGateAttrsAlwaysThree(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		attrs := GateSpanAttributes(
+			genGateType().Draw(t, "gate_type"),
+			rapid.Bool().Draw(t, "passed"),
+			rapid.IntRange(0, 10).Draw(t, "retry_attempt"),
+		)
+		if len(attrs) != 3 {
+			t.Fatalf("expected 3 attributes, got %d", len(attrs))
+		}
+	})
+}
+
+func TestPropGatePassedIsLowercaseBool(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		attrs := GateSpanAttributes("command", rapid.Bool().Draw(t, "passed"), 0)
+		got := attrMap(attrs)["xylem.gate.passed"]
+		if got != "true" && got != "false" {
+			t.Fatalf("expected true or false, got %q", got)
+		}
+	})
+}
+
+func TestPropAllVesselKeysLowercase(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		_ = t
+		for _, attr := range combinedAttrs() {
+			if attr.Key != strings.ToLower(attr.Key) {
+				t.Fatalf("key %q is not lowercase", attr.Key)
+			}
+		}
+	})
+}
+
+func TestPropAttributesDeterministic(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		id := genVesselString().Draw(t, "id")
+		source := genVesselString().Draw(t, "source")
+		workflow := genVesselString().Draw(t, "workflow")
+		ref := genVesselString().Draw(t, "ref")
+		name := genVesselString().Draw(t, "name")
+		index := rapid.IntRange(0, 10000).Draw(t, "index")
+		phaseType := genPhaseType().Draw(t, "phase_type")
+		provider := genVesselString().Draw(t, "provider")
+		model := genVesselString().Draw(t, "model")
+		inputTokens := rapid.IntRange(0, 1000000).Draw(t, "input_tokens")
+		outputTokens := rapid.IntRange(0, 1000000).Draw(t, "output_tokens")
+		cost := rapid.Float64Range(0.0, 100.0).Draw(t, "cost")
+		duration := int64(rapid.Int64Range(0, 600000).Draw(t, "duration"))
+		gateType := genGateType().Draw(t, "gate_type")
+		passed := rapid.Bool().Draw(t, "passed")
+		retryAttempt := rapid.IntRange(0, 10).Draw(t, "retry_attempt")
+
+		checkDeterministic := func(name string, a, b []SpanAttribute) {
+			t.Helper()
+			if len(a) != len(b) {
+				t.Fatalf("%s length mismatch: %d vs %d", name, len(a), len(b))
+			}
+			for i := range a {
+				if a[i] != b[i] {
+					t.Fatalf("%s mismatch at %d: %#v vs %#v", name, i, a[i], b[i])
+				}
+			}
+		}
+
+		checkDeterministic(
+			"VesselSpanAttributes",
+			VesselSpanAttributes(id, source, workflow, ref),
+			VesselSpanAttributes(id, source, workflow, ref),
+		)
+		checkDeterministic(
+			"PhaseSpanAttributes",
+			PhaseSpanAttributes(name, index, phaseType, provider, model),
+			PhaseSpanAttributes(name, index, phaseType, provider, model),
+		)
+		checkDeterministic(
+			"PhaseResultAttributes",
+			PhaseResultAttributes(inputTokens, outputTokens, cost, duration),
+			PhaseResultAttributes(inputTokens, outputTokens, cost, duration),
+		)
+		checkDeterministic(
+			"GateSpanAttributes",
+			GateSpanAttributes(gateType, passed, retryAttempt),
+			GateSpanAttributes(gateType, passed, retryAttempt),
+		)
+	})
+}

--- a/cli/internal/observability/vessel_test.go
+++ b/cli/internal/observability/vessel_test.go
@@ -1,0 +1,124 @@
+package observability
+
+import "testing"
+
+func TestSmoke_S1_VesselSpanAttributesIncludesIDSourceWorkflowRef(t *testing.T) {
+	attrs := VesselSpanAttributes("vessel-123", "github", "fix-bug", "refs/pull/42/head")
+	got := attrMap(attrs)
+
+	if len(attrs) != 4 {
+		t.Fatalf("expected 4 attributes, got %d", len(attrs))
+	}
+
+	want := map[string]string{
+		"xylem.vessel.id":       "vessel-123",
+		"xylem.vessel.source":   "github",
+		"xylem.vessel.workflow": "fix-bug",
+		"xylem.vessel.ref":      "refs/pull/42/head",
+	}
+	for key, value := range want {
+		if got[key] != value {
+			t.Fatalf("%s = %q, want %q", key, got[key], value)
+		}
+	}
+}
+
+func TestSmoke_S2_VesselSpanAttributesOmitsEmptyRef(t *testing.T) {
+	attrs := VesselSpanAttributes("vessel-456", "manual", "implement-feature", "")
+	got := attrMap(attrs)
+
+	if len(attrs) != 3 {
+		t.Fatalf("expected 3 attributes, got %d", len(attrs))
+	}
+	if _, ok := got["xylem.vessel.ref"]; ok {
+		t.Fatal("did not expect xylem.vessel.ref attribute when ref is empty")
+	}
+}
+
+func TestSmoke_S3_PhaseSpanAttributesIncludesAllFive(t *testing.T) {
+	attrs := PhaseSpanAttributes("analyse", 0, "prompt", "anthropic", "claude-sonnet-4-20250514")
+	got := attrMap(attrs)
+
+	if len(attrs) != 5 {
+		t.Fatalf("expected 5 attributes, got %d", len(attrs))
+	}
+
+	want := map[string]string{
+		"xylem.phase.name":     "analyse",
+		"xylem.phase.index":    "0",
+		"xylem.phase.type":     "prompt",
+		"xylem.phase.provider": "anthropic",
+		"xylem.phase.model":    "claude-sonnet-4-20250514",
+	}
+	for key, value := range want {
+		if got[key] != value {
+			t.Fatalf("%s = %q, want %q", key, got[key], value)
+		}
+	}
+}
+
+func TestSmoke_S4_PhaseResultAttributesFormatsTokensAndCost(t *testing.T) {
+	attrs := PhaseResultAttributes(1200, 300, 0.0081, 4500)
+	got := attrMap(attrs)
+
+	if len(attrs) != 4 {
+		t.Fatalf("expected 4 attributes, got %d", len(attrs))
+	}
+
+	want := map[string]string{
+		"xylem.phase.input_tokens_est":  "1200",
+		"xylem.phase.output_tokens_est": "300",
+		"xylem.phase.cost_usd_est":      "0.008100",
+		"xylem.phase.duration_ms":       "4500",
+	}
+	for key, value := range want {
+		if got[key] != value {
+			t.Fatalf("%s = %q, want %q", key, got[key], value)
+		}
+	}
+}
+
+func TestSmoke_S5_GateSpanAttributesFormatsBooleanAndIntAsStrings(t *testing.T) {
+	attrs := GateSpanAttributes("command", true, 2)
+	got := attrMap(attrs)
+
+	if len(attrs) != 3 {
+		t.Fatalf("expected 3 attributes, got %d", len(attrs))
+	}
+	if got["xylem.gate.type"] != "command" {
+		t.Fatalf("xylem.gate.type = %q, want %q", got["xylem.gate.type"], "command")
+	}
+	if got["xylem.gate.passed"] != "true" {
+		t.Fatalf("xylem.gate.passed = %q, want %q", got["xylem.gate.passed"], "true")
+	}
+	if got["xylem.gate.passed"] == "True" || got["xylem.gate.passed"] == "1" {
+		t.Fatalf("xylem.gate.passed should be lowercase bool string, got %q", got["xylem.gate.passed"])
+	}
+	if got["xylem.gate.retry_attempt"] != "2" {
+		t.Fatalf("xylem.gate.retry_attempt = %q, want %q", got["xylem.gate.retry_attempt"], "2")
+	}
+}
+
+func TestVesselSpanAttributesAllowsEmptyCoreFields(t *testing.T) {
+	attrs := VesselSpanAttributes("", "", "", "")
+	got := attrMap(attrs)
+
+	if len(attrs) != 3 {
+		t.Fatalf("expected 3 attributes, got %d", len(attrs))
+	}
+	if got["xylem.vessel.id"] != "" || got["xylem.vessel.source"] != "" || got["xylem.vessel.workflow"] != "" {
+		t.Fatalf("expected empty values to be preserved, got %#v", got)
+	}
+}
+
+func TestPhaseResultAttributesFormatsNegativeDuration(t *testing.T) {
+	attrs := PhaseResultAttributes(1, 2, 3.5, -1)
+	got := attrMap(attrs)
+
+	if got["xylem.phase.duration_ms"] != "-1" {
+		t.Fatalf("xylem.phase.duration_ms = %q, want %q", got["xylem.phase.duration_ms"], "-1")
+	}
+	if got["xylem.phase.cost_usd_est"] != "3.500000" {
+		t.Fatalf("xylem.phase.cost_usd_est = %q, want %q", got["xylem.phase.cost_usd_est"], "3.500000")
+	}
+}

--- a/cli/internal/observability/vessel_test.go
+++ b/cli/internal/observability/vessel_test.go
@@ -3,7 +3,12 @@ package observability
 import "testing"
 
 func TestSmoke_S1_VesselSpanAttributesIncludesIDSourceWorkflowRef(t *testing.T) {
-	attrs := VesselSpanAttributes("vessel-123", "github", "fix-bug", "refs/pull/42/head")
+	attrs := VesselSpanAttributes(VesselSpanData{
+		ID:       "vessel-123",
+		Source:   "github",
+		Workflow: "fix-bug",
+		Ref:      "refs/pull/42/head",
+	})
 	got := attrMap(attrs)
 
 	if len(attrs) != 4 {
@@ -24,7 +29,11 @@ func TestSmoke_S1_VesselSpanAttributesIncludesIDSourceWorkflowRef(t *testing.T) 
 }
 
 func TestSmoke_S2_VesselSpanAttributesOmitsEmptyRef(t *testing.T) {
-	attrs := VesselSpanAttributes("vessel-456", "manual", "implement-feature", "")
+	attrs := VesselSpanAttributes(VesselSpanData{
+		ID:       "vessel-456",
+		Source:   "manual",
+		Workflow: "implement-feature",
+	})
 	got := attrMap(attrs)
 
 	if len(attrs) != 3 {
@@ -36,7 +45,13 @@ func TestSmoke_S2_VesselSpanAttributesOmitsEmptyRef(t *testing.T) {
 }
 
 func TestSmoke_S3_PhaseSpanAttributesIncludesAllFive(t *testing.T) {
-	attrs := PhaseSpanAttributes("analyse", 0, "prompt", "anthropic", "claude-sonnet-4-20250514")
+	attrs := PhaseSpanAttributes(PhaseSpanData{
+		Name:     "analyse",
+		Index:    0,
+		Type:     "prompt",
+		Provider: "anthropic",
+		Model:    "claude-sonnet-4-20250514",
+	})
 	got := attrMap(attrs)
 
 	if len(attrs) != 5 {
@@ -58,7 +73,12 @@ func TestSmoke_S3_PhaseSpanAttributesIncludesAllFive(t *testing.T) {
 }
 
 func TestSmoke_S4_PhaseResultAttributesFormatsTokensAndCost(t *testing.T) {
-	attrs := PhaseResultAttributes(1200, 300, 0.0081, 4500)
+	attrs := PhaseResultAttributes(PhaseResultData{
+		InputTokensEst:  1200,
+		OutputTokensEst: 300,
+		CostUSDEst:      0.0081,
+		DurationMS:      4500,
+	})
 	got := attrMap(attrs)
 
 	if len(attrs) != 4 {
@@ -79,7 +99,11 @@ func TestSmoke_S4_PhaseResultAttributesFormatsTokensAndCost(t *testing.T) {
 }
 
 func TestSmoke_S5_GateSpanAttributesFormatsBooleanAndIntAsStrings(t *testing.T) {
-	attrs := GateSpanAttributes("command", true, 2)
+	attrs := GateSpanAttributes(GateSpanData{
+		Type:         "command",
+		Passed:       true,
+		RetryAttempt: 2,
+	})
 	got := attrMap(attrs)
 
 	if len(attrs) != 3 {
@@ -100,7 +124,7 @@ func TestSmoke_S5_GateSpanAttributesFormatsBooleanAndIntAsStrings(t *testing.T) 
 }
 
 func TestVesselSpanAttributesAllowsEmptyCoreFields(t *testing.T) {
-	attrs := VesselSpanAttributes("", "", "", "")
+	attrs := VesselSpanAttributes(VesselSpanData{})
 	got := attrMap(attrs)
 
 	if len(attrs) != 3 {
@@ -112,7 +136,12 @@ func TestVesselSpanAttributesAllowsEmptyCoreFields(t *testing.T) {
 }
 
 func TestPhaseResultAttributesFormatsNegativeDuration(t *testing.T) {
-	attrs := PhaseResultAttributes(1, 2, 3.5, -1)
+	attrs := PhaseResultAttributes(PhaseResultData{
+		InputTokensEst:  1,
+		OutputTokensEst: 2,
+		CostUSDEst:      3.5,
+		DurationMS:      -1,
+	})
 	got := attrMap(attrs)
 
 	if got["xylem.phase.duration_ms"] != "-1" {


### PR DESCRIPTION
## Summary
Implements vessel-level span attribute helpers from Section 5.3 of the harness spec for https://github.com/nicholls-inc/xylem/issues/81.

## Smoke scenarios covered
- S1: VesselSpanAttributes includes id, source, and workflow
- S2: VesselSpanAttributes omits ref when empty
- S3: PhaseSpanAttributes includes name, index, type, provider, and model
- S4: PhaseResultAttributes formats tokens and cost as strings
- S5: GateSpanAttributes formats boolean and int as strings

## Changes summary
- Added cli/internal/observability/vessel.go with VesselSpanAttributes, PhaseSpanAttributes, PhaseResultAttributes, and GateSpanAttributes
- Added cli/internal/observability/vessel_test.go with smoke tests S1-S5 plus edge coverage for empty vessel fields and negative durations
- Added cli/internal/observability/vessel_prop_test.go with property-based coverage for attribute counts, namespacing, deterministic output, lowercase keys, index stringification, and cost formatting
- Trimmed cli/internal/observability/observability_test.go back to the pre-existing signal, bridge, and tracer coverage

## Test plan
- cd cli && go vet ./...
- cd cli && go build ./cmd/xylem
- cd cli && go test ./...
