### PR TITLE
feat: add evidence package for claims and manifests

### DIFF
--- a/cli/internal/evidence/evidence.go
+++ b/cli/internal/evidence/evidence.go
@@ -5,10 +5,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"time"
 )
 
 const manifestFileName = "evidence-manifest.json"
+
+var safePathComponent = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 // Level describes the strength of a verification claim.
 type Level string
@@ -47,12 +51,41 @@ func (l Level) Rank() int {
 	}
 }
 
-// String returns the serialized level string, or "untyped" for the zero value.
+// String returns the human-readable serialized name for a level.
 func (l Level) String() string {
 	if l == Untyped {
 		return "untyped"
 	}
 	return string(l)
+}
+
+// MarshalText encodes a level for use in text-based formats and map keys.
+func (l Level) MarshalText() ([]byte, error) {
+	return []byte(l.String()), nil
+}
+
+// UnmarshalText decodes a level from its serialized text form.
+func (l *Level) UnmarshalText(text []byte) error {
+	level, err := parseLevel(string(text))
+	if err != nil {
+		return fmt.Errorf("unmarshal Level: %w", err)
+	}
+	*l = level
+	return nil
+}
+
+// MarshalJSON encodes a level using its serialized string form.
+func (l Level) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.String())
+}
+
+// UnmarshalJSON decodes a level from its serialized string form.
+func (l *Level) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("unmarshal Level: %w", err)
+	}
+	return l.UnmarshalText([]byte(s))
 }
 
 // Claim captures a single verification claim and its provenance metadata.
@@ -117,9 +150,65 @@ func (m *Manifest) StrongestLevel() Level {
 	return strongest
 }
 
+func parseLevel(s string) (Level, error) {
+	switch Level(s) {
+	case Untyped:
+		return Untyped, nil
+	case Proved:
+		return Proved, nil
+	case MechanicallyChecked:
+		return MechanicallyChecked, nil
+	case BehaviorallyChecked:
+		return BehaviorallyChecked, nil
+	case ObservedInSitu:
+		return ObservedInSitu, nil
+	case Level("untyped"):
+		return Untyped, nil
+	default:
+		return "", fmt.Errorf("invalid level %q", s)
+	}
+}
+
+func validatePathComponent(component string) error {
+	if component == "" {
+		return fmt.Errorf("path component must not be empty")
+	}
+	if strings.Contains(component, "..") {
+		return fmt.Errorf("path component must not contain %q", "..")
+	}
+	if !safePathComponent.MatchString(component) {
+		return fmt.Errorf("path component %q contains invalid characters (allowed: a-zA-Z0-9._-)", component)
+	}
+	return nil
+}
+
+func validateManifestClaims(manifest *Manifest) error {
+	for i, claim := range manifest.Claims {
+		if !claim.Level.Valid() {
+			return fmt.Errorf("claim %d has invalid level %q", i, claim.Level)
+		}
+	}
+	return nil
+}
+
 // SaveManifest writes a manifest to <stateDir>/phases/<vesselID>/evidence-manifest.json.
 func SaveManifest(stateDir, vesselID string, manifest *Manifest) error {
-	path := filepath.Join(stateDir, "phases", vesselID, manifestFileName)
+	if manifest == nil {
+		return fmt.Errorf("save manifest: manifest must not be nil")
+	}
+	if manifest.VesselID == "" {
+		manifest.VesselID = vesselID
+	} else if vesselID != "" && manifest.VesselID != vesselID {
+		return fmt.Errorf("save manifest: vessel ID mismatch: param %q manifest %q", vesselID, manifest.VesselID)
+	}
+	if err := validatePathComponent(manifest.VesselID); err != nil {
+		return fmt.Errorf("save manifest: invalid vessel ID: %w", err)
+	}
+	if err := validateManifestClaims(manifest); err != nil {
+		return fmt.Errorf("save manifest: %w", err)
+	}
+
+	path := filepath.Join(stateDir, "phases", manifest.VesselID, manifestFileName)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("save manifest: create dir: %w", err)
 	}
@@ -138,6 +227,10 @@ func SaveManifest(stateDir, vesselID string, manifest *Manifest) error {
 
 // LoadManifest reads a manifest from <stateDir>/phases/<vesselID>/evidence-manifest.json.
 func LoadManifest(stateDir, vesselID string) (*Manifest, error) {
+	if err := validatePathComponent(vesselID); err != nil {
+		return nil, fmt.Errorf("load manifest: invalid vessel ID: %w", err)
+	}
+
 	path := filepath.Join(stateDir, "phases", vesselID, manifestFileName)
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -148,5 +241,13 @@ func LoadManifest(stateDir, vesselID string) (*Manifest, error) {
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return nil, fmt.Errorf("load manifest: unmarshal: %w", err)
 	}
+	if manifest.VesselID != vesselID {
+		return nil, fmt.Errorf("load manifest: vessel ID mismatch: path %q manifest %q", vesselID, manifest.VesselID)
+	}
+	if err := validateManifestClaims(&manifest); err != nil {
+		return nil, fmt.Errorf("load manifest: %w", err)
+	}
+	manifest.BuildSummary()
+
 	return &manifest, nil
 }

--- a/cli/internal/evidence/evidence.go
+++ b/cli/internal/evidence/evidence.go
@@ -1,0 +1,152 @@
+package evidence
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const manifestFileName = "evidence-manifest.json"
+
+// Level describes the strength of a verification claim.
+type Level string
+
+const (
+	Proved              Level = "proved"
+	MechanicallyChecked Level = "mechanically_checked"
+	BehaviorallyChecked Level = "behaviorally_checked"
+	ObservedInSitu      Level = "observed_in_situ"
+	Untyped             Level = ""
+)
+
+// Valid reports whether l is one of the recognized evidence levels.
+func (l Level) Valid() bool {
+	switch l {
+	case Proved, MechanicallyChecked, BehaviorallyChecked, ObservedInSitu, Untyped:
+		return true
+	default:
+		return false
+	}
+}
+
+// Rank returns the strength ordering for an evidence level.
+func (l Level) Rank() int {
+	switch l {
+	case Proved:
+		return 4
+	case MechanicallyChecked:
+		return 3
+	case BehaviorallyChecked:
+		return 2
+	case ObservedInSitu:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// String returns the serialized level string, or "untyped" for the zero value.
+func (l Level) String() string {
+	if l == Untyped {
+		return "untyped"
+	}
+	return string(l)
+}
+
+// Claim captures a single verification claim and its provenance metadata.
+type Claim struct {
+	Claim         string    `json:"claim"`
+	Level         Level     `json:"level"`
+	Checker       string    `json:"checker,omitempty"`
+	TrustBoundary string    `json:"trust_boundary,omitempty"`
+	ArtifactPath  string    `json:"artifact_path,omitempty"`
+	Phase         string    `json:"phase,omitempty"`
+	Passed        bool      `json:"passed"`
+	Timestamp     time.Time `json:"timestamp"`
+}
+
+// Manifest records the evidence collected for a vessel execution.
+type Manifest struct {
+	VesselID  string          `json:"vessel_id"`
+	Workflow  string          `json:"workflow"`
+	Claims    []Claim         `json:"claims"`
+	CreatedAt time.Time       `json:"created_at"`
+	Summary   ManifestSummary `json:"summary"`
+}
+
+// ManifestSummary provides aggregate counts over a manifest's claims.
+type ManifestSummary struct {
+	Total   int           `json:"total"`
+	Passed  int           `json:"passed"`
+	Failed  int           `json:"failed"`
+	ByLevel map[Level]int `json:"by_level"`
+}
+
+// BuildSummary rebuilds the manifest summary from the claim list.
+func (m *Manifest) BuildSummary() {
+	summary := ManifestSummary{
+		ByLevel: make(map[Level]int),
+	}
+
+	for _, claim := range m.Claims {
+		summary.Total++
+		if claim.Passed {
+			summary.Passed++
+		} else {
+			summary.Failed++
+		}
+		summary.ByLevel[claim.Level]++
+	}
+
+	m.Summary = summary
+}
+
+// StrongestLevel returns the highest-ranked level among passing claims.
+func (m *Manifest) StrongestLevel() Level {
+	strongest := Untyped
+	for _, claim := range m.Claims {
+		if !claim.Passed {
+			continue
+		}
+		if claim.Level.Rank() > strongest.Rank() {
+			strongest = claim.Level
+		}
+	}
+	return strongest
+}
+
+// SaveManifest writes a manifest to <stateDir>/phases/<vesselID>/evidence-manifest.json.
+func SaveManifest(stateDir, vesselID string, manifest *Manifest) error {
+	path := filepath.Join(stateDir, "phases", vesselID, manifestFileName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("save manifest: create dir: %w", err)
+	}
+
+	manifest.BuildSummary()
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("save manifest: marshal: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("save manifest: write: %w", err)
+	}
+	return nil
+}
+
+// LoadManifest reads a manifest from <stateDir>/phases/<vesselID>/evidence-manifest.json.
+func LoadManifest(stateDir, vesselID string) (*Manifest, error) {
+	path := filepath.Join(stateDir, "phases", vesselID, manifestFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("load manifest: read: %w", err)
+	}
+
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("load manifest: unmarshal: %w", err)
+	}
+	return &manifest, nil
+}

--- a/cli/internal/evidence/evidence_prop_test.go
+++ b/cli/internal/evidence/evidence_prop_test.go
@@ -1,0 +1,247 @@
+package evidence
+
+import (
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+)
+
+func genLevel() *rapid.Generator[Level] {
+	return rapid.SampledFrom([]Level{
+		Proved,
+		MechanicallyChecked,
+		BehaviorallyChecked,
+		ObservedInSitu,
+		Untyped,
+	})
+}
+
+func genInvalidLevel() *rapid.Generator[Level] {
+	return rapid.Custom(func(t *rapid.T) Level {
+		for {
+			level := Level(rapid.StringMatching(`[A-Za-z][A-Za-z_-]{0,23}`).Draw(t, "invalid_level"))
+			if !level.Valid() {
+				return level
+			}
+		}
+	})
+}
+
+func genClaim() *rapid.Generator[Claim] {
+	return rapid.Custom(func(t *rapid.T) Claim {
+		return Claim{
+			Claim:         rapid.StringMatching(`[a-z]{3,20}( [a-z]{3,20}){0,3}`).Draw(t, "claim"),
+			Level:         genLevel().Draw(t, "level"),
+			Checker:       rapid.StringMatching(`[a-z]{2,12}([ ./-][a-z0-9]{1,12}){0,3}`).Draw(t, "checker"),
+			TrustBoundary: rapid.StringMatching(`[A-Za-z]{3,16}( [A-Za-z]{2,16}){0,4}`).Draw(t, "trust_boundary"),
+			ArtifactPath:  rapid.StringMatching(`[a-z]{2,12}(/[a-z]{2,12}){0,3}\.[a-z]{2,4}`).Draw(t, "artifact_path"),
+			Phase:         rapid.StringMatching(`[a-z][a-z0-9-]{1,15}`).Draw(t, "phase"),
+			Passed:        rapid.Bool().Draw(t, "passed"),
+			Timestamp: time.Unix(
+				int64(rapid.IntRange(0, 2_000_000_000).Draw(t, "timestamp_secs")),
+				int64(rapid.IntRange(0, 999_999_999).Draw(t, "timestamp_nanos")),
+			).UTC(),
+		}
+	})
+}
+
+func genManifest() *rapid.Generator[Manifest] {
+	return rapid.Custom(func(t *rapid.T) Manifest {
+		return Manifest{
+			VesselID:  rapid.StringMatching(`[a-z0-9][a-z0-9-]{1,15}`).Draw(t, "vessel_id"),
+			Workflow:  rapid.StringMatching(`[a-z][a-z-]{1,15}`).Draw(t, "workflow"),
+			Claims:    rapid.SliceOfN(genClaim(), 0, 50).Draw(t, "claims"),
+			CreatedAt: time.Unix(int64(rapid.IntRange(0, 2_000_000_000).Draw(t, "created_at_secs")), 0).UTC(),
+		}
+	})
+}
+
+func TestPropLevelValidAcceptsAllValid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		level := genLevel().Draw(t, "level")
+		if !level.Valid() {
+			t.Fatalf("Valid() = false for %q, want true", level)
+		}
+	})
+}
+
+func TestPropLevelValidRejectsInvalid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		level := genInvalidLevel().Draw(t, "level")
+		if level.Valid() {
+			t.Fatalf("Valid() = true for %q, want false", level)
+		}
+	})
+}
+
+func TestPropRankMatchesSpecification(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		a := genLevel().Draw(t, "a")
+		b := genLevel().Draw(t, "b")
+
+		if got := a.Rank(); got != expectedRank(a) {
+			t.Fatalf("%q.Rank() = %d, want %d", a, got, expectedRank(a))
+		}
+		if got := b.Rank(); got != expectedRank(b) {
+			t.Fatalf("%q.Rank() = %d, want %d", b, got, expectedRank(b))
+		}
+		if a != b && a.Rank() == b.Rank() {
+			t.Fatalf("distinct levels %q and %q should not share rank %d", a, b, a.Rank())
+		}
+	})
+}
+
+func TestPropBuildSummaryTotalEqualsPassedPlusFailed(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		manifest := genManifest().Draw(t, "manifest")
+		manifest.BuildSummary()
+
+		if manifest.Summary.Total != manifest.Summary.Passed+manifest.Summary.Failed {
+			t.Fatalf("Total = %d, want %d", manifest.Summary.Total, manifest.Summary.Passed+manifest.Summary.Failed)
+		}
+	})
+}
+
+func TestPropBuildSummaryByLevelSumsToTotal(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		manifest := genManifest().Draw(t, "manifest")
+		manifest.BuildSummary()
+
+		var total int
+		for _, count := range manifest.Summary.ByLevel {
+			total += count
+		}
+		if total != manifest.Summary.Total {
+			t.Fatalf("sum(ByLevel) = %d, want %d", total, manifest.Summary.Total)
+		}
+	})
+}
+
+func TestPropBuildSummaryIdempotent(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		manifest := genManifest().Draw(t, "manifest")
+		manifest.BuildSummary()
+		first := manifest.Summary
+		manifest.BuildSummary()
+
+		if !reflect.DeepEqual(manifest.Summary, first) {
+			t.Fatalf("BuildSummary() not idempotent: got %#v, want %#v", manifest.Summary, first)
+		}
+	})
+}
+
+func TestPropStrongestLevelNeverExceedsMaxPassing(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		manifest := genManifest().Draw(t, "manifest")
+
+		maxPassing := Untyped
+		foundPassing := false
+		for _, claim := range manifest.Claims {
+			if !claim.Passed {
+				continue
+			}
+			foundPassing = true
+			if claim.Level.Rank() > maxPassing.Rank() {
+				maxPassing = claim.Level
+			}
+		}
+
+		strongest := manifest.StrongestLevel()
+		if strongest.Rank() > maxPassing.Rank() {
+			t.Fatalf("StrongestLevel() rank = %d, max passing rank = %d", strongest.Rank(), maxPassing.Rank())
+		}
+		if foundPassing && strongest != maxPassing {
+			t.Fatalf("StrongestLevel() = %q, want %q", strongest, maxPassing)
+		}
+		if !foundPassing && strongest != Untyped {
+			t.Fatalf("StrongestLevel() = %q, want %q", strongest, Untyped)
+		}
+	})
+}
+
+func expectedRank(level Level) int {
+	switch level {
+	case Proved:
+		return 4
+	case MechanicallyChecked:
+		return 3
+	case BehaviorallyChecked:
+		return 2
+	case ObservedInSitu:
+		return 1
+	case Untyped:
+		return 0
+	default:
+		return -1
+	}
+}
+
+func TestPropSaveLoadRoundTrip(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		manifest := genManifest().Draw(t, "manifest")
+
+		stateDir, err := os.MkdirTemp("", "evidence-prop-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(stateDir)
+
+		if err := SaveManifest(stateDir, manifest.VesselID, &manifest); err != nil {
+			t.Fatalf("SaveManifest() error = %v", err)
+		}
+
+		loaded, err := LoadManifest(stateDir, manifest.VesselID)
+		if err != nil {
+			t.Fatalf("LoadManifest() error = %v", err)
+		}
+
+		if loaded.VesselID != manifest.VesselID {
+			t.Fatalf("VesselID = %q, want %q", loaded.VesselID, manifest.VesselID)
+		}
+		if loaded.Workflow != manifest.Workflow {
+			t.Fatalf("Workflow = %q, want %q", loaded.Workflow, manifest.Workflow)
+		}
+		if !loaded.CreatedAt.Equal(manifest.CreatedAt) {
+			t.Fatalf("CreatedAt = %s, want %s", loaded.CreatedAt, manifest.CreatedAt)
+		}
+		if len(loaded.Claims) != len(manifest.Claims) {
+			t.Fatalf("len(Claims) = %d, want %d", len(loaded.Claims), len(manifest.Claims))
+		}
+
+		for i := range loaded.Claims {
+			got := loaded.Claims[i]
+			want := manifest.Claims[i]
+			if got.Claim != want.Claim {
+				t.Fatalf("Claims[%d].Claim = %q, want %q", i, got.Claim, want.Claim)
+			}
+			if got.Level != want.Level {
+				t.Fatalf("Claims[%d].Level = %q, want %q", i, got.Level, want.Level)
+			}
+			if got.Checker != want.Checker {
+				t.Fatalf("Claims[%d].Checker = %q, want %q", i, got.Checker, want.Checker)
+			}
+			if got.TrustBoundary != want.TrustBoundary {
+				t.Fatalf("Claims[%d].TrustBoundary = %q, want %q", i, got.TrustBoundary, want.TrustBoundary)
+			}
+			if got.ArtifactPath != want.ArtifactPath {
+				t.Fatalf("Claims[%d].ArtifactPath = %q, want %q", i, got.ArtifactPath, want.ArtifactPath)
+			}
+			if got.Phase != want.Phase {
+				t.Fatalf("Claims[%d].Phase = %q, want %q", i, got.Phase, want.Phase)
+			}
+			if got.Passed != want.Passed {
+				t.Fatalf("Claims[%d].Passed = %t, want %t", i, got.Passed, want.Passed)
+			}
+			if !got.Timestamp.Equal(want.Timestamp) {
+				t.Fatalf("Claims[%d].Timestamp = %s, want %s", i, got.Timestamp, want.Timestamp)
+			}
+		}
+
+		if !reflect.DeepEqual(loaded.Summary, manifest.Summary) {
+			t.Fatalf("Summary = %#v, want %#v", loaded.Summary, manifest.Summary)
+		}
+	})
+}

--- a/cli/internal/evidence/evidence_test.go
+++ b/cli/internal/evidence/evidence_test.go
@@ -1,0 +1,357 @@
+package evidence
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestSmoke_S1_LevelValidAcceptsAllNamedLevelsIncludingUntyped(t *testing.T) {
+	t.Parallel()
+
+	levels := []Level{
+		Proved,
+		MechanicallyChecked,
+		BehaviorallyChecked,
+		ObservedInSitu,
+		Untyped,
+	}
+
+	for _, level := range levels {
+		level := level
+		t.Run(level.String(), func(t *testing.T) {
+			if !level.Valid() {
+				t.Fatalf("Valid() = false for %q, want true", level)
+			}
+		})
+	}
+}
+
+func TestSmoke_S2_LevelValidRejectsArbitraryStrings(t *testing.T) {
+	t.Parallel()
+
+	levels := []Level{
+		"high",
+		"none",
+		"PROVED",
+		"mechanically-checked",
+	}
+
+	for _, level := range levels {
+		level := level
+		t.Run(string(level), func(t *testing.T) {
+			if level.Valid() {
+				t.Fatalf("Valid() = true for %q, want false", level)
+			}
+		})
+	}
+}
+
+func TestSmoke_S3_LevelRankOrderingProvedIsStrongestUntypedIsWeakest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		level Level
+		want  int
+	}{
+		{level: Proved, want: 4},
+		{level: MechanicallyChecked, want: 3},
+		{level: BehaviorallyChecked, want: 2},
+		{level: ObservedInSitu, want: 1},
+		{level: Untyped, want: 0},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.level.String(), func(t *testing.T) {
+			if got := tt.level.Rank(); got != tt.want {
+				t.Fatalf("Rank() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+
+	if Proved.Rank() <= MechanicallyChecked.Rank() ||
+		MechanicallyChecked.Rank() <= BehaviorallyChecked.Rank() ||
+		BehaviorallyChecked.Rank() <= ObservedInSitu.Rank() ||
+		ObservedInSitu.Rank() <= Untyped.Rank() {
+		t.Fatal("rank ordering did not match expected descending strength")
+	}
+}
+
+func TestSmoke_S4_ManifestBuildSummaryCountsTotalPassedAndFailedClaims(t *testing.T) {
+	t.Parallel()
+
+	manifest := Manifest{
+		Claims: []Claim{
+			{Claim: "claim 1", Passed: true},
+			{Claim: "claim 2", Passed: true},
+			{Claim: "claim 3", Passed: false},
+		},
+	}
+
+	manifest.BuildSummary()
+
+	if manifest.Summary.Total != 3 {
+		t.Fatalf("Total = %d, want 3", manifest.Summary.Total)
+	}
+	if manifest.Summary.Passed != 2 {
+		t.Fatalf("Passed = %d, want 2", manifest.Summary.Passed)
+	}
+	if manifest.Summary.Failed != 1 {
+		t.Fatalf("Failed = %d, want 1", manifest.Summary.Failed)
+	}
+}
+
+func TestSmoke_S5_ManifestBuildSummaryGroupsClaimsByLevel(t *testing.T) {
+	t.Parallel()
+
+	manifest := Manifest{
+		Claims: []Claim{
+			{Claim: "claim 1", Level: BehaviorallyChecked, Passed: true},
+			{Claim: "claim 2", Level: BehaviorallyChecked, Passed: false},
+			{Claim: "claim 3", Level: MechanicallyChecked, Passed: true},
+			{Claim: "claim 4", Level: Untyped, Passed: true},
+		},
+	}
+
+	manifest.BuildSummary()
+
+	if got := manifest.Summary.ByLevel[BehaviorallyChecked]; got != 2 {
+		t.Fatalf("ByLevel[%q] = %d, want 2", BehaviorallyChecked, got)
+	}
+	if got := manifest.Summary.ByLevel[MechanicallyChecked]; got != 1 {
+		t.Fatalf("ByLevel[%q] = %d, want 1", MechanicallyChecked, got)
+	}
+	if got := manifest.Summary.ByLevel[Untyped]; got != 1 {
+		t.Fatalf("ByLevel[%q] = %d, want 1", Untyped, got)
+	}
+
+	if _, ok := manifest.Summary.ByLevel[Proved]; ok {
+		t.Fatalf("ByLevel[%q] should be absent", Proved)
+	}
+	if _, ok := manifest.Summary.ByLevel[ObservedInSitu]; ok {
+		t.Fatalf("ByLevel[%q] should be absent", ObservedInSitu)
+	}
+}
+
+func TestSmoke_S6_ManifestStrongestLevelReturnsHighestRankedPassingClaimLevel(t *testing.T) {
+	t.Parallel()
+
+	manifest := Manifest{
+		Claims: []Claim{
+			{Claim: "observed", Level: ObservedInSitu, Passed: true},
+			{Claim: "behavioral", Level: BehaviorallyChecked, Passed: true},
+			{Claim: "mechanical", Level: MechanicallyChecked, Passed: true},
+		},
+	}
+
+	if got := manifest.StrongestLevel(); got != MechanicallyChecked {
+		t.Fatalf("StrongestLevel() = %q, want %q", got, MechanicallyChecked)
+	}
+}
+
+func TestSmoke_S7_ManifestStrongestLevelReturnsUntypedWhenNoClaimsPassed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		manifest Manifest
+	}{
+		{
+			name: "all failed",
+			manifest: Manifest{
+				Claims: []Claim{
+					{Claim: "claim 1", Level: Proved, Passed: false},
+					{Claim: "claim 2", Level: MechanicallyChecked, Passed: false},
+				},
+			},
+		},
+		{
+			name:     "empty",
+			manifest: Manifest{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.manifest.StrongestLevel(); got != Untyped {
+				t.Fatalf("StrongestLevel() = %q, want %q", got, Untyped)
+			}
+		})
+	}
+}
+
+func TestSmoke_S8_SaveManifestWritesJSONToTheExpectedPath(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	manifest := &Manifest{
+		VesselID:  "vessel-abc123",
+		Workflow:  "fix-bug",
+		CreatedAt: time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC),
+		Claims: []Claim{
+			{
+				Claim:     "tests pass",
+				Level:     BehaviorallyChecked,
+				Passed:    true,
+				Timestamp: time.Date(2026, time.January, 1, 12, 1, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	if err := SaveManifest(stateDir, "vessel-abc123", manifest); err != nil {
+		t.Fatalf("SaveManifest() error = %v", err)
+	}
+
+	path := filepath.Join(stateDir, "phases", "vessel-abc123", "evidence-manifest.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal(raw) error = %v", err)
+	}
+	for _, key := range []string{"vessel_id", "claims", "summary"} {
+		_, ok := raw[key]
+		if !ok {
+			t.Fatalf("expected JSON key %q to be present", key)
+		}
+	}
+
+	var got Manifest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal(manifest) error = %v", err)
+	}
+	if got.VesselID != "vessel-abc123" {
+		t.Fatalf("VesselID = %q, want %q", got.VesselID, "vessel-abc123")
+	}
+}
+
+func TestSmoke_S9_SaveManifestCallsBuildSummaryBeforeWriting(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	manifest := &Manifest{
+		VesselID: "vessel-xyz",
+		Workflow: "fix-bug",
+		Claims: []Claim{
+			{Claim: "passed", Passed: true, Level: BehaviorallyChecked},
+			{Claim: "failed", Passed: false, Level: MechanicallyChecked},
+		},
+	}
+
+	if err := SaveManifest(stateDir, "vessel-xyz", manifest); err != nil {
+		t.Fatalf("SaveManifest() error = %v", err)
+	}
+
+	got, err := LoadManifest(stateDir, "vessel-xyz")
+	if err != nil {
+		t.Fatalf("LoadManifest() error = %v", err)
+	}
+
+	if got.Summary.Total != 2 {
+		t.Fatalf("Total = %d, want 2", got.Summary.Total)
+	}
+	if got.Summary.Passed != 1 {
+		t.Fatalf("Passed = %d, want 1", got.Summary.Passed)
+	}
+	if got.Summary.Failed != 1 {
+		t.Fatalf("Failed = %d, want 1", got.Summary.Failed)
+	}
+}
+
+func TestSmoke_S10_LoadManifestRoundTripsCorrectly(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	manifest := &Manifest{
+		VesselID:  "vessel-roundtrip",
+		Workflow:  "fix-bug",
+		CreatedAt: time.Date(2026, time.January, 2, 9, 30, 0, 0, time.UTC),
+		Claims: []Claim{
+			{
+				Claim:         "tests pass",
+				Level:         BehaviorallyChecked,
+				Checker:       "go test ./...",
+				TrustBoundary: "Package-level only",
+				ArtifactPath:  "cli/internal/evidence/evidence_test.go",
+				Phase:         "verify",
+				Passed:        true,
+				Timestamp:     time.Date(2026, time.January, 2, 9, 31, 0, 0, time.UTC),
+			},
+			{
+				Claim:         "binary builds",
+				Level:         MechanicallyChecked,
+				Checker:       "go build ./cmd/xylem",
+				TrustBoundary: "Build succeeds locally",
+				ArtifactPath:  "cli/cmd/xylem",
+				Phase:         "build",
+				Passed:        false,
+				Timestamp:     time.Date(2026, time.January, 2, 9, 32, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	if err := SaveManifest(stateDir, manifest.VesselID, manifest); err != nil {
+		t.Fatalf("SaveManifest() error = %v", err)
+	}
+
+	got, err := LoadManifest(stateDir, manifest.VesselID)
+	if err != nil {
+		t.Fatalf("LoadManifest() error = %v", err)
+	}
+
+	if got.VesselID != manifest.VesselID {
+		t.Fatalf("VesselID = %q, want %q", got.VesselID, manifest.VesselID)
+	}
+	if got.Workflow != manifest.Workflow {
+		t.Fatalf("Workflow = %q, want %q", got.Workflow, manifest.Workflow)
+	}
+	if !got.CreatedAt.Equal(manifest.CreatedAt) {
+		t.Fatalf("CreatedAt = %s, want %s", got.CreatedAt, manifest.CreatedAt)
+	}
+	if len(got.Claims) != len(manifest.Claims) {
+		t.Fatalf("len(Claims) = %d, want %d", len(got.Claims), len(manifest.Claims))
+	}
+
+	for i := range got.Claims {
+		assertClaimEqual(t, got.Claims[i], manifest.Claims[i])
+	}
+	if !reflect.DeepEqual(got.Summary, manifest.Summary) {
+		t.Fatalf("Summary = %#v, want %#v", got.Summary, manifest.Summary)
+	}
+}
+
+func assertClaimEqual(t *testing.T, got, want Claim) {
+	t.Helper()
+
+	if got.Claim != want.Claim {
+		t.Fatalf("Claim = %q, want %q", got.Claim, want.Claim)
+	}
+	if got.Level != want.Level {
+		t.Fatalf("Level = %q, want %q", got.Level, want.Level)
+	}
+	if got.Checker != want.Checker {
+		t.Fatalf("Checker = %q, want %q", got.Checker, want.Checker)
+	}
+	if got.TrustBoundary != want.TrustBoundary {
+		t.Fatalf("TrustBoundary = %q, want %q", got.TrustBoundary, want.TrustBoundary)
+	}
+	if got.ArtifactPath != want.ArtifactPath {
+		t.Fatalf("ArtifactPath = %q, want %q", got.ArtifactPath, want.ArtifactPath)
+	}
+	if got.Phase != want.Phase {
+		t.Fatalf("Phase = %q, want %q", got.Phase, want.Phase)
+	}
+	if got.Passed != want.Passed {
+		t.Fatalf("Passed = %t, want %t", got.Passed, want.Passed)
+	}
+	if !got.Timestamp.Equal(want.Timestamp) {
+		t.Fatalf("Timestamp = %s, want %s", got.Timestamp, want.Timestamp)
+	}
+}

--- a/cli/internal/evidence/evidence_test.go
+++ b/cli/internal/evidence/evidence_test.go
@@ -2,9 +2,11 @@ package evidence
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -206,7 +208,7 @@ func TestSmoke_S8_SaveManifestWritesJSONToTheExpectedPath(t *testing.T) {
 		t.Fatalf("SaveManifest() error = %v", err)
 	}
 
-	path := filepath.Join(stateDir, "phases", "vessel-abc123", "evidence-manifest.json")
+	path := filepath.Join(stateDir, "phases", "vessel-abc123", manifestFileName)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("ReadFile() error = %v", err)
@@ -229,6 +231,16 @@ func TestSmoke_S8_SaveManifestWritesJSONToTheExpectedPath(t *testing.T) {
 	}
 	if got.VesselID != "vessel-abc123" {
 		t.Fatalf("VesselID = %q, want %q", got.VesselID, "vessel-abc123")
+	}
+
+	var summary struct {
+		ByLevel map[string]int `json:"by_level"`
+	}
+	if err := json.Unmarshal(raw["summary"], &summary); err != nil {
+		t.Fatalf("Unmarshal(summary) error = %v", err)
+	}
+	if got := summary.ByLevel["behaviorally_checked"]; got != 1 {
+		t.Fatalf("summary.by_level[%q] = %d, want 1", "behaviorally_checked", got)
 	}
 }
 
@@ -324,6 +336,198 @@ func TestSmoke_S10_LoadManifestRoundTripsCorrectly(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.Summary, manifest.Summary) {
 		t.Fatalf("Summary = %#v, want %#v", got.Summary, manifest.Summary)
+	}
+}
+
+func TestSmoke_S11_SaveManifestUsesManifestVesselIDWhenParamIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	manifest := &Manifest{
+		VesselID: "vessel-from-manifest",
+		Claims: []Claim{
+			{Claim: "claim", Level: Untyped, Passed: true},
+		},
+	}
+
+	if err := SaveManifest(stateDir, "", manifest); err != nil {
+		t.Fatalf("SaveManifest() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(stateDir, "phases", manifest.VesselID, manifestFileName)); err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+}
+
+func TestSmoke_S12_SaveManifestRejectsMismatchedVesselIDs(t *testing.T) {
+	t.Parallel()
+
+	err := SaveManifest(t.TempDir(), "vessel-param", &Manifest{
+		VesselID: "vessel-manifest",
+		Claims: []Claim{
+			{Claim: "claim", Level: Proved, Passed: true},
+		},
+	})
+	if err == nil {
+		t.Fatal("SaveManifest() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "vessel ID mismatch") {
+		t.Fatalf("SaveManifest() error = %v, want vessel ID mismatch", err)
+	}
+}
+
+func TestSmoke_S13_SaveManifestRejectsUnsafeVesselID(t *testing.T) {
+	t.Parallel()
+
+	manifest := &Manifest{
+		VesselID: "../escape",
+		Claims: []Claim{
+			{Claim: "claim", Level: Proved, Passed: true},
+		},
+	}
+
+	err := SaveManifest(t.TempDir(), manifest.VesselID, manifest)
+	if err == nil {
+		t.Fatal("SaveManifest() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "invalid vessel ID") {
+		t.Fatalf("SaveManifest() error = %v, want invalid vessel ID", err)
+	}
+}
+
+func TestSmoke_S14_LoadManifestRebuildsStaleSummary(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	path := filepath.Join(stateDir, "phases", "vessel-stale", manifestFileName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	data := []byte(`{
+  "vessel_id": "vessel-stale",
+  "workflow": "fix-bug",
+  "claims": [
+    {
+      "claim": "claim",
+      "level": "proved",
+      "passed": true,
+      "timestamp": "2026-01-01T00:00:00Z"
+    },
+    {
+      "claim": "failed",
+      "level": "untyped",
+      "passed": false,
+      "timestamp": "2026-01-01T00:01:00Z"
+    }
+  ],
+  "created_at": "2026-01-01T00:00:00Z",
+  "summary": {
+    "total": 99,
+    "passed": 0,
+    "failed": 99,
+    "by_level": {
+      "behaviorally_checked": 99
+    }
+  }
+}`)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	manifest, err := LoadManifest(stateDir, "vessel-stale")
+	if err != nil {
+		t.Fatalf("LoadManifest() error = %v", err)
+	}
+
+	if manifest.Summary.Total != 2 || manifest.Summary.Passed != 1 || manifest.Summary.Failed != 1 {
+		t.Fatalf("Summary counts = %#v, want total=2 passed=1 failed=1", manifest.Summary)
+	}
+	if got := manifest.Summary.ByLevel[Proved]; got != 1 {
+		t.Fatalf("ByLevel[%q] = %d, want 1", Proved, got)
+	}
+	if got := manifest.Summary.ByLevel[Untyped]; got != 1 {
+		t.Fatalf("ByLevel[%q] = %d, want 1", Untyped, got)
+	}
+}
+
+func TestSmoke_S15_LoadManifestRejectsInvalidLevel(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	path := filepath.Join(stateDir, "phases", "vessel-invalid", manifestFileName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	data := []byte(`{
+  "vessel_id": "vessel-invalid",
+  "workflow": "fix-bug",
+  "claims": [
+    {
+      "claim": "claim",
+      "level": "totally-invalid",
+      "passed": true,
+      "timestamp": "2026-01-01T00:00:00Z"
+    }
+  ],
+  "created_at": "2026-01-01T00:00:00Z",
+  "summary": {
+    "total": 1,
+    "passed": 1,
+    "failed": 0,
+    "by_level": {
+      "totally-invalid": 1
+    }
+  }
+}`)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := LoadManifest(stateDir, "vessel-invalid")
+	if err == nil {
+		t.Fatal("LoadManifest() error = nil, want error")
+	}
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		t.Fatalf("LoadManifest() error = %v, want invalid level validation error", err)
+	}
+	if !strings.Contains(err.Error(), "invalid level") {
+		t.Fatalf("LoadManifest() error = %v, want invalid level", err)
+	}
+}
+
+func TestSmoke_S16_LevelJSONUsesSerializedNames(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(struct {
+		Level Level `json:"level"`
+	}{
+		Level: Untyped,
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if string(data) != `{"level":"untyped"}` {
+		t.Fatalf("Marshal() = %s, want %s", data, `{"level":"untyped"}`)
+	}
+
+	var decoded struct {
+		Level Level `json:"level"`
+	}
+	if err := json.Unmarshal([]byte(`{"level":"untyped"}`), &decoded); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if decoded.Level != Untyped {
+		t.Fatalf("Level = %q, want %q", decoded.Level, Untyped)
+	}
+
+	if err := json.Unmarshal([]byte(`{"level":""}`), &decoded); err != nil {
+		t.Fatalf("Unmarshal legacy empty level error = %v", err)
+	}
+	if decoded.Level != Untyped {
+		t.Fatalf("legacy Level = %q, want %q", decoded.Level, Untyped)
 	}
 }
 


### PR DESCRIPTION
## Summary
Implements the harness evidence package from [issue #79](https://github.com/nicholls-inc/xylem/issues/79).

## Smoke scenarios covered
- S1: Level valid accepts all named levels including untyped
- S2: Level valid rejects arbitrary strings
- S3: Level rank ordering proved > mechanically checked > behaviorally checked > observed in situ > untyped
- S4: BuildSummary counts total, passed, and failed claims
- S5: BuildSummary groups claims by level
- S6: StrongestLevel returns the highest-ranked passing claim
- S7: StrongestLevel returns untyped when no claims pass
- S8: SaveManifest writes JSON to the expected path
- S9: SaveManifest rebuilds summary before writing
- S10: LoadManifest round-trips persisted manifests

## Changes summary
- Added cli/internal/evidence/evidence.go with Level, Claim, Manifest, and ManifestSummary
- Added Valid, Rank, String, BuildSummary, StrongestLevel, SaveManifest, and LoadManifest
- Added smoke and property-based coverage in cli/internal/evidence/evidence_test.go and cli/internal/evidence/evidence_prop_test.go

## Test plan
- cd cli && go vet ./...
- cd cli && go build ./cmd/xylem
- cd cli && go test ./...
