### PR TITLE
feat: add harness config helpers and validation

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gofrs/flock v0.13.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
+	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.42.0
@@ -18,6 +19,7 @@ require (
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -26,6 +28,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -3,13 +3,25 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
+	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
 	"gopkg.in/yaml.v3"
 )
 
 const minTimeout = 30 * time.Second
+
+var DefaultProtectedSurfaces = []string{
+	".xylem/HARNESS.md",
+	".xylem.yml",
+	".xylem/workflows/*.yaml",
+	".xylem/prompts/*/*.md",
+}
+
+const DefaultAuditLogPath = "audit.jsonl"
 
 type Config struct {
 	Repo          string                  `yaml:"repo,omitempty"`
@@ -26,6 +38,9 @@ type Config struct {
 	Claude        ClaudeConfig            `yaml:"claude"`
 	Copilot       CopilotConfig           `yaml:"copilot,omitempty"`
 	Daemon        DaemonConfig            `yaml:"daemon,omitempty"`
+	Harness       HarnessConfig           `yaml:"harness,omitempty"`
+	Observability ObservabilityConfig     `yaml:"observability,omitempty"`
+	Cost          CostConfig              `yaml:"cost,omitempty"`
 }
 
 type SourceConfig struct {
@@ -79,6 +94,42 @@ type CopilotConfig struct {
 type DaemonConfig struct {
 	ScanInterval  string `yaml:"scan_interval,omitempty"`
 	DrainInterval string `yaml:"drain_interval,omitempty"`
+}
+
+type HarnessConfig struct {
+	ProtectedSurfaces ProtectedSurfacesConfig `yaml:"protected_surfaces,omitempty"`
+	Policy            PolicyConfig            `yaml:"policy,omitempty"`
+	AuditLog          string                  `yaml:"audit_log,omitempty"`
+}
+
+type ProtectedSurfacesConfig struct {
+	Paths []string `yaml:"paths,omitempty"`
+}
+
+type PolicyConfig struct {
+	Rules []PolicyRuleConfig `yaml:"rules,omitempty"`
+}
+
+type PolicyRuleConfig struct {
+	Action   string `yaml:"action"`
+	Resource string `yaml:"resource"`
+	Effect   string `yaml:"effect"`
+}
+
+type ObservabilityConfig struct {
+	Enabled    *bool   `yaml:"enabled,omitempty"`
+	Endpoint   string  `yaml:"endpoint,omitempty"`
+	Insecure   bool    `yaml:"insecure,omitempty"`
+	SampleRate float64 `yaml:"sample_rate,omitempty"`
+}
+
+type CostConfig struct {
+	Budget *BudgetConfig `yaml:"budget,omitempty"`
+}
+
+type BudgetConfig struct {
+	MaxCostUSD float64 `yaml:"max_cost_usd,omitempty"`
+	MaxTokens  int     `yaml:"max_tokens,omitempty"`
 }
 
 func Load(path string) (*Config, error) {
@@ -235,7 +286,92 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	if err := c.validateHarness(); err != nil {
+		return err
+	}
+	if err := c.validateObservability(); err != nil {
+		return err
+	}
+	if err := c.validateCost(); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (c *Config) EffectiveProtectedSurfaces() []string {
+	if len(c.Harness.ProtectedSurfaces.Paths) == 0 {
+		return DefaultProtectedSurfaces
+	}
+	if len(c.Harness.ProtectedSurfaces.Paths) == 1 && c.Harness.ProtectedSurfaces.Paths[0] == "none" {
+		return nil
+	}
+	return c.Harness.ProtectedSurfaces.Paths
+}
+
+func (c *Config) EffectiveAuditLogPath() string {
+	if c.Harness.AuditLog != "" {
+		return c.Harness.AuditLog
+	}
+	return DefaultAuditLogPath
+}
+
+func (c *Config) ObservabilityEnabled() bool {
+	if c.Observability.Enabled == nil {
+		return true
+	}
+	return *c.Observability.Enabled
+}
+
+func (c *Config) ObservabilitySampleRate() float64 {
+	if c.Observability.SampleRate <= 0 || c.Observability.SampleRate > 1.0 {
+		return 1.0
+	}
+	return c.Observability.SampleRate
+}
+
+func (c *Config) VesselBudget() *cost.Budget {
+	if c.Cost.Budget == nil {
+		return nil
+	}
+	b := c.Cost.Budget
+	if b.MaxCostUSD <= 0 && b.MaxTokens <= 0 {
+		return nil
+	}
+	return &cost.Budget{
+		TokenLimit:   b.MaxTokens,
+		CostLimitUSD: b.MaxCostUSD,
+	}
+}
+
+func (c *Config) BuildIntermediaryPolicies() []intermediary.Policy {
+	if len(c.Harness.Policy.Rules) == 0 {
+		return []intermediary.Policy{DefaultPolicy()}
+	}
+	rules := make([]intermediary.Rule, len(c.Harness.Policy.Rules))
+	for i, r := range c.Harness.Policy.Rules {
+		rules[i] = intermediary.Rule{
+			Action:   r.Action,
+			Resource: r.Resource,
+			Effect:   intermediary.Effect(r.Effect),
+		}
+	}
+	return []intermediary.Policy{{Name: "user", Rules: rules}}
+}
+
+func DefaultPolicy() intermediary.Policy {
+	return intermediary.Policy{
+		Name: "default",
+		Rules: []intermediary.Rule{
+			{Action: "file_write", Resource: ".xylem/HARNESS.md", Effect: intermediary.Deny},
+			{Action: "file_write", Resource: ".xylem.yml", Effect: intermediary.Deny},
+			{Action: "file_write", Resource: ".xylem/workflows/*", Effect: intermediary.Deny},
+			{Action: "file_write", Resource: ".xylem/prompts/*", Effect: intermediary.Deny},
+			{Action: "git_push", Resource: "*", Effect: intermediary.RequireApproval},
+			{Action: "pr_create", Resource: "*", Effect: intermediary.RequireApproval},
+			{Action: "*", Resource: "*", Effect: intermediary.Allow},
+		},
+	}
 }
 
 // CleanupAfterDuration returns the parsed cleanup_after duration, defaulting to
@@ -249,6 +385,52 @@ func (c *Config) CleanupAfterDuration() time.Duration {
 		return 168 * time.Hour
 	}
 	return d
+}
+
+func (c *Config) validateHarness() error {
+	for _, pattern := range c.Harness.ProtectedSurfaces.Paths {
+		if pattern == "none" {
+			continue
+		}
+		if _, err := filepath.Match(pattern, "test"); err != nil {
+			return fmt.Errorf("harness.protected_surfaces.paths: invalid glob %q: %w", pattern, err)
+		}
+	}
+	for i, rule := range c.Harness.Policy.Rules {
+		if rule.Action == "" {
+			return fmt.Errorf("harness.policy.rules[%d]: action is required", i)
+		}
+		if rule.Resource == "" {
+			return fmt.Errorf("harness.policy.rules[%d]: resource is required", i)
+		}
+		switch intermediary.Effect(rule.Effect) {
+		case intermediary.Allow, intermediary.Deny, intermediary.RequireApproval:
+		default:
+			return fmt.Errorf("harness.policy.rules[%d]: invalid effect %q (must be allow, deny, or require_approval)", i, rule.Effect)
+		}
+	}
+	return nil
+}
+
+func (c *Config) validateObservability() error {
+	if c.Observability.SampleRate != 0 {
+		if c.Observability.SampleRate < 0 || c.Observability.SampleRate > 1.0 {
+			return fmt.Errorf("observability.sample_rate must be in [0.0, 1.0]")
+		}
+	}
+	return nil
+}
+
+func (c *Config) validateCost() error {
+	if c.Cost.Budget != nil {
+		if c.Cost.Budget.MaxCostUSD < 0 {
+			return fmt.Errorf("cost.budget.max_cost_usd must be non-negative")
+		}
+		if c.Cost.Budget.MaxTokens < 0 {
+			return fmt.Errorf("cost.budget.max_tokens must be non-negative")
+		}
+	}
+	return nil
 }
 
 func validateGitHubSource(name string, src SourceConfig) error {

--- a/cli/internal/config/config_prop_test.go
+++ b/cli/internal/config/config_prop_test.go
@@ -1,0 +1,158 @@
+package config
+
+import (
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+	"pgregory.net/rapid"
+)
+
+func protectedSurfacePathGen() *rapid.Generator[string] {
+	return rapid.SampledFrom([]string{
+		".xylem/HARNESS.md",
+		".xylem.yml",
+		".xylem/workflows/*.yaml",
+		".xylem/prompts/*/*.md",
+		"docs/*.md",
+		"configs/*.yml",
+	})
+}
+
+func policyRuleConfigGen() *rapid.Generator[PolicyRuleConfig] {
+	effects := []string{string(intermediary.Allow), string(intermediary.Deny), string(intermediary.RequireApproval)}
+
+	return rapid.Custom(func(t *rapid.T) PolicyRuleConfig {
+		return PolicyRuleConfig{
+			Action:   rapid.SampledFrom([]string{"file_write", "git_push", "phase_execute", "*"}).Draw(t, "action"),
+			Resource: rapid.SampledFrom([]string{".xylem/HARNESS.md", ".xylem.yml", "*", "main", "lint"}).Draw(t, "resource"),
+			Effect:   rapid.SampledFrom(effects).Draw(t, "effect"),
+		}
+	})
+}
+
+func TestPropEffectiveProtectedSurfacesIdempotent(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := &Config{
+			Harness: HarnessConfig{
+				ProtectedSurfaces: ProtectedSurfacesConfig{
+					Paths: rapid.SliceOf(protectedSurfacePathGen()).Draw(t, "paths"),
+				},
+			},
+		}
+
+		first := cfg.EffectiveProtectedSurfaces()
+		second := cfg.EffectiveProtectedSurfaces()
+		if !reflect.DeepEqual(first, second) {
+			t.Fatalf("EffectiveProtectedSurfaces not idempotent: first=%v second=%v", first, second)
+		}
+	})
+}
+
+func TestPropEffectiveProtectedSurfacesNoneIsNil(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := &Config{
+			Harness: HarnessConfig{
+				ProtectedSurfaces: ProtectedSurfacesConfig{Paths: []string{"none"}},
+			},
+		}
+
+		if got := cfg.EffectiveProtectedSurfaces(); got != nil {
+			t.Fatalf("EffectiveProtectedSurfaces() = %v, want nil", got)
+		}
+	})
+}
+
+func TestPropObservabilitySampleRateInRange(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := &Config{
+			Concurrency: 1,
+			MaxTurns:    1,
+			Timeout:     "30s",
+			Claude:      ClaudeConfig{Command: "claude"},
+			Observability: ObservabilityConfig{
+				SampleRate: rapid.Float64Range(0.0, 1.0).Draw(t, "sampleRate"),
+			},
+		}
+
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("Validate() returned error: %v", err)
+		}
+
+		got := cfg.ObservabilitySampleRate()
+		if got <= 0.0 || got > 1.0 {
+			t.Fatalf("ObservabilitySampleRate() = %f, want in (0.0, 1.0]", got)
+		}
+	})
+}
+
+func TestPropVesselBudgetNilWhenNoLimits(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := &Config{
+			Cost: CostConfig{
+				Budget: &BudgetConfig{
+					MaxCostUSD: rapid.Float64Range(-100.0, 0.0).Draw(t, "maxCostUSD"),
+					MaxTokens:  rapid.IntRange(-1000000, 0).Draw(t, "maxTokens"),
+				},
+			},
+		}
+
+		if got := cfg.VesselBudget(); got != nil {
+			t.Fatalf("VesselBudget() = %#v, want nil", got)
+		}
+	})
+}
+
+func TestPropBuildIntermediaryPoliciesNonEmpty(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := &Config{}
+		if rapid.Bool().Draw(t, "hasRules") {
+			cfg.Harness.Policy.Rules = rapid.SliceOfN(policyRuleConfigGen(), 1, 5).Draw(t, "rules")
+		}
+
+		policies := cfg.BuildIntermediaryPolicies()
+		if len(policies) == 0 {
+			t.Fatal("BuildIntermediaryPolicies() returned no policies")
+		}
+		for i, policy := range policies {
+			if len(policy.Rules) == 0 {
+				t.Fatalf("BuildIntermediaryPolicies()[%d] has no rules", i)
+			}
+		}
+	})
+}
+
+func TestPropDefaultPolicyLastRuleIsAllowAll(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		policy := DefaultPolicy()
+		if len(policy.Rules) == 0 {
+			t.Fatal("DefaultPolicy() returned no rules")
+		}
+		last := policy.Rules[len(policy.Rules)-1]
+		if last.Action != "*" || last.Resource != "*" || last.Effect != intermediary.Allow {
+			t.Fatalf("last rule = %+v, want allow-all", last)
+		}
+	})
+}
+
+func TestPropValidateRejectsOutOfRangeSampleRate(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		rate := rapid.Custom(func(t *rapid.T) float64 {
+			if rapid.Bool().Draw(t, "negative") {
+				return rapid.Float64Range(-1000, -math.SmallestNonzeroFloat64).Draw(t, "negativeRate")
+			}
+			return 1 + rapid.Float64Range(0.125, 1000).Draw(t, "overflowRate")
+		}).Draw(t, "sampleRate")
+
+		cfg := &Config{
+			Observability: ObservabilityConfig{
+				SampleRate: rate,
+			},
+		}
+
+		if err := cfg.validateObservability(); err == nil {
+			t.Fatalf("validateObservability() succeeded for out-of-range sample rate %f", rate)
+		}
+	})
+}

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -3,8 +3,13 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func writeConfigFile(t *testing.T, yaml string) string {
@@ -991,4 +996,333 @@ func TestValidateUnknownSourceType(t *testing.T) {
 	}
 	err := cfg.Validate()
 	requireErrorContains(t, err, "unknown type")
+}
+
+func TestSmoke_S1_FullConfigLoadsWithHarnessSection(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+harness:
+  audit_log: ".xylem/audit.jsonl"
+  protected_surfaces:
+    paths:
+      - ".xylem/HARNESS.md"
+      - ".xylem.yml"
+      - ".xylem/workflows/*.yaml"
+      - ".xylem/prompts/*/*.md"
+  policy:
+    rules:
+      - action: "file_write"
+        resource: ".xylem/*"
+        effect: "deny"
+      - action: "git_push"
+        resource: "*"
+        effect: "require_approval"
+      - action: "pr_create"
+        resource: "*"
+        effect: "require_approval"
+      - action: "*"
+        resource: "*"
+        effect: "allow"
+observability:
+  enabled: true
+  endpoint: "localhost:4317"
+  insecure: true
+  sample_rate: 1.0
+cost:
+  budget:
+    max_cost_usd: 10.0
+    max_tokens: 1000000
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.NotNil(t, cfg.Observability.Enabled)
+	require.NotNil(t, cfg.Cost.Budget)
+
+	assert.Equal(t, ".xylem/audit.jsonl", cfg.Harness.AuditLog)
+	assert.Len(t, cfg.Harness.ProtectedSurfaces.Paths, 4)
+	assert.Len(t, cfg.Harness.Policy.Rules, 4)
+	assert.True(t, *cfg.Observability.Enabled)
+	assert.Equal(t, 1.0, cfg.Observability.SampleRate)
+	assert.Equal(t, 10.0, cfg.Cost.Budget.MaxCostUSD)
+	assert.Equal(t, 1000000, cfg.Cost.Budget.MaxTokens)
+}
+
+func TestSmoke_S2_DefaultsActivateWhenHarnessSectionAbsent(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.True(t, reflect.DeepEqual(cfg.EffectiveProtectedSurfaces(), DefaultProtectedSurfaces))
+	assert.Equal(t, DefaultAuditLogPath, cfg.EffectiveAuditLogPath())
+	assert.True(t, cfg.ObservabilityEnabled())
+	assert.Equal(t, 1.0, cfg.ObservabilitySampleRate())
+	assert.Nil(t, cfg.VesselBudget())
+
+	policies := cfg.BuildIntermediaryPolicies()
+	require.Len(t, policies, 1)
+	assert.Equal(t, "default", policies[0].Name)
+}
+
+func TestSmoke_S3_PathsNoneDisablesSurfaceProtection(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+harness:
+  protected_surfaces:
+    paths: ["none"]
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Nil(t, cfg.EffectiveProtectedSurfaces())
+}
+
+func TestSmoke_S4_InvalidGlobPatternRejected(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+harness:
+  protected_surfaces:
+    paths:
+      - "[invalid-glob"
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "harness.protected_surfaces.paths")
+	assert.Contains(t, err.Error(), "invalid glob")
+	assert.Contains(t, err.Error(), "[invalid-glob")
+}
+
+func TestSmoke_S5_UnknownPolicyEffectRejected(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+harness:
+  policy:
+    rules:
+      - action: "file_write"
+        resource: "*"
+        effect: "approve_maybe"
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "harness.policy.rules[0]")
+	assert.Contains(t, err.Error(), "invalid effect")
+	assert.Contains(t, err.Error(), "approve_maybe")
+}
+
+func TestSmoke_S6_DefaultPolicyDeniesFileWriteToHarness(t *testing.T) {
+	cfg := &Config{}
+	inter := intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), nil, nil)
+
+	result := inter.Evaluate(intermediary.Intent{
+		Action:   "file_write",
+		Resource: ".xylem/HARNESS.md",
+		AgentID:  "vessel-001",
+	})
+
+	require.NotNil(t, result.MatchedRule)
+	assert.Equal(t, intermediary.Deny, result.Effect)
+	assert.Equal(t, "file_write", result.MatchedRule.Action)
+	assert.Equal(t, ".xylem/HARNESS.md", result.MatchedRule.Resource)
+}
+
+func TestSmoke_S7_DefaultPolicyRequiresApprovalForGitPush(t *testing.T) {
+	cfg := &Config{}
+	inter := intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), nil, nil)
+
+	result := inter.Evaluate(intermediary.Intent{
+		Action:   "git_push",
+		Resource: "main",
+		AgentID:  "vessel-002",
+	})
+
+	assert.Equal(t, intermediary.RequireApproval, result.Effect)
+}
+
+func TestSmoke_S8_DefaultPolicyAllowsPhaseExecute(t *testing.T) {
+	cfg := &Config{}
+	inter := intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), nil, nil)
+
+	result := inter.Evaluate(intermediary.Intent{
+		Action:   "phase_execute",
+		Resource: "lint",
+		AgentID:  "vessel-003",
+	})
+
+	require.NotNil(t, result.MatchedRule)
+	assert.Equal(t, intermediary.Allow, result.Effect)
+	assert.Equal(t, "*", result.MatchedRule.Action)
+	assert.Equal(t, "*", result.MatchedRule.Resource)
+}
+
+func TestSmoke_S29_ObservabilityDefaultsWhenAbsent(t *testing.T) {
+	cfg := &Config{}
+
+	assert.True(t, cfg.ObservabilityEnabled())
+	assert.Equal(t, 1.0, cfg.ObservabilitySampleRate())
+}
+
+func TestSmoke_S30_CostBudgetLoadsCorrectly(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+cost:
+  budget:
+    max_cost_usd: 5.0
+    max_tokens: 500000
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	budget := cfg.VesselBudget()
+	require.NotNil(t, budget)
+	assert.Equal(t, 5.0, budget.CostLimitUSD)
+	assert.Equal(t, 500000, budget.TokenLimit)
+}
+
+func TestSmoke_S31_NegativeSampleRateRejected(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+observability:
+  sample_rate: -0.5
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "observability.sample_rate")
+}
+
+func TestSmoke_S32_NegativeMaxCostRejected(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+cost:
+  budget:
+    max_cost_usd: -1.0
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cost.budget.max_cost_usd")
+}
+
+func TestValidateHarnessPolicyRuleMissingAction(t *testing.T) {
+	cfg := validConfig()
+	cfg.Harness.Policy.Rules = []PolicyRuleConfig{
+		{Resource: "*", Effect: string(intermediary.Allow)},
+	}
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, "harness.policy.rules[0]: action is required")
+}
+
+func TestValidateCostNegativeMaxTokens(t *testing.T) {
+	cfg := validConfig()
+	cfg.Cost.Budget = &BudgetConfig{MaxTokens: -1}
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, "cost.budget.max_tokens")
+}
+
+func TestValidateObservabilitySampleRateAboveOneRejected(t *testing.T) {
+	cfg := validConfig()
+	cfg.Observability.SampleRate = 1.5
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, "observability.sample_rate")
 }


### PR DESCRIPTION
## Summary
Implements https://github.com/nicholls-inc/xylem/issues/77 by adding harness, observability, and cost config types plus helper/default/validation logic in `cli/internal/config`.

## Smoke scenarios covered
- S1 — Full config loads with harness section
- S2 — Defaults activate when harness section absent
- S3 — `paths: ["none"]` disables surface protection
- S4 — Invalid glob pattern rejected
- S5 — Unknown policy effect rejected
- S6 — Default policy denies file write to harness
- S7 — Default policy requires approval for git push
- S8 — Default policy allows phase execute
- S29 — Observability defaults when absent
- S30 — Cost budget loads correctly
- S31 — Negative sample rate rejected
- S32 — Negative max cost rejected

## Changes summary
- Modified `cli/internal/config/config.go`
  - Added `HarnessConfig`, `ProtectedSurfacesConfig`, `PolicyConfig`, `PolicyRuleConfig`, `ObservabilityConfig`, `CostConfig`, and `BudgetConfig`
  - Added `Config.Harness`, `Config.Observability`, and `Config.Cost`
  - Added `DefaultProtectedSurfaces`, `DefaultAuditLogPath`, `EffectiveProtectedSurfaces`, `EffectiveAuditLogPath`, `ObservabilityEnabled`, `ObservabilitySampleRate`, `VesselBudget`, `BuildIntermediaryPolicies`, `DefaultPolicy`, and harness/observability/cost validation helpers
- Modified `cli/internal/config/config_test.go`
  - Added smoke tests for S1-S8 and S29-S32 plus targeted validation tests for invalid policy/cost/observability values
- Added `cli/internal/config/config_prop_test.go`
  - Added property-based tests covering protected surface behavior, sample-rate validation, budget nil semantics, and intermediary policy defaults
- Modified `cli/go.mod`
  - Added `testify` requirement used by the expanded config test suite

## Test plan
- `cd cli && go test ./internal/config -run 'TestSmoke_|TestProp|TestValidateHarnessPolicyRuleMissingAction|TestValidateCostNegativeMaxTokens|TestValidateObservabilitySampleRateAboveOneRejected'`
- `cd cli && go test ./internal/config`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`
