### PR TITLE
feat: add SHA256 surface integrity package

### DIFF
--- a/cli/internal/surface/surface.go
+++ b/cli/internal/surface/surface.go
@@ -3,11 +3,13 @@ package surface
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 type FileHash struct {
@@ -25,20 +27,29 @@ type Violation struct {
 	After  string `json:"after"`  // hex hash, or "deleted"
 }
 
+var errSymlinkNotSupported = errors.New("symlinks are not supported")
+
 func TakeSnapshot(worktreeRoot string, patterns []string) (Snapshot, error) {
 	seen := make(map[string]struct{})
 	files := make([]FileHash, 0)
 
 	for _, pattern := range patterns {
+		if err := validatePattern(pattern); err != nil {
+			return Snapshot{}, fmt.Errorf("validate pattern %q: %w", pattern, err)
+		}
+
 		matches, err := filepath.Glob(filepath.Join(worktreeRoot, pattern))
 		if err != nil {
-			continue
+			return Snapshot{}, fmt.Errorf("glob pattern %q: %w", pattern, err)
 		}
 
 		for _, match := range matches {
-			info, err := os.Stat(match)
+			info, err := os.Lstat(match)
 			if err != nil {
-				return Snapshot{}, fmt.Errorf("stat %q: %w", match, err)
+				return Snapshot{}, fmt.Errorf("lstat %q: %w", match, err)
+			}
+			if info.Mode()&os.ModeSymlink != 0 {
+				return Snapshot{}, fmt.Errorf("lstat %q: %w", match, errSymlinkNotSupported)
 			}
 			if info.IsDir() {
 				continue
@@ -47,6 +58,9 @@ func TakeSnapshot(worktreeRoot string, patterns []string) (Snapshot, error) {
 			relPath, err := filepath.Rel(worktreeRoot, match)
 			if err != nil {
 				return Snapshot{}, fmt.Errorf("relative path for %q: %w", match, err)
+			}
+			if !isPathWithinRoot(relPath) {
+				return Snapshot{}, fmt.Errorf("relative path for %q escapes worktree root: %q", match, relPath)
 			}
 
 			relPath = filepath.ToSlash(relPath)
@@ -72,6 +86,24 @@ func TakeSnapshot(worktreeRoot string, patterns []string) (Snapshot, error) {
 	})
 
 	return Snapshot{Files: files}, nil
+}
+
+func validatePattern(pattern string) error {
+	if filepath.IsAbs(pattern) {
+		return fmt.Errorf("pattern must be relative")
+	}
+	if !isPathWithinRoot(pattern) {
+		return fmt.Errorf("pattern must stay within worktree root")
+	}
+
+	return nil
+}
+
+func isPathWithinRoot(path string) bool {
+	cleaned := filepath.Clean(path)
+	parentPrefix := ".." + string(filepath.Separator)
+
+	return cleaned != ".." && !strings.HasPrefix(cleaned, parentPrefix)
 }
 
 func Compare(before, after Snapshot) []Violation {

--- a/cli/internal/surface/surface.go
+++ b/cli/internal/surface/surface.go
@@ -1,0 +1,139 @@
+package surface
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+type FileHash struct {
+	Path string `json:"path"` // relative to worktree root
+	Hash string `json:"hash"` // hex-encoded SHA256
+}
+
+type Snapshot struct {
+	Files []FileHash `json:"files"`
+}
+
+type Violation struct {
+	Path   string `json:"path"`
+	Before string `json:"before"` // hex hash, or "absent"
+	After  string `json:"after"`  // hex hash, or "deleted"
+}
+
+func TakeSnapshot(worktreeRoot string, patterns []string) (Snapshot, error) {
+	seen := make(map[string]struct{})
+	files := make([]FileHash, 0)
+
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(filepath.Join(worktreeRoot, pattern))
+		if err != nil {
+			continue
+		}
+
+		for _, match := range matches {
+			info, err := os.Stat(match)
+			if err != nil {
+				return Snapshot{}, fmt.Errorf("stat %q: %w", match, err)
+			}
+			if info.IsDir() {
+				continue
+			}
+
+			relPath, err := filepath.Rel(worktreeRoot, match)
+			if err != nil {
+				return Snapshot{}, fmt.Errorf("relative path for %q: %w", match, err)
+			}
+
+			relPath = filepath.ToSlash(relPath)
+			if _, ok := seen[relPath]; ok {
+				continue
+			}
+
+			hash, err := hashFile(match)
+			if err != nil {
+				return Snapshot{}, fmt.Errorf("hash file %q: %w", match, err)
+			}
+
+			seen[relPath] = struct{}{}
+			files = append(files, FileHash{
+				Path: relPath,
+				Hash: hash,
+			})
+		}
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+
+	return Snapshot{Files: files}, nil
+}
+
+func Compare(before, after Snapshot) []Violation {
+	beforeByPath := make(map[string]string, len(before.Files))
+	for _, file := range before.Files {
+		beforeByPath[file.Path] = file.Hash
+	}
+
+	afterByPath := make(map[string]string, len(after.Files))
+	for _, file := range after.Files {
+		afterByPath[file.Path] = file.Hash
+	}
+
+	violations := make([]Violation, 0)
+	for path, beforeHash := range beforeByPath {
+		afterHash, ok := afterByPath[path]
+		if !ok {
+			violations = append(violations, Violation{
+				Path:   path,
+				Before: beforeHash,
+				After:  "deleted",
+			})
+			continue
+		}
+		if beforeHash != afterHash {
+			violations = append(violations, Violation{
+				Path:   path,
+				Before: beforeHash,
+				After:  afterHash,
+			})
+		}
+	}
+
+	for path, afterHash := range afterByPath {
+		if _, ok := beforeByPath[path]; ok {
+			continue
+		}
+		violations = append(violations, Violation{
+			Path:   path,
+			Before: "absent",
+			After:  afterHash,
+		})
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		return violations[i].Path < violations[j].Path
+	})
+
+	return violations
+}
+
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open file: %w", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("hash contents: %w", err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/cli/internal/surface/surface_prop_test.go
+++ b/cli/internal/surface/surface_prop_test.go
@@ -1,0 +1,248 @@
+package surface
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+var knownPaths = []string{
+	".xylem.yml",
+	".xylem/HARNESS.md",
+	".xylem/workflows/fix-bug.yaml",
+	".xylem/workflows/implement-feature.yaml",
+	"docs/ignored.txt",
+	"src/main.go",
+}
+
+var knownPatterns = []string{
+	".xylem.yml",
+	".xylem/HARNESS.md",
+	".xylem/workflows/*.yaml",
+	".xylem/*",
+	"docs/*",
+	"src/*",
+}
+
+func genFileHash(t *rapid.T) FileHash {
+	return FileHash{
+		Path: rapid.StringMatching(`[a-z0-9./_-]{1,32}`).Draw(t, "path"),
+		Hash: rapid.StringMatching(`[0-9a-f]{64}`).Draw(t, "hash"),
+	}
+}
+
+func genSnapshot(t *rapid.T) Snapshot {
+	count := rapid.IntRange(0, 10).Draw(t, "count")
+	byPath := make(map[string]FileHash, count)
+	for range count {
+		fh := genFileHash(t)
+		byPath[fh.Path] = fh
+	}
+
+	files := make([]FileHash, 0, len(byPath))
+	for _, fh := range byPath {
+		files = append(files, fh)
+	}
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+
+	return Snapshot{Files: files}
+}
+
+func genFileContent(t *rapid.T) string {
+	return rapid.StringMatching(`[ -~]{0,64}`).Draw(t, "content")
+}
+
+func genFilesystemFixture(t *rapid.T) (map[string]string, []string) {
+	files := make(map[string]string)
+	for _, path := range knownPaths {
+		if rapid.Bool().Draw(t, "includeFile"+path) {
+			files[path] = genFileContent(t)
+		}
+	}
+
+	patterns := make([]string, 0, len(knownPatterns))
+	for _, pattern := range knownPatterns {
+		if rapid.Bool().Draw(t, "includePattern"+pattern) {
+			patterns = append(patterns, pattern)
+		}
+	}
+
+	return files, patterns
+}
+
+func TestProp_TakeSnapshotAlwaysSorted(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		dir, err := os.MkdirTemp("", "surface-prop-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(dir)
+
+		files, patterns := genFilesystemFixture(t)
+		for relPath, content := range files {
+			if err := writeFileAt(dir, relPath, content); err != nil {
+				t.Fatalf("writeFileAt() error = %v", err)
+			}
+		}
+
+		snap, err := TakeSnapshot(dir, patterns)
+		if err != nil {
+			t.Fatalf("TakeSnapshot() error = %v", err)
+		}
+
+		for i := 1; i < len(snap.Files); i++ {
+			if snap.Files[i-1].Path > snap.Files[i].Path {
+				t.Fatalf("files not sorted: %q before %q", snap.Files[i-1].Path, snap.Files[i].Path)
+			}
+		}
+	})
+}
+
+func TestProp_TakeSnapshotDeterministic(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		dir, err := os.MkdirTemp("", "surface-prop-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(dir)
+
+		files, patterns := genFilesystemFixture(t)
+		for relPath, content := range files {
+			if err := writeFileAt(dir, relPath, content); err != nil {
+				t.Fatalf("writeFileAt() error = %v", err)
+			}
+		}
+
+		first, err := TakeSnapshot(dir, patterns)
+		if err != nil {
+			t.Fatalf("first TakeSnapshot() error = %v", err)
+		}
+		second, err := TakeSnapshot(dir, patterns)
+		if err != nil {
+			t.Fatalf("second TakeSnapshot() error = %v", err)
+		}
+
+		if len(first.Files) != len(second.Files) {
+			t.Fatalf("snapshot lengths differ: %d != %d", len(first.Files), len(second.Files))
+		}
+		for i := range first.Files {
+			if first.Files[i] != second.Files[i] {
+				t.Fatalf("snapshot entry %d differs: %#v != %#v", i, first.Files[i], second.Files[i])
+			}
+		}
+	})
+}
+
+func TestProp_CompareIdenticalIsEmpty(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		snap := genSnapshot(t)
+		violations := Compare(snap, snap)
+		if len(violations) != 0 {
+			t.Fatalf("len(violations) = %d, want 0", len(violations))
+		}
+	})
+}
+
+func TestProp_CompareDetectsAllDeletions(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		before := genSnapshot(t)
+		violations := Compare(before, Snapshot{})
+		if len(violations) != len(before.Files) {
+			t.Fatalf("len(violations) = %d, want %d", len(violations), len(before.Files))
+		}
+		for i, violation := range violations {
+			if violation.Path != before.Files[i].Path {
+				t.Fatalf("violation %d path = %q, want %q", i, violation.Path, before.Files[i].Path)
+			}
+			if violation.Before != before.Files[i].Hash {
+				t.Fatalf("violation %d before = %q, want %q", i, violation.Before, before.Files[i].Hash)
+			}
+			if violation.After != "deleted" {
+				t.Fatalf("violation %d after = %q, want %q", i, violation.After, "deleted")
+			}
+		}
+	})
+}
+
+func TestProp_CompareDetectsAllCreations(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		after := genSnapshot(t)
+		violations := Compare(Snapshot{}, after)
+		if len(violations) != len(after.Files) {
+			t.Fatalf("len(violations) = %d, want %d", len(violations), len(after.Files))
+		}
+		for i, violation := range violations {
+			if violation.Path != after.Files[i].Path {
+				t.Fatalf("violation %d path = %q, want %q", i, violation.Path, after.Files[i].Path)
+			}
+			if violation.Before != "absent" {
+				t.Fatalf("violation %d before = %q, want %q", i, violation.Before, "absent")
+			}
+			if violation.After != after.Files[i].Hash {
+				t.Fatalf("violation %d after = %q, want %q", i, violation.After, after.Files[i].Hash)
+			}
+		}
+	})
+}
+
+func TestProp_CompareSymmetry(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		a := genSnapshot(t)
+		b := genSnapshot(t)
+
+		ab := Compare(a, b)
+		ba := Compare(b, a)
+
+		abByPath := make(map[string]Violation, len(ab))
+		for _, violation := range ab {
+			abByPath[violation.Path] = violation
+		}
+
+		baByPath := make(map[string]Violation, len(ba))
+		for _, violation := range ba {
+			baByPath[violation.Path] = violation
+		}
+
+		for path, forward := range abByPath {
+			reverse, ok := baByPath[path]
+			if !ok {
+				t.Fatalf("missing reverse violation for path %q", path)
+			}
+
+			switch {
+			case forward.After == "deleted":
+				if reverse.Before != "absent" || reverse.After != forward.Before {
+					t.Fatalf("deletion symmetry mismatch for %q: forward=%#v reverse=%#v", path, forward, reverse)
+				}
+			case forward.Before == "absent":
+				if reverse.After != "deleted" || reverse.Before != forward.After {
+					t.Fatalf("creation symmetry mismatch for %q: forward=%#v reverse=%#v", path, forward, reverse)
+				}
+			default:
+				if reverse.Before != forward.After || reverse.After != forward.Before {
+					t.Fatalf("modification symmetry mismatch for %q: forward=%#v reverse=%#v", path, forward, reverse)
+				}
+			}
+		}
+
+		if len(abByPath) != len(baByPath) {
+			t.Fatalf("violation set sizes differ: %d != %d", len(abByPath), len(baByPath))
+		}
+	})
+}
+
+func TestProp_CompareResultsStaySorted(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		violations := Compare(genSnapshot(t), genSnapshot(t))
+		for i := 1; i < len(violations); i++ {
+			if strings.Compare(violations[i-1].Path, violations[i].Path) > 0 {
+				t.Fatalf("violations not sorted: %q before %q", violations[i-1].Path, violations[i].Path)
+			}
+		}
+	})
+}

--- a/cli/internal/surface/surface_test.go
+++ b/cli/internal/surface/surface_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -259,6 +260,85 @@ func TestTakeSnapshotPropagatesReadError(t *testing.T) {
 	}
 	if !errors.Is(err, os.ErrPermission) {
 		t.Fatalf("TakeSnapshot() error = %v, want os.ErrPermission", err)
+	}
+}
+
+func TestTakeSnapshotRejectsInvalidGlobPattern(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := TakeSnapshot(dir, []string{"["})
+	if err == nil {
+		t.Fatal("TakeSnapshot() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), `glob pattern "["`) {
+		t.Fatalf("TakeSnapshot() error = %v, want wrapped glob pattern error", err)
+	}
+	if !errors.Is(err, filepath.ErrBadPattern) {
+		t.Fatalf("TakeSnapshot() error = %v, want filepath.ErrBadPattern", err)
+	}
+}
+
+func TestTakeSnapshotRejectsUnsafePatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{name: "parent segment", pattern: "../outside.txt"},
+		{name: "absolute path", pattern: filepath.Join(string(filepath.Separator), "tmp", "outside.txt")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := TakeSnapshot(t.TempDir(), []string{tt.pattern})
+			if err == nil {
+				t.Fatal("TakeSnapshot() error = nil, want non-nil")
+			}
+			if !strings.Contains(err.Error(), fmt.Sprintf("validate pattern %q", tt.pattern)) {
+				t.Fatalf("TakeSnapshot() error = %v, want wrapped validation error", err)
+			}
+		})
+	}
+}
+
+func TestTakeSnapshotRejectsEscapingMatches(t *testing.T) {
+	dir := t.TempDir()
+	parent := filepath.Dir(dir)
+	outsideName := filepath.Base(dir) + "-outside.txt"
+	outsidePath := filepath.Join(parent, outsideName)
+	if err := os.WriteFile(outsidePath, []byte("outside"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	defer os.Remove(outsidePath)
+
+	_, err := TakeSnapshot(dir, []string{"../" + outsideName})
+	if err == nil {
+		t.Fatal("TakeSnapshot() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "validate pattern") {
+		t.Fatalf("TakeSnapshot() error = %v, want validation error", err)
+	}
+}
+
+func TestTakeSnapshotRejectsSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(target, []byte("target"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	link := filepath.Join(dir, ".xylem.yml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	_, err := TakeSnapshot(dir, []string{".xylem.yml"})
+	if err == nil {
+		t.Fatal("TakeSnapshot() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), `lstat "`) {
+		t.Fatalf("TakeSnapshot() error = %v, want lstat context", err)
+	}
+	if !errors.Is(err, errSymlinkNotSupported) {
+		t.Fatalf("TakeSnapshot() error = %v, want errSymlinkNotSupported", err)
 	}
 }
 

--- a/cli/internal/surface/surface_test.go
+++ b/cli/internal/surface/surface_test.go
@@ -1,0 +1,288 @@
+package surface
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func sha256hex(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])
+}
+
+func writeFileAt(dir, relPath, content string) error {
+	path := filepath.Join(dir, relPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func writeFile(t *testing.T, dir, relPath, content string) {
+	t.Helper()
+
+	if err := writeFileAt(dir, relPath, content); err != nil {
+		t.Fatalf("write %q: %v", filepath.Join(dir, relPath), err)
+	}
+}
+
+func TestSmoke_S9_TakeSnapshotEmptyDir(t *testing.T) {
+	snap, err := TakeSnapshot(t.TempDir(), []string{".xylem/HARNESS.md", ".xylem.yml"})
+	if err != nil {
+		t.Fatalf("TakeSnapshot() error = %v", err)
+	}
+	if len(snap.Files) != 0 {
+		t.Fatalf("len(Files) = %d, want 0", len(snap.Files))
+	}
+}
+
+func TestSmoke_S10_TakeSnapshotMatchesAndHashes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".xylem/HARNESS.md", "harness content")
+	writeFile(t, dir, ".xylem.yml", "config content")
+	writeFile(t, dir, "src/main.go", "package main")
+
+	snap, err := TakeSnapshot(dir, []string{".xylem/HARNESS.md", ".xylem.yml"})
+	if err != nil {
+		t.Fatalf("TakeSnapshot() error = %v", err)
+	}
+	if len(snap.Files) != 2 {
+		t.Fatalf("len(Files) = %d, want 2", len(snap.Files))
+	}
+
+	byPath := make(map[string]FileHash, len(snap.Files))
+	for _, file := range snap.Files {
+		byPath[file.Path] = file
+		if file.Hash == "" {
+			t.Fatalf("hash for %q is empty", file.Path)
+		}
+	}
+
+	if _, ok := byPath[".xylem/HARNESS.md"]; !ok {
+		t.Fatal(`snapshot missing ".xylem/HARNESS.md"`)
+	}
+	if got, want := byPath[".xylem/HARNESS.md"].Hash, sha256hex("harness content"); got != want {
+		t.Fatalf(`hash for ".xylem/HARNESS.md" = %q, want %q`, got, want)
+	}
+	if _, ok := byPath[".xylem.yml"]; !ok {
+		t.Fatal(`snapshot missing ".xylem.yml"`)
+	}
+	if got, want := byPath[".xylem.yml"].Hash, sha256hex("config content"); got != want {
+		t.Fatalf(`hash for ".xylem.yml" = %q, want %q`, got, want)
+	}
+	if _, ok := byPath["src/main.go"]; ok {
+		t.Fatal(`snapshot unexpectedly contains "src/main.go"`)
+	}
+}
+
+func TestSmoke_S11_TakeSnapshotDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".xylem.yml", "stable content")
+
+	snap1, err := TakeSnapshot(dir, []string{".xylem.yml"})
+	if err != nil {
+		t.Fatalf("first TakeSnapshot() error = %v", err)
+	}
+
+	snap2, err := TakeSnapshot(dir, []string{".xylem.yml"})
+	if err != nil {
+		t.Fatalf("second TakeSnapshot() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(snap1, snap2) {
+		t.Fatalf("snapshots differ: first=%#v second=%#v", snap1, snap2)
+	}
+}
+
+func TestSmoke_S12_TakeSnapshotSortedByPath(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".xylem/workflows/implement-feature.yaml", "feature")
+	writeFile(t, dir, ".xylem/workflows/fix-bug.yaml", "bug")
+	writeFile(t, dir, ".xylem.yml", "config")
+
+	snap, err := TakeSnapshot(dir, []string{".xylem/workflows/*.yaml", ".xylem.yml"})
+	if err != nil {
+		t.Fatalf("TakeSnapshot() error = %v", err)
+	}
+
+	for i := 1; i < len(snap.Files); i++ {
+		if snap.Files[i-1].Path > snap.Files[i].Path {
+			t.Fatalf("files not sorted: %q before %q", snap.Files[i-1].Path, snap.Files[i].Path)
+		}
+	}
+}
+
+func TestSmoke_S13_CompareIdenticalSnapshots(t *testing.T) {
+	snap := Snapshot{
+		Files: []FileHash{
+			{Path: ".xylem.yml", Hash: "abc123"},
+		},
+	}
+
+	violations := Compare(snap, snap)
+	if len(violations) != 0 {
+		t.Fatalf("len(violations) = %d, want 0", len(violations))
+	}
+}
+
+func TestSmoke_S14_CompareDetectsModified(t *testing.T) {
+	before := Snapshot{Files: []FileHash{{Path: ".xylem.yml", Hash: "aaa"}}}
+	after := Snapshot{Files: []FileHash{{Path: ".xylem.yml", Hash: "bbb"}}}
+
+	violations := Compare(before, after)
+	if len(violations) != 1 {
+		t.Fatalf("len(violations) = %d, want 1", len(violations))
+	}
+	if got := violations[0].Path; got != ".xylem.yml" {
+		t.Fatalf("path = %q, want %q", got, ".xylem.yml")
+	}
+	if got := violations[0].Before; got != "aaa" {
+		t.Fatalf("before = %q, want %q", got, "aaa")
+	}
+	if got := violations[0].After; got != "bbb" {
+		t.Fatalf("after = %q, want %q", got, "bbb")
+	}
+}
+
+func TestSmoke_S15_CompareDetectsDeleted(t *testing.T) {
+	before := Snapshot{Files: []FileHash{{Path: ".xylem/HARNESS.md", Hash: "ddd"}}}
+
+	violations := Compare(before, Snapshot{})
+	if len(violations) != 1 {
+		t.Fatalf("len(violations) = %d, want 1", len(violations))
+	}
+	if got := violations[0].Path; got != ".xylem/HARNESS.md" {
+		t.Fatalf("path = %q, want %q", got, ".xylem/HARNESS.md")
+	}
+	if got := violations[0].Before; got != "ddd" {
+		t.Fatalf("before = %q, want %q", got, "ddd")
+	}
+	if got := violations[0].After; got != "deleted" {
+		t.Fatalf("after = %q, want %q", got, "deleted")
+	}
+}
+
+func TestSmoke_S16_CompareDetectsCreated(t *testing.T) {
+	after := Snapshot{Files: []FileHash{{Path: ".xylem/workflows/new.yaml", Hash: "eee"}}}
+
+	violations := Compare(Snapshot{}, after)
+	if len(violations) != 1 {
+		t.Fatalf("len(violations) = %d, want 1", len(violations))
+	}
+	if got := violations[0].Path; got != ".xylem/workflows/new.yaml" {
+		t.Fatalf("path = %q, want %q", got, ".xylem/workflows/new.yaml")
+	}
+	if got := violations[0].Before; got != "absent" {
+		t.Fatalf("before = %q, want %q", got, "absent")
+	}
+	if got := violations[0].After; got != "eee" {
+		t.Fatalf("after = %q, want %q", got, "eee")
+	}
+}
+
+func TestTakeSnapshotDeduplicatesOverlappingPatterns(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".xylem.yml", "config")
+
+	snap, err := TakeSnapshot(dir, []string{".xylem.yml", "*"})
+	if err != nil {
+		t.Fatalf("TakeSnapshot() error = %v", err)
+	}
+	if len(snap.Files) != 1 {
+		t.Fatalf("len(Files) = %d, want 1", len(snap.Files))
+	}
+	if snap.Files[0].Path != ".xylem.yml" {
+		t.Fatalf("path = %q, want %q", snap.Files[0].Path, ".xylem.yml")
+	}
+}
+
+func TestTakeSnapshotWithNilPatternsReturnsEmptySnapshot(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".xylem.yml", "config")
+
+	snap, err := TakeSnapshot(dir, nil)
+	if err != nil {
+		t.Fatalf("TakeSnapshot() error = %v", err)
+	}
+	if len(snap.Files) != 0 {
+		t.Fatalf("len(Files) = %d, want 0", len(snap.Files))
+	}
+}
+
+func TestTakeSnapshotSkipsDirectories(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".xylem/workflows/fix-bug.yaml", "bug")
+
+	snap, err := TakeSnapshot(dir, []string{".xylem/*", ".xylem/workflows/*.yaml"})
+	if err != nil {
+		t.Fatalf("TakeSnapshot() error = %v", err)
+	}
+
+	want := Snapshot{
+		Files: []FileHash{
+			{Path: ".xylem/workflows/fix-bug.yaml", Hash: sha256hex("bug")},
+		},
+	}
+	if !reflect.DeepEqual(snap, want) {
+		t.Fatalf("TakeSnapshot() = %#v, want %#v", snap, want)
+	}
+}
+
+func TestTakeSnapshotPropagatesReadError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".xylem.yml")
+	if err := os.WriteFile(path, []byte("config"), 0o000); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	defer func() {
+		if err := os.Chmod(path, 0o644); err != nil {
+			t.Fatalf("Chmod() cleanup error = %v", err)
+		}
+	}()
+
+	_, err := TakeSnapshot(dir, []string{".xylem.yml"})
+	if err == nil {
+		t.Fatal("TakeSnapshot() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "hash file") {
+		t.Fatalf("TakeSnapshot() error = %v, want wrapped hash error", err)
+	}
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("TakeSnapshot() error = %v, want os.ErrPermission", err)
+	}
+}
+
+func TestCompareReturnsSortedViolations(t *testing.T) {
+	before := Snapshot{
+		Files: []FileHash{
+			{Path: ".xylem/workflows/fix-bug.yaml", Hash: "aaa"},
+			{Path: ".xylem.yml", Hash: "bbb"},
+		},
+	}
+	after := Snapshot{
+		Files: []FileHash{
+			{Path: ".xylem.yml", Hash: "ccc"},
+			{Path: ".xylem/HARNESS.md", Hash: "ddd"},
+		},
+	}
+
+	violations := Compare(before, after)
+	want := []Violation{
+		{Path: ".xylem.yml", Before: "bbb", After: "ccc"},
+		{Path: ".xylem/HARNESS.md", Before: "absent", After: "ddd"},
+		{Path: ".xylem/workflows/fix-bug.yaml", Before: "aaa", After: "deleted"},
+	}
+	if !reflect.DeepEqual(violations, want) {
+		t.Fatalf("Compare() = %#v, want %#v", violations, want)
+	}
+}


### PR DESCRIPTION
## Summary
- implements the harness spec in https://github.com/nicholls-inc/xylem/issues/78
- adds a new `cli/internal/surface` package for SHA256-based worktree integrity snapshots and before/after comparisons
- covers the requested smoke scenarios and property checks for deterministic, sorted, diffable snapshots

## Smoke scenarios covered
- S9: `TakeSnapshot` returns an empty snapshot for an empty directory
- S10: `TakeSnapshot` matches requested files and records SHA256 hashes
- S11: `TakeSnapshot` is deterministic across repeated calls
- S12: `TakeSnapshot` returns files sorted by path
- S13: `Compare` returns no violations for identical snapshots
- S14: `Compare` detects modified files
- S15: `Compare` detects deleted files
- S16: `Compare` detects created files

## Changes
- added `cli/internal/surface/surface.go`
  - `FileHash`, `Snapshot`, and `Violation` types
  - `TakeSnapshot(worktreeRoot, patterns)` for globbing, hashing, deduping, and sorting matched files
  - `Compare(before, after)` for reporting created, modified, and deleted files in path order
- added `cli/internal/surface/surface_test.go`
  - smoke coverage for S9-S16 plus focused unit tests for deduplication, nil patterns, directory skipping, read errors, and sorted violations
- added `cli/internal/surface/surface_prop_test.go`
  - property tests for snapshot sorting, determinism, and comparison invariants using `rapid`

## Test plan
- `cd cli && go test -count=1 ./internal/surface/...`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test -count=1 ./...`
