### PR TITLE
feat: add github-pr provider failure DTU scenario

### DIFF
--- a/cli/internal/dtu/scenario_test.go
+++ b/cli/internal/dtu/scenario_test.go
@@ -1100,3 +1100,73 @@ func TestScenarioGithubMergeProviderFailure(t *testing.T) {
 		t.Fatalf("missing postmerge result with exit code 2: %#v", events)
 	}
 }
+
+func TestScenarioGithubPRProviderFailure(t *testing.T) {
+	env := newScenarioEnv(t, "github-pr-provider-failure.yaml")
+	defer withWorkingDir(t, env.repoDir)()
+
+	writeScenarioWorkflow(t, env.repoDir, "review-pr", []scenarioPhase{
+		{name: "review", prompt: "Review PR {{.Issue.Number}}"},
+	})
+
+	cfg := baseScenarioConfig(env.stateDir)
+	cfg.Sources = map[string]config.SourceConfig{
+		"pull-requests": {
+			Type: "github-pr",
+			Repo: "owner/repo",
+			Tasks: map[string]config.Task{
+				"ready-prs": {
+					Labels:   []string{"ready"},
+					Workflow: "review-pr",
+					StatusLabels: &config.StatusLabels{
+						Running: "in-progress",
+						Failed:  "failed",
+					},
+				},
+			},
+		},
+	}
+
+	scan := scanner.New(cfg, env.queue, env.cmdRunner)
+	scanResult, err := scan.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if scanResult.Added != 1 {
+		t.Fatalf("ScanResult.Added = %d, want 1", scanResult.Added)
+	}
+
+	src := &source.GitHubPR{Repo: "owner/repo", CmdRunner: env.cmdRunner}
+	drainer := newDrainRunner(cfg, env.queue, env.cmdRunner, env.repoDir, src)
+	drainResult, err := drainer.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("Drain() error = %v", err)
+	}
+	if drainResult.Failed != 1 {
+		t.Fatalf("DrainResult.Failed = %d, want 1", drainResult.Failed)
+	}
+
+	vessel, err := env.queue.FindByID("pr-15")
+	if err != nil {
+		t.Fatalf("FindByID(pr-15) error = %v", err)
+	}
+	if vessel.State != queue.StateFailed {
+		t.Fatalf("vessel.State = %q, want %q", vessel.State, queue.StateFailed)
+	}
+	if !strings.Contains(vessel.Error, "exit status 2") {
+		t.Fatalf("vessel.Error = %q, want exit status 2", vessel.Error)
+	}
+	assertStringSliceEqual(t, readPRLabels(t, env.store, "owner/repo", 15), []string{"failed", "ready"})
+
+	events := readEvents(t, env.store)
+	var reviewResult *dtu.ShimEvent
+	for _, event := range events {
+		if event.Kind == dtu.EventKindShimResult && event.Shim != nil && event.Shim.Command == "claude" && event.Shim.Phase == "review" {
+			reviewResult = event.Shim
+			break
+		}
+	}
+	if reviewResult == nil || reviewResult.ExitCode == nil || *reviewResult.ExitCode != 2 {
+		t.Fatalf("missing review result with exit code 2: %#v", events)
+	}
+}

--- a/cli/internal/dtu/testdata/github-pr-provider-failure.yaml
+++ b/cli/internal/dtu/testdata/github-pr-provider-failure.yaml
@@ -1,0 +1,27 @@
+metadata:
+  name: github-pr-provider-failure
+  scenario: provider failure during PR review workflow
+repositories:
+  - owner: owner
+    name: repo
+    default_branch: main
+    labels:
+      - name: ready
+      - name: failed
+    pull_requests:
+      - number: 15
+        title: add caching layer
+        body: review the new caching implementation
+        state: open
+        labels: [ready]
+        base_branch: main
+        head_branch: feature-caching
+        head_sha: deadbeef12345678
+providers:
+  scripts:
+    - name: review
+      provider: claude
+      match:
+        phase: review
+      stderr: provider crashed
+      exit_code: 2


### PR DESCRIPTION
## Summary
- Adds `github-pr-provider-failure.yaml` manifest: configures a `github-pr` source with a provider script that crashes (exit code 2, stderr noise) during the review phase
- Adds `TestScenarioGithubPRProviderFailure` test: scans the PR, drains it, and asserts the vessel reaches `failed` state with correct error message, failure label applied to the PR, and shim event exit code recorded
- Closes Gap 3 in DTU spec compliance: every source type now has both happy-path and failure-path scenarios

Note: this branch includes the full DTU infrastructure (dtu, dtushim packages and supporting changes) since those packages are not yet on main. The specific new files for this PR are:
- `cli/internal/dtu/testdata/github-pr-provider-failure.yaml`
- The `TestScenarioGithubPRProviderFailure` function in `cli/internal/dtu/scenario_test.go`

## Test plan
- [x] `go test ./internal/dtu/... -run TestScenarioGithubPRProviderFailure -v` passes
- [x] `go test ./internal/dtu/... -v` -- all 50 DTU tests pass (46 PASS, 4 SKIP)
- [x] `go vet ./...` clean
- [x] `goimports -l .` clean
- [x] Pre-commit hooks pass (goimports, golangci-lint, go build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)