### PR TITLE
docs: update README and getting-started with accurate info

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ daemon:
   drain_interval: "30s"
 ```
 
-See the [Configuration Reference](docs/configuration.md) for all fields, defaults, and validation rules.
+This example covers the most common fields. Additional configuration is available for per-source provider overrides (`llm`, `model`), agent safety guardrails (`harness`), OpenTelemetry tracing (`observability`), and token budget enforcement (`cost`). See the [Configuration Reference](docs/configuration.md) for all fields, defaults, and validation rules.
 
 ## Workflows
 
@@ -128,7 +128,7 @@ Use `noop.match` on a phase to let that phase complete the workflow early when i
 **Built-in workflows:**
 
 - **fix-bug** -- Analyze, Plan, Implement (with test gate), PR
-- **implement-feature** -- Analyze, Plan (with label gate for approval), Implement, PR
+- **implement-feature** -- Analyze, Plan (with label gate for approval), Implement (with test gate), PR
 
 See the [Workflows Guide](docs/workflows.md) for template variables, custom workflows, and prompt authoring tips.
 
@@ -194,6 +194,8 @@ The CLI includes standalone packages under `cli/internal/` implementing foundati
 | `bootstrap` | Repo analysis and AGENTS.md generation |
 | `catalog` | Tool catalog with overlap detection and permission scopes |
 | `observability` | OpenTelemetry span attributes for missions, agents, and signals |
+| `evidence` | Verification claims and evidence manifests with typed assurance levels |
+| `surface` | SHA256 surface integrity for protected files |
 
 See the [Architecture](docs/architecture.md) document for details on the control flow, isolation model, and how these packages fit together.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,18 +23,16 @@ If you use Claude with `--bare`, you also need an Anthropic API key. Set it in y
 
 ## Installation
 
-Install xylem in two steps: install the LLM CLI you want to use, then install the Go CLI binary.
+Install the xylem Go CLI binary:
 
 ```bash
-# 1. If you use Claude, add the marketplace and install the plugin
-claude plugin marketplace add nicholls-inc/claude-code-marketplace
-claude plugin install xylem@nicholls
-
-# 2. Install the Go CLI
 go install github.com/nicholls-inc/xylem/cli/cmd/xylem@latest
 ```
 
-If you use GitHub Copilot instead, install the Copilot CLI separately and make sure the `copilot` binary is on your PATH before running xylem.
+You also need at least one supported LLM CLI on your PATH:
+
+- **Claude Code**: Install from [docs.anthropic.com](https://docs.anthropic.com/en/docs/claude-code)
+- **GitHub Copilot CLI**: Install separately and ensure `copilot` is on your PATH
 
 Verify the installation:
 


### PR DESCRIPTION
## Summary
- Add note after config example about additional fields (model, harness, observability, cost)
- Fix implement-feature description to mention test gate on implement phase
- Add `evidence` and `surface` packages to harness library table
- Remove fictional Claude plugin marketplace commands from getting-started, align with README

## Test plan
- [x] Cross-referenced workflow descriptions against scaffolded content in `init.go`
- [x] Verified harness packages exist in `cli/internal/`
- [x] Documentation-only change — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)