### PR TITLE
feat: add per-source timeout support

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -49,6 +49,7 @@ type SourceConfig struct {
 	Repo    string          `yaml:"repo,omitempty"`
 	LLM     string          `yaml:"llm,omitempty"`
 	Model   string          `yaml:"model,omitempty"`
+	Timeout string          `yaml:"timeout,omitempty"`
 	Exclude []string        `yaml:"exclude,omitempty"`
 	Tasks   map[string]Task `yaml:"tasks,omitempty"`
 }
@@ -267,6 +268,16 @@ func (c *Config) Validate() error {
 			// valid
 		default:
 			return fmt.Errorf("source %q: llm must be \"claude\" or \"copilot\", got %q", name, src.LLM)
+		}
+
+		if src.Timeout != "" {
+			dur, err := time.ParseDuration(src.Timeout)
+			if err != nil {
+				return fmt.Errorf("source %q: timeout must be a valid duration: %w", name, err)
+			}
+			if dur < minTimeout {
+				return fmt.Errorf("source %q: timeout must be at least %s", name, minTimeout)
+			}
 		}
 
 		switch src.Type {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -1397,3 +1397,70 @@ func TestSmoke_S32_NegativeMaxCostRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cost.budget.max_cost_usd")
 }
+
+func TestSourceTimeoutValid(t *testing.T) {
+	cfg := validConfig()
+	cfg.Sources = map[string]SourceConfig{
+		"slow": {
+			Type:    "github",
+			Repo:    "owner/name",
+			Timeout: "1h",
+			Tasks: map[string]Task{
+				"impl": {Labels: []string{"implement"}, Workflow: "implement-feature"},
+			},
+		},
+	}
+	err := cfg.Validate()
+	if err != nil {
+		t.Fatalf("expected valid config with source timeout, got: %v", err)
+	}
+}
+
+func TestSourceTimeoutInvalidDuration(t *testing.T) {
+	cfg := validConfig()
+	cfg.Sources = map[string]SourceConfig{
+		"bad": {
+			Type:    "github",
+			Repo:    "owner/name",
+			Timeout: "bad",
+			Tasks: map[string]Task{
+				"impl": {Labels: []string{"implement"}, Workflow: "implement-feature"},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "valid duration")
+}
+
+func TestSourceTimeoutTooShort(t *testing.T) {
+	cfg := validConfig()
+	cfg.Sources = map[string]SourceConfig{
+		"fast": {
+			Type:    "github",
+			Repo:    "owner/name",
+			Timeout: "5s",
+			Tasks: map[string]Task{
+				"impl": {Labels: []string{"implement"}, Workflow: "implement-feature"},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "at least")
+}
+
+func TestSourceTimeoutEmptyInheritsGlobal(t *testing.T) {
+	cfg := validConfig()
+	cfg.Sources = map[string]SourceConfig{
+		"default": {
+			Type: "github",
+			Repo: "owner/name",
+			Tasks: map[string]Task{
+				"impl": {Labels: []string{"implement"}, Workflow: "implement-feature"},
+			},
+		},
+	}
+	err := cfg.Validate()
+	if err != nil {
+		t.Fatalf("expected valid config with no source timeout (inherits global), got: %v", err)
+	}
+}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -129,7 +129,13 @@ func (r *Runner) Drain(ctx context.Context) (DrainResult, error) {
 				vesselBaseCtx = oteltrace.ContextWithSpanContext(context.Background(), oteltrace.SpanContextFromContext(vesselSpan.Context()))
 			}
 
-			vesselCtx, cancel := context.WithTimeout(vesselBaseCtx, timeout)
+			srcCfg := r.sourceConfigFromMeta(j)
+			vesselTimeout, resolveErr := resolveTimeout(r.Config, srcCfg)
+			if resolveErr != nil {
+				vesselTimeout = timeout // fallback to global
+			}
+
+			vesselCtx, cancel := context.WithTimeout(vesselBaseCtx, vesselTimeout)
 			defer cancel()
 
 			outcome := r.runVessel(vesselCtx, j)
@@ -1971,8 +1977,13 @@ func (r *Runner) CheckHungVessels(ctx context.Context) {
 		if vessel.StartedAt == nil {
 			continue
 		}
+		srcCfg := r.sourceConfigFromMeta(vessel)
+		vesselTimeout, resolveErr := resolveTimeout(r.Config, srcCfg)
+		if resolveErr != nil {
+			vesselTimeout = timeout
+		}
 		elapsed := r.runtimeSince(*vessel.StartedAt)
-		if elapsed <= timeout {
+		if elapsed <= vesselTimeout {
 			continue
 		}
 
@@ -2196,6 +2207,16 @@ func providerAttempt(p *workflow.Phase, retriesRemaining int) int {
 
 func isDTUProviderRun() bool {
 	return strings.TrimSpace(os.Getenv(dtu.EnvStatePath)) != ""
+}
+
+// resolveTimeout returns the effective timeout for a vessel.
+// Resolution order: Source.Timeout > Config.Timeout.
+func resolveTimeout(cfg *config.Config, srcCfg *config.SourceConfig) (time.Duration, error) {
+	raw := cfg.Timeout
+	if srcCfg != nil && srcCfg.Timeout != "" {
+		raw = srcCfg.Timeout
+	}
+	return time.ParseDuration(raw)
 }
 
 // resolveProvider determines which LLM provider to use for a phase invocation.

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -132,6 +132,7 @@ func (r *Runner) Drain(ctx context.Context) (DrainResult, error) {
 			srcCfg := r.sourceConfigFromMeta(j)
 			vesselTimeout, resolveErr := resolveTimeout(r.Config, srcCfg)
 			if resolveErr != nil {
+				log.Printf("warn: resolve timeout for vessel %s (config_source=%q): %v; using global timeout %s", j.ID, r.sourceConfigNameFromMeta(j), resolveErr, timeout)
 				vesselTimeout = timeout // fallback to global
 			}
 
@@ -1753,10 +1754,7 @@ func (r *Runner) logReporterError(action string, vesselID string, err error) {
 // sourceConfigFromMeta returns the SourceConfig for a vessel by looking up
 // the config source name stored in vessel Meta at scan time.
 func (r *Runner) sourceConfigFromMeta(v queue.Vessel) *config.SourceConfig {
-	if v.Meta == nil {
-		return nil
-	}
-	name := v.Meta["config_source"]
+	name := r.sourceConfigNameFromMeta(v)
 	if name == "" {
 		return nil
 	}
@@ -1764,6 +1762,13 @@ func (r *Runner) sourceConfigFromMeta(v queue.Vessel) *config.SourceConfig {
 		return &sc
 	}
 	return nil
+}
+
+func (r *Runner) sourceConfigNameFromMeta(v queue.Vessel) string {
+	if v.Meta == nil {
+		return ""
+	}
+	return v.Meta["config_source"]
 }
 
 func (r *Runner) loadWorkflow(name string) (*workflow.Workflow, error) {
@@ -1980,6 +1985,7 @@ func (r *Runner) CheckHungVessels(ctx context.Context) {
 		srcCfg := r.sourceConfigFromMeta(vessel)
 		vesselTimeout, resolveErr := resolveTimeout(r.Config, srcCfg)
 		if resolveErr != nil {
+			log.Printf("warn: resolve timeout for vessel %s (config_source=%q): %v; using global timeout %s", vessel.ID, r.sourceConfigNameFromMeta(vessel), resolveErr, timeout)
 			vesselTimeout = timeout
 		}
 		elapsed := r.runtimeSince(*vessel.StartedAt)

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -5176,3 +5176,132 @@ func TestDrainPromptOnlyRateLimitRetry(t *testing.T) {
 		t.Errorf("phase calls = %d, want 2 (1 rate limit + 1 success)", got)
 	}
 }
+
+// --- Per-source timeout ---
+
+func TestCheckHungVessels_PerSourceTimeout(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.Timeout = "1s" // short global timeout
+
+	// Add a slow source with a long timeout
+	cfg.Sources["slow-source"] = config.SourceConfig{
+		Type:    "github",
+		Repo:    "owner/repo",
+		Timeout: "1h",
+		Tasks:   map[string]config.Task{"impl": {Labels: []string{"implement"}, Workflow: "implement-feature"}},
+	}
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	now := time.Now().UTC()
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:        "slow-1",
+		Source:    "manual",
+		State:     queue.StatePending,
+		CreatedAt: now,
+		Meta:      map[string]string{"config_source": "slow-source"},
+	})
+	vessel, _ := q.Dequeue()
+	if vessel == nil {
+		t.Fatal("expected dequeued vessel")
+	}
+
+	// Backdate StartedAt by 5 minutes — exceeds global 1s but not source 1h
+	old := now.Add(-5 * time.Minute)
+	vessel.StartedAt = &old
+	if err := q.UpdateVessel(*vessel); err != nil {
+		t.Fatalf("update vessel: %v", err)
+	}
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	r.CheckHungVessels(context.Background())
+
+	vessels, _ := q.List()
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	if vessels[0].State != queue.StateRunning {
+		t.Errorf("expected vessel still running (source timeout 1h), got %s", vessels[0].State)
+	}
+}
+
+func TestCheckHungVessels_PerSourceTimeoutExpired(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.Timeout = "1h" // long global timeout
+
+	// Add a fast source with a short timeout
+	cfg.Sources["fast-source"] = config.SourceConfig{
+		Type:    "github",
+		Repo:    "owner/repo",
+		Timeout: "1s",
+		Tasks:   map[string]config.Task{"impl": {Labels: []string{"implement"}, Workflow: "implement-feature"}},
+	}
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	now := time.Now().UTC()
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:        "fast-1",
+		Source:    "manual",
+		State:     queue.StatePending,
+		CreatedAt: now,
+		Meta:      map[string]string{"config_source": "fast-source"},
+	})
+	vessel, _ := q.Dequeue()
+	if vessel == nil {
+		t.Fatal("expected dequeued vessel")
+	}
+
+	// Backdate StartedAt by 5 minutes — exceeds source 1s
+	old := now.Add(-5 * time.Minute)
+	vessel.StartedAt = &old
+	if err := q.UpdateVessel(*vessel); err != nil {
+		t.Fatalf("update vessel: %v", err)
+	}
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	r.CheckHungVessels(context.Background())
+
+	vessels, _ := q.List()
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	if vessels[0].State != queue.StateTimedOut {
+		t.Errorf("expected vessel timed_out (source timeout 1s), got %s", vessels[0].State)
+	}
+}
+
+func TestResolveTimeout(t *testing.T) {
+	cfg := &config.Config{Timeout: "30m"}
+
+	// nil srcCfg returns global
+	d, err := resolveTimeout(cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != 30*time.Minute {
+		t.Errorf("expected 30m, got %s", d)
+	}
+
+	// srcCfg with empty Timeout returns global
+	src := &config.SourceConfig{}
+	d, err = resolveTimeout(cfg, src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != 30*time.Minute {
+		t.Errorf("expected 30m, got %s", d)
+	}
+
+	// srcCfg with set Timeout returns source timeout
+	src = &config.SourceConfig{Timeout: "2h"}
+	d, err = resolveTimeout(cfg, src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != 2*time.Hour {
+		t.Errorf("expected 2h, got %s", d)
+	}
+}

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -5276,32 +5276,33 @@ func TestCheckHungVessels_PerSourceTimeoutExpired(t *testing.T) {
 func TestResolveTimeout(t *testing.T) {
 	cfg := &config.Config{Timeout: "30m"}
 
-	// nil srcCfg returns global
-	d, err := resolveTimeout(cfg, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if d != 30*time.Minute {
-		t.Errorf("expected 30m, got %s", d)
-	}
-
-	// srcCfg with empty Timeout returns global
-	src := &config.SourceConfig{}
-	d, err = resolveTimeout(cfg, src)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if d != 30*time.Minute {
-		t.Errorf("expected 30m, got %s", d)
+	tests := []struct {
+		name    string
+		srcCfg  *config.SourceConfig
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "nil source config uses global timeout", want: 30 * time.Minute},
+		{name: "empty source timeout uses global timeout", srcCfg: &config.SourceConfig{}, want: 30 * time.Minute},
+		{name: "source timeout overrides global timeout", srcCfg: &config.SourceConfig{Timeout: "2h"}, want: 2 * time.Hour},
+		{name: "invalid source timeout returns error", srcCfg: &config.SourceConfig{Timeout: "not-a-duration"}, wantErr: true},
 	}
 
-	// srcCfg with set Timeout returns source timeout
-	src = &config.SourceConfig{Timeout: "2h"}
-	d, err = resolveTimeout(cfg, src)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if d != 2*time.Hour {
-		t.Errorf("expected 2h, got %s", d)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveTimeout(cfg, tt.srcCfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveTimeout() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveTimeout() = %s, want %s", got, tt.want)
+			}
+		})
 	}
 }

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -4665,6 +4665,7 @@ func TestCheckHungVessels_NotTimedOut(t *testing.T) {
 	vessel, _ := q.Dequeue()
 	if vessel == nil {
 		t.Fatal("expected dequeued vessel")
+		return
 	}
 
 	wt := &mockWorktree{}
@@ -5205,6 +5206,7 @@ func TestCheckHungVessels_PerSourceTimeout(t *testing.T) {
 	vessel, _ := q.Dequeue()
 	if vessel == nil {
 		t.Fatal("expected dequeued vessel")
+		return
 	}
 
 	// Backdate StartedAt by 5 minutes — exceeds global 1s but not source 1h
@@ -5252,6 +5254,7 @@ func TestCheckHungVessels_PerSourceTimeoutExpired(t *testing.T) {
 	vessel, _ := q.Dequeue()
 	if vessel == nil {
 		t.Fatal("expected dequeued vessel")
+		return
 	}
 
 	// Backdate StartedAt by 5 minutes — exceeds source 1s


### PR DESCRIPTION
## Summary
- Adds an optional `timeout` field to `SourceConfig` so individual sources can override the global timeout (e.g., `harness-impl` can set `timeout: "90m"` while others use the default 45m)
- Adds `resolveTimeout()` helper following the same pattern as `resolveProvider`/`resolveModel` — resolution order: Source.Timeout > Config.Timeout
- Updates `Drain()` and `CheckHungVessels()` to resolve per-vessel timeout via `sourceConfigFromMeta`
- Adds config validation (invalid duration, below minimum) and 7 new tests across config and runner

## Test plan
- [x] Config validation: valid source timeout passes
- [x] Config validation: invalid duration string rejected
- [x] Config validation: timeout below 30s minimum rejected
- [x] Config validation: empty timeout inherits global (passes)
- [x] CheckHungVessels: vessel with long source timeout not timed out despite short global timeout
- [x] CheckHungVessels: vessel with short source timeout timed out despite long global timeout
- [x] resolveTimeout: nil/empty/set source config returns correct duration
- [x] Full test suite passes (`go test ./... -count=1`)
- [x] `go vet ./...` clean
- [x] `goimports` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)