### PR TITLE
feat: add visualize command for triggers and workflows

### DIFF
--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -37,7 +37,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "dtu", "shim-dispatch", "scan", "drain", "status", "pause", "resume", "cancel", "cleanup", "enqueue", "daemon", "retry"}
+	expected := []string{"init", "dtu", "shim-dispatch", "scan", "drain", "status", "pause", "resume", "cancel", "cleanup", "enqueue", "daemon", "retry", "visualize"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -33,8 +33,14 @@ func newRootCmd() *cobra.Command {
 				return nil
 			}
 
-			if _, err := exec.LookPath("git"); err != nil {
-				return fmt.Errorf("error: git not found on PATH")
+			// visualize is a read-only command that only parses config and
+			// workflow YAML; it doesn't shell out to git or gh.
+			skipTooling := cmd.Name() == "visualize"
+
+			if !skipTooling {
+				if _, err := exec.LookPath("git"); err != nil {
+					return fmt.Errorf("error: git not found on PATH")
+				}
 			}
 
 			configPath := viper.GetString("config")
@@ -44,7 +50,7 @@ func newRootCmd() *cobra.Command {
 			}
 
 			// Only require gh if a GitHub source is configured
-			if hasGitHubSource(cfg) {
+			if !skipTooling && hasGitHubSource(cfg) {
 				if _, err := exec.LookPath("gh"); err != nil {
 					return fmt.Errorf("error: gh not found on PATH (required for github source)")
 				}
@@ -81,6 +87,7 @@ func newRootCmd() *cobra.Command {
 		newCleanupCmd(),
 		newDaemonCmd(),
 		newRetryCmd(),
+		newVisualizeCmd(),
 	)
 
 	return cmd

--- a/cli/cmd/xylem/visualize.go
+++ b/cli/cmd/xylem/visualize.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/visualize"
+)
+
+func newVisualizeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "visualize",
+		Aliases: []string{"viz"},
+		Short:   "Visualize triggers and workflows from .xylem.yml",
+		Long: `Render the sources, triggers, and workflows configured in .xylem.yml
+as a diagram. Workflows referenced by a task are loaded from
+.xylem/workflows/<name>.yaml and their phases and gates are included.
+
+Supported output formats:
+  mermaid  flowchart text suitable for GitHub/VSCode markdown (default)
+  dot      Graphviz digraph text for ` + "`dot -Tpng`" + `
+  json     the intermediate graph as indented JSON`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format, _ := cmd.Flags().GetString("format")
+			output, _ := cmd.Flags().GetString("output")
+			workflowsDir, _ := cmd.Flags().GetString("workflows-dir")
+			return cmdVisualize(deps.cfg, workflowsDir, format, output)
+		},
+	}
+	cmd.Flags().StringP("format", "f", "mermaid", "Output format: mermaid|dot|json")
+	cmd.Flags().StringP("output", "o", "", "Write to file instead of stdout")
+	cmd.Flags().String("workflows-dir", filepath.Join(".xylem", "workflows"), "Directory containing workflow YAML files")
+	return cmd
+}
+
+func cmdVisualize(cfg *config.Config, workflowsDir, format, output string) error {
+	g, err := visualize.Build(cfg, workflowsDir)
+	if err != nil {
+		return fmt.Errorf("build graph: %w", err)
+	}
+
+	render, err := pickRenderer(format)
+	if err != nil {
+		return err
+	}
+
+	var w io.Writer = os.Stdout
+	if output != "" {
+		f, err := os.Create(output)
+		if err != nil {
+			return fmt.Errorf("create output file: %w", err)
+		}
+		defer f.Close()
+		w = f
+	}
+
+	if err := render(g, w); err != nil {
+		return fmt.Errorf("render %s: %w", format, err)
+	}
+
+	// Surface missing workflows so the diagram isn't silently incomplete.
+	if len(g.MissingWorkflows) > 0 {
+		fmt.Fprintf(os.Stderr, "warning: %d workflow(s) referenced but not found under %s:\n", len(g.MissingWorkflows), workflowsDir)
+		for _, name := range g.MissingWorkflows {
+			fmt.Fprintf(os.Stderr, "  - %s\n", name)
+		}
+	}
+
+	return nil
+}
+
+func pickRenderer(format string) (func(*visualize.Graph, io.Writer) error, error) {
+	switch format {
+	case "", "mermaid":
+		return visualize.RenderMermaid, nil
+	case "dot":
+		return visualize.RenderDOT, nil
+	case "json":
+		return visualize.RenderJSON, nil
+	default:
+		return nil, fmt.Errorf("unknown format %q (supported: mermaid, dot, json)", format)
+	}
+}

--- a/cli/internal/visualize/build.go
+++ b/cli/internal/visualize/build.go
@@ -1,0 +1,150 @@
+package visualize
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sort"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
+)
+
+// Build converts a loaded xylem Config and a workflows directory into a
+// Graph. Workflows referenced by a task but missing from disk are collected
+// into Graph.MissingWorkflows rather than failing the build; any other
+// workflow-load error is returned.
+//
+// Sources and workflows in the returned graph are sorted by name to make
+// output deterministic.
+func Build(cfg *config.Config, workflowsDir string) (*Graph, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("visualize: nil config")
+	}
+
+	g := &Graph{}
+
+	sourceNames := make([]string, 0, len(cfg.Sources))
+	for name := range cfg.Sources {
+		sourceNames = append(sourceNames, name)
+	}
+	sort.Strings(sourceNames)
+
+	// Track unique workflow names so each workflow file is only loaded once.
+	workflowSet := map[string]struct{}{}
+
+	for _, name := range sourceNames {
+		src := cfg.Sources[name]
+		node := Source{
+			Name:    name,
+			Type:    src.Type,
+			Repo:    src.Repo,
+			LLM:     src.LLM,
+			Model:   src.Model,
+			Exclude: append([]string(nil), src.Exclude...),
+		}
+
+		taskNames := make([]string, 0, len(src.Tasks))
+		for tname := range src.Tasks {
+			taskNames = append(taskNames, tname)
+		}
+		sort.Strings(taskNames)
+
+		for _, tname := range taskNames {
+			task := src.Tasks[tname]
+			trig := Trigger{
+				TaskName: tname,
+				Workflow: task.Workflow,
+				Labels:   append([]string(nil), task.Labels...),
+			}
+			if task.On != nil {
+				trig.OnReview = task.On.ReviewSubmitted
+				trig.OnChecks = task.On.ChecksFailed
+				trig.OnComment = task.On.Commented
+				trig.AuthorAllow = append([]string(nil), task.On.AuthorAllow...)
+				trig.AuthorDeny = append([]string(nil), task.On.AuthorDeny...)
+				// For PR-event sources, labels may live under task.On.
+				if len(trig.Labels) == 0 && len(task.On.Labels) > 0 {
+					trig.Labels = append([]string(nil), task.On.Labels...)
+				}
+			}
+			node.Triggers = append(node.Triggers, trig)
+			if task.Workflow != "" {
+				workflowSet[task.Workflow] = struct{}{}
+			}
+		}
+		g.Sources = append(g.Sources, node)
+	}
+
+	workflowNames := make([]string, 0, len(workflowSet))
+	for name := range workflowSet {
+		workflowNames = append(workflowNames, name)
+	}
+	sort.Strings(workflowNames)
+
+	for _, name := range workflowNames {
+		path := filepath.Join(workflowsDir, name+".yaml")
+		wf, err := workflow.Load(path)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				g.MissingWorkflows = append(g.MissingWorkflows, name)
+				continue
+			}
+			return nil, fmt.Errorf("load workflow %q: %w", name, err)
+		}
+		g.Workflows = append(g.Workflows, convertWorkflow(wf))
+	}
+
+	return g, nil
+}
+
+func convertWorkflow(w *workflow.Workflow) Workflow {
+	out := Workflow{
+		Name:        w.Name,
+		Description: w.Description,
+		LLM:         derefString(w.LLM),
+		Model:       derefString(w.Model),
+	}
+	for _, p := range w.Phases {
+		out.Phases = append(out.Phases, convertPhase(p))
+	}
+	return out
+}
+
+func convertPhase(p workflow.Phase) Phase {
+	out := Phase{
+		Name:      p.Name,
+		Type:      p.Type,
+		LLM:       derefString(p.LLM),
+		Model:     derefString(p.Model),
+		DependsOn: append([]string(nil), p.DependsOn...),
+		NoOp:      p.NoOp != nil,
+	}
+	if p.Gate != nil {
+		out.Gate = &Gate{
+			Type:    p.Gate.Type,
+			Run:     truncate(p.Gate.Run, 60),
+			WaitFor: p.Gate.WaitFor,
+			Retries: p.Gate.Retries,
+		}
+	}
+	return out
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}

--- a/cli/internal/visualize/build_test.go
+++ b/cli/internal/visualize/build_test.go
@@ -1,0 +1,318 @@
+package visualize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+)
+
+// writeWorkflowYAML writes a workflow YAML plus a stub prompt file so the
+// workflow.Load validator (which stats prompt_file) is satisfied.
+func writeWorkflowYAML(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name+".yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writePrompt(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuild_GitHubSourceWithSequentialWorkflow(t *testing.T) {
+	tmp := t.TempDir()
+	// Workflow load validates prompt_file paths relative to cwd.
+	oldCwd, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldCwd) //nolint:errcheck
+
+	writePrompt(t, "prompts/analyze.md")
+	writePrompt(t, "prompts/fix.md")
+	writeWorkflowYAML(t, "workflows", "fix-bug", `name: fix-bug
+description: Fix a reported bug
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 30
+  - name: fix
+    prompt_file: prompts/fix.md
+    max_turns: 60
+    gate:
+      type: command
+      run: "go test ./..."
+      retries: 2
+`)
+
+	cfg := &config.Config{
+		Sources: map[string]config.SourceConfig{
+			"bugs": {
+				Type: "github",
+				Repo: "owner/repo",
+				Tasks: map[string]config.Task{
+					"fix-bugs": {
+						Labels:   []string{"bug", "ready"},
+						Workflow: "fix-bug",
+					},
+				},
+			},
+		},
+	}
+
+	g, err := Build(cfg, "workflows")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if len(g.Sources) != 1 {
+		t.Fatalf("want 1 source, got %d", len(g.Sources))
+	}
+	src := g.Sources[0]
+	if src.Name != "bugs" || src.Type != "github" || src.Repo != "owner/repo" {
+		t.Errorf("unexpected source: %+v", src)
+	}
+	if len(src.Triggers) != 1 {
+		t.Fatalf("want 1 trigger, got %d", len(src.Triggers))
+	}
+	trig := src.Triggers[0]
+	if trig.Workflow != "fix-bug" || len(trig.Labels) != 2 {
+		t.Errorf("unexpected trigger: %+v", trig)
+	}
+
+	if len(g.Workflows) != 1 {
+		t.Fatalf("want 1 workflow, got %d", len(g.Workflows))
+	}
+	wf := g.Workflows[0]
+	if wf.Name != "fix-bug" || wf.Description != "Fix a reported bug" {
+		t.Errorf("unexpected workflow: %+v", wf)
+	}
+	if len(wf.Phases) != 2 {
+		t.Fatalf("want 2 phases, got %d", len(wf.Phases))
+	}
+	if wf.Phases[1].Gate == nil || wf.Phases[1].Gate.Type != "command" {
+		t.Errorf("expected command gate on fix phase")
+	}
+	if wf.Phases[1].Gate.Retries != 2 {
+		t.Errorf("gate retries: want 2, got %d", wf.Phases[1].Gate.Retries)
+	}
+}
+
+func TestBuild_PREventsSource(t *testing.T) {
+	tmp := t.TempDir()
+	oldCwd, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldCwd) //nolint:errcheck
+
+	writePrompt(t, "prompts/respond.md")
+	writeWorkflowYAML(t, "workflows", "respond-to-pr-review", `name: respond-to-pr-review
+phases:
+  - name: respond
+    prompt_file: prompts/respond.md
+    max_turns: 10
+`)
+
+	cfg := &config.Config{
+		Sources: map[string]config.SourceConfig{
+			"pr-lifecycle": {
+				Type: "github-pr-events",
+				Repo: "owner/repo",
+				Tasks: map[string]config.Task{
+					"respond-reviews": {
+						Workflow: "respond-to-pr-review",
+						On: &config.PREventsConfig{
+							ReviewSubmitted: true,
+							AuthorAllow:     []string{"copilot[bot]"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	g, err := Build(cfg, "workflows")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	trig := g.Sources[0].Triggers[0]
+	if !trig.OnReview {
+		t.Errorf("expected OnReview to be true")
+	}
+	if len(trig.AuthorAllow) != 1 || trig.AuthorAllow[0] != "copilot[bot]" {
+		t.Errorf("unexpected author allow: %+v", trig.AuthorAllow)
+	}
+}
+
+func TestBuild_MissingWorkflow(t *testing.T) {
+	tmp := t.TempDir()
+	oldCwd, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldCwd) //nolint:errcheck
+
+	if err := os.MkdirAll("workflows", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Sources: map[string]config.SourceConfig{
+			"bugs": {
+				Type: "github",
+				Repo: "owner/repo",
+				Tasks: map[string]config.Task{
+					"fix-bugs": {
+						Labels:   []string{"bug"},
+						Workflow: "does-not-exist",
+					},
+				},
+			},
+		},
+	}
+
+	g, err := Build(cfg, "workflows")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(g.MissingWorkflows) != 1 || g.MissingWorkflows[0] != "does-not-exist" {
+		t.Errorf("expected missing workflow entry, got %+v", g.MissingWorkflows)
+	}
+	if len(g.Workflows) != 0 {
+		t.Errorf("expected no loaded workflows, got %d", len(g.Workflows))
+	}
+}
+
+func TestBuild_DependsOnPhases(t *testing.T) {
+	tmp := t.TempDir()
+	oldCwd, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldCwd) //nolint:errcheck
+
+	writePrompt(t, "prompts/a.md")
+	writePrompt(t, "prompts/b.md")
+	writePrompt(t, "prompts/c.md")
+	writeWorkflowYAML(t, "workflows", "fanout", `name: fanout
+phases:
+  - name: setup
+    prompt_file: prompts/a.md
+    max_turns: 10
+  - name: left
+    prompt_file: prompts/b.md
+    max_turns: 10
+    depends_on: [setup]
+  - name: right
+    prompt_file: prompts/c.md
+    max_turns: 10
+    depends_on: [setup]
+`)
+
+	cfg := &config.Config{
+		Sources: map[string]config.SourceConfig{
+			"src": {
+				Type: "github",
+				Repo: "owner/repo",
+				Tasks: map[string]config.Task{
+					"t": {Labels: []string{"x"}, Workflow: "fanout"},
+				},
+			},
+		},
+	}
+
+	g, err := Build(cfg, "workflows")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wf := g.Workflows[0]
+	if len(wf.Phases) != 3 {
+		t.Fatalf("want 3 phases, got %d", len(wf.Phases))
+	}
+	if len(wf.Phases[1].DependsOn) != 1 || wf.Phases[1].DependsOn[0] != "setup" {
+		t.Errorf("expected left to depend on setup, got %+v", wf.Phases[1].DependsOn)
+	}
+}
+
+func TestBuild_NilConfig(t *testing.T) {
+	if _, err := Build(nil, "workflows"); err == nil {
+		t.Errorf("expected error for nil config")
+	}
+}
+
+func TestBuild_SortsSourcesAndWorkflows(t *testing.T) {
+	tmp := t.TempDir()
+	oldCwd, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldCwd) //nolint:errcheck
+
+	writePrompt(t, "prompts/a.md")
+	writeWorkflowYAML(t, "workflows", "a-wf", `name: a-wf
+phases:
+  - name: only
+    prompt_file: prompts/a.md
+    max_turns: 1
+`)
+	writeWorkflowYAML(t, "workflows", "z-wf", `name: z-wf
+phases:
+  - name: only
+    prompt_file: prompts/a.md
+    max_turns: 1
+`)
+
+	cfg := &config.Config{
+		Sources: map[string]config.SourceConfig{
+			"zebra": {
+				Type: "github", Repo: "o/r",
+				Tasks: map[string]config.Task{"t": {Labels: []string{"x"}, Workflow: "z-wf"}},
+			},
+			"alpha": {
+				Type: "github", Repo: "o/r",
+				Tasks: map[string]config.Task{"t": {Labels: []string{"x"}, Workflow: "a-wf"}},
+			},
+		},
+	}
+	g, err := Build(cfg, "workflows")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if g.Sources[0].Name != "alpha" || g.Sources[1].Name != "zebra" {
+		t.Errorf("sources not sorted: %s, %s", g.Sources[0].Name, g.Sources[1].Name)
+	}
+	if g.Workflows[0].Name != "a-wf" || g.Workflows[1].Name != "z-wf" {
+		t.Errorf("workflows not sorted: %s, %s", g.Workflows[0].Name, g.Workflows[1].Name)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		in   string
+		max  int
+		want string
+	}{
+		{"short", 10, "short"},
+		{"exactly10!", 10, "exactly10!"},
+		{"this is a longer string", 10, "this is..."},
+		{"abc", 2, "ab"},
+	}
+	for _, tc := range cases {
+		if got := truncate(tc.in, tc.max); got != tc.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
+		}
+	}
+}

--- a/cli/internal/visualize/dot.go
+++ b/cli/internal/visualize/dot.go
@@ -1,0 +1,160 @@
+package visualize
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// RenderDOT writes the graph as a Graphviz digraph. The output can be piped
+// through `dot -Tpng` (or any Graphviz frontend) to produce an image.
+func RenderDOT(g *Graph, w io.Writer) error {
+	var b strings.Builder
+
+	b.WriteString("digraph xylem {\n")
+	b.WriteString("  rankdir=LR;\n")
+	b.WriteString("  node [fontname=\"Helvetica\"];\n")
+	b.WriteString("  edge [fontname=\"Helvetica\", fontsize=10];\n\n")
+
+	// Sources.
+	b.WriteString("  // sources\n")
+	for _, src := range g.Sources {
+		id := sourceID(src.Name)
+		label := dotLabel(sourceHeader(src))
+		fmt.Fprintf(&b, "  %s [shape=box, style=\"filled,rounded\", fillcolor=\"#dbeafe\", color=\"#1d4ed8\", label=\"%s\"];\n", id, label)
+	}
+	b.WriteString("\n")
+
+	// Workflows as clusters.
+	workflowByName := map[string]*Workflow{}
+	for i := range g.Workflows {
+		workflowByName[g.Workflows[i].Name] = &g.Workflows[i]
+	}
+
+	for _, wf := range g.Workflows {
+		writeDOTCluster(&b, &wf)
+		b.WriteString("\n")
+	}
+
+	// Missing workflow placeholders.
+	for _, name := range g.MissingWorkflows {
+		id := workflowID(name)
+		label := dotLabel(fmt.Sprintf("%s\n(workflow file not found)", name))
+		fmt.Fprintf(&b, "  %s [shape=box, style=\"filled,rounded,dashed\", fillcolor=\"#fee2e2\", color=\"#b91c1c\", label=\"%s\"];\n", id, label)
+	}
+	if len(g.MissingWorkflows) > 0 {
+		b.WriteString("\n")
+	}
+
+	// Source -> workflow edges.
+	b.WriteString("  // triggers\n")
+	for _, src := range g.Sources {
+		for _, trig := range src.Triggers {
+			if trig.Workflow == "" {
+				continue
+			}
+			from := sourceID(src.Name)
+			to := workflowEntryID(trig.Workflow, workflowByName)
+			label := dotEdgeLabel(triggerLabel(trig))
+			if label == "" {
+				fmt.Fprintf(&b, "  %s -> %s;\n", from, to)
+			} else {
+				fmt.Fprintf(&b, "  %s -> %s [label=\"%s\"];\n", from, to, label)
+			}
+		}
+	}
+
+	b.WriteString("}\n")
+
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+func writeDOTCluster(b *strings.Builder, wf *Workflow) {
+	fmt.Fprintf(b, "  subgraph cluster_%s {\n", sanitizeID(wf.Name))
+	title := wf.Name
+	if wf.Description != "" {
+		title = fmt.Sprintf("%s: %s", wf.Name, wf.Description)
+	}
+	fmt.Fprintf(b, "    label=\"%s\";\n", dotLabel(title))
+	b.WriteString("    style=\"filled,rounded\";\n")
+	b.WriteString("    color=\"#6d28d9\";\n")
+	b.WriteString("    fillcolor=\"#ede9fe\";\n")
+
+	for _, p := range wf.Phases {
+		nodeID := phaseID(wf.Name, p.Name)
+		label := dotLabel(phaseLabel(p))
+		fmt.Fprintf(b, "    %s [shape=box, style=\"filled,rounded\", fillcolor=\"#ecfdf5\", color=\"#059669\", label=\"%s\"];\n", nodeID, label)
+		if p.Gate != nil {
+			gid := gateID(wf.Name, p.Name)
+			gl := dotLabel(gateLabel(p.Gate))
+			fmt.Fprintf(b, "    %s [shape=diamond, style=\"filled\", fillcolor=\"#fef3c7\", color=\"#b45309\", label=\"%s\"];\n", gid, gl)
+		}
+	}
+
+	writeDOTPhaseEdges(b, wf)
+
+	b.WriteString("  }\n")
+}
+
+func writeDOTPhaseEdges(b *strings.Builder, wf *Workflow) {
+	hasDeps := false
+	for _, p := range wf.Phases {
+		if len(p.DependsOn) > 0 {
+			hasDeps = true
+			break
+		}
+	}
+
+	if hasDeps {
+		for _, p := range wf.Phases {
+			for _, dep := range p.DependsOn {
+				from := phaseID(wf.Name, dep)
+				to := phaseID(wf.Name, p.Name)
+				fmt.Fprintf(b, "    %s -> %s;\n", from, to)
+			}
+		}
+		for _, p := range wf.Phases {
+			if p.Gate == nil {
+				continue
+			}
+			from := phaseID(wf.Name, p.Name)
+			fmt.Fprintf(b, "    %s -> %s;\n", from, gateID(wf.Name, p.Name))
+		}
+		return
+	}
+
+	for i := 0; i < len(wf.Phases); i++ {
+		cur := wf.Phases[i]
+		curID := phaseID(wf.Name, cur.Name)
+		if i == len(wf.Phases)-1 {
+			if cur.Gate != nil {
+				fmt.Fprintf(b, "    %s -> %s;\n", curID, gateID(wf.Name, cur.Name))
+			}
+			continue
+		}
+		next := wf.Phases[i+1]
+		nextID := phaseID(wf.Name, next.Name)
+		if cur.Gate != nil {
+			gid := gateID(wf.Name, cur.Name)
+			fmt.Fprintf(b, "    %s -> %s -> %s;\n", curID, gid, nextID)
+		} else {
+			fmt.Fprintf(b, "    %s -> %s;\n", curID, nextID)
+		}
+	}
+}
+
+// dotLabel escapes a multi-line label for a DOT string. DOT uses \n for
+// line breaks inside a label, and " must be escaped.
+func dotLabel(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\"", "\\\"")
+	return strings.ReplaceAll(s, "\n", "\\n")
+}
+
+// dotEdgeLabel collapses newlines into a space so edge labels stay single-line.
+func dotEdgeLabel(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\"", "\\\"")
+	return strings.ReplaceAll(s, "\n", " ")
+}

--- a/cli/internal/visualize/dot_test.go
+++ b/cli/internal/visualize/dot_test.go
@@ -1,0 +1,82 @@
+package visualize
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderDOT(t *testing.T) {
+	g := fixtureGraph()
+	var sb strings.Builder
+	if err := RenderDOT(g, &sb); err != nil {
+		t.Fatalf("RenderDOT: %v", err)
+	}
+	out := sb.String()
+
+	mustContain := []string{
+		"digraph xylem {",
+		"rankdir=LR;",
+		"src_bugs [",
+		"src_pr_lifecycle [",
+		"subgraph cluster_fix_bug {",
+		"wf_fix_bug__analyze [",
+		"wf_fix_bug__fix [",
+		"wf_fix_bug__fix_gate [shape=diamond",
+		"subgraph cluster_respond_to_pr_review {",
+		// Trigger edge with labels.
+		"src_bugs -> wf_fix_bug__analyze",
+		"labels: bug, ready",
+		"on: review_submitted",
+		// Missing workflow placeholder.
+		"wf_ghost [",
+		"workflow file not found",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(out, want) {
+			t.Errorf("dot output missing %q\n---\n%s", want, out)
+		}
+	}
+
+	// Sequential edge chain.
+	if !strings.Contains(out, "wf_fix_bug__analyze -> wf_fix_bug__fix") {
+		t.Errorf("expected sequential analyze -> fix edge:\n%s", out)
+	}
+	if !strings.Contains(out, "wf_fix_bug__fix -> wf_fix_bug__fix_gate") {
+		t.Errorf("expected fix -> gate edge:\n%s", out)
+	}
+}
+
+func TestRenderDOT_EscapesLabel(t *testing.T) {
+	// Verify that double quotes in strings are escaped.
+	g := &Graph{
+		Sources: []Source{
+			{
+				Name: "s",
+				Type: "github",
+				Triggers: []Trigger{
+					{TaskName: "t", Workflow: "wf", Labels: []string{"quote\"label"}},
+				},
+			},
+		},
+		Workflows: []Workflow{
+			{Name: "wf", Phases: []Phase{{Name: "only"}}},
+		},
+	}
+	var sb strings.Builder
+	if err := RenderDOT(g, &sb); err != nil {
+		t.Fatalf("RenderDOT: %v", err)
+	}
+	out := sb.String()
+	if !strings.Contains(out, `quote\"label`) {
+		t.Errorf("expected escaped quote in output:\n%s", out)
+	}
+}
+
+func TestDotLabel(t *testing.T) {
+	if got := dotLabel("line1\nline2"); got != `line1\nline2` {
+		t.Errorf("dotLabel newline escape: %q", got)
+	}
+	if got := dotLabel(`he said "hi"`); got != `he said \"hi\"` {
+		t.Errorf("dotLabel quote escape: %q", got)
+	}
+}

--- a/cli/internal/visualize/json.go
+++ b/cli/internal/visualize/json.go
@@ -1,0 +1,14 @@
+package visualize
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// RenderJSON writes the graph as indented JSON. This is the intermediate
+// format exposed verbatim so other tools can consume it.
+func RenderJSON(g *Graph, w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(g)
+}

--- a/cli/internal/visualize/json_test.go
+++ b/cli/internal/visualize/json_test.go
@@ -1,0 +1,38 @@
+package visualize
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestRenderJSON(t *testing.T) {
+	g := fixtureGraph()
+	var buf bytes.Buffer
+	if err := RenderJSON(g, &buf); err != nil {
+		t.Fatalf("RenderJSON: %v", err)
+	}
+
+	var round Graph
+	if err := json.Unmarshal(buf.Bytes(), &round); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+
+	if len(round.Sources) != len(g.Sources) {
+		t.Errorf("source count mismatch: got %d want %d", len(round.Sources), len(g.Sources))
+	}
+	if len(round.Workflows) != len(g.Workflows) {
+		t.Errorf("workflow count mismatch: got %d want %d", len(round.Workflows), len(g.Workflows))
+	}
+	if len(round.MissingWorkflows) != 1 || round.MissingWorkflows[0] != "ghost" {
+		t.Errorf("missing workflow round-trip failed: %+v", round.MissingWorkflows)
+	}
+
+	// Gate should round-trip as a pointer to the correct type.
+	if round.Workflows[0].Phases[1].Gate == nil {
+		t.Fatalf("expected gate on fix phase")
+	}
+	if round.Workflows[0].Phases[1].Gate.Type != "command" {
+		t.Errorf("gate type mismatch: %s", round.Workflows[0].Phases[1].Gate.Type)
+	}
+}

--- a/cli/internal/visualize/mermaid.go
+++ b/cli/internal/visualize/mermaid.go
@@ -1,0 +1,281 @@
+package visualize
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// RenderMermaid writes the graph as a Mermaid flowchart. The output is text
+// that can be pasted into a ```mermaid fenced block on GitHub/GitLab/VSCode
+// or piped through the mermaid CLI.
+func RenderMermaid(g *Graph, w io.Writer) error {
+	var b strings.Builder
+
+	b.WriteString("flowchart LR\n")
+
+	// Class definitions for visual distinction.
+	b.WriteString("  classDef source fill:#dbeafe,stroke:#1d4ed8,color:#0b1f4d;\n")
+	b.WriteString("  classDef workflow fill:#ede9fe,stroke:#6d28d9,color:#2e1065;\n")
+	b.WriteString("  classDef phase fill:#ecfdf5,stroke:#059669,color:#064e3b;\n")
+	b.WriteString("  classDef gate fill:#fef3c7,stroke:#b45309,color:#451a03;\n")
+	b.WriteString("  classDef missing fill:#fee2e2,stroke:#b91c1c,color:#450a0a,stroke-dasharray: 4 2;\n")
+	b.WriteString("\n")
+
+	// Source nodes.
+	for _, src := range g.Sources {
+		id := sourceID(src.Name)
+		label := mermaidLabel(sourceHeader(src))
+		fmt.Fprintf(&b, "  %s[%q]:::source\n", id, label)
+	}
+	b.WriteString("\n")
+
+	// Workflow subgraphs with phase and gate nodes.
+	workflowByName := map[string]*Workflow{}
+	for i := range g.Workflows {
+		workflowByName[g.Workflows[i].Name] = &g.Workflows[i]
+	}
+
+	for _, wf := range g.Workflows {
+		writeWorkflowSubgraph(&b, &wf)
+		b.WriteString("\n")
+	}
+
+	// Missing workflow placeholders.
+	for _, name := range g.MissingWorkflows {
+		id := workflowID(name)
+		label := mermaidLabel(fmt.Sprintf("%s\n(workflow file not found)", name))
+		fmt.Fprintf(&b, "  %s[%q]:::missing\n", id, label)
+	}
+	if len(g.MissingWorkflows) > 0 {
+		b.WriteString("\n")
+	}
+
+	// Source -> workflow edges, labeled with the trigger condition.
+	for _, src := range g.Sources {
+		for _, trig := range src.Triggers {
+			if trig.Workflow == "" {
+				continue
+			}
+			srcNode := sourceID(src.Name)
+			targetNode := workflowEntryID(trig.Workflow, workflowByName)
+			label := mermaidEdgeLabel(triggerLabel(trig))
+			if label == "" {
+				fmt.Fprintf(&b, "  %s --> %s\n", srcNode, targetNode)
+			} else {
+				fmt.Fprintf(&b, "  %s -- %q --> %s\n", srcNode, label, targetNode)
+			}
+		}
+	}
+
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+// writeWorkflowSubgraph emits a Mermaid subgraph containing the workflow's
+// phases, gates, and internal edges.
+func writeWorkflowSubgraph(b *strings.Builder, wf *Workflow) {
+	subID := workflowID(wf.Name)
+	title := wf.Name
+	if wf.Description != "" {
+		title = fmt.Sprintf("%s: %s", wf.Name, wf.Description)
+	}
+	fmt.Fprintf(b, "  subgraph %s[%q]\n", subID, mermaidLabel(title))
+	fmt.Fprintf(b, "    direction LR\n")
+
+	for _, p := range wf.Phases {
+		nodeID := phaseID(wf.Name, p.Name)
+		label := mermaidLabel(phaseLabel(p))
+		fmt.Fprintf(b, "    %s[%q]:::phase\n", nodeID, label)
+		if p.Gate != nil {
+			gid := gateID(wf.Name, p.Name)
+			gl := mermaidLabel(gateLabel(p.Gate))
+			// Mermaid's {{label}} renders a hexagon; good enough as a gate shape.
+			fmt.Fprintf(b, "    %s{{%q}}:::gate\n", gid, gl)
+		}
+	}
+
+	// Phase edges.
+	writePhaseEdges(b, wf)
+
+	b.WriteString("  end\n")
+}
+
+// writePhaseEdges emits edges between phases. If any phase has depends_on,
+// those edges are drawn; otherwise phases are linked sequentially. Gates are
+// inserted between a phase and its successor.
+func writePhaseEdges(b *strings.Builder, wf *Workflow) {
+	hasDeps := false
+	for _, p := range wf.Phases {
+		if len(p.DependsOn) > 0 {
+			hasDeps = true
+			break
+		}
+	}
+
+	if hasDeps {
+		for _, p := range wf.Phases {
+			for _, dep := range p.DependsOn {
+				from := phaseID(wf.Name, dep)
+				to := phaseID(wf.Name, p.Name)
+				fmt.Fprintf(b, "    %s --> %s\n", from, to)
+			}
+		}
+		// Dependency graphs still want gates drawn, but there is no canonical
+		// "next phase" to connect the gate to. Render the gate as a leaf from
+		// the gated phase so it is visible.
+		for _, p := range wf.Phases {
+			if p.Gate == nil {
+				continue
+			}
+			from := phaseID(wf.Name, p.Name)
+			gid := gateID(wf.Name, p.Name)
+			fmt.Fprintf(b, "    %s --> %s\n", from, gid)
+		}
+		return
+	}
+
+	for i := 0; i < len(wf.Phases); i++ {
+		cur := wf.Phases[i]
+		curID := phaseID(wf.Name, cur.Name)
+		if i == len(wf.Phases)-1 {
+			if cur.Gate != nil {
+				fmt.Fprintf(b, "    %s --> %s\n", curID, gateID(wf.Name, cur.Name))
+			}
+			continue
+		}
+		next := wf.Phases[i+1]
+		nextID := phaseID(wf.Name, next.Name)
+		if cur.Gate != nil {
+			gid := gateID(wf.Name, cur.Name)
+			fmt.Fprintf(b, "    %s --> %s --> %s\n", curID, gid, nextID)
+		} else {
+			fmt.Fprintf(b, "    %s --> %s\n", curID, nextID)
+		}
+	}
+}
+
+// workflowEntryID returns the Mermaid node ID that an incoming edge should
+// point at for a given workflow name. If the workflow is loaded and has
+// phases, it's the first phase; otherwise it's the workflow ID (placeholder).
+func workflowEntryID(name string, workflows map[string]*Workflow) string {
+	if wf, ok := workflows[name]; ok && len(wf.Phases) > 0 {
+		return phaseID(name, wf.Phases[0].Name)
+	}
+	return workflowID(name)
+}
+
+func sourceHeader(s Source) string {
+	var parts []string
+	parts = append(parts, s.Name)
+	if s.Type != "" {
+		parts = append(parts, "("+s.Type+")")
+	}
+	if s.Repo != "" {
+		parts = append(parts, s.Repo)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func phaseLabel(p Phase) string {
+	var lines []string
+	lines = append(lines, p.Name)
+	typ := p.Type
+	if typ == "" {
+		typ = "prompt"
+	}
+	lines = append(lines, "("+typ+")")
+	if p.LLM != "" {
+		model := p.LLM
+		if p.Model != "" {
+			model += "/" + p.Model
+		}
+		lines = append(lines, model)
+	}
+	if p.NoOp {
+		lines = append(lines, "noop-capable")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func gateLabel(g *Gate) string {
+	var lines []string
+	lines = append(lines, "gate: "+g.Type)
+	switch g.Type {
+	case "command":
+		if g.Run != "" {
+			lines = append(lines, g.Run)
+		}
+		if g.Retries > 0 {
+			lines = append(lines, fmt.Sprintf("retries=%d", g.Retries))
+		}
+	case "label":
+		if g.WaitFor != "" {
+			lines = append(lines, "wait_for: "+g.WaitFor)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func triggerLabel(t Trigger) string {
+	var parts []string
+	if len(t.Labels) > 0 {
+		parts = append(parts, "labels: "+strings.Join(t.Labels, ", "))
+	}
+	var events []string
+	if t.OnReview {
+		events = append(events, "review_submitted")
+	}
+	if t.OnChecks {
+		events = append(events, "checks_failed")
+	}
+	if t.OnComment {
+		events = append(events, "commented")
+	}
+	if len(events) > 0 {
+		parts = append(parts, "on: "+strings.Join(events, ", "))
+	}
+	return strings.Join(parts, " | ")
+}
+
+// mermaidLabel converts an internal multi-line label into Mermaid's quoted
+// label form. Newlines become <br/>, and embedded double quotes are escaped
+// using Mermaid's #quot; entity so fmt's %q quoting stays valid.
+func mermaidLabel(s string) string {
+	s = strings.ReplaceAll(s, "\"", "#quot;")
+	return strings.ReplaceAll(s, "\n", "<br/>")
+}
+
+// mermaidEdgeLabel is like mermaidLabel but collapses newlines to a space so
+// edge labels stay on one line.
+func mermaidEdgeLabel(s string) string {
+	s = strings.ReplaceAll(s, "\"", "#quot;")
+	return strings.ReplaceAll(s, "\n", " ")
+}
+
+// sanitizeID turns an arbitrary name into a valid Mermaid node id
+// (alphanumeric + underscore). Empty input becomes "_".
+func sanitizeID(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "_"
+	}
+	return b.String()
+}
+
+func sourceID(name string) string   { return "src_" + sanitizeID(name) }
+func workflowID(name string) string { return "wf_" + sanitizeID(name) }
+func phaseID(workflow, phase string) string {
+	return "wf_" + sanitizeID(workflow) + "__" + sanitizeID(phase)
+}
+func gateID(workflow, phase string) string {
+	return phaseID(workflow, phase) + "_gate"
+}

--- a/cli/internal/visualize/mermaid_test.go
+++ b/cli/internal/visualize/mermaid_test.go
@@ -1,0 +1,155 @@
+package visualize
+
+import (
+	"strings"
+	"testing"
+)
+
+func fixtureGraph() *Graph {
+	return &Graph{
+		Sources: []Source{
+			{
+				Name: "bugs",
+				Type: "github",
+				Repo: "owner/repo",
+				Triggers: []Trigger{
+					{
+						TaskName: "fix-bugs",
+						Workflow: "fix-bug",
+						Labels:   []string{"bug", "ready"},
+					},
+				},
+			},
+			{
+				Name: "pr-lifecycle",
+				Type: "github-pr-events",
+				Repo: "owner/repo",
+				Triggers: []Trigger{
+					{
+						TaskName: "respond",
+						Workflow: "respond-to-pr-review",
+						OnReview: true,
+					},
+				},
+			},
+		},
+		Workflows: []Workflow{
+			{
+				Name:        "fix-bug",
+				Description: "Fix a reported bug",
+				Phases: []Phase{
+					{Name: "analyze", Type: "prompt"},
+					{
+						Name: "fix",
+						Type: "prompt",
+						Gate: &Gate{Type: "command", Run: "go test ./...", Retries: 2},
+					},
+				},
+			},
+			{
+				Name: "respond-to-pr-review",
+				Phases: []Phase{
+					{Name: "respond", Type: "prompt"},
+				},
+			},
+		},
+		MissingWorkflows: []string{"ghost"},
+	}
+}
+
+func TestRenderMermaid(t *testing.T) {
+	g := fixtureGraph()
+	var sb strings.Builder
+	if err := RenderMermaid(g, &sb); err != nil {
+		t.Fatalf("RenderMermaid: %v", err)
+	}
+	out := sb.String()
+
+	mustContain := []string{
+		"flowchart LR",
+		"classDef source",
+		"classDef workflow",
+		"classDef phase",
+		"classDef gate",
+		"src_bugs",
+		"src_pr_lifecycle",
+		"subgraph wf_fix_bug",
+		"wf_fix_bug__analyze",
+		"wf_fix_bug__fix",
+		"wf_fix_bug__fix_gate",
+		"subgraph wf_respond_to_pr_review",
+		// Source -> first phase edge with labels trigger summary.
+		"src_bugs -- ",
+		"labels: bug, ready",
+		"--> wf_fix_bug__analyze",
+		// PR-event trigger label.
+		"on: review_submitted",
+		// Missing workflow placeholder.
+		"wf_ghost",
+		"workflow file not found",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(out, want) {
+			t.Errorf("mermaid output missing %q\n---\n%s", want, out)
+		}
+	}
+
+	// Sequential edge: analyze -> gate -> fix should be present when a phase
+	// has a gate and a successor.
+	// In this fixture, analyze has no gate but fix is the last phase with a
+	// gate, so we should see: analyze --> fix, then fix --> fix_gate.
+	if !strings.Contains(out, "wf_fix_bug__analyze --> wf_fix_bug__fix") {
+		t.Errorf("expected analyze -> fix sequential edge, got:\n%s", out)
+	}
+	if !strings.Contains(out, "wf_fix_bug__fix --> wf_fix_bug__fix_gate") {
+		t.Errorf("expected fix -> fix_gate edge, got:\n%s", out)
+	}
+}
+
+func TestRenderMermaid_DependsOn(t *testing.T) {
+	g := &Graph{
+		Sources: []Source{
+			{
+				Name:     "s",
+				Type:     "github",
+				Triggers: []Trigger{{TaskName: "t", Workflow: "wf", Labels: []string{"x"}}},
+			},
+		},
+		Workflows: []Workflow{
+			{
+				Name: "wf",
+				Phases: []Phase{
+					{Name: "setup"},
+					{Name: "left", DependsOn: []string{"setup"}},
+					{Name: "right", DependsOn: []string{"setup"}},
+				},
+			},
+		},
+	}
+	var sb strings.Builder
+	if err := RenderMermaid(g, &sb); err != nil {
+		t.Fatalf("RenderMermaid: %v", err)
+	}
+	out := sb.String()
+	if !strings.Contains(out, "wf_wf__setup --> wf_wf__left") {
+		t.Errorf("expected setup -> left depends_on edge:\n%s", out)
+	}
+	if !strings.Contains(out, "wf_wf__setup --> wf_wf__right") {
+		t.Errorf("expected setup -> right depends_on edge:\n%s", out)
+	}
+}
+
+func TestSanitizeID(t *testing.T) {
+	cases := map[string]string{
+		"fix-bug":              "fix_bug",
+		"github-pr-events":     "github_pr_events",
+		"alphaNumeric123":      "alphaNumeric123",
+		"":                     "_",
+		"with spaces and dots": "with_spaces_and_dots",
+	}
+	for in, want := range cases {
+		if got := sanitizeID(in); got != want {
+			t.Errorf("sanitizeID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cli/internal/visualize/model.go
+++ b/cli/internal/visualize/model.go
@@ -1,0 +1,77 @@
+// Package visualize builds an intermediate graph representation of a xylem
+// project's triggers and workflows, then renders it to various formats.
+//
+// The graph is a normalized, renderer-agnostic view of the two configuration
+// layers:
+//
+//   - .xylem.yml declares sources (triggers) and maps labels / PR events to
+//     tasks, which reference workflows by name.
+//   - .xylem/workflows/<name>.yaml declares phases with optional gates and
+//     depends_on edges.
+//
+// Build() stitches these together into a Graph. Renderers (RenderMermaid,
+// RenderDOT, RenderJSON) turn the Graph into a specific output format.
+package visualize
+
+// Graph is the intermediate representation that renderers consume.
+type Graph struct {
+	Sources   []Source   `json:"sources"`
+	Workflows []Workflow `json:"workflows"`
+	// MissingWorkflows lists workflow names referenced by a task whose YAML
+	// file could not be found on disk. The graph is still rendered, but these
+	// workflows appear as empty placeholders so the user sees the gap.
+	MissingWorkflows []string `json:"missing_workflows,omitempty"`
+}
+
+// Source corresponds to one entry under .xylem.yml#sources.
+type Source struct {
+	Name     string    `json:"name"`
+	Type     string    `json:"type"`
+	Repo     string    `json:"repo,omitempty"`
+	LLM      string    `json:"llm,omitempty"`
+	Model    string    `json:"model,omitempty"`
+	Exclude  []string  `json:"exclude,omitempty"`
+	Triggers []Trigger `json:"triggers"`
+}
+
+// Trigger describes one task within a source: the condition that fires it
+// and the workflow it runs.
+type Trigger struct {
+	TaskName    string   `json:"task_name"`
+	Workflow    string   `json:"workflow"`
+	Labels      []string `json:"labels,omitempty"`
+	OnReview    bool     `json:"on_review_submitted,omitempty"`
+	OnChecks    bool     `json:"on_checks_failed,omitempty"`
+	OnComment   bool     `json:"on_commented,omitempty"`
+	AuthorAllow []string `json:"author_allow,omitempty"`
+	AuthorDeny  []string `json:"author_deny,omitempty"`
+}
+
+// Workflow is a flattened view of workflow.Workflow.
+type Workflow struct {
+	Name        string  `json:"name"`
+	Description string  `json:"description,omitempty"`
+	LLM         string  `json:"llm,omitempty"`
+	Model       string  `json:"model,omitempty"`
+	Phases      []Phase `json:"phases"`
+}
+
+// Phase is a flattened view of workflow.Phase with *string fields
+// dereferenced and the gate summarized.
+type Phase struct {
+	Name      string   `json:"name"`
+	Type      string   `json:"type,omitempty"` // "prompt" | "command"
+	LLM       string   `json:"llm,omitempty"`
+	Model     string   `json:"model,omitempty"`
+	DependsOn []string `json:"depends_on,omitempty"`
+	NoOp      bool     `json:"noop,omitempty"`
+	Gate      *Gate    `json:"gate,omitempty"`
+}
+
+// Gate is a flattened view of workflow.Gate.
+type Gate struct {
+	Type    string `json:"type"` // "command" | "label"
+	Run     string `json:"run,omitempty"`
+	WaitFor string `json:"wait_for,omitempty"`
+	Retries int    `json:"retries,omitempty"`
+}


### PR DESCRIPTION
`xylem visualize` renders the sources, triggers, and workflows configured in .xylem.yml as a diagram. Config and workflow YAML files are first normalized into an intermediate graph model (visualize.Graph), then emitted via one of three renderers: mermaid (default, pastes into markdown), dot (Graphviz digraph), or json (the intermediate model verbatim).

Gates render as diamond nodes between a phase and its successor; depends_on is honored when present, otherwise phases link sequentially. Workflows referenced by a task but missing on disk are collected into Graph.MissingWorkflows and surfaced as placeholder nodes plus a warning on stderr so the diagram isn't silently incomplete.

Implemented with only stdlib text formatting — Mermaid and DOT are text grammars, so no new dependencies are added. The command is also exempt from the git/gh PATH check in PersistentPreRunE since it only reads local YAML.

https://claude.ai/code/session_01KmACYDHTYv378sJvxHt9Mv