### PR TITLE
feat: harness cost estimation and pricing lookup

### DIFF
--- a/cli/internal/cost/cost_prop_test.go
+++ b/cli/internal/cost/cost_prop_test.go
@@ -48,9 +48,9 @@ func genUsageRecord() *rapid.Generator[UsageRecord] {
 	})
 }
 
-// TestProp_TotalCostEqualsSumOfRecords verifies that TotalCost always equals
+// TestPropTotalCostEqualsSum verifies that TotalCost always equals
 // the sum of all recorded CostUSD values.
-func TestProp_TotalCostEqualsSumOfRecords(t *testing.T) {
+func TestPropTotalCostEqualsSum(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		records := rapid.SliceOfN(genUsageRecord(), 1, 50).Draw(t, "records")
 		tr := NewTracker(nil)
@@ -69,8 +69,8 @@ func TestProp_TotalCostEqualsSumOfRecords(t *testing.T) {
 	})
 }
 
-// TestProp_TotalTokensEqualsSumOfRecords verifies token sum invariant.
-func TestProp_TotalTokensEqualsSumOfRecords(t *testing.T) {
+// TestPropTotalTokensEqualsSum verifies token sum invariant.
+func TestPropTotalTokensEqualsSum(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		records := rapid.SliceOfN(genUsageRecord(), 1, 50).Draw(t, "records")
 		tr := NewTracker(nil)
@@ -89,8 +89,8 @@ func TestProp_TotalTokensEqualsSumOfRecords(t *testing.T) {
 	})
 }
 
-// TestProp_CostByRoleSumsToTotalCost verifies that per-role costs sum to total.
-func TestProp_CostByRoleSumsToTotalCost(t *testing.T) {
+// TestPropCostByRoleSumsToTotal verifies that per-role costs sum to total.
+func TestPropCostByRoleSumsToTotal(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		records := rapid.SliceOfN(genUsageRecord(), 1, 50).Draw(t, "records")
 		tr := NewTracker(nil)
@@ -112,8 +112,8 @@ func TestProp_CostByRoleSumsToTotalCost(t *testing.T) {
 	})
 }
 
-// TestProp_CostByPurposeSumsToTotalCost verifies that per-purpose costs sum to total.
-func TestProp_CostByPurposeSumsToTotalCost(t *testing.T) {
+// TestPropCostByPurposeSumsToTotal verifies that per-purpose costs sum to total.
+func TestPropCostByPurposeSumsToTotal(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		records := rapid.SliceOfN(genUsageRecord(), 1, 50).Draw(t, "records")
 		tr := NewTracker(nil)
@@ -135,8 +135,8 @@ func TestProp_CostByPurposeSumsToTotalCost(t *testing.T) {
 	})
 }
 
-// TestProp_CostByModelSumsToTotalCost verifies that per-model costs sum to total.
-func TestProp_CostByModelSumsToTotalCost(t *testing.T) {
+// TestPropCostByModelSumsToTotal verifies that per-model costs sum to total.
+func TestPropCostByModelSumsToTotal(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		records := rapid.SliceOfN(genUsageRecord(), 1, 50).Draw(t, "records")
 		tr := NewTracker(nil)
@@ -158,9 +158,9 @@ func TestProp_CostByModelSumsToTotalCost(t *testing.T) {
 	})
 }
 
-// TestProp_BudgetExceededIsMonotonic verifies that once BudgetExceeded returns
+// TestPropBudgetExceededIsMonotonic verifies that once BudgetExceeded returns
 // true, it never reverts to false.
-func TestProp_BudgetExceededIsMonotonic(t *testing.T) {
+func TestPropBudgetExceededIsMonotonic(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		limit := float64(rapid.IntRange(1, 100).Draw(t, "limit_cents")) / 100.0
 		budget := &Budget{CostLimitUSD: limit}
@@ -182,8 +182,8 @@ func TestProp_BudgetExceededIsMonotonic(t *testing.T) {
 	})
 }
 
-// TestProp_ReportRoundTrip verifies that saving and loading a report preserves data.
-func TestProp_ReportRoundTrip(t *testing.T) {
+// TestPropReportRoundTrip verifies that saving and loading a report preserves data.
+func TestPropReportRoundTrip(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		records := rapid.SliceOfN(genUsageRecord(), 1, 20).Draw(t, "records")
 		tr := NewTracker(nil)
@@ -245,9 +245,9 @@ func TestProp_ReportRoundTrip(t *testing.T) {
 	})
 }
 
-// TestProp_AnomalyRatioAlwaysExceedsThreshold verifies that every anomaly
+// TestPropAnomalyRatioAboveThreshold verifies that every anomaly
 // reported has a ratio > 2.0.
-func TestProp_AnomalyRatioAlwaysExceedsThreshold(t *testing.T) {
+func TestPropAnomalyRatioAboveThreshold(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		// Generate a current report with potentially high values.
 		currentCost := float64(rapid.IntRange(1, 10000).Draw(t, "current_cost")) / 100.0
@@ -283,9 +283,9 @@ func TestProp_AnomalyRatioAlwaysExceedsThreshold(t *testing.T) {
 	})
 }
 
-// TestProp_ZeroCostRecordPreservesTotalCost verifies that recording a zero-cost
+// TestPropZeroCostRecordPreservesTotal verifies that recording a zero-cost
 // event never changes the running total.
-func TestProp_ZeroCostRecordPreservesTotalCost(t *testing.T) {
+func TestPropZeroCostRecordPreservesTotal(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		records := rapid.SliceOfN(genUsageRecord(), 1, 20).Draw(t, "records")
 		tr := NewTracker(nil)
@@ -315,9 +315,9 @@ func TestProp_ZeroCostRecordPreservesTotalCost(t *testing.T) {
 	})
 }
 
-// TestPropWindowedTotalCostEqualsSumOfRecords verifies that TotalCost always
+// TestPropWindowedTotalCostEqualsSum verifies that TotalCost always
 // equals the sum of all CostUSD values regardless of window rotation.
-func TestPropWindowedTotalCostEqualsSumOfRecords(t *testing.T) {
+func TestPropWindowedTotalCostEqualsSum(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		window := time.Duration(rapid.IntRange(1, 60).Draw(t, "window_minutes")) * time.Minute
 		budget := Budget{CostLimitUSD: 1000.0, Window: window}
@@ -345,9 +345,9 @@ func TestPropWindowedTotalCostEqualsSumOfRecords(t *testing.T) {
 	})
 }
 
-// TestPropWindowedCostNeverNegative verifies that both window cost and total
+// TestPropWindowedCostsNeverNegative verifies that both window cost and total
 // cost are never negative.
-func TestPropWindowedCostNeverNegative(t *testing.T) {
+func TestPropWindowedCostsNeverNegative(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		window := time.Duration(rapid.IntRange(1, 60).Draw(t, "window_minutes")) * time.Minute
 		budget := Budget{CostLimitUSD: 1000.0, Window: window}
@@ -412,8 +412,8 @@ func TestPropWindowedExceededResetsOnRotation(t *testing.T) {
 	})
 }
 
-// TestProp_BudgetUtilizationMatchesCost verifies utilization = totalCost / limit.
-func TestProp_BudgetUtilizationMatchesCost(t *testing.T) {
+// TestPropBudgetUtilizationMatchesCost verifies utilization = totalCost / limit.
+func TestPropBudgetUtilizationMatchesCost(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		limit := float64(rapid.IntRange(1, 1000).Draw(t, "limit_cents")) / 100.0
 		budget := &Budget{CostLimitUSD: limit}

--- a/cli/internal/cost/estimate_prop_test.go
+++ b/cli/internal/cost/estimate_prop_test.go
@@ -18,7 +18,7 @@ func genPricedModel() *rapid.Generator[string] {
 	return rapid.SampledFrom(models)
 }
 
-func TestProp_EstimateTokensAlwaysNonNegative(t *testing.T) {
+func TestPropEstimateTokensNonNegative(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		content := rapid.String().Draw(t, "content")
 		if got := EstimateTokens(content); got < 0 {
@@ -27,7 +27,7 @@ func TestProp_EstimateTokensAlwaysNonNegative(t *testing.T) {
 	})
 }
 
-func TestProp_EstimateTokensMonotonicallyIncreasing(t *testing.T) {
+func TestPropEstimateTokensMonotonicallyIncreasing(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		base := rapid.String().Draw(t, "base")
 		suffix := rapid.String().Draw(t, "suffix")
@@ -40,7 +40,7 @@ func TestProp_EstimateTokensMonotonicallyIncreasing(t *testing.T) {
 	})
 }
 
-func TestProp_EstimateCostNonNegativeForValidInputs(t *testing.T) {
+func TestPropEstimateCostNonNegative(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		inputTokens := rapid.IntRange(0, 1_000_000).Draw(t, "input_tokens")
 		outputTokens := rapid.IntRange(0, 1_000_000).Draw(t, "output_tokens")
@@ -55,7 +55,7 @@ func TestProp_EstimateCostNonNegativeForValidInputs(t *testing.T) {
 	})
 }
 
-func TestProp_EstimateCostNilPricingAlwaysZero(t *testing.T) {
+func TestPropEstimateCostNilPricingAlwaysZero(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		inputTokens := rapid.IntRange(0, 1_000_000).Draw(t, "input_tokens")
 		outputTokens := rapid.IntRange(0, 1_000_000).Draw(t, "output_tokens")
@@ -66,7 +66,7 @@ func TestProp_EstimateCostNilPricingAlwaysZero(t *testing.T) {
 	})
 }
 
-func TestProp_EstimateCostLinearInTokens(t *testing.T) {
+func TestPropEstimateCostLinearInTokens(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		inputTokens := rapid.IntRange(0, 500_000).Draw(t, "input_tokens")
 		outputTokens := rapid.IntRange(0, 500_000).Draw(t, "output_tokens")
@@ -83,7 +83,7 @@ func TestProp_EstimateCostLinearInTokens(t *testing.T) {
 	})
 }
 
-func TestProp_LookupPricingExactMatchAlwaysReturnsEntry(t *testing.T) {
+func TestPropLookupPricingExactMatchAlwaysReturns(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		model := genPricedModel().Draw(t, "model")
 		got := LookupPricing(model)
@@ -99,7 +99,7 @@ func TestProp_LookupPricingExactMatchAlwaysReturnsEntry(t *testing.T) {
 	})
 }
 
-func TestProp_LookupPricingPrefixAppendNeverReturnsNil(t *testing.T) {
+func TestPropLookupPricingPrefixAppendNeverNil(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		model := genPricedModel().Draw(t, "model")
 		suffix := rapid.StringMatching(`[a-z0-9-]{1,20}`).Draw(t, "suffix")

--- a/cli/internal/cost/estimate_test.go
+++ b/cli/internal/cost/estimate_test.go
@@ -1,90 +1,72 @@
 package cost
 
 import (
-	"math"
 	"testing"
 
 	"github.com/nicholls-inc/xylem/cli/internal/ctxmgr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSmoke_S17_EstimateTokensKnownString(t *testing.T) {
+func TestSmoke_S17_EstimateTokensReturnsLen4ForKnownString(t *testing.T) {
 	content := "Hello, world! This is a test string."
 
-	if got := EstimateTokens(content); got != 9 {
-		t.Fatalf("EstimateTokens(%q) = %d, want 9", content, got)
-	}
+	assert.Equal(t, 9, EstimateTokens(content))
 }
 
-func TestSmoke_S18_EstimateTokensEmptyString(t *testing.T) {
-	if got := EstimateTokens(""); got != 0 {
-		t.Fatalf(`EstimateTokens("") = %d, want 0`, got)
-	}
+func TestSmoke_S18_EstimateTokensReturnsZeroForEmptyString(t *testing.T) {
+	assert.Equal(t, 0, EstimateTokens(""))
 }
 
-func TestSmoke_S19_EstimateCostKnownPricing(t *testing.T) {
+func TestSmoke_S19_EstimateCostWithKnownPricingProducesCorrectArithmetic(t *testing.T) {
 	got := EstimateCost(1_000_000, 500_000, &ModelPricing{
 		InputPer1M:  3.00,
 		OutputPer1M: 15.00,
 	})
 
-	if math.Abs(got-10.5) > 1e-9 {
-		t.Fatalf("EstimateCost() = %f, want 10.5", got)
-	}
+	assert.InDelta(t, 10.5, got, 1e-9)
 }
 
-func TestSmoke_S20_EstimateCostNilPricing(t *testing.T) {
-	if got := EstimateCost(5000, 1000, nil); got != 0 {
-		t.Fatalf("EstimateCost() = %f, want 0", got)
-	}
+func TestSmoke_S20_EstimateCostWithNilPricingReturnsZero(t *testing.T) {
+	assert.Equal(t, 0.0, EstimateCost(5000, 1000, nil))
 }
 
-func TestSmoke_S21_LookupPricingExactMatch(t *testing.T) {
+func TestSmoke_S21_LookupPricingExactMatchReturnsCorrectPricing(t *testing.T) {
 	pricing := LookupPricing("claude-sonnet-4")
-	if pricing == nil {
-		t.Fatal("LookupPricing() returned nil, want pricing")
-		return
-	}
-	if pricing.InputPer1M != 3.00 || pricing.OutputPer1M != 15.00 {
-		t.Fatalf("LookupPricing() = %+v, want input=3.00 output=15.00", *pricing)
-	}
+
+	require.NotNil(t, pricing)
+	assert.Equal(t, 3.00, pricing.InputPer1M)
+	assert.Equal(t, 15.00, pricing.OutputPer1M)
 }
 
-func TestSmoke_S22_LookupPricingPrefixFallback(t *testing.T) {
+func TestSmoke_S22_LookupPricingFallsBackToPrefixMatchForVersionedModelName(t *testing.T) {
 	pricing := LookupPricing("claude-sonnet-4-20250514")
-	if pricing == nil {
-		t.Fatal("LookupPricing() returned nil, want pricing")
-		return
-	}
-	if pricing.InputPer1M != 3.00 || pricing.OutputPer1M != 15.00 {
-		t.Fatalf("LookupPricing() = %+v, want input=3.00 output=15.00", *pricing)
-	}
+
+	require.NotNil(t, pricing)
+	assert.Equal(t, 3.00, pricing.InputPer1M)
+	assert.Equal(t, 15.00, pricing.OutputPer1M)
 }
 
-func TestSmoke_S23_LookupPricingLongestPrefix(t *testing.T) {
+func TestSmoke_S23_LookupPricingLongestPrefixWinsWhenMultiplePrefixesMatch(t *testing.T) {
 	original := DefaultPricingTable
 	DefaultPricingTable = map[string]ModelPricing{
-		"claude":         {InputPer1M: 99.0, OutputPer1M: 99.0},
 		"claude-haiku":   {InputPer1M: 9.0, OutputPer1M: 9.0},
+		"claude-haiku-3": {InputPer1M: 0.25, OutputPer1M: 1.25},
 		"claude-haiku-4": {InputPer1M: 0.80, OutputPer1M: 4.00},
 	}
 	t.Cleanup(func() {
 		DefaultPricingTable = original
 	})
 
-	pricing := LookupPricing("claude-haiku-4-20250514")
-	if pricing == nil {
-		t.Fatal("LookupPricing() returned nil, want pricing")
-		return
-	}
-	if pricing.InputPer1M != 0.80 || pricing.OutputPer1M != 4.00 {
-		t.Fatalf("LookupPricing() = %+v, want input=0.80 output=4.00", *pricing)
-	}
+	pricing := LookupPricing("claude-haiku-4-5")
+
+	require.NotNil(t, pricing)
+	assert.Equal(t, 0.80, pricing.InputPer1M)
+	assert.Equal(t, 4.00, pricing.OutputPer1M)
 }
 
-func TestSmoke_S24_LookupPricingUnrecognised(t *testing.T) {
-	if pricing := LookupPricing("gpt-4o"); pricing != nil {
-		t.Fatalf("LookupPricing() = %+v, want nil", *pricing)
-	}
+func TestSmoke_S24_LookupPricingReturnsNilForUnrecognisedModel(t *testing.T) {
+	assert.Nil(t, LookupPricing("gpt-4o"))
 }
 
 func TestEstimateTokensMatchesCtxmgr(t *testing.T) {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -1009,7 +1011,7 @@ func TestDrainPromptOnlyWithRef(t *testing.T) {
 	}
 }
 
-func TestSmoke_WS3_S25_PerVesselTrackerCreatedFresh(t *testing.T) {
+func TestSmoke_S25_PerVesselTrackerIsCreatedFreshForEachVessel(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)
 	cfg.StateDir = filepath.Join(dir, ".xylem")
@@ -1041,31 +1043,27 @@ func TestSmoke_WS3_S25_PerVesselTrackerCreatedFresh(t *testing.T) {
 	}
 
 	result, err := r.Drain(context.Background())
-	if err != nil {
-		t.Fatalf("Drain() error = %v", err)
-	}
-	if result.Completed != 2 {
-		t.Fatalf("Completed = %d, want 2", result.Completed)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Completed)
 
 	summary1 := loadSummary(t, cfg.StateDir, "issue-1")
 	summary2 := loadSummary(t, cfg.StateDir, "issue-2")
-	if summary1.BudgetExceeded {
-		t.Fatal("summary1.BudgetExceeded = true, want false")
-	}
-	if summary2.BudgetExceeded {
-		t.Fatal("summary2.BudgetExceeded = true, want false")
-	}
-	if len(summary2.Phases) != 1 {
-		t.Fatalf("len(summary2.Phases) = %d, want 1", len(summary2.Phases))
-	}
-	wantTokens := summary2.Phases[0].InputTokensEst + summary2.Phases[0].OutputTokensEst
-	if summary2.TotalTokensEst != wantTokens {
-		t.Fatalf("summary2.TotalTokensEst = %d, want %d", summary2.TotalTokensEst, wantTokens)
-	}
+	require.Len(t, summary1.Phases, 1)
+	require.Len(t, summary2.Phases, 1)
+
+	phase1Tokens := summary1.Phases[0].InputTokensEst + summary1.Phases[0].OutputTokensEst
+	phase2Tokens := summary2.Phases[0].InputTokensEst + summary2.Phases[0].OutputTokensEst
+
+	assert.False(t, summary1.BudgetExceeded)
+	assert.False(t, summary2.BudgetExceeded)
+	assert.Positive(t, phase1Tokens)
+	assert.Equal(t, phase1Tokens, summary1.TotalTokensEst)
+	assert.Equal(t, phase2Tokens, summary2.TotalTokensEst)
+	assert.Less(t, phase1Tokens, 150)
+	assert.Greater(t, phase1Tokens*2, 150)
 }
 
-func TestSmoke_WS3_S26_CostRecordedAfterEachPromptPhase(t *testing.T) {
+func TestSmoke_S26_CostRecordedAfterEachPromptTypePhase(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)
 	cfg.StateDir = filepath.Join(dir, ".xylem")
@@ -1096,28 +1094,21 @@ func TestSmoke_WS3_S26_CostRecordedAfterEachPromptPhase(t *testing.T) {
 	}
 
 	result, err := r.Drain(context.Background())
-	if err != nil {
-		t.Fatalf("Drain() error = %v", err)
-	}
-	if result.Completed != 1 {
-		t.Fatalf("Completed = %d, want 1", result.Completed)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
 
 	summary := loadSummary(t, cfg.StateDir, "issue-1")
-	if len(summary.Phases) != 2 {
-		t.Fatalf("len(summary.Phases) = %d, want 2", len(summary.Phases))
-	}
-	if summary.TotalTokensEst <= 0 {
-		t.Fatalf("summary.TotalTokensEst = %d, want > 0", summary.TotalTokensEst)
-	}
+	require.Len(t, summary.Phases, 2)
+	assert.Positive(t, summary.TotalTokensEst)
 	for i, phaseSummary := range summary.Phases {
-		if phaseSummary.InputTokensEst <= 0 {
-			t.Fatalf("summary.Phases[%d].InputTokensEst = %d, want > 0", i, phaseSummary.InputTokensEst)
-		}
+		assert.Equal(t, "prompt", phaseSummary.Type, "phase %d type", i)
+		assert.Positive(t, phaseSummary.InputTokensEst, "phase %d input tokens", i)
+		assert.Positive(t, phaseSummary.OutputTokensEst, "phase %d output tokens", i)
+		assert.Positive(t, phaseSummary.CostUSDEst, "phase %d cost", i)
 	}
 }
 
-func TestSmoke_WS3_S27_CommandPhaseNoCostRecord(t *testing.T) {
+func TestSmoke_S27_CommandTypePhasesDoNotGenerateCostRecords(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)
 	cfg.StateDir = filepath.Join(dir, ".xylem")
@@ -1153,31 +1144,27 @@ func TestSmoke_WS3_S27_CommandPhaseNoCostRecord(t *testing.T) {
 	}
 
 	result, err := r.Drain(context.Background())
-	if err != nil {
-		t.Fatalf("Drain() error = %v", err)
-	}
-	if result.Completed != 1 {
-		t.Fatalf("Completed = %d, want 1", result.Completed)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
 
 	summary := loadSummary(t, cfg.StateDir, "issue-1")
-	if len(summary.Phases) != 2 {
-		t.Fatalf("len(summary.Phases) = %d, want 2", len(summary.Phases))
-	}
+	require.Len(t, summary.Phases, 2)
+	promptPhase := summary.Phases[0]
 	commandPhase := summary.Phases[1]
-	if commandPhase.Type != "command" {
-		t.Fatalf("commandPhase.Type = %q, want command", commandPhase.Type)
-	}
-	if commandPhase.InputTokensEst != 0 || commandPhase.OutputTokensEst != 0 || commandPhase.CostUSDEst != 0 {
-		t.Fatalf("command phase usage = %+v, want zero usage", commandPhase)
-	}
-	wantTotal := summary.Phases[0].InputTokensEst + summary.Phases[0].OutputTokensEst
-	if summary.TotalTokensEst != wantTotal {
-		t.Fatalf("summary.TotalTokensEst = %d, want %d", summary.TotalTokensEst, wantTotal)
-	}
+
+	assert.Equal(t, "prompt", promptPhase.Type)
+	assert.Positive(t, promptPhase.InputTokensEst)
+	assert.Positive(t, promptPhase.OutputTokensEst)
+	assert.Positive(t, promptPhase.CostUSDEst)
+	assert.Equal(t, "command", commandPhase.Type)
+	assert.Zero(t, commandPhase.InputTokensEst)
+	assert.Zero(t, commandPhase.OutputTokensEst)
+	assert.Zero(t, commandPhase.CostUSDEst)
+	assert.Equal(t, promptPhase.InputTokensEst+promptPhase.OutputTokensEst, summary.TotalTokensEst)
+	assert.Equal(t, promptPhase.CostUSDEst, summary.TotalCostUSDEst)
 }
 
-func TestSmoke_WS3_S28_BudgetEnforcementFailsVessel(t *testing.T) {
+func TestSmoke_S28_BudgetEnforcementFailsVesselWhenBudgetIsExceeded(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)
 	cfg.StateDir = filepath.Join(dir, ".xylem")
@@ -1188,7 +1175,9 @@ func TestSmoke_WS3_S28_BudgetEnforcementFailsVessel(t *testing.T) {
 	_, _ = q.Enqueue(makeVessel(1, "budget-fail"))
 
 	writeWorkflowFile(t, dir, "budget-fail", []testPhase{
-		{name: "implement", promptContent: "Budget failure path", maxTurns: 5},
+		{name: "plan", promptContent: "Budget failure phase 1", maxTurns: 5},
+		{name: "implement", promptContent: "Budget failure phase 2", maxTurns: 5},
+		{name: "verify", promptContent: "Budget failure phase 3", maxTurns: 5},
 	})
 
 	oldWd, _ := os.Getwd()
@@ -1197,7 +1186,7 @@ func TestSmoke_WS3_S28_BudgetEnforcementFailsVessel(t *testing.T) {
 
 	cmdRunner := &mockCmdRunner{
 		phaseOutputs: map[string][]byte{
-			"Budget failure path": []byte(strings.Repeat("y", 4000)),
+			"Budget failure phase 1": []byte(strings.Repeat("y", 4000)),
 		},
 	}
 	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
@@ -1206,37 +1195,27 @@ func TestSmoke_WS3_S28_BudgetEnforcementFailsVessel(t *testing.T) {
 	}
 
 	result, err := r.Drain(context.Background())
-	if err != nil {
-		t.Fatalf("Drain() error = %v", err)
-	}
-	if result.Failed != 1 {
-		t.Fatalf("Failed = %d, want 1", result.Failed)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
 
 	vessels, err := q.List()
-	if err != nil {
-		t.Fatalf("List() error = %v", err)
-	}
-	if !strings.Contains(vessels[0].Error, "budget exceeded") {
-		t.Fatalf("vessel.Error = %q, want budget exceeded", vessels[0].Error)
-	}
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, queue.StateFailed, vessels[0].State)
+	assert.Contains(t, vessels[0].Error, "budget exceeded")
+	assert.Contains(t, vessels[0].Error, "estimated cost")
+	assert.Contains(t, vessels[0].Error, "estimated tokens")
+	require.Len(t, cmdRunner.phaseCalls, 1)
+	assert.Contains(t, cmdRunner.phaseCalls[0].prompt, "Budget failure phase 1")
 
 	summary := loadSummary(t, cfg.StateDir, "issue-1")
-	if summary.State != "failed" {
-		t.Fatalf("summary.State = %q, want failed", summary.State)
-	}
-	if len(summary.Phases) != 1 {
-		t.Fatalf("len(summary.Phases) = %d, want 1", len(summary.Phases))
-	}
-	if summary.Phases[0].Status != "failed" {
-		t.Fatalf("summary.Phases[0].Status = %q, want failed", summary.Phases[0].Status)
-	}
-	if !summary.BudgetExceeded {
-		t.Fatal("summary.BudgetExceeded = false, want true")
-	}
+	assert.Equal(t, "failed", summary.State)
+	require.Len(t, summary.Phases, 1)
+	assert.Equal(t, "failed", summary.Phases[0].Status)
+	assert.True(t, summary.BudgetExceeded)
 }
 
-func TestSmoke_WS3_S29_NilBudgetNoEnforcement(t *testing.T) {
+func TestSmoke_S29_NilBudgetMeansNoEnforcement(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)
 	cfg.StateDir = filepath.Join(dir, ".xylem")
@@ -1264,20 +1243,18 @@ func TestSmoke_WS3_S29_NilBudgetNoEnforcement(t *testing.T) {
 	}
 
 	result, err := r.Drain(context.Background())
-	if err != nil {
-		t.Fatalf("Drain() error = %v", err)
-	}
-	if result.Completed != 1 {
-		t.Fatalf("Completed = %d, want 1", result.Completed)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
+
+	vessels, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, queue.StateCompleted, vessels[0].State)
+	assert.NotContains(t, vessels[0].Error, "budget exceeded")
 
 	summary := loadSummary(t, cfg.StateDir, "issue-1")
-	if summary.State != "completed" {
-		t.Fatalf("summary.State = %q, want completed", summary.State)
-	}
-	if summary.BudgetExceeded {
-		t.Fatal("summary.BudgetExceeded = true, want false")
-	}
+	assert.Equal(t, "completed", summary.State)
+	assert.False(t, summary.BudgetExceeded)
 }
 
 func TestSmoke_WS6_S5_BudgetExceededShortCircuitsBeforeGate(t *testing.T) {


### PR DESCRIPTION
## Summary

Improves test quality for the cost estimation and pricing lookup implementation (issue #80, spec section 6.1):

- Migrates smoke tests (S17-S24) and integration tests (S25-S29) from manual `if/t.Fatalf` assertions to `testify/assert` and `testify/require` for clearer failure messages
- Standardises test naming to match smoke scenario titles (e.g. `TestSmoke_S17_EstimateTokensReturnsLen4ForKnownString`)
- Normalises property test names from `TestProp_FooBar` to `TestPropFooBar` for consistency with Go naming conventions
- Strengthens S28 budget enforcement test with a 3-phase workflow and assertions on estimated cost/token values in error messages
- Adds additional token count assertions to S25 per-vessel tracker test

### Smoke scenarios covered

| Scenario | Test | Description |
|----------|------|-------------|
| S17 | `TestSmoke_S17_EstimateTokensReturnsLen4ForKnownString` | EstimateTokens returns len/4 for known string |
| S18 | `TestSmoke_S18_EstimateTokensReturnsZeroForEmptyString` | EstimateTokens returns 0 for empty string |
| S19 | `TestSmoke_S19_EstimateCostWithKnownPricingProducesCorrectArithmetic` | EstimateCost with known pricing |
| S20 | `TestSmoke_S20_EstimateCostWithNilPricingReturnsZero` | EstimateCost with nil pricing returns 0 |
| S21 | `TestSmoke_S21_LookupPricingExactMatchReturnsCorrectPricing` | LookupPricing exact match |
| S22 | `TestSmoke_S22_LookupPricingFallsBackToPrefixMatchForVersionedModelName` | LookupPricing prefix fallback |
| S23 | `TestSmoke_S23_LookupPricingLongestPrefixWinsWhenMultiplePrefixesMatch` | LookupPricing longest prefix wins |
| S24 | `TestSmoke_S24_LookupPricingReturnsNilForUnrecognisedModel` | LookupPricing returns nil for unknown model |
| S25 | `TestSmoke_S25_PerVesselTrackerIsCreatedFreshForEachVessel` | Per-vessel tracker isolation |
| S26 | `TestSmoke_S26_CostRecordedAfterEachPromptTypePhase` | Cost recorded per prompt phase |
| S27 | `TestSmoke_S27_CommandTypePhasesDoNotGenerateCostRecords` | Command phases skip cost recording |
| S28 | `TestSmoke_S28_BudgetEnforcementFailsVesselWhenBudgetIsExceeded` | Budget enforcement fails vessel |
| S29 | `TestSmoke_S29_NilBudgetMeansNoEnforcement` | Nil budget skips enforcement |

Closes #80

## Test plan

- [x] `go build ./cmd/xylem` succeeds
- [x] `go test ./...` — all 30 packages pass
- [x] `go vet ./...` — no issues
- [x] Smoke scenarios S17-S24 pass as unit tests in `cost/estimate_test.go`
- [x] Property-based tests pass in `cost/estimate_prop_test.go` and `cost/cost_prop_test.go`
- [x] Integration tests S25-S29 pass in `runner/runner_test.go`


🤖 Generated with [Claude Code](https://claude.com/claude-code)