### PR TITLE
fix: require default_model for active LLM providers

### DIFF
--- a/cli/cmd/xylem/init.go
+++ b/cli/cmd/xylem/init.go
@@ -136,6 +136,7 @@ llm: claude
 
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
   flags: "--bare --dangerously-skip-permissions"
   env:
     ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -329,6 +329,10 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	if err := c.validateProviderDefaultModels(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -471,6 +475,34 @@ func (c *Config) validateCost() error {
 	}
 	if c.Cost.Budget.MaxTokens < 0 {
 		return fmt.Errorf("cost.budget.max_tokens must be non-negative")
+	}
+	return nil
+}
+
+// validateProviderDefaultModels ensures every active LLM provider has a
+// default_model configured. A provider is active if it is the global llm value
+// or referenced by any source's llm field.
+func (c *Config) validateProviderDefaultModels() error {
+	active := map[string]bool{}
+	switch c.LLM {
+	case "", "claude":
+		active["claude"] = true
+	case "copilot":
+		active["copilot"] = true
+	}
+	for _, src := range c.Sources {
+		switch src.LLM {
+		case "claude":
+			active["claude"] = true
+		case "copilot":
+			active["copilot"] = true
+		}
+	}
+	if active["claude"] && c.Claude.DefaultModel == "" {
+		return fmt.Errorf("claude.default_model must be set when claude is an active provider")
+	}
+	if active["copilot"] && c.Copilot.DefaultModel == "" {
+		return fmt.Errorf("copilot.default_model must be set when copilot is an active provider")
 	}
 	return nil
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -49,6 +49,7 @@ state_dir: ".xylem"
 exclude: [wontfix, duplicate]
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
   flags: "--bare"
   env:
     ANTHROPIC_API_KEY: "test-key"
@@ -127,6 +128,8 @@ tasks:
   fix-bugs:
     labels: [bug]
     workflow: fix-bug
+claude:
+  default_model: "claude-sonnet-4-6"
 `)
 
 	cfg, err := Load(path)
@@ -202,7 +205,8 @@ func validConfig() *Config {
 		MaxTurns:    50,
 		Timeout:     "30m",
 		Claude: ClaudeConfig{
-			Command: "claude",
+			Command:      "claude",
+			DefaultModel: "claude-sonnet-4-6",
 		},
 	}
 }
@@ -212,7 +216,7 @@ func TestValidateMissingRepoInGitHubSource(t *testing.T) {
 		Concurrency: 2,
 		MaxTurns:    50,
 		Timeout:     "30m",
-		Claude:      ClaudeConfig{Command: "claude"},
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
 		Sources: map[string]SourceConfig{
 			"github": {Type: "github", Repo: "", Tasks: map[string]Task{
 				"fix-bugs": {Labels: []string{"bug"}, Workflow: "fix-bug"},
@@ -228,7 +232,7 @@ func TestValidateNoSourcesNoRepoIsValid(t *testing.T) {
 		Concurrency: 2,
 		MaxTurns:    50,
 		Timeout:     "30m",
-		Claude:      ClaudeConfig{Command: "claude"},
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
 	}
 	err := cfg.Validate()
 	if err != nil {
@@ -241,7 +245,7 @@ func TestValidateEmptyTasksInGitHubSource(t *testing.T) {
 		Concurrency: 2,
 		MaxTurns:    50,
 		Timeout:     "30m",
-		Claude:      ClaudeConfig{Command: "claude"},
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
 		Sources: map[string]SourceConfig{
 			"github": {Type: "github", Repo: "owner/name", Tasks: nil},
 		},
@@ -479,6 +483,7 @@ max_turns: 50
 timeout: "30m"
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
   flags: "--bare --dangerously-skip-permissions"
   env:
     ANTHROPIC_API_KEY: "sk-test-123"
@@ -575,7 +580,7 @@ claude:
 	}
 }
 
-func TestLoadDefaultModelEmpty(t *testing.T) {
+func TestValidateClaudeDefaultModelRequired(t *testing.T) {
 	path := writeConfigFile(t, `sources:
   github:
     type: github
@@ -591,14 +596,8 @@ claude:
   command: "claude"
 `)
 
-	cfg, err := Load(path)
-	if err != nil {
-		t.Fatalf("Load returned error: %v", err)
-	}
-
-	if cfg.Claude.DefaultModel != "" {
-		t.Fatalf("Claude.DefaultModel = %q, want empty", cfg.Claude.DefaultModel)
-	}
+	_, err := Load(path)
+	requireErrorContains(t, err, "claude.default_model must be set")
 }
 
 func TestLoadStatusLabels(t *testing.T) {
@@ -621,6 +620,7 @@ max_turns: 50
 timeout: "30m"
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
 `)
 
 	cfg, err := Load(path)
@@ -672,6 +672,7 @@ max_turns: 50
 timeout: "30m"
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
 `)
 
 	cfg, err := Load(path)
@@ -699,6 +700,7 @@ max_turns: 50
 timeout: "30m"
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
 daemon:
   scan_interval: "120s"
   drain_interval: "45s"
@@ -733,9 +735,9 @@ func TestValidateLLM(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := validConfig()
 			cfg.LLM = tt.llm
-			// Ensure copilot command is set for "copilot" to avoid command validation failure
+			// Ensure copilot config is set for "copilot" to avoid command/model validation failure
 			if tt.llm == "copilot" {
-				cfg.Copilot = CopilotConfig{Command: "copilot"}
+				cfg.Copilot = CopilotConfig{Command: "copilot", DefaultModel: "gpt-5.4"}
 			}
 			err := cfg.Validate()
 			if tt.wantErr != "" {
@@ -776,6 +778,7 @@ copilot:
     GITHUB_TOKEN: "ghp-test"
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
 `)
 
 	cfg, err := Load(path)
@@ -814,6 +817,7 @@ max_turns: 50
 timeout: "30m"
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
 `)
 
 	cfg, err := Load(path)
@@ -841,6 +845,7 @@ max_turns: 50
 timeout: "30m"
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
 `)
 
 	cfg, err := Load(path)
@@ -858,7 +863,7 @@ func TestValidateGitHubPREventsValid(t *testing.T) {
 		Concurrency: 2,
 		MaxTurns:    50,
 		Timeout:     "30m",
-		Claude:      ClaudeConfig{Command: "claude"},
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
 		Sources: map[string]SourceConfig{
 			"pr-events": {
 				Type: "github-pr-events",
@@ -886,7 +891,7 @@ func TestValidateGitHubPREventsReviewSubmittedRequiresAuthorFilter(t *testing.T)
 		Concurrency: 2,
 		MaxTurns:    50,
 		Timeout:     "30m",
-		Claude:      ClaudeConfig{Command: "claude"},
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
 		Sources: map[string]SourceConfig{
 			"pr-events": {
 				Type: "github-pr-events",
@@ -909,7 +914,7 @@ func TestValidateGitHubPREventsCommentedRequiresAuthorFilter(t *testing.T) {
 		Concurrency: 2,
 		MaxTurns:    50,
 		Timeout:     "30m",
-		Claude:      ClaudeConfig{Command: "claude"},
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
 		Sources: map[string]SourceConfig{
 			"pr-events": {
 				Type: "github-pr-events",
@@ -932,7 +937,7 @@ func TestValidateGitHubPREventsAuthorDenyAloneIsEnough(t *testing.T) {
 		Concurrency: 2,
 		MaxTurns:    50,
 		Timeout:     "30m",
-		Claude:      ClaudeConfig{Command: "claude"},
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
 		Sources: map[string]SourceConfig{
 			"pr-events": {
 				Type: "github-pr-events",
@@ -962,7 +967,7 @@ func TestValidateGitHubPREventsChecksFailedNoAuthorFilter(t *testing.T) {
 		Concurrency: 2,
 		MaxTurns:    50,
 		Timeout:     "30m",
-		Claude:      ClaudeConfig{Command: "claude"},
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
 		Sources: map[string]SourceConfig{
 			"pr-events": {
 				Type: "github-pr-events",
@@ -986,7 +991,7 @@ func TestValidateGitHubPREventsMissingOn(t *testing.T) {
 		Concurrency: 2,
 		MaxTurns:    50,
 		Timeout:     "30m",
-		Claude:      ClaudeConfig{Command: "claude"},
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
 		Sources: map[string]SourceConfig{
 			"pr-events": {
 				Type: "github-pr-events",
@@ -1006,7 +1011,7 @@ func TestValidateGitHubPREventsEmptyTriggers(t *testing.T) {
 		Concurrency: 2,
 		MaxTurns:    50,
 		Timeout:     "30m",
-		Claude:      ClaudeConfig{Command: "claude"},
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
 		Sources: map[string]SourceConfig{
 			"pr-events": {
 				Type: "github-pr-events",
@@ -1029,7 +1034,7 @@ func TestValidateGitHubPREventsMissingRepo(t *testing.T) {
 		Concurrency: 2,
 		MaxTurns:    50,
 		Timeout:     "30m",
-		Claude:      ClaudeConfig{Command: "claude"},
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
 		Sources: map[string]SourceConfig{
 			"pr-events": {
 				Type: "github-pr-events",
@@ -1052,7 +1057,7 @@ func TestValidateGitHubMergeValid(t *testing.T) {
 		Concurrency: 2,
 		MaxTurns:    50,
 		Timeout:     "30m",
-		Claude:      ClaudeConfig{Command: "claude"},
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
 		Sources: map[string]SourceConfig{
 			"merge": {
 				Type: "github-merge",
@@ -1073,7 +1078,7 @@ func TestValidateGitHubMergeMissingRepo(t *testing.T) {
 		Concurrency: 2,
 		MaxTurns:    50,
 		Timeout:     "30m",
-		Claude:      ClaudeConfig{Command: "claude"},
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
 		Sources: map[string]SourceConfig{
 			"merge": {
 				Type:  "github-merge",
@@ -1091,7 +1096,7 @@ func TestValidateUnknownSourceType(t *testing.T) {
 		Concurrency: 2,
 		MaxTurns:    50,
 		Timeout:     "30m",
-		Claude:      ClaudeConfig{Command: "claude"},
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
 		Sources: map[string]SourceConfig{
 			"unknown": {
 				Type: "bitbucket",
@@ -1121,6 +1126,7 @@ timeout: "30m"
 model: claude-sonnet-4-6
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
 `)
 
 	cfg, err := Load(path)
@@ -1149,6 +1155,7 @@ max_turns: 50
 timeout: "30m"
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
 `)
 
 	cfg, err := Load(path)
@@ -1201,6 +1208,7 @@ max_turns: 50
 timeout: "30m"
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
 `+extra)
 }
 

--- a/cli/internal/dtu/testdata/manual-smoke/ws3-observability-cost/.xylem.yml
+++ b/cli/internal/dtu/testdata/manual-smoke/ws3-observability-cost/.xylem.yml
@@ -20,6 +20,7 @@ state_dir: ".xylem-state"
 llm: claude
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
 
 observability:
   enabled: true

--- a/cli/internal/dtu/testdata/manual-smoke/ws3-summary-artifacts/.xylem.yml
+++ b/cli/internal/dtu/testdata/manual-smoke/ws3-summary-artifacts/.xylem.yml
@@ -20,6 +20,7 @@ state_dir: ".xylem-state"
 llm: claude
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
 
 observability:
   enabled: true

--- a/cli/internal/dtu/testdata/manual-smoke/ws4-evidence-model/.xylem.yml
+++ b/cli/internal/dtu/testdata/manual-smoke/ws4-evidence-model/.xylem.yml
@@ -20,3 +20,4 @@ state_dir: ".xylem-state"
 llm: claude
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"

--- a/cli/internal/dtu/testdata/manual-smoke/ws5-eval-suite/.xylem.yml
+++ b/cli/internal/dtu/testdata/manual-smoke/ws5-eval-suite/.xylem.yml
@@ -20,3 +20,4 @@ state_dir: ".xylem-state"
 llm: claude
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"

--- a/cli/internal/dtu/testdata/manual-smoke/ws6-cross-cutting/.xylem.yml
+++ b/cli/internal/dtu/testdata/manual-smoke/ws6-cross-cutting/.xylem.yml
@@ -20,6 +20,7 @@ state_dir: ".xylem-state"
 llm: claude
 claude:
   command: "claude"
+  default_model: "claude-sonnet-4-6"
 
 harness:
   protected_surfaces:

--- a/cli/internal/dtu/testdata/ws1-smoke-fixture/.xylem.defaults-only.yml
+++ b/cli/internal/dtu/testdata/ws1-smoke-fixture/.xylem.defaults-only.yml
@@ -18,3 +18,5 @@ max_turns: 5
 timeout: "1m"
 state_dir: ".xylem"
 default_branch: main
+claude:
+  default_model: "claude-sonnet-4-6"

--- a/cli/internal/dtu/testdata/ws1-smoke-fixture/.xylem.policy-deny.yml
+++ b/cli/internal/dtu/testdata/ws1-smoke-fixture/.xylem.policy-deny.yml
@@ -18,6 +18,8 @@ max_turns: 5
 timeout: "1m"
 state_dir: ".xylem"
 default_branch: main
+claude:
+  default_model: "claude-sonnet-4-6"
 harness:
   audit_log: "audit.jsonl"
   protected_surfaces:

--- a/cli/internal/dtu/testdata/ws1-smoke-fixture/.xylem.require-approval.yml
+++ b/cli/internal/dtu/testdata/ws1-smoke-fixture/.xylem.require-approval.yml
@@ -18,6 +18,8 @@ max_turns: 5
 timeout: "1m"
 state_dir: ".xylem"
 default_branch: main
+claude:
+  default_model: "claude-sonnet-4-6"
 harness:
   audit_log: "audit.jsonl"
   protected_surfaces:

--- a/cli/internal/dtu/testdata/ws1-smoke-fixture/.xylem.surface-violation.yml
+++ b/cli/internal/dtu/testdata/ws1-smoke-fixture/.xylem.surface-violation.yml
@@ -18,6 +18,8 @@ max_turns: 5
 timeout: "1m"
 state_dir: ".xylem"
 default_branch: main
+claude:
+  default_model: "claude-sonnet-4-6"
 harness:
   audit_log: "audit.jsonl"
   protected_surfaces:

--- a/cli/internal/dtu/testdata/ws1-smoke-fixture/.xylem.yml
+++ b/cli/internal/dtu/testdata/ws1-smoke-fixture/.xylem.yml
@@ -18,6 +18,8 @@ max_turns: 5
 timeout: "1m"
 state_dir: ".xylem"
 default_branch: main
+claude:
+  default_model: "claude-sonnet-4-6"
 harness:
   audit_log: "audit.jsonl"
   protected_surfaces:

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -2077,7 +2077,7 @@ func (r *Runner) runPhaseWithRateLimitRetry(
 }
 
 // buildPhaseArgs constructs the claude CLI arguments for a phase invocation.
-// Model resolution follows the hierarchy: Phase.Model > Workflow.Model > Source.Model > Config.Model > ClaudeConfig.DefaultModel.
+// Model resolution follows the hierarchy: Phase.Model > Workflow.Model > Source.Model > ClaudeConfig.DefaultModel.
 // When a model is resolved from the hierarchy, any --model flag in Claude.Flags is stripped to avoid duplication.
 func buildPhaseArgs(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, harnessContent string) []string {
 	args := []string{"-p"}
@@ -2116,7 +2116,7 @@ func buildPhaseArgs(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflo
 }
 
 // buildCopilotPhaseArgs constructs the GitHub Copilot CLI arguments for a phase invocation.
-// Model resolution follows the hierarchy: Phase.Model > Workflow.Model > Source.Model > Config.Model > CopilotConfig.DefaultModel.
+// Model resolution follows the hierarchy: Phase.Model > Workflow.Model > Source.Model > CopilotConfig.DefaultModel.
 // The rendered prompt and harness content are combined into the -p flag value because
 // copilot has no --system-prompt equivalent.
 func buildCopilotPhaseArgs(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, harnessContent, renderedPrompt string) []string {
@@ -2244,7 +2244,9 @@ func resolveProvider(cfg *config.Config, srcCfg *config.SourceConfig, wf *workfl
 }
 
 // resolveModel determines the model string for a phase invocation.
-// Resolution order: Phase.Model > Workflow.Model > Source.Model > Config.Model > provider's DefaultModel.
+// Resolution order: Phase.Model > Workflow.Model > Source.Model > provider's DefaultModel.
+// The provider's DefaultModel ensures the fallback is always compatible with the
+// resolved provider, avoiding cross-provider model leaks (e.g. gpt-* sent to claude).
 func resolveModel(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, provider string) string {
 	if p != nil && p.Model != nil && *p.Model != "" {
 		return *p.Model
@@ -2257,9 +2259,6 @@ func resolveModel(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.
 	}
 	if cfg == nil {
 		return ""
-	}
-	if cfg.Model != "" {
-		return cfg.Model
 	}
 	switch provider {
 	case "copilot":

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -2611,24 +2611,24 @@ func TestResolveProviderWithSource(t *testing.T) {
 func TestResolveModelWithSourceAndConfigModel(t *testing.T) {
 	tests := []struct {
 		name       string
-		cfgModel   string
 		srcModel   string
 		wfModel    *string
 		phaseModel *string
 		provider   string
 		want       string
 	}{
-		{"config model used when no phase/wf/src", "global-model", "", nil, nil, "claude", "global-model"},
-		{"config model beats provider default", "global-model", "", nil, nil, "claude", "global-model"},
-		{"source model beats config model", "global-model", "src-model", nil, nil, "claude", "src-model"},
-		{"workflow model beats source model", "global-model", "src-model", strPtrRunner("wf-model"), nil, "claude", "wf-model"},
-		{"phase model beats all", "global-model", "src-model", strPtrRunner("wf-model"), strPtrRunner("phase-model"), "claude", "phase-model"},
-		{"config model works for copilot", "global-model", "", nil, nil, "copilot", "global-model"},
-		{"empty source falls to config model", "", "", nil, nil, "claude", ""},
+		{"provider default used when no phase/wf/src for claude", "", nil, nil, "claude", "claude-default"},
+		{"provider default used when no phase/wf/src for copilot", "", nil, nil, "copilot", "copilot-default"},
+		{"source model beats provider default", "src-model", nil, nil, "claude", "src-model"},
+		{"workflow model beats source model", "src-model", strPtrRunner("wf-model"), nil, "claude", "wf-model"},
+		{"phase model beats all", "src-model", strPtrRunner("wf-model"), strPtrRunner("phase-model"), "claude", "phase-model"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &config.Config{Model: tt.cfgModel}
+			cfg := &config.Config{
+				Claude:  config.ClaudeConfig{DefaultModel: "claude-default"},
+				Copilot: config.CopilotConfig{DefaultModel: "copilot-default"},
+			}
 			var srcCfg *config.SourceConfig
 			if tt.srcModel != "" {
 				srcCfg = &config.SourceConfig{Model: tt.srcModel}


### PR DESCRIPTION
## Summary

- Remove `cfg.Model` (provider-agnostic top-level field) from `resolveModel` fallback chain — the final fallback is now always the provider-specific `default_model`, preventing cross-provider model leaks (e.g. `gpt-5.4` sent to `claude` CLI)
- Add config validation requiring `default_model` on every active LLM provider (determined from global `llm` + per-source `llm` fields)
- Update scaffold config, test fixtures, and tests to match

## Test plan

- [x] `go test ./...` — all 27 packages pass
- [ ] Verify `xylem init` scaffold includes `default_model` in generated config
- [ ] Verify config without `claude.default_model` fails validation with clear error message
- [ ] Verify config without `copilot.default_model` (when copilot is active) fails validation
- [ ] Verify mixed-provider workflows resolve the correct model per phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)