### PR TITLE
feat: harden runner execution order and allow timed_out retry

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -31,8 +31,8 @@ sources:
     repo: nicholls-inc/xylem
     exclude:
       [wontfix, duplicate, in-progress, no-bot, needs-refinement, xylem-failed]
-    llm: claude
-    model: claude-haiku-4-5
+    llm: copilot
+    model: gpt-5-mini
     tasks:
       triage-issues:
         labels: [needs-triage]
@@ -55,6 +55,7 @@ sources:
   harness-impl:
     type: github
     repo: nicholls-inc/xylem
+    timeout: "90m"
     exclude: [wontfix, duplicate, in-progress, no-bot, blocked, xylem-failed]
     tasks:
       implement-harness-steps:
@@ -139,12 +140,13 @@ timeout: "45m"
 state_dir: ".xylem"
 
 # llm selects the global default LLM provider: "claude" (default) or "copilot"
-llm: claude
-model: claude-sonnet-4-6
+llm: copilot
+model: gpt-5.4
 
 claude:
   command: "claude"
   flags: "--dangerously-skip-permissions"
+  default_model: "claude-sonnet-4-6"
   env:
     ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
   # allowed_tools:
@@ -154,7 +156,7 @@ claude:
 
 copilot:
   command: "copilot"
-  flags: "--yolo --autopilot"
+  flags: "--yolo --autopilot --effort medium"
   default_model: "gpt-5.4"
   env:
     COPILOT_GITHUB_TOKEN: "${COPILOT_GITHUB_TOKEN}"

--- a/.xylem/prompts/implement-harness/pr_draft.md
+++ b/.xylem/prompts/implement-harness/pr_draft.md
@@ -1,21 +1,13 @@
-Draft a pull request for this harness spec implementation.
+Your sole deliverable is a file named `pr_draft.json` at the worktree root. If this file does not exist when you finish, the workflow fails. Everything else (commit, push) is preparation for creating that file.
 
-Issue: {{.Issue.Title}}
-URL: {{.Issue.URL}}
+## Steps
 
-## Analysis
-{{.PreviousOutputs.analyze}}
+1. Stage and commit all changes with the message: `feat: {{.Issue.Title}}`
+   Reference the issue in the commit body: `Implements {{.Issue.URL}}`
 
-## Plan
-{{.PreviousOutputs.plan}}
+2. Push the branch.
 
-Stage and commit all changes with the message: `feat: {{.Issue.Title}}`
-
-Reference the issue in the commit body: `Implements {{.Issue.URL}}`
-
-Push the branch.
-
-Then write a JSON file at the worktree root named `pr_draft.json` with this exact structure:
+3. Write `pr_draft.json` at the worktree root with this exact structure:
 
 ```json
 {
@@ -24,11 +16,26 @@ Then write a JSON file at the worktree root named `pr_draft.json` with this exac
 }
 ```
 
-The PR body must include:
+The PR body MUST include:
 - Summary linking to {{.Issue.URL}}
 - Smoke scenarios covered (list IDs and titles)
 - Changes summary (files added/modified, key types and functions)
 - Test plan
 
-Do NOT run `gh pr create` — a separate script handles PR creation.
-Do NOT include `Fixes #N` or `Closes #N` in the body — that is appended automatically.
+## Constraints
+
+- You MUST create `pr_draft.json`. The next phase reads it — if missing, the entire workflow fails.
+- Do NOT run `gh pr create` — a separate script handles PR creation.
+- Do NOT include `Fixes #N` or `Closes #N` in the body — that is appended automatically.
+- Do NOT narrate your process. Execute the steps and produce the file.
+
+## Context
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+### Analysis
+{{.PreviousOutputs.analyze}}
+
+### Plan
+{{.PreviousOutputs.plan}}

--- a/.xylem/workflows/implement-harness.yaml
+++ b/.xylem/workflows/implement-harness.yaml
@@ -11,7 +11,7 @@ phases:
   - name: plan
     prompt_file: .xylem/prompts/implement-harness/plan.md
     max_turns: 30
-    llm: claude
+    llm: copilot
   - name: implement
     prompt_file: .xylem/prompts/implement-harness/implement.md
     max_turns: 80
@@ -24,7 +24,7 @@ phases:
   - name: verify
     prompt_file: .xylem/prompts/implement-harness/verify.md
     max_turns: 80
-    llm: claude
+    llm: copilot
     gate:
       type: command
       run: "cd cli && go test ./..."

--- a/cli/cmd/xylem/retry.go
+++ b/cli/cmd/xylem/retry.go
@@ -34,8 +34,8 @@ func cmdRetry(q *queue.Queue, cfg *config.Config, id string, fromScratch bool) e
 		return fmt.Errorf("retry error: %w", err)
 	}
 
-	if vessel.State != queue.StateFailed {
-		return fmt.Errorf("error: vessel %s is not in failed state (current: %s)", id, vessel.State)
+	if vessel.State != queue.StateFailed && vessel.State != queue.StateTimedOut {
+		return fmt.Errorf("error: vessel %s is not in a retryable state (current: %s)", id, vessel.State)
 	}
 
 	newID := retryID(vessel.ID, q)

--- a/cli/cmd/xylem/retry_test.go
+++ b/cli/cmd/xylem/retry_test.go
@@ -90,7 +90,37 @@ func TestRetryCreatesNewVessel(t *testing.T) {
 	}
 }
 
-func TestRetryNonFailedVessel(t *testing.T) {
+func TestRetryTimedOutVessel(t *testing.T) {
+	q := newRetryTestQueue(t)
+	cfg := newRetryTestConfig(t)
+	now := time.Now().UTC()
+	v := queue.Vessel{
+		ID: "issue-50", Source: "github-issue", Workflow: "implement-harness",
+		Ref:   "https://github.com/owner/repo/issues/50",
+		State: queue.StatePending, CreatedAt: now,
+	}
+	q.Enqueue(v)                                                     //nolint:errcheck
+	q.Update("issue-50", queue.StateRunning, "")                     //nolint:errcheck
+	q.Update("issue-50", queue.StateTimedOut, "timed out after 45m") //nolint:errcheck
+
+	err := cmdRetry(q, cfg, "issue-50", true)
+	if err != nil {
+		t.Fatalf("unexpected error retrying timed_out vessel: %v", err)
+	}
+
+	retry, err := q.FindByID("issue-50-retry-1")
+	if err != nil {
+		t.Fatalf("retry vessel not found: %v", err)
+	}
+	if retry.State != queue.StatePending {
+		t.Errorf("retry should be pending, got %s", retry.State)
+	}
+	if retry.RetryOf != "issue-50" {
+		t.Errorf("retry_of should be issue-50, got %s", retry.RetryOf)
+	}
+}
+
+func TestRetryNonRetryableVessel(t *testing.T) {
 	tests := []struct {
 		name  string
 		setup func(t *testing.T, q *queue.Queue)
@@ -120,10 +150,10 @@ func TestRetryNonFailedVessel(t *testing.T) {
 
 			err := cmdRetry(q, cfg, "issue-1", false)
 			if err == nil {
-				t.Fatal("expected error retrying non-failed vessel")
+				t.Fatal("expected error retrying non-retryable vessel")
 			}
-			if !strings.Contains(err.Error(), "not in failed state") {
-				t.Errorf("expected 'not in failed state' error, got: %v", err)
+			if !strings.Contains(err.Error(), "not in a retryable state") {
+				t.Errorf("expected 'not in a retryable state' error, got: %v", err)
 			}
 		})
 	}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -435,15 +435,16 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				}
 				beforeSnapshot, checkProtectedSurfaces, err = r.takeProtectedSurfaceSnapshot(worktreePath)
 				if err != nil {
-					finishCurrentPhaseSpan(err)
-					r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, err))
+					snapErr := fmt.Errorf("protected surface snapshot failed: %w", err)
+					finishCurrentPhaseSpan(snapErr)
+					r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, snapErr))
 					if err := src.OnFail(ctx, vessel); err != nil {
 						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
 					}
 					issueNum := r.parseIssueNum(vessel)
 					if issueNum > 0 && r.Reporter != nil {
 						r.logReporterError("post vessel-failed comment", vessel.ID,
-							r.Reporter.VesselFailed(ctx, issueNum, p.Name, err.Error(), ""))
+							r.Reporter.VesselFailed(ctx, issueNum, p.Name, snapErr.Error(), ""))
 					}
 					return "failed"
 				}
@@ -495,15 +496,16 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				}
 				beforeSnapshot, checkProtectedSurfaces, err = r.takeProtectedSurfaceSnapshot(worktreePath)
 				if err != nil {
-					finishCurrentPhaseSpan(err)
-					r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, err))
+					snapErr := fmt.Errorf("protected surface snapshot failed: %w", err)
+					finishCurrentPhaseSpan(snapErr)
+					r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, snapErr))
 					if err := src.OnFail(ctx, vessel); err != nil {
 						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
 					}
 					issueNum := r.parseIssueNum(vessel)
 					if issueNum > 0 && r.Reporter != nil {
 						r.logReporterError("post vessel-failed comment", vessel.ID,
-							r.Reporter.VesselFailed(ctx, issueNum, p.Name, err.Error(), ""))
+							r.Reporter.VesselFailed(ctx, issueNum, p.Name, snapErr.Error(), ""))
 					}
 					return "failed"
 				}
@@ -524,6 +526,23 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			fmt.Printf("Phase %s complete: %s\n", p.Name, outputPath)
 			phaseDuration = r.runtimeSince(phaseStart)
 
+			if runErr != nil {
+				finishCurrentPhaseSpan(runErr)
+				log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
+				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()))
+				vessel.FailedPhase = p.Name
+				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, runErr))
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
+				issueNum := r.parseIssueNum(vessel)
+				if issueNum > 0 && r.Reporter != nil {
+					r.logReporterError("post vessel-failed comment", vessel.ID,
+						r.Reporter.VesselFailed(ctx, issueNum, p.Name, runErr.Error(), ""))
+				}
+				return "failed"
+			}
+
 			if checkProtectedSurfaces {
 				if err := r.verifyProtectedSurfaces(vessel, p, worktreePath, beforeSnapshot); err != nil {
 					finishCurrentPhaseSpan(err)
@@ -541,23 +560,6 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					}
 					return "failed"
 				}
-			}
-
-			if runErr != nil {
-				finishCurrentPhaseSpan(runErr)
-				log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
-				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()))
-				vessel.FailedPhase = p.Name
-				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, runErr))
-				if err := src.OnFail(ctx, vessel); err != nil {
-					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-				}
-				issueNum := r.parseIssueNum(vessel)
-				if issueNum > 0 && r.Reporter != nil {
-					r.logReporterError("post vessel-failed comment", vessel.ID,
-						r.Reporter.VesselFailed(ctx, issueNum, p.Name, runErr.Error(), ""))
-				}
-				return "failed"
 			}
 
 			recordedAt := r.runtimeNow()
@@ -763,7 +765,8 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 	model := resolveModel(r.Config, nil, nil, nil, provider)
 	beforeSnapshot, checkProtectedSurfaces, err := r.takeProtectedSurfaceSnapshot(worktreePath)
 	if err != nil {
-		r.failVessel(vessel.ID, err.Error())
+		snapErr := fmt.Errorf("protected surface snapshot failed: %w", err)
+		r.failVessel(vessel.ID, snapErr.Error())
 		if err := src.OnFail(ctx, vessel); err != nil {
 			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
 		}
@@ -771,6 +774,13 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 	}
 
 	output, runErr := r.runPhaseWithRateLimitRetry(ctx, worktreePath, prompt, cmd, args)
+	if runErr != nil {
+		r.failVessel(vessel.ID, runErr.Error())
+		if err := src.OnFail(ctx, vessel); err != nil {
+			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+		}
+		return "failed"
+	}
 	if checkProtectedSurfaces {
 		if err := r.verifyProtectedSurfaces(vessel, workflow.Phase{Name: "prompt-only"}, worktreePath, beforeSnapshot); err != nil {
 			r.failVessel(vessel.ID, err.Error())
@@ -792,14 +802,6 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 			}
 			return "failed"
 		}
-	}
-
-	if runErr != nil {
-		r.failVessel(vessel.ID, runErr.Error())
-		if err := src.OnFail(ctx, vessel); err != nil {
-			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-		}
-		return "failed"
 	}
 
 	if err := src.OnComplete(ctx, vessel); err != nil {
@@ -1185,15 +1187,16 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			}
 			beforeSnapshot, checkProtectedSurfaces, err = r.takeProtectedSurfaceSnapshot(worktreePath)
 			if err != nil {
-				finishCurrentPhaseSpan(err)
-				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, err))
+				snapErr := fmt.Errorf("protected surface snapshot failed: %w", err)
+				finishCurrentPhaseSpan(snapErr)
+				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, snapErr))
 				if err := src.OnFail(ctx, vessel); err != nil {
 					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
 				}
 				issueNum := r.parseIssueNum(vessel)
 				if issueNum > 0 && r.Reporter != nil {
 					r.logReporterError("post vessel-failed comment", vessel.ID,
-						r.Reporter.VesselFailed(ctx, issueNum, p.Name, err.Error(), ""))
+						r.Reporter.VesselFailed(ctx, issueNum, p.Name, snapErr.Error(), ""))
 				}
 				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
 			}
@@ -1244,15 +1247,16 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			}
 			beforeSnapshot, checkProtectedSurfaces, err = r.takeProtectedSurfaceSnapshot(worktreePath)
 			if err != nil {
-				finishCurrentPhaseSpan(err)
-				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, err))
+				snapErr := fmt.Errorf("protected surface snapshot failed: %w", err)
+				finishCurrentPhaseSpan(snapErr)
+				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, snapErr))
 				if err := src.OnFail(ctx, vessel); err != nil {
 					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
 				}
 				issueNum := r.parseIssueNum(vessel)
 				if issueNum > 0 && r.Reporter != nil {
 					r.logReporterError("post vessel-failed comment", vessel.ID,
-						r.Reporter.VesselFailed(ctx, issueNum, p.Name, err.Error(), ""))
+						r.Reporter.VesselFailed(ctx, issueNum, p.Name, snapErr.Error(), ""))
 				}
 				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
 			}
@@ -1273,6 +1277,26 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		fmt.Printf("Phase %s complete: %s\n", p.Name, outputPath)
 		phaseDuration = r.runtimeSince(phaseStart)
 
+		if runErr != nil {
+			finishCurrentPhaseSpan(runErr)
+			log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
+			vessel.FailedPhase = p.Name
+			r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, runErr))
+			if err := src.OnFail(ctx, vessel); err != nil {
+				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+			}
+			issueNum := r.parseIssueNum(vessel)
+			if issueNum > 0 && r.Reporter != nil {
+				r.logReporterError("post vessel-failed comment", vessel.ID,
+					r.Reporter.VesselFailed(ctx, issueNum, p.Name, runErr.Error(), ""))
+			}
+			return singlePhaseResult{
+				status:       "failed",
+				duration:     phaseDuration,
+				phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()),
+			}
+		}
+
 		if checkProtectedSurfaces {
 			if err := r.verifyProtectedSurfaces(vessel, p, worktreePath, beforeSnapshot); err != nil {
 				finishCurrentPhaseSpan(err)
@@ -1292,26 +1316,6 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					duration:     phaseDuration,
 					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error()),
 				}
-			}
-		}
-
-		if runErr != nil {
-			finishCurrentPhaseSpan(runErr)
-			log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
-			vessel.FailedPhase = p.Name
-			r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, runErr))
-			if err := src.OnFail(ctx, vessel); err != nil {
-				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-			}
-			issueNum := r.parseIssueNum(vessel)
-			if issueNum > 0 && r.Reporter != nil {
-				r.logReporterError("post vessel-failed comment", vessel.ID,
-					r.Reporter.VesselFailed(ctx, issueNum, p.Name, runErr.Error(), ""))
-			}
-			return singlePhaseResult{
-				status:       "failed",
-				duration:     phaseDuration,
-				phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()),
 			}
 		}
 
@@ -1610,11 +1614,16 @@ func (r *Runner) enforcePhasePolicy(vessel queue.Vessel, p workflow.Phase) error
 		return nil
 	}
 
+	justification := fmt.Sprintf("execute workflow phase %q", p.Name)
+	if vessel.Workflow != "" {
+		justification = fmt.Sprintf("execute phase %q of workflow %q", p.Name, vessel.Workflow)
+	}
+
 	intent := intermediary.Intent{
 		Action:        phaseActionType(&p),
 		Resource:      p.Name,
 		AgentID:       vessel.ID,
-		Justification: fmt.Sprintf("execute workflow phase %q", p.Name),
+		Justification: justification,
 		Metadata: map[string]string{
 			"phase":      p.Name,
 			"source":     vessel.Source,
@@ -1643,11 +1652,20 @@ func (r *Runner) enforcePhasePolicy(vessel queue.Vessel, p workflow.Phase) error
 	case intermediary.Allow:
 		return nil
 	case intermediary.RequireApproval:
-		return fmt.Errorf("phase %s requires approval: automatic approval not yet supported", p.Name)
+		if result.Reason != "" {
+			return fmt.Errorf("phase %q requires approval (automatic approval not yet supported): %s", p.Name, result.Reason)
+		}
+		return fmt.Errorf("phase %q requires approval (automatic approval not yet supported)", p.Name)
 	case intermediary.Deny:
-		return fmt.Errorf("phase %s denied by policy", p.Name)
+		if result.Reason != "" {
+			return fmt.Errorf("phase %q denied by policy: %s", p.Name, result.Reason)
+		}
+		return fmt.Errorf("phase %q denied by policy", p.Name)
 	default:
-		return fmt.Errorf("phase %s denied by policy", p.Name)
+		if result.Reason != "" {
+			return fmt.Errorf("phase %q denied by policy: %s", p.Name, result.Reason)
+		}
+		return fmt.Errorf("phase %q denied by policy", p.Name)
 	}
 }
 
@@ -1687,7 +1705,9 @@ func (r *Runner) verifyProtectedSurfaces(vessel queue.Vessel, p workflow.Phase, 
 
 	after, err := surface.TakeSnapshot(worktreePath, patterns)
 	if err != nil {
-		return fmt.Errorf("verify protected surfaces: %w", err)
+		log.Printf("%sphase %q protected surface verification skipped: %v",
+			vesselLabel(vessel), p.Name, err)
+		return nil
 	}
 
 	violations := surface.Compare(before, after)
@@ -1695,36 +1715,37 @@ func (r *Runner) verifyProtectedSurfaces(vessel queue.Vessel, p workflow.Phase, 
 		return nil
 	}
 
-	errMsg := fmt.Sprintf("phase %s violated protected surfaces: %s", p.Name, formatSurfaceViolations(violations))
-	if err := r.recordProtectedSurfaceViolation(vessel, p, errMsg, violations); err != nil {
+	errMsg := fmt.Sprintf("phase %q violated protected surfaces: %s", p.Name, formatViolations(violations))
+	if err := r.recordProtectedSurfaceViolations(vessel, p, errMsg, violations); err != nil {
 		return fmt.Errorf("%s (record audit evidence: %w)", errMsg, err)
 	}
 	return fmt.Errorf("%s", errMsg)
 }
 
-func (r *Runner) recordProtectedSurfaceViolation(vessel queue.Vessel, p workflow.Phase, errMsg string, violations []surface.Violation) error {
-	paths := make([]string, 0, len(violations))
+func (r *Runner) recordProtectedSurfaceViolations(vessel queue.Vessel, p workflow.Phase, errMsg string, violations []surface.Violation) error {
 	for _, violation := range violations {
-		paths = append(paths, violation.Path)
-	}
-
-	return r.appendAuditEntry(intermediary.AuditEntry{
-		Intent: intermediary.Intent{
-			Action:        "protected_surface_violation",
-			Resource:      p.Name,
-			AgentID:       vessel.ID,
-			Justification: fmt.Sprintf("verify protected surfaces after phase %q", p.Name),
-			Metadata: map[string]string{
-				"phase":    p.Name,
-				"paths":    strings.Join(paths, ","),
-				"source":   vessel.Source,
-				"workflow": vessel.Workflow,
+		if err := r.appendAuditEntry(intermediary.AuditEntry{
+			Intent: intermediary.Intent{
+				Action:        "file_write",
+				Resource:      violation.Path,
+				AgentID:       vessel.ID,
+				Justification: fmt.Sprintf("verify protected surfaces after phase %q", p.Name),
+				Metadata: map[string]string{
+					"phase":    p.Name,
+					"before":   violation.Before,
+					"after":    violation.After,
+					"source":   vessel.Source,
+					"workflow": vessel.Workflow,
+				},
 			},
-		},
-		Decision:  intermediary.Deny,
-		Timestamp: time.Now().UTC(),
-		Error:     errMsg,
-	})
+			Decision:  intermediary.Deny,
+			Timestamp: time.Now().UTC(),
+			Error:     errMsg,
+		}); err != nil {
+			return fmt.Errorf("append surface violation audit for %s: %w", violation.Path, err)
+		}
+	}
+	return nil
 }
 
 func (r *Runner) appendAuditEntry(entry intermediary.AuditEntry) error {
@@ -1737,12 +1758,12 @@ func (r *Runner) appendAuditEntry(entry intermediary.AuditEntry) error {
 	return nil
 }
 
-func formatSurfaceViolations(violations []surface.Violation) string {
+func formatViolations(violations []surface.Violation) string {
 	parts := make([]string, 0, len(violations))
 	for _, violation := range violations {
-		parts = append(parts, fmt.Sprintf("%s (%s -> %s)", violation.Path, violation.Before, violation.After))
+		parts = append(parts, fmt.Sprintf("%s (before: %s, after: %s)", violation.Path, violation.Before, violation.After))
 	}
-	return strings.Join(parts, ", ")
+	return strings.Join(parts, "; ")
 }
 
 func (r *Runner) logReporterError(action string, vesselID string, err error) {

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/surface"
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"pgregory.net/rapid"
 )
@@ -103,6 +105,36 @@ func TestProp_BudgetExceededIsMonotonic(t *testing.T) {
 			if exceeded && !tracker.BudgetExceeded() {
 				t.Fatal("BudgetExceeded reverted to false")
 			}
+		}
+	})
+}
+
+func TestProp_FormatViolationsIncludesEveryViolation(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		count := rapid.IntRange(0, 8).Draw(t, "count")
+		violations := make([]surface.Violation, 0, count)
+		wantParts := make([]string, 0, count)
+		for i := range count {
+			violation := surface.Violation{
+				Path:   rapid.StringMatching(`[a-z0-9./_-]{1,32}`).Draw(t, "path"+string(rune('a'+i))),
+				Before: rapid.StringMatching(`(absent|deleted|[0-9a-f]{1,16})`).Draw(t, "before"+string(rune('a'+i))),
+				After:  rapid.StringMatching(`(absent|deleted|[0-9a-f]{1,16})`).Draw(t, "after"+string(rune('a'+i))),
+			}
+			violations = append(violations, violation)
+			wantParts = append(wantParts, fmt.Sprintf("%s (before: %s, after: %s)", violation.Path, violation.Before, violation.After))
+		}
+
+		formatted := formatViolations(violations)
+		if count == 0 {
+			if formatted != "" {
+				t.Fatalf("formatViolations(nil) = %q, want empty string", formatted)
+			}
+			return
+		}
+
+		want := strings.Join(wantParts, "; ")
+		if formatted != want {
+			t.Fatalf("formatViolations() = %q, want %q", formatted, want)
 		}
 	})
 }

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
+	"github.com/nicholls-inc/xylem/cli/internal/surface"
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -307,6 +308,15 @@ func countRunOutputCalls(m *mockCmdRunner, name string) int {
 		}
 	}
 	return count
+}
+
+func loadSingleVessel(t *testing.T, q *queue.Queue) queue.Vessel {
+	t.Helper()
+
+	vessels, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	return vessels[0]
 }
 
 func setBudget(cfg *config.Config, maxCostUSD float64, maxTokens int) {
@@ -646,6 +656,438 @@ func TestPhaseActionType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSmoke_S1_PolicyDenialShortCircuitsBeforeSurfaceSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "policy-deny"))
+
+	writeWorkflowFile(t, dir, "policy-deny", []testPhase{
+		{name: "solve", promptContent: "Solve the issue", maxTurns: 5},
+	})
+	require.NoError(t, os.Symlink("broken-target", filepath.Join(dir, ".xylem.yml")))
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.Intermediary = intermediary.NewIntermediary([]intermediary.Policy{{
+		Name:  "deny-all",
+		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.Deny}},
+	}}, nil, nil)
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+
+	vessel := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, vessel.State)
+	assert.Contains(t, vessel.Error, "denied by policy")
+	assert.Len(t, cmdRunner.phaseCalls, 0)
+
+	_, statErr := os.Stat(filepath.Join(cfg.StateDir, "phases", "issue-1", "solve.output"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestSmoke_S2_SurfacePreSnapshotFailureShortCircuitsBeforePhaseExecution(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "snapshot-fail"))
+
+	writeWorkflowFile(t, dir, "snapshot-fail", []testPhase{
+		{name: "plan", promptContent: "Plan the fix", maxTurns: 5},
+	})
+	require.NoError(t, os.Symlink("broken-target", filepath.Join(dir, ".xylem.yml")))
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+
+	vessel := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, vessel.State)
+	assert.Contains(t, vessel.Error, "snapshot failed")
+	assert.Len(t, cmdRunner.phaseCalls, 0)
+
+	_, statErr := os.Stat(filepath.Join(cfg.StateDir, "phases", "issue-1", "plan.output"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestSmoke_S3_PhaseExecutionFailureShortCircuitsBeforeSurfacePostVerification(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "phase-fail"))
+
+	writeWorkflowFile(t, dir, "phase-fail", []testPhase{
+		{name: "implement", promptContent: "Implement the fix", maxTurns: 5},
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem.yml"), []byte("repo: owner/repo\n"), 0o644))
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		runPhaseHook: func(worktreePath, _, _ string, _ ...string) ([]byte, error, bool) {
+			if err := os.WriteFile(filepath.Join(worktreePath, ".xylem.yml"), []byte("tampered: true\n"), 0o644); err != nil {
+				return nil, err, true
+			}
+			return nil, errors.New("phase boom"), true
+		},
+	}
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, cfg.EffectiveAuditLogPath()))
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.AuditLog = auditLog
+	r.Intermediary = intermediary.NewIntermediary([]intermediary.Policy{{
+		Name:  "allow-all",
+		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.Allow}},
+	}}, auditLog, nil)
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+
+	vessel := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, vessel.State)
+	assert.Contains(t, vessel.Error, "phase boom")
+	assert.NotContains(t, vessel.Error, "violated protected surfaces")
+	assert.Len(t, cmdRunner.phaseCalls, 1)
+
+	entries, entryErr := auditLog.Entries()
+	require.NoError(t, entryErr)
+	for _, entry := range entries {
+		assert.NotEqual(t, "file_write", entry.Intent.Action)
+	}
+}
+
+func TestSmoke_S4_SurfaceViolationShortCircuitsBeforeBudgetCheck(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	setPricedModel(cfg)
+	setBudget(cfg, 0.0001, 0)
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "surface-before-budget"))
+
+	writeWorkflowFile(t, dir, "surface-before-budget", []testPhase{
+		{name: "implement", promptContent: "Implement the fix", maxTurns: 5},
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem.yml"), []byte("repo: owner/repo\n"), 0o644))
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		runPhaseHook: func(worktreePath, _, _ string, _ ...string) ([]byte, error, bool) {
+			if err := os.WriteFile(filepath.Join(worktreePath, ".xylem.yml"), []byte("tampered: true\n"), 0o644); err != nil {
+				return nil, err, true
+			}
+			return []byte(strings.Repeat("x", 4000)), nil, true
+		},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+
+	vessel := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, vessel.State)
+	assert.Contains(t, vessel.Error, "violated protected surfaces")
+	assert.NotContains(t, vessel.Error, "budget exceeded")
+
+	summary := loadSummary(t, cfg.StateDir, "issue-1")
+	assert.False(t, summary.BudgetExceeded)
+	assert.Zero(t, summary.TotalTokensEst)
+}
+
+func TestSmoke_S17_RunnerWithNilIntermediarySkipsPolicyCheck(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "nil-intermediary"))
+
+	writeWorkflowFile(t, dir, "nil-intermediary", []testPhase{
+		{name: "solve", promptContent: "Solve the issue", maxTurns: 5},
+	})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{"Solve the issue": []byte("done")},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
+
+	vessel := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateCompleted, vessel.State)
+	assert.Empty(t, vessel.Error)
+	assert.Len(t, cmdRunner.phaseCalls, 1)
+}
+
+func TestSmoke_S18_RunnerPolicyDeniesPhase(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "deny-phase"))
+
+	writeWorkflowFile(t, dir, "deny-phase", []testPhase{
+		{name: "solve", promptContent: "Solve the issue", maxTurns: 5},
+	})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.Intermediary = intermediary.NewIntermediary([]intermediary.Policy{{
+		Name:  "deny-all",
+		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.Deny}},
+	}}, nil, nil)
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+
+	vessel := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, vessel.State)
+	assert.Contains(t, vessel.Error, "denied by policy")
+	assert.Contains(t, vessel.Error, "solve")
+	assert.Len(t, cmdRunner.phaseCalls, 0)
+}
+
+func TestSmoke_S19_RunnerPolicyRequireApproval(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "approval-phase"))
+
+	writeWorkflowFile(t, dir, "approval-phase", []testPhase{
+		{name: "deploy", promptContent: "Deploy the fix", maxTurns: 5},
+	})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.Intermediary = intermediary.NewIntermediary([]intermediary.Policy{{
+		Name:  "require-approval",
+		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.RequireApproval}},
+	}}, nil, nil)
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+
+	vessel := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, vessel.State)
+	assert.Contains(t, vessel.Error, "requires approval")
+	assert.Contains(t, vessel.Error, "deploy")
+	assert.Contains(t, vessel.Error, "automatic approval not yet supported")
+	assert.Len(t, cmdRunner.phaseCalls, 0)
+}
+
+func TestSmoke_S20_SurfacePreSnapshotIsTakenBeforePhaseExecution(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "surface-order"))
+
+	writeWorkflowFile(t, dir, "surface-order", []testPhase{
+		{name: "implement", promptContent: "Implement the fix", maxTurns: 5},
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem.yml"), []byte("repo: owner/repo\n"), 0o644))
+	withTestWorkingDir(t, dir)
+
+	var sawOriginal atomic.Bool
+	cmdRunner := &mockCmdRunner{
+		runPhaseHook: func(worktreePath, _, _ string, _ ...string) ([]byte, error, bool) {
+			data, err := os.ReadFile(filepath.Join(worktreePath, ".xylem.yml"))
+			if err != nil {
+				return nil, err, true
+			}
+			sawOriginal.Store(string(data) == "repo: owner/repo\n")
+			if err := os.WriteFile(filepath.Join(worktreePath, ".xylem.yml"), []byte("tampered: true\n"), 0o644); err != nil {
+				return nil, err, true
+			}
+			return []byte("mutated"), nil, true
+		},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+	assert.True(t, sawOriginal.Load())
+
+	vessel := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, vessel.State)
+	assert.Contains(t, vessel.Error, "violated protected surfaces")
+	assert.Contains(t, vessel.Error, ".xylem.yml")
+}
+
+func TestSmoke_S21_SurfacePostVerificationDetectsMutation(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "surface-mutation"))
+
+	writeWorkflowFile(t, dir, "surface-mutation", []testPhase{
+		{name: "implement", promptContent: "Implement the fix", maxTurns: 5},
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem.yml"), []byte("repo: owner/repo\n"), 0o644))
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		runPhaseHook: func(worktreePath, _, _ string, _ ...string) ([]byte, error, bool) {
+			if err := os.WriteFile(filepath.Join(worktreePath, ".xylem.yml"), []byte("tampered: true\n"), 0o644); err != nil {
+				return nil, err, true
+			}
+			return []byte("mutated"), nil, true
+		},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+
+	vessel := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, vessel.State)
+	assert.Contains(t, vessel.Error, "violated protected surfaces")
+	assert.Contains(t, vessel.Error, ".xylem.yml")
+}
+
+func TestSmoke_S22_AuditLogRecordsPolicyDecisions(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "audit-policy"))
+
+	writeWorkflowFile(t, dir, "audit-policy", []testPhase{
+		{name: "implement", promptContent: "Implement the fix", maxTurns: 5},
+	})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{"Implement the fix": []byte("done")},
+	}
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, cfg.EffectiveAuditLogPath()))
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.AuditLog = auditLog
+	r.Intermediary = intermediary.NewIntermediary([]intermediary.Policy{{
+		Name:  "allow-all",
+		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.Allow}},
+	}}, auditLog, nil)
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
+
+	entries, entryErr := auditLog.Entries()
+	require.NoError(t, entryErr)
+	require.NotEmpty(t, entries)
+	assert.Equal(t, "phase_execute", entries[0].Intent.Action)
+	assert.Equal(t, "issue-1", entries[0].Intent.AgentID)
+	assert.Equal(t, intermediary.Allow, entries[0].Decision)
+}
+
+func TestSmoke_S23_AuditLogRecordsSurfaceViolations(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "audit-surface"))
+
+	writeWorkflowFile(t, dir, "audit-surface", []testPhase{
+		{name: "implement", promptContent: "Implement the fix", maxTurns: 5},
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem.yml"), []byte("repo: owner/repo\n"), 0o644))
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		runPhaseHook: func(worktreePath, _, _ string, _ ...string) ([]byte, error, bool) {
+			if err := os.WriteFile(filepath.Join(worktreePath, ".xylem.yml"), []byte("tampered: true\n"), 0o644); err != nil {
+				return nil, err, true
+			}
+			return []byte("mutated"), nil, true
+		},
+	}
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, cfg.EffectiveAuditLogPath()))
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.AuditLog = auditLog
+	r.Intermediary = intermediary.NewIntermediary([]intermediary.Policy{{
+		Name:  "allow-all",
+		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.Allow}},
+	}}, auditLog, nil)
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+
+	entries, entryErr := auditLog.Entries()
+	require.NoError(t, entryErr)
+
+	found := false
+	for _, entry := range entries {
+		if entry.Intent.Action == "file_write" && entry.Intent.Resource == ".xylem.yml" {
+			found = true
+			assert.Equal(t, intermediary.Deny, entry.Decision)
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestSmoke_S24_PhaseActionTypeReturnsExternalCommandForCommandPhases(t *testing.T) {
+	assert.Equal(t, "external_command", phaseActionType(&workflow.Phase{Type: "command"}))
+}
+
+func TestSmoke_S25_PhaseActionTypeReturnsPhaseExecuteForPromptPhases(t *testing.T) {
+	assert.Equal(t, "phase_execute", phaseActionType(&workflow.Phase{}))
+}
+
+func TestSmoke_S26_FormatViolationsProducesHumanReadableOutput(t *testing.T) {
+	got := formatViolations([]surface.Violation{
+		{Path: ".xylem.yml", Before: "abc", After: "xyz"},
+		{Path: ".xylem/HARNESS.md", Before: "111", After: "deleted"},
+	})
+
+	assert.Contains(t, got, ".xylem.yml")
+	assert.Contains(t, got, "before: abc")
+	assert.Contains(t, got, "after: xyz")
+	assert.Contains(t, got, ".xylem/HARNESS.md")
+	assert.Contains(t, got, "deleted")
 }
 
 func TestDrainSingleVessel(t *testing.T) {
@@ -1011,7 +1453,7 @@ func TestDrainPromptOnlyWithRef(t *testing.T) {
 	}
 }
 
-func TestSmoke_S25_PerVesselTrackerIsCreatedFreshForEachVessel(t *testing.T) {
+func TestSmoke_WS3_S25_PerVesselTrackerIsCreatedFreshForEachVessel(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)
 	cfg.StateDir = filepath.Join(dir, ".xylem")
@@ -1063,7 +1505,7 @@ func TestSmoke_S25_PerVesselTrackerIsCreatedFreshForEachVessel(t *testing.T) {
 	assert.Greater(t, phase1Tokens*2, 150)
 }
 
-func TestSmoke_S26_CostRecordedAfterEachPromptTypePhase(t *testing.T) {
+func TestSmoke_WS3_S26_CostRecordedAfterEachPromptTypePhase(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)
 	cfg.StateDir = filepath.Join(dir, ".xylem")
@@ -3944,15 +4386,27 @@ func TestDrainOrchestratedProtectedSurfaceViolationFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AuditLog.Entries() error = %v", err)
 	}
-	if len(entries) < 2 {
-		t.Fatalf("len(entries) = %d, want at least 2", len(entries))
+	found := false
+	for _, entry := range entries {
+		if entry.Intent.Action != "file_write" || entry.Intent.Resource != ".xylem.yml" {
+			continue
+		}
+		found = true
+		if entry.Decision != intermediary.Deny {
+			t.Fatalf("file_write entry decision = %q, want %q", entry.Decision, intermediary.Deny)
+		}
+		if !strings.Contains(entry.Error, "violated protected surfaces") {
+			t.Fatalf("file_write entry error = %q, want to contain %q", entry.Error, "violated protected surfaces")
+		}
+		if entry.Intent.Metadata["phase"] != "tamper" {
+			t.Fatalf("file_write entry phase metadata = %q, want tamper", entry.Intent.Metadata["phase"])
+		}
+		if entry.Intent.Metadata["before"] == "" || entry.Intent.Metadata["after"] == "" {
+			t.Fatalf("file_write entry missing before/after metadata: %+v", entry.Intent.Metadata)
+		}
 	}
-	last := entries[len(entries)-1]
-	if last.Decision != intermediary.Deny {
-		t.Fatalf("last entry decision = %q, want %q", last.Decision, intermediary.Deny)
-	}
-	if !strings.Contains(last.Error, "violated protected surfaces") {
-		t.Fatalf("last entry error = %q, want to contain %q", last.Error, "violated protected surfaces")
+	if !found {
+		t.Fatalf("no file_write audit entry recorded; entries = %+v", entries)
 	}
 }
 
@@ -4028,15 +4482,12 @@ func TestVerifyProtectedSurfacesSkipsWhenWorktreeMissing(t *testing.T) {
 		t.Fatalf("expected 'no longer exists' in log, got: %q", logBuf.String())
 	}
 
-	// No audit entry should have been recorded — there was no violation.
 	entries, err := auditLog.Entries()
 	if err != nil {
 		t.Fatalf("AuditLog.Entries() = %v", err)
 	}
-	for _, e := range entries {
-		if e.Intent.Action == "protected_surface_violation" {
-			t.Fatalf("unexpected protected_surface_violation audit entry: %+v", e)
-		}
+	if len(entries) != 0 {
+		t.Fatalf("AuditLog.Entries() len = %d, want 0; entries = %+v", len(entries), entries)
 	}
 }
 
@@ -4101,16 +4552,22 @@ func TestVerifyProtectedSurfacesDetectsLegitimateDeletionWhenWorktreeExists(t *t
 	}
 	found := false
 	for _, e := range entries {
-		if e.Intent.Action == "protected_surface_violation" && e.Decision == intermediary.Deny {
+		if e.Intent.Action == "file_write" && e.Intent.Resource == ".xylem.yml" && e.Decision == intermediary.Deny {
 			found = true
 			if !strings.Contains(e.Error, ".xylem.yml") {
 				t.Fatalf("audit entry error = %q, want to mention .xylem.yml", e.Error)
+			}
+			if e.Intent.Metadata["phase"] != "implement" {
+				t.Fatalf("audit entry phase metadata = %q, want implement", e.Intent.Metadata["phase"])
+			}
+			if e.Intent.Metadata["after"] != "deleted" {
+				t.Fatalf("audit entry after metadata = %q, want deleted", e.Intent.Metadata["after"])
 			}
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("no protected_surface_violation audit entry recorded; entries = %+v", entries)
+		t.Fatalf("no file_write audit entry recorded; entries = %+v", entries)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Check `runErr` before protected surface verification so a failed phase short-circuits without a spurious surface-violation report
- Wrap snapshot errors with `"protected surface snapshot failed"` for clearer diagnostics
- Write per-violation audit entries (one per file) instead of a single batch entry
- Include policy denial reasons in error messages and workflow name in justification
- Allow retrying `timed_out` vessels alongside `failed` ones
- Graceful handling when post-snapshot fails during verification (log + skip instead of error)
- Config and prompt updates for copilot provider and implement-harness workflow

## Test plan
- [x] New smoke tests S1-S4, S17+ covering execution-order invariants
- [x] Property test for `formatViolations` output
- [x] `TestRetryTimedOutVessel` and renamed `TestRetryNonRetryableVessel`
- [x] `go test ./cmd/xylem/... ./internal/runner/...` passes
- [x] `golangci-lint run ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)