### PR TITLE
Surface vessel health in status and telemetry

### DIFF
--- a/cli/cmd/xylem/status.go
+++ b/cli/cmd/xylem/status.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
 )
 
 func newStatusCmd() *cobra.Command {
@@ -20,7 +22,7 @@ func newStatusCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			jsonMode, _ := cmd.Flags().GetBool("json")
 			stateFilter, _ := cmd.Flags().GetString("state")
-			return cmdStatus(deps.q, jsonMode, stateFilter)
+			return cmdStatus(deps.cfg, deps.q, jsonMode, stateFilter)
 		},
 	}
 	cmd.Flags().Bool("json", false, "Output as JSON")
@@ -28,7 +30,13 @@ func newStatusCmd() *cobra.Command {
 	return cmd
 }
 
-func cmdStatus(q *queue.Queue, jsonMode bool, stateFilter string) error {
+type statusRow struct {
+	queue.Vessel
+	Health    string                 `json:"health"`
+	Anomalies []runner.VesselAnomaly `json:"anomalies,omitempty"`
+}
+
+func cmdStatus(cfg *config.Config, q *queue.Queue, jsonMode bool, stateFilter string) error {
 	var vessels []queue.Vessel
 	var err error
 	if stateFilter != "" {
@@ -40,13 +48,33 @@ func cmdStatus(q *queue.Queue, jsonMode bool, stateFilter string) error {
 		return fmt.Errorf("error reading queue: %w", err)
 	}
 
+	var summaries map[string]*runner.VesselSummary
+	if cfg != nil && cfg.StateDir != "" {
+		ids := make([]string, len(vessels))
+		for i, vessel := range vessels {
+			ids[i] = vessel.ID
+		}
+		summaries, err = runner.LoadVesselSummaries(cfg.StateDir, ids)
+		if err != nil {
+			return fmt.Errorf("load vessel summaries: %w", err)
+		}
+	}
+
+	rows := make([]statusRow, len(vessels))
+	for i, vessel := range vessels {
+		status := runner.AnalyzeVesselStatus(vessel, summaries[vessel.ID])
+		rows[i] = statusRow{
+			Vessel:    vessel,
+			Health:    string(status.Health),
+			Anomalies: status.Anomalies,
+		}
+	}
+	fleet := runner.AnalyzeFleetStatus(vessels, summaries)
+
 	if jsonMode {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		if vessels == nil {
-			vessels = []queue.Vessel{}
-		}
-		enc.Encode(vessels) //nolint:errcheck
+		enc.Encode(rows) //nolint:errcheck
 		return nil
 	}
 
@@ -55,13 +83,13 @@ func cmdStatus(q *queue.Queue, jsonMode bool, stateFilter string) error {
 		return nil
 	}
 
-	fmt.Printf("%-14s  %-14s  %-20s  %-10s  %-30s  %-12s  %s\n",
-		"ID", "Source", "Workflow", "State", "Info", "Started", "Duration")
-	fmt.Printf("%-14s  %-14s  %-20s  %-10s  %-30s  %-12s  %s\n",
-		"----", "------", "-----", "-----", "----", "-------", "--------")
+	fmt.Printf("%-14s  %-14s  %-20s  %-10s  %-10s  %-42s  %-12s  %s\n",
+		"ID", "Source", "Workflow", "State", "Health", "Info", "Started", "Duration")
+	fmt.Printf("%-14s  %-14s  %-20s  %-10s  %-10s  %-42s  %-12s  %s\n",
+		"----", "------", "-----", "-----", "------", "----", "-------", "--------")
 
 	counts := map[queue.VesselState]int{}
-	for _, j := range vessels {
+	for i, j := range vessels {
 		counts[j.State]++
 		started := "—"
 		duration := "—"
@@ -77,9 +105,9 @@ func cmdStatus(q *queue.Queue, jsonMode bool, stateFilter string) error {
 		if wf == "" {
 			wf = "(prompt)"
 		}
-		info := vesselInfo(j)
-		fmt.Printf("%-14s  %-14s  %-20s  %-10s  %-30s  %-12s  %s\n",
-			j.ID, j.Source, wf, string(j.State), info, started, duration)
+		info := vesselInfo(j, rows[i].Anomalies)
+		fmt.Printf("%-14s  %-14s  %-20s  %-10s  %-10s  %-42s  %-12s  %s\n",
+			j.ID, j.Source, wf, string(j.State), rows[i].Health, info, started, duration)
 	}
 
 	fmt.Printf("\nSummary: %d pending, %d running, %d completed, %d failed, %d cancelled, %d waiting, %d timed_out\n",
@@ -87,19 +115,31 @@ func cmdStatus(q *queue.Queue, jsonMode bool, stateFilter string) error {
 		counts[queue.StateCompleted], counts[queue.StateFailed],
 		counts[queue.StateCancelled], counts[queue.StateWaiting],
 		counts[queue.StateTimedOut])
+	fmt.Printf("Health: %d healthy, %d degraded, %d unhealthy\n",
+		fleet.Healthy, fleet.Degraded, fleet.Unhealthy)
+	if len(fleet.Patterns) > 0 {
+		fmt.Printf("Patterns: %s\n", runner.FormatFleetPatterns(fleet.Patterns))
+	}
 	return nil
 }
 
 // vesselInfo returns additional context for the Info column based on vessel state.
-func vesselInfo(v queue.Vessel) string {
+func vesselInfo(v queue.Vessel, anomalies []runner.VesselAnomaly) string {
+	parts := make([]string, 0, len(anomalies)+1)
 	if v.State == queue.StateWaiting && v.WaitingFor != "" {
 		elapsed := "unknown"
 		if v.WaitingSince != nil {
 			elapsed = time.Since(*v.WaitingSince).Round(time.Second).String()
 		}
-		return fmt.Sprintf("waiting for %q (%s)", v.WaitingFor, elapsed)
+		parts = append(parts, fmt.Sprintf("waiting for %q (%s)", v.WaitingFor, elapsed))
 	}
-	return ""
+	for _, anomaly := range anomalies {
+		if anomaly.Code == "waiting_on_gate" {
+			continue
+		}
+		parts = append(parts, anomaly.Message)
+	}
+	return strings.Join(parts, "; ")
 }
 
 func pauseMarkerPath(cfg *config.Config) string {

--- a/cli/cmd/xylem/status_test.go
+++ b/cli/cmd/xylem/status_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
 
@@ -32,12 +33,16 @@ func testStatusVessel(id string, state queue.VesselState) queue.Vessel {
 	}
 }
 
+func testStatusConfig(dir string) *config.Config {
+	return &config.Config{StateDir: filepath.Join(dir, ".xylem")}
+}
+
 func TestStatusEmpty(t *testing.T) {
 	dir := t.TempDir()
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
 
 	var err error
-	out := captureStdout(func() { err = cmdStatus(q, false, "") })
+	out := captureStdout(func() { err = cmdStatus(testStatusConfig(dir), q, false, "") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -53,7 +58,7 @@ func TestStatusTable(t *testing.T) {
 	q.Enqueue(testStatusVessel("issue-55", queue.StateCompleted)) //nolint:errcheck
 
 	var err error
-	out := captureStdout(func() { err = cmdStatus(q, false, "") })
+	out := captureStdout(func() { err = cmdStatus(testStatusConfig(dir), q, false, "") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -83,7 +88,7 @@ func TestStatusJSON(t *testing.T) {
 	q.Enqueue(testStatusVessel("issue-1", queue.StatePending)) //nolint:errcheck
 
 	var err error
-	out := captureStdout(func() { err = cmdStatus(q, true, "") })
+	out := captureStdout(func() { err = cmdStatus(testStatusConfig(dir), q, true, "") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -103,7 +108,7 @@ func TestStatusStateFilter(t *testing.T) {
 	q.Enqueue(testStatusVessel("issue-2", queue.StateCompleted)) //nolint:errcheck
 
 	var err error
-	out := captureStdout(func() { err = cmdStatus(q, false, "pending") })
+	out := captureStdout(func() { err = cmdStatus(testStatusConfig(dir), q, false, "pending") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -126,7 +131,7 @@ func TestStatusRunningVesselShowsDuration(t *testing.T) {
 	})
 
 	var err error
-	out := captureStdout(func() { err = cmdStatus(q, false, "") })
+	out := captureStdout(func() { err = cmdStatus(testStatusConfig(dir), q, false, "") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -154,7 +159,7 @@ func TestStatusCompletedVesselShowsFixedDuration(t *testing.T) {
 	})
 
 	var err error
-	out := captureStdout(func() { err = cmdStatus(q, false, "") })
+	out := captureStdout(func() { err = cmdStatus(testStatusConfig(dir), q, false, "") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -177,7 +182,7 @@ func TestStatusShowsWaitingVessels(t *testing.T) {
 	})
 
 	var err error
-	out := captureStdout(func() { err = cmdStatus(q, false, "") })
+	out := captureStdout(func() { err = cmdStatus(testStatusConfig(dir), q, false, "") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -208,7 +213,7 @@ func TestStatusShowsTimedOutVessels(t *testing.T) {
 	})
 
 	var err error
-	out := captureStdout(func() { err = cmdStatus(q, false, "") })
+	out := captureStdout(func() { err = cmdStatus(testStatusConfig(dir), q, false, "") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -236,7 +241,7 @@ func TestStatusFilterByWaiting(t *testing.T) {
 	})
 
 	var err error
-	out := captureStdout(func() { err = cmdStatus(q, false, "waiting") })
+	out := captureStdout(func() { err = cmdStatus(testStatusConfig(dir), q, false, "waiting") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -288,7 +293,7 @@ func TestStatusSummaryCounts(t *testing.T) {
 	})
 
 	var err error
-	out := captureStdout(func() { err = cmdStatus(q, false, "") })
+	out := captureStdout(func() { err = cmdStatus(testStatusConfig(dir), q, false, "") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -332,7 +337,7 @@ func TestStatusJSONIncludesWaitingFields(t *testing.T) {
 	})
 
 	var err error
-	out := captureStdout(func() { err = cmdStatus(q, true, "") })
+	out := captureStdout(func() { err = cmdStatus(testStatusConfig(dir), q, true, "") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -350,5 +355,139 @@ func TestStatusJSONIncludesWaitingFields(t *testing.T) {
 	}
 	if v.WaitingSince == nil {
 		t.Error("expected waiting_since to be set")
+	}
+}
+
+func TestStatusSurfacesHealthAndPatterns(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testStatusConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	started := now.Add(-10 * time.Minute)
+	ended := now.Add(-5 * time.Minute)
+
+	q.Enqueue(queue.Vessel{ //nolint:errcheck
+		ID: "issue-1", Source: "github-issue", Workflow: "fix-bug",
+		State: queue.StateCompleted, CreatedAt: now,
+		StartedAt: &started, EndedAt: &ended,
+	})
+	q.Enqueue(queue.Vessel{ //nolint:errcheck
+		ID: "issue-2", Source: "github-issue", Workflow: "fix-bug",
+		State: queue.StateFailed, CreatedAt: now,
+		StartedAt: &started, EndedAt: &ended,
+	})
+
+	summaryDir := filepath.Join(cfg.StateDir, "phases", "issue-2")
+	if err := os.MkdirAll(summaryDir, 0o755); err != nil {
+		t.Fatalf("mkdir summary dir: %v", err)
+	}
+	summary := `{
+  "vessel_id": "issue-2",
+  "source": "github-issue",
+  "workflow": "fix-bug",
+  "state": "failed",
+  "started_at": "2026-04-08T20:00:00Z",
+  "ended_at": "2026-04-08T20:05:00Z",
+  "duration_ms": 300000,
+  "phases": [
+    {
+      "name": "implement",
+      "type": "prompt",
+      "duration_ms": 1000,
+      "status": "failed",
+      "gate_type": "command",
+      "gate_passed": false,
+      "error": "exit status 1"
+    }
+  ],
+  "total_input_tokens_est": 0,
+  "total_output_tokens_est": 0,
+  "total_tokens_est": 0,
+  "total_cost_usd_est": 0,
+  "budget_exceeded": true,
+  "note": "test"
+}`
+	if err := os.WriteFile(filepath.Join(summaryDir, "summary.json"), []byte(summary), 0o644); err != nil {
+		t.Fatalf("write summary: %v", err)
+	}
+
+	var err error
+	out := captureStdout(func() { err = cmdStatus(cfg, q, false, "") })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "Health") {
+		t.Fatalf("expected Health column/header in output, got: %s", out)
+	}
+	if !strings.Contains(out, "issue-2") || !strings.Contains(out, "unhealthy") {
+		t.Fatalf("expected unhealthy issue-2 row, got: %s", out)
+	}
+	if !strings.Contains(out, "budget exceeded") {
+		t.Fatalf("expected anomaly details in output, got: %s", out)
+	}
+	if !strings.Contains(out, "Health: 1 healthy, 0 degraded, 1 unhealthy") {
+		t.Fatalf("expected health summary counts, got: %s", out)
+	}
+	if !strings.Contains(out, "Patterns:") || !strings.Contains(out, "budget_exceeded=1") {
+		t.Fatalf("expected pattern summary, got: %s", out)
+	}
+}
+
+func TestStatusJSONIncludesHealthAndAnomalies(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testStatusConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	waitingSince := now.Add(-5 * time.Minute)
+
+	q.Enqueue(queue.Vessel{ //nolint:errcheck
+		ID: "issue-3", Source: "github-issue", Workflow: "fix-bug",
+		State: queue.StateWaiting, CreatedAt: now,
+		WaitingFor: "plan-approved", WaitingSince: &waitingSince,
+	})
+
+	var err error
+	out := captureStdout(func() { err = cmdStatus(cfg, q, true, "") })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var rows []statusRow
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+		t.Fatalf("expected valid JSON, got: %s\nerr: %v", out, err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].Health != "degraded" {
+		t.Fatalf("expected degraded health, got %q", rows[0].Health)
+	}
+	if len(rows[0].Anomalies) != 1 || rows[0].Anomalies[0].Code != "waiting_on_gate" {
+		t.Fatalf("expected waiting_on_gate anomaly, got %#v", rows[0].Anomalies)
+	}
+}
+
+func TestStatusSkipsSummaryLookupForUnsafeVesselIDs(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testStatusConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+
+	q.Enqueue(queue.Vessel{ //nolint:errcheck
+		ID: "manual/task", Source: "manual", Workflow: "fix-bug",
+		State: queue.StatePending, CreatedAt: now,
+	})
+
+	var err error
+	out := captureStdout(func() { err = cmdStatus(cfg, q, false, "") })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "manual/task") {
+		t.Fatalf("expected unsafe vessel ID in output, got: %s", out)
+	}
+	if !strings.Contains(out, "healthy") {
+		t.Fatalf("expected health column to still render, got: %s", out)
 	}
 }

--- a/cli/internal/observability/vessel.go
+++ b/cli/internal/observability/vessel.go
@@ -1,6 +1,9 @@
 package observability
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // VesselSpanData holds vessel information for attribute extraction.
 type VesselSpanData struct {
@@ -24,6 +27,24 @@ func VesselSpanAttributes(data VesselSpanData) []SpanAttribute {
 	return attrs
 }
 
+// VesselHealthData holds derived vessel health and anomaly data.
+type VesselHealthData struct {
+	State        string   `json:"state"`
+	Health       string   `json:"health"`
+	AnomalyCount int      `json:"anomaly_count"`
+	Anomalies    []string `json:"anomalies,omitempty"`
+}
+
+// VesselHealthAttributes returns span attributes for derived vessel health.
+func VesselHealthAttributes(data VesselHealthData) []SpanAttribute {
+	return []SpanAttribute{
+		{Key: "xylem.vessel.state", Value: data.State},
+		{Key: "xylem.vessel.health", Value: data.Health},
+		{Key: "xylem.vessel.anomaly_count", Value: fmt.Sprintf("%d", data.AnomalyCount)},
+		{Key: "xylem.vessel.anomalies", Value: strings.Join(data.Anomalies, ",")},
+	}
+}
+
 // DrainSpanData holds drain-run information for attribute extraction.
 type DrainSpanData struct {
 	Concurrency int    `json:"concurrency"`
@@ -35,6 +56,24 @@ func DrainSpanAttributes(data DrainSpanData) []SpanAttribute {
 	return []SpanAttribute{
 		{Key: "xylem.drain.concurrency", Value: fmt.Sprintf("%d", data.Concurrency)},
 		{Key: "xylem.drain.timeout", Value: data.Timeout},
+	}
+}
+
+// DrainHealthData holds aggregate health information for a drain run.
+type DrainHealthData struct {
+	Healthy   int    `json:"healthy"`
+	Degraded  int    `json:"degraded"`
+	Unhealthy int    `json:"unhealthy"`
+	Patterns  string `json:"patterns,omitempty"`
+}
+
+// DrainHealthAttributes returns span attributes for aggregate vessel health.
+func DrainHealthAttributes(data DrainHealthData) []SpanAttribute {
+	return []SpanAttribute{
+		{Key: "xylem.drain.healthy_vessels", Value: fmt.Sprintf("%d", data.Healthy)},
+		{Key: "xylem.drain.degraded_vessels", Value: fmt.Sprintf("%d", data.Degraded)},
+		{Key: "xylem.drain.unhealthy_vessels", Value: fmt.Sprintf("%d", data.Unhealthy)},
+		{Key: "xylem.drain.unhealthy_patterns", Value: data.Patterns},
 	}
 }
 

--- a/cli/internal/observability/vessel_test.go
+++ b/cli/internal/observability/vessel_test.go
@@ -135,6 +135,29 @@ func TestVesselSpanAttributesAllowsEmptyCoreFields(t *testing.T) {
 	}
 }
 
+func TestVesselHealthAttributesIncludeDerivedHealth(t *testing.T) {
+	attrs := VesselHealthAttributes(VesselHealthData{
+		State:        "failed",
+		Health:       "unhealthy",
+		AnomalyCount: 2,
+		Anomalies:    []string{"run_failed", "budget_exceeded"},
+	})
+	got := attrMap(attrs)
+
+	if got["xylem.vessel.state"] != "failed" {
+		t.Fatalf("xylem.vessel.state = %q, want failed", got["xylem.vessel.state"])
+	}
+	if got["xylem.vessel.health"] != "unhealthy" {
+		t.Fatalf("xylem.vessel.health = %q, want unhealthy", got["xylem.vessel.health"])
+	}
+	if got["xylem.vessel.anomaly_count"] != "2" {
+		t.Fatalf("xylem.vessel.anomaly_count = %q, want 2", got["xylem.vessel.anomaly_count"])
+	}
+	if got["xylem.vessel.anomalies"] != "run_failed,budget_exceeded" {
+		t.Fatalf("xylem.vessel.anomalies = %q, want joined anomalies", got["xylem.vessel.anomalies"])
+	}
+}
+
 func TestPhaseResultAttributesFormatsNegativeDuration(t *testing.T) {
 	attrs := PhaseResultAttributes(PhaseResultData{
 		InputTokensEst:  1,
@@ -179,5 +202,28 @@ func TestDrainSpanAttributes_ConcurrencyFormatted(t *testing.T) {
 
 	if got["xylem.drain.concurrency"] != "17" {
 		t.Fatalf("xylem.drain.concurrency = %q, want %q", got["xylem.drain.concurrency"], "17")
+	}
+}
+
+func TestDrainHealthAttributesIncludePatterns(t *testing.T) {
+	attrs := DrainHealthAttributes(DrainHealthData{
+		Healthy:   1,
+		Degraded:  2,
+		Unhealthy: 3,
+		Patterns:  "budget_exceeded=2, run_failed=1",
+	})
+	got := attrMap(attrs)
+
+	if got["xylem.drain.healthy_vessels"] != "1" {
+		t.Fatalf("xylem.drain.healthy_vessels = %q, want 1", got["xylem.drain.healthy_vessels"])
+	}
+	if got["xylem.drain.degraded_vessels"] != "2" {
+		t.Fatalf("xylem.drain.degraded_vessels = %q, want 2", got["xylem.drain.degraded_vessels"])
+	}
+	if got["xylem.drain.unhealthy_vessels"] != "3" {
+		t.Fatalf("xylem.drain.unhealthy_vessels = %q, want 3", got["xylem.drain.unhealthy_vessels"])
+	}
+	if got["xylem.drain.unhealthy_patterns"] != "budget_exceeded=2, run_failed=1" {
+		t.Fatalf("xylem.drain.unhealthy_patterns = %q, want joined patterns", got["xylem.drain.unhealthy_patterns"])
 	}
 }

--- a/cli/internal/runner/health.go
+++ b/cli/internal/runner/health.go
@@ -1,0 +1,215 @@
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+type VesselHealth string
+
+const (
+	VesselHealthHealthy   VesselHealth = "healthy"
+	VesselHealthDegraded  VesselHealth = "degraded"
+	VesselHealthUnhealthy VesselHealth = "unhealthy"
+)
+
+type VesselAnomaly struct {
+	Code     string `json:"code"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+}
+
+type VesselStatusReport struct {
+	Health    VesselHealth    `json:"health"`
+	Anomalies []VesselAnomaly `json:"anomalies,omitempty"`
+}
+
+type FleetPattern struct {
+	Code  string `json:"code"`
+	Count int    `json:"count"`
+}
+
+type FleetStatusReport struct {
+	Healthy   int            `json:"healthy"`
+	Degraded  int            `json:"degraded"`
+	Unhealthy int            `json:"unhealthy"`
+	Patterns  []FleetPattern `json:"patterns,omitempty"`
+}
+
+func LoadVesselSummary(stateDir, vesselID string) (*VesselSummary, error) {
+	if err := validateSummaryPathComponent(vesselID); err != nil {
+		return nil, fmt.Errorf("load vessel summary: invalid vessel ID: %w", err)
+	}
+
+	data, err := os.ReadFile(summaryPath(stateDir, vesselID))
+	if err != nil {
+		return nil, fmt.Errorf("load vessel summary: read: %w", err)
+	}
+
+	var summary VesselSummary
+	if err := json.Unmarshal(data, &summary); err != nil {
+		return nil, fmt.Errorf("load vessel summary: unmarshal: %w", err)
+	}
+	if summary.Phases == nil {
+		summary.Phases = []PhaseSummary{}
+	}
+
+	return &summary, nil
+}
+
+func LoadVesselSummaries(stateDir string, vesselIDs []string) (map[string]*VesselSummary, error) {
+	summaries := make(map[string]*VesselSummary, len(vesselIDs))
+	for _, vesselID := range vesselIDs {
+		if err := validateSummaryPathComponent(vesselID); err != nil {
+			continue
+		}
+		summary, err := LoadVesselSummary(stateDir, vesselID)
+		if err == nil {
+			summaries[vesselID] = summary
+			continue
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		return nil, err
+	}
+	return summaries, nil
+}
+
+func AnalyzeVesselStatus(vessel queue.Vessel, summary *VesselSummary) VesselStatusReport {
+	report := VesselStatusReport{
+		Health:    VesselHealthHealthy,
+		Anomalies: []VesselAnomaly{},
+	}
+	seen := make(map[string]struct{})
+	addAnomaly := func(code, severity, message string) {
+		if _, ok := seen[code]; ok {
+			return
+		}
+		seen[code] = struct{}{}
+		report.Anomalies = append(report.Anomalies, VesselAnomaly{
+			Code:     code,
+			Severity: severity,
+			Message:  message,
+		})
+		switch severity {
+		case "critical":
+			report.Health = VesselHealthUnhealthy
+		case "warning":
+			if report.Health == VesselHealthHealthy {
+				report.Health = VesselHealthDegraded
+			}
+		}
+	}
+
+	if summary != nil {
+		switch summary.State {
+		case string(queue.StateFailed):
+			addAnomaly("run_failed", "critical", "run failed")
+		case string(queue.StateTimedOut):
+			addAnomaly("timed_out", "critical", "run timed out")
+		case string(queue.StateCancelled):
+			addAnomaly("cancelled", "warning", "run cancelled")
+		}
+		if summary.BudgetExceeded {
+			severity := "warning"
+			if summary.State != string(queue.StateCompleted) {
+				severity = "critical"
+			}
+			addAnomaly("budget_exceeded", severity, "budget exceeded")
+		}
+		for _, phase := range summary.Phases {
+			if phase.GatePassed != nil && !*phase.GatePassed {
+				msg := "gate failed"
+				if phase.GateType != "" {
+					msg = phase.GateType + " gate failed"
+				}
+				if phase.Name != "" {
+					msg = fmt.Sprintf("phase %q %s", phase.Name, msg)
+				}
+				addAnomaly("gate_failed", "critical", msg)
+			}
+			if phase.Status == "failed" {
+				msg := "phase failed"
+				if phase.Name != "" {
+					msg = fmt.Sprintf("phase %q failed", phase.Name)
+				}
+				addAnomaly("phase_failed", "critical", msg)
+			}
+		}
+	}
+
+	switch vessel.State {
+	case queue.StateWaiting:
+		msg := "waiting on label gate"
+		if vessel.WaitingFor != "" {
+			msg = fmt.Sprintf("waiting for %q", vessel.WaitingFor)
+		}
+		addAnomaly("waiting_on_gate", "warning", msg)
+	case queue.StateTimedOut:
+		addAnomaly("timed_out", "critical", "run timed out")
+	case queue.StateFailed:
+		addAnomaly("run_failed", "critical", "run failed")
+	case queue.StateCancelled:
+		addAnomaly("cancelled", "warning", "run cancelled")
+	}
+
+	return report
+}
+
+func AnalyzeFleetStatus(vessels []queue.Vessel, summaries map[string]*VesselSummary) FleetStatusReport {
+	report := FleetStatusReport{}
+	patternCounts := make(map[string]int)
+	for _, vessel := range vessels {
+		status := AnalyzeVesselStatus(vessel, summaries[vessel.ID])
+		switch status.Health {
+		case VesselHealthHealthy:
+			report.Healthy++
+		case VesselHealthDegraded:
+			report.Degraded++
+		case VesselHealthUnhealthy:
+			report.Unhealthy++
+		}
+		for _, anomaly := range status.Anomalies {
+			patternCounts[anomaly.Code]++
+		}
+	}
+
+	report.Patterns = make([]FleetPattern, 0, len(patternCounts))
+	for code, count := range patternCounts {
+		report.Patterns = append(report.Patterns, FleetPattern{Code: code, Count: count})
+	}
+	sort.Slice(report.Patterns, func(i, j int) bool {
+		if report.Patterns[i].Count == report.Patterns[j].Count {
+			return report.Patterns[i].Code < report.Patterns[j].Code
+		}
+		return report.Patterns[i].Count > report.Patterns[j].Count
+	})
+
+	return report
+}
+
+func AnomalyCodes(anomalies []VesselAnomaly) []string {
+	codes := make([]string, len(anomalies))
+	for i, anomaly := range anomalies {
+		codes[i] = anomaly.Code
+	}
+	return codes
+}
+
+func FormatFleetPatterns(patterns []FleetPattern) string {
+	if len(patterns) == 0 {
+		return ""
+	}
+	parts := make([]string, len(patterns))
+	for i, pattern := range patterns {
+		parts[i] = fmt.Sprintf("%s=%d", pattern.Code, pattern.Count)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/cli/internal/runner/health_test.go
+++ b/cli/internal/runner/health_test.go
@@ -1,0 +1,110 @@
+package runner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+func TestAnalyzeVesselStatusHealthyCompletedRun(t *testing.T) {
+	now := time.Now().UTC()
+	vessel := queue.Vessel{
+		ID:        "issue-1",
+		State:     queue.StateCompleted,
+		CreatedAt: now,
+	}
+	summary := &VesselSummary{
+		VesselID: "issue-1",
+		State:    "completed",
+		Phases: []PhaseSummary{
+			{Name: "implement", Status: "completed"},
+		},
+	}
+
+	report := AnalyzeVesselStatus(vessel, summary)
+	if report.Health != VesselHealthHealthy {
+		t.Fatalf("Health = %q, want %q", report.Health, VesselHealthHealthy)
+	}
+	if len(report.Anomalies) != 0 {
+		t.Fatalf("Anomalies = %#v, want none", report.Anomalies)
+	}
+}
+
+func TestAnalyzeVesselStatusFlagsBudgetAndGateFailures(t *testing.T) {
+	now := time.Now().UTC()
+	failedGate := false
+	vessel := queue.Vessel{
+		ID:        "issue-2",
+		State:     queue.StateFailed,
+		CreatedAt: now,
+	}
+	summary := &VesselSummary{
+		VesselID:        "issue-2",
+		State:           "failed",
+		BudgetExceeded:  true,
+		TotalTokensEst:  10,
+		TotalCostUSDEst: 0.5,
+		Phases: []PhaseSummary{
+			{Name: "implement", Status: "failed", GateType: "command", GatePassed: &failedGate},
+		},
+	}
+
+	report := AnalyzeVesselStatus(vessel, summary)
+	if report.Health != VesselHealthUnhealthy {
+		t.Fatalf("Health = %q, want %q", report.Health, VesselHealthUnhealthy)
+	}
+	if len(report.Anomalies) != 4 {
+		t.Fatalf("len(Anomalies) = %d, want 4", len(report.Anomalies))
+	}
+}
+
+func TestAnalyzeFleetStatusAggregatesPatterns(t *testing.T) {
+	now := time.Now().UTC()
+	waitingSince := now.Add(-time.Minute)
+	vessels := []queue.Vessel{
+		{ID: "issue-1", State: queue.StateCompleted, CreatedAt: now},
+		{ID: "issue-2", State: queue.StateWaiting, CreatedAt: now, WaitingFor: "approved", WaitingSince: &waitingSince},
+		{ID: "issue-3", State: queue.StateFailed, CreatedAt: now},
+	}
+	summaries := map[string]*VesselSummary{
+		"issue-1": {VesselID: "issue-1", State: "completed", Phases: []PhaseSummary{}},
+	}
+
+	report := AnalyzeFleetStatus(vessels, summaries)
+	if report.Healthy != 1 || report.Degraded != 1 || report.Unhealthy != 1 {
+		t.Fatalf("unexpected fleet counts: %#v", report)
+	}
+	if len(report.Patterns) != 2 {
+		t.Fatalf("len(Patterns) = %d, want 2", len(report.Patterns))
+	}
+	if got := FormatFleetPatterns(report.Patterns); got != "run_failed=1, waiting_on_gate=1" {
+		t.Fatalf("FormatFleetPatterns() = %q", got)
+	}
+}
+
+func TestLoadVesselSummariesSkipsIDsThatCannotHaveSummaryFiles(t *testing.T) {
+	stateDir := t.TempDir()
+	summary := &VesselSummary{
+		VesselID: "issue-1",
+		State:    string(queue.StateCompleted),
+		Phases:   []PhaseSummary{},
+	}
+	if err := SaveVesselSummary(stateDir, summary); err != nil {
+		t.Fatalf("SaveVesselSummary() error = %v", err)
+	}
+
+	summaries, err := LoadVesselSummaries(stateDir, []string{"issue-1", "manual/task"})
+	if err != nil {
+		t.Fatalf("LoadVesselSummaries() error = %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("len(summaries) = %d, want 1", len(summaries))
+	}
+	if got := summaries["issue-1"]; got == nil {
+		t.Fatal("expected summary for issue-1")
+	}
+	if _, ok := summaries["manual/task"]; ok {
+		t.Fatalf("did not expect summary entry for invalid vessel ID")
+	}
+}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -3,11 +3,13 @@ package runner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -96,6 +98,8 @@ func (r *Runner) Drain(ctx context.Context) (DrainResult, error) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var result DrainResult
+	healthCounts := FleetStatusReport{}
+	patternCounts := map[string]int{}
 
 	for {
 		select {
@@ -118,8 +122,9 @@ func (r *Runner) Drain(ctx context.Context) (DrainResult, error) {
 			defer func() { <-sem }()
 
 			vesselBaseCtx := context.Background()
+			var vesselSpan observability.SpanContext
 			if r.Tracer != nil {
-				vesselSpan := r.Tracer.StartSpan(ctx, "vessel:"+j.ID, observability.VesselSpanAttributes(observability.VesselSpanData{
+				vesselSpan = r.Tracer.StartSpan(ctx, "vessel:"+j.ID, observability.VesselSpanAttributes(observability.VesselSpanData{
 					ID:       j.ID,
 					Source:   j.Source,
 					Workflow: j.Workflow,
@@ -140,6 +145,21 @@ func (r *Runner) Drain(ctx context.Context) (DrainResult, error) {
 			defer cancel()
 
 			outcome := r.runVessel(vesselCtx, j)
+			finalVessel := j
+			if current, findErr := r.Queue.FindByID(j.ID); findErr != nil {
+				log.Printf("warn: inspect vessel %s after run: %v", j.ID, findErr)
+			} else if current != nil {
+				finalVessel = *current
+			}
+			status := r.inspectVesselStatus(finalVessel)
+			if r.Tracer != nil {
+				vesselSpan.AddAttributes(observability.VesselHealthAttributes(observability.VesselHealthData{
+					State:        string(finalVessel.State),
+					Health:       string(status.Health),
+					AnomalyCount: len(status.Anomalies),
+					Anomalies:    AnomalyCodes(status.Anomalies),
+				}))
+			}
 
 			mu.Lock()
 			switch outcome {
@@ -152,12 +172,41 @@ func (r *Runner) Drain(ctx context.Context) (DrainResult, error) {
 			default:
 				result.Skipped++
 			}
+			switch status.Health {
+			case VesselHealthHealthy:
+				healthCounts.Healthy++
+			case VesselHealthDegraded:
+				healthCounts.Degraded++
+			case VesselHealthUnhealthy:
+				healthCounts.Unhealthy++
+			}
+			for _, anomaly := range status.Anomalies {
+				patternCounts[anomaly.Code]++
+			}
 			mu.Unlock()
 		}(*vessel)
 	}
 
 wait:
 	wg.Wait()
+	if r.Tracer != nil {
+		patterns := make([]FleetPattern, 0, len(patternCounts))
+		for code, count := range patternCounts {
+			patterns = append(patterns, FleetPattern{Code: code, Count: count})
+		}
+		sort.Slice(patterns, func(i, j int) bool {
+			if patterns[i].Count == patterns[j].Count {
+				return patterns[i].Code < patterns[j].Code
+			}
+			return patterns[i].Count > patterns[j].Count
+		})
+		drainSpan.AddAttributes(observability.DrainHealthAttributes(observability.DrainHealthData{
+			Healthy:   healthCounts.Healthy,
+			Degraded:  healthCounts.Degraded,
+			Unhealthy: healthCounts.Unhealthy,
+			Patterns:  FormatFleetPatterns(patterns),
+		}))
+	}
 	return result, nil
 }
 
@@ -2034,6 +2083,17 @@ func (r *Runner) runtimeNow() time.Time {
 		return time.Now().UTC()
 	}
 	return now.UTC()
+}
+
+func (r *Runner) inspectVesselStatus(vessel queue.Vessel) VesselStatusReport {
+	summary, err := LoadVesselSummary(r.Config.StateDir, vessel.ID)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Printf("warn: load vessel summary for %s: %v", vessel.ID, err)
+		}
+		return AnalyzeVesselStatus(vessel, nil)
+	}
+	return AnalyzeVesselStatus(vessel, summary)
 }
 
 func (r *Runner) runtimeSince(start time.Time) time.Duration {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -586,6 +586,84 @@ func TestBuildCommandDirectPromptWithRef(t *testing.T) {
 	}
 }
 
+func TestDrainTracingSurfacesVesselHealthAndPatterns(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "trace-health"))
+
+	writeWorkflowFile(t, dir, "trace-health", []testPhase{
+		{name: "implement", promptContent: "Implement change", maxTurns: 5},
+	})
+	withTestWorkingDir(t, dir)
+
+	tracer, rec := newTestTracer(t)
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Implement change": []byte("broken output"),
+		},
+		phaseErr: errors.New("boom"),
+	}
+	r := New(cfg, q, &mockWorktree{}, cmdRunner)
+	r.Tracer = tracer
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("Drain() error = %v", err)
+	}
+	if result.Failed != 1 {
+		t.Fatalf("DrainResult.Failed = %d, want 1", result.Failed)
+	}
+
+	vesselSpan := endedSpanByName(t, rec, "vessel:issue-1")
+	vesselAttrs := spanAttrMap(vesselSpan)
+	if vesselAttrs["xylem.vessel.health"] != "unhealthy" {
+		t.Fatalf("xylem.vessel.health = %q, want unhealthy", vesselAttrs["xylem.vessel.health"])
+	}
+	if vesselAttrs["xylem.vessel.anomalies"] != "run_failed,phase_failed" {
+		t.Fatalf("xylem.vessel.anomalies = %q, want failure anomalies", vesselAttrs["xylem.vessel.anomalies"])
+	}
+
+	drainSpan := endedSpanByName(t, rec, "drain_run")
+	drainAttrs := spanAttrMap(drainSpan)
+	if drainAttrs["xylem.drain.unhealthy_vessels"] != "1" {
+		t.Fatalf("xylem.drain.unhealthy_vessels = %q, want 1", drainAttrs["xylem.drain.unhealthy_vessels"])
+	}
+	if drainAttrs["xylem.drain.unhealthy_patterns"] != "phase_failed=1, run_failed=1" {
+		t.Fatalf("xylem.drain.unhealthy_patterns = %q, want joined pattern counts", drainAttrs["xylem.drain.unhealthy_patterns"])
+	}
+}
+
+func TestInspectVesselStatusMissingSummaryDoesNotWarn(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	r := New(cfg, nil, nil, nil)
+	buf := captureStandardLogger(t)
+
+	report := r.inspectVesselStatus(queue.Vessel{
+		ID:        "issue-1",
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+
+	if report.Health != VesselHealthHealthy {
+		t.Fatalf("Health = %q, want %q", report.Health, VesselHealthHealthy)
+	}
+	if len(report.Anomalies) != 0 {
+		t.Fatalf("Anomalies = %#v, want none", report.Anomalies)
+	}
+	if strings.Contains(buf.String(), "load vessel summary") {
+		t.Fatalf("expected no warning for missing summary, got %q", buf.String())
+	}
+}
+
 func TestBuildCommandWorkflowBased(t *testing.T) {
 	cfg := &config.Config{
 		MaxTurns: 50,

--- a/cli/internal/runner/summary.go
+++ b/cli/internal/runner/summary.go
@@ -258,7 +258,7 @@ func SaveVesselSummary(stateDir string, summary *VesselSummary) error {
 		return fmt.Errorf("save vessel summary: invalid vessel ID: %w", err)
 	}
 
-	path := filepath.Join(stateDir, "phases", summary.VesselID, summaryFileName)
+	path := summaryPath(stateDir, summary.VesselID)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("save vessel summary: create dir: %w", err)
 	}
@@ -276,6 +276,10 @@ func SaveVesselSummary(stateDir string, summary *VesselSummary) error {
 	}
 
 	return nil
+}
+
+func summaryPath(stateDir, vesselID string) string {
+	return filepath.Join(stateDir, "phases", vesselID, summaryFileName)
 }
 
 func validateSummaryPathComponent(component string) error {


### PR DESCRIPTION
## Summary
- add runner health analysis for vessel anomalies and fleet pattern aggregation
- surface vessel health and anomaly context in `xylem status` text and JSON output
- attach derived vessel and drain health attributes to telemetry spans and extend tests

Closes https://github.com/nicholls-inc/xylem/issues/112
