### PR TITLE
Protect control surfaces and mediate risky actions

### DIFF
--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -62,6 +62,9 @@ func cmdDrain(cfg *config.Config, q *queue.Queue, wt *worktree.Manager, dryRun b
 
 func buildDrainRunner(cfg *config.Config, q *queue.Queue, wt runner.WorktreeManager, cmdRunner *realCmdRunner) (*runner.Runner, func()) {
 	tracer := buildConfiguredTracer(cfg)
+	if configurable, ok := wt.(interface{ SetProtectedSurfaces([]string) }); ok {
+		configurable.SetProtectedSurfaces(cfg.EffectiveProtectedSurfaces())
+	}
 
 	r := runner.New(cfg, q, wt, cmdRunner)
 	r.Sources = buildSourceMap(cfg, q, cmdRunner)

--- a/cli/cmd/xylem/drain_test.go
+++ b/cli/cmd/xylem/drain_test.go
@@ -42,6 +42,18 @@ type recordingExporter struct {
 	shutdownCalled bool
 }
 
+type configurableWorktreeStub struct {
+	patterns []string
+}
+
+func (w *configurableWorktreeStub) Create(context.Context, string) (string, error) { return "", nil }
+
+func (w *configurableWorktreeStub) Remove(context.Context, string) error { return nil }
+
+func (w *configurableWorktreeStub) SetProtectedSurfaces(patterns []string) {
+	w.patterns = append([]string(nil), patterns...)
+}
+
 func (e *recordingExporter) ExportSpans(context.Context, []sdktrace.ReadOnlySpan) error {
 	return nil
 }
@@ -198,6 +210,25 @@ func TestBuildDrainRunnerWiresSharedScaffolding(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "audit.jsonl")); err != nil {
 		t.Fatalf("Stat(audit.jsonl) error = %v", err)
+	}
+}
+
+func TestBuildDrainRunnerPropagatesProtectedSurfaces(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeDrainConfig(dir)
+	cfg.Harness.ProtectedSurfaces.Paths = []string{"docs/*.txt"}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	wt := &configurableWorktreeStub{}
+	cmdRunner := newCmdRunner(cfg)
+
+	r, cleanup := buildDrainRunner(cfg, q, wt, cmdRunner)
+	defer cleanup()
+
+	if r == nil {
+		t.Fatal("buildDrainRunner() returned nil runner")
+	}
+	if got := wt.patterns; len(got) != 1 || got[0] != "docs/*.txt" {
+		t.Fatalf("protected surfaces = %#v, want %#v", got, []string{"docs/*.txt"})
 	}
 }
 

--- a/cli/cmd/xylem/init.go
+++ b/cli/cmd/xylem/init.go
@@ -131,6 +131,11 @@ max_turns: 50
 timeout: "30m"
 state_dir: ".xylem"
 
+# Default harness policy denies writes to xylem control files and requires
+# approval for git_push and pr_create. Keep the scaffolded PR phase behind an
+# approval step in your workflow, or replace it with a deterministic command
+# phase after review.
+
 # llm selects the global default LLM provider: "claude" (default) or "copilot"
 llm: claude
 
@@ -232,6 +237,7 @@ phases:
   - name: pr
     prompt_file: .xylem/prompts/fix-bug/pr.md
     max_turns: 3
+    # High-risk phase: default harness policy requires approval for git_push and pr_create.
 `
 
 const implementFeatureWorkflowContent = `name: implement-feature
@@ -259,6 +265,7 @@ phases:
   - name: pr
     prompt_file: .xylem/prompts/implement-feature/pr.md
     max_turns: 3
+    # High-risk phase: default harness policy requires approval for git_push and pr_create.
 `
 
 const analyzePrompt = `Analyze the following GitHub issue and identify the relevant code.
@@ -316,6 +323,10 @@ Implement the changes now. Follow the plan precisely.
 
 const prPrompt = `Create a pull request for the changes.
 
+This phase is high-risk. Under the default harness policy, actions that push a
+branch or create a pull request require approval. Do not work around that
+policy boundary.
+
 Issue: {{.Issue.Title}}
 URL: {{.Issue.URL}}
 
@@ -325,7 +336,8 @@ URL: {{.Issue.URL}}
 ## Plan
 {{.PreviousOutputs.plan}}
 
-Commit all changes with a clear commit message, push the branch, and create a PR using:
+Commit all changes with a clear commit message. Push the branch and create a PR
+only when the repository policy or workflow has explicitly approved ` + "`git_push`" + ` and ` + "`pr_create`" + `. Use:
 gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>"
 `
 

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -198,6 +198,10 @@ func TestInitScaffoldConfigLoads(t *testing.T) {
 	if len(cfg.Sources) == 0 {
 		t.Error("expected at least one source in scaffold config")
 	}
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "approval for git_push and pr_create")
 }
 
 func TestInitRespectsConfigFlag(t *testing.T) {
@@ -225,6 +229,13 @@ func TestInitRespectsConfigFlag(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, ".xylem.yml")); err == nil {
 		t.Error(".xylem.yml was created despite --config pointing elsewhere")
 	}
+}
+
+func TestPromptContentPRMentionsApprovalBoundary(t *testing.T) {
+	content := promptContent("fix-bug", "pr")
+	assert.Contains(t, content, "default harness policy")
+	assert.Contains(t, content, "`git_push`")
+	assert.Contains(t, content, "`pr_create`")
 }
 
 func TestInitCreatesV2Files(t *testing.T) {

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -423,7 +423,7 @@ func DefaultPolicy() intermediary.Policy {
 			{Action: "file_write", Resource: ".xylem/HARNESS.md", Effect: intermediary.Deny},
 			{Action: "file_write", Resource: ".xylem.yml", Effect: intermediary.Deny},
 			{Action: "file_write", Resource: ".xylem/workflows/*", Effect: intermediary.Deny},
-			{Action: "file_write", Resource: ".xylem/prompts/*", Effect: intermediary.Deny},
+			{Action: "file_write", Resource: ".xylem/prompts/*/*.md", Effect: intermediary.Deny},
 			{Action: "git_push", Resource: "*", Effect: intermediary.RequireApproval},
 			{Action: "pr_create", Resource: "*", Effect: intermediary.RequireApproval},
 			{Action: "*", Resource: "*", Effect: intermediary.Allow},

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -1348,6 +1348,18 @@ func TestSmoke_S7_DefaultPolicyRequiresApprovalForGitPush(t *testing.T) {
 	assert.Equal(t, "*", result.MatchedRule.Resource)
 }
 
+func TestDefaultPolicyDeniesPromptFileWrite(t *testing.T) {
+	result := newSmokeIntermediary(t, validConfig()).Evaluate(intermediary.Intent{
+		Action:   "file_write",
+		Resource: ".xylem/prompts/fix-bug/analyze.md",
+		AgentID:  "vessel-004",
+	})
+
+	assert.Equal(t, intermediary.Deny, result.Effect)
+	require.NotNil(t, result.MatchedRule)
+	assert.Equal(t, ".xylem/prompts/*/*.md", result.MatchedRule.Resource)
+}
+
 func TestSmoke_S8_DefaultPolicyAllowsPhaseExecute(t *testing.T) {
 	result := newSmokeIntermediary(t, validConfig()).Evaluate(intermediary.Intent{
 		Action:   "phase_execute",

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -418,7 +418,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if wErr := os.WriteFile(filepath.Join(phasesDir, p.Name+".command"), []byte(rendered), 0o644); wErr != nil {
 					log.Printf("warn: write command file: %v", wErr)
 				}
-				if policyErr := r.enforcePhasePolicy(vessel, p); policyErr != nil {
+				if policyErr := r.enforcePhasePolicy(vessel, p, rendered, ""); policyErr != nil {
 					finishCurrentPhaseSpan(policyErr)
 					log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
 					vessel.FailedPhase = p.Name
@@ -462,7 +462,8 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					}
 					return "failed"
 				}
-				rendered, err := phase.RenderPrompt(string(promptContent), td)
+				promptTemplate := string(promptContent)
+				rendered, err := phase.RenderPrompt(promptTemplate, td)
 				if err != nil {
 					finishCurrentPhaseSpan(err)
 					r.failVessel(vessel.ID, fmt.Sprintf("render prompt for phase %s: %v", p.Name, err))
@@ -479,7 +480,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if wErr := os.WriteFile(promptPath, []byte(rendered), 0o644); wErr != nil {
 					log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
 				}
-				if policyErr := r.enforcePhasePolicy(vessel, p); policyErr != nil {
+				if policyErr := r.enforcePhasePolicy(vessel, p, "", promptTemplate); policyErr != nil {
 					finishCurrentPhaseSpan(policyErr)
 					log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
 					vessel.FailedPhase = p.Name
@@ -1170,7 +1171,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if wErr := os.WriteFile(filepath.Join(phasesDir, p.Name+".command"), []byte(rendered), 0o644); wErr != nil {
 				log.Printf("warn: write command file: %v", wErr)
 			}
-			if policyErr := r.enforcePhasePolicy(vessel, p); policyErr != nil {
+			if policyErr := r.enforcePhasePolicy(vessel, p, rendered, ""); policyErr != nil {
 				finishCurrentPhaseSpan(policyErr)
 				log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
 				vessel.FailedPhase = p.Name
@@ -1213,7 +1214,8 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				}
 				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
 			}
-			rendered, err := phase.RenderPrompt(string(promptContent), td)
+			promptTemplate := string(promptContent)
+			rendered, err := phase.RenderPrompt(promptTemplate, td)
 			if err != nil {
 				finishCurrentPhaseSpan(err)
 				r.failVessel(vessel.ID, fmt.Sprintf("render prompt for phase %s: %v", p.Name, err))
@@ -1230,7 +1232,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if wErr := os.WriteFile(promptPath, []byte(rendered), 0o644); wErr != nil {
 				log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
 			}
-			if policyErr := r.enforcePhasePolicy(vessel, p); policyErr != nil {
+			if policyErr := r.enforcePhasePolicy(vessel, p, "", promptTemplate); policyErr != nil {
 				finishCurrentPhaseSpan(policyErr)
 				log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
 				vessel.FailedPhase = p.Name
@@ -1609,64 +1611,206 @@ func phaseActionType(p *workflow.Phase) string {
 	return "phase_execute"
 }
 
-func (r *Runner) enforcePhasePolicy(vessel queue.Vessel, p workflow.Phase) error {
+func (r *Runner) enforcePhasePolicy(vessel queue.Vessel, p workflow.Phase, renderedCommand, renderedPrompt string) error {
 	if r.Intermediary == nil {
 		return nil
 	}
 
-	justification := fmt.Sprintf("execute workflow phase %q", p.Name)
-	if vessel.Workflow != "" {
-		justification = fmt.Sprintf("execute phase %q of workflow %q", p.Name, vessel.Workflow)
+	for _, intent := range r.phasePolicyIntents(vessel, p, renderedCommand, renderedPrompt) {
+		result := r.Intermediary.Evaluate(intent)
+		entry := intermediary.AuditEntry{
+			Intent:    intent,
+			Decision:  result.Effect,
+			Timestamp: time.Now().UTC(),
+		}
+		if result.Effect != intermediary.Allow {
+			entry.Error = result.Reason
+		}
+		if err := r.appendAuditEntry(entry); err != nil {
+			return fmt.Errorf("record audit evidence: %w", err)
+		}
+		if result.Effect != intermediary.Allow {
+			return formatPolicyDecisionError(p.Name, intent, result)
+		}
 	}
+	return nil
+}
 
-	intent := intermediary.Intent{
-		Action:        phaseActionType(&p),
+func (r *Runner) phasePolicyIntents(vessel queue.Vessel, p workflow.Phase, renderedCommand, renderedPrompt string) []intermediary.Intent {
+	baseAction := phaseActionType(&p)
+	intents := []intermediary.Intent{{
+		Action:        baseAction,
 		Resource:      p.Name,
 		AgentID:       vessel.ID,
-		Justification: justification,
-		Metadata: map[string]string{
-			"phase":      p.Name,
-			"source":     vessel.Source,
-			"workflow":   vessel.Workflow,
-			"phase_type": p.Type,
-		},
+		Justification: phaseIntentJustification(vessel, p.Name),
+		Metadata:      phaseIntentMetadata(vessel, p, ""),
+	}}
+
+	classificationText := renderedPrompt
+	classifiedFrom := "prompt"
+	if p.Type == "command" {
+		classificationText = renderedCommand
+		classifiedFrom = "command"
 	}
-	if intent.Metadata["phase_type"] == "" {
-		intent.Metadata["phase_type"] = "prompt"
+	if classificationText == "" {
+		return intents
 	}
 
-	result := r.Intermediary.Evaluate(intent)
-	entry := intermediary.AuditEntry{
-		Intent:    intent,
-		Decision:  result.Effect,
-		Timestamp: time.Now().UTC(),
+	sourceRepo := strings.TrimSpace(r.resolveRepo(vessel))
+	if sourceCfg := r.sourceConfigFromMeta(vessel); sourceCfg != nil && strings.TrimSpace(sourceCfg.Repo) != "" {
+		sourceRepo = strings.TrimSpace(sourceCfg.Repo)
 	}
-	if result.Effect != intermediary.Allow {
-		entry.Error = result.Reason
+	seen := map[string]struct{}{
+		baseAction + "\x00" + p.Name: {},
 	}
-	if err := r.appendAuditEntry(entry); err != nil {
-		return fmt.Errorf("record audit evidence: %w", err)
+
+	appendIntent := func(action, resource string) {
+		key := action + "\x00" + resource
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		intents = append(intents, intermediary.Intent{
+			Action:        action,
+			Resource:      resource,
+			AgentID:       vessel.ID,
+			Justification: fmt.Sprintf("phase %q may perform %s", p.Name, action),
+			Metadata:      phaseIntentMetadata(vessel, p, classifiedFrom),
+		})
+	}
+
+	if indicatesGitCommit(classificationText) {
+		appendIntent("git_commit", "*")
+	}
+	if indicatesGitPush(classificationText) {
+		appendIntent("git_push", extractGitPushResource(classificationText))
+	}
+	if indicatesPRCreate(classificationText) {
+		appendIntent("pr_create", extractRepoFlag(classificationText, sourceRepo))
+	}
+
+	return intents
+}
+
+func phaseIntentJustification(vessel queue.Vessel, phaseName string) string {
+	if vessel.Workflow != "" {
+		return fmt.Sprintf("execute phase %q of workflow %q", phaseName, vessel.Workflow)
+	}
+	return fmt.Sprintf("execute workflow phase %q", phaseName)
+}
+
+func phaseIntentMetadata(vessel queue.Vessel, p workflow.Phase, classifiedFrom string) map[string]string {
+	metadata := map[string]string{
+		"phase":      p.Name,
+		"source":     vessel.Source,
+		"workflow":   vessel.Workflow,
+		"phase_type": p.Type,
+	}
+	if metadata["phase_type"] == "" {
+		metadata["phase_type"] = "prompt"
+	}
+	if classifiedFrom != "" {
+		metadata["classified_from"] = classifiedFrom
+	}
+	return metadata
+}
+
+func formatPolicyDecisionError(phaseName string, intent intermediary.Intent, result intermediary.PolicyResult) error {
+	qualifier := ""
+	if intent.Action != "" && intent.Action != "phase_execute" && intent.Action != "external_command" {
+		qualifier = " for " + intent.Action
+		if intent.Resource != "" && intent.Resource != "*" {
+			qualifier += " on " + intent.Resource
+		}
 	}
 
 	switch result.Effect {
-	case intermediary.Allow:
-		return nil
 	case intermediary.RequireApproval:
 		if result.Reason != "" {
-			return fmt.Errorf("phase %q requires approval (automatic approval not yet supported): %s", p.Name, result.Reason)
+			return fmt.Errorf("phase %q requires approval%s (automatic approval not yet supported): %s", phaseName, qualifier, result.Reason)
 		}
-		return fmt.Errorf("phase %q requires approval (automatic approval not yet supported)", p.Name)
+		return fmt.Errorf("phase %q requires approval%s (automatic approval not yet supported)", phaseName, qualifier)
 	case intermediary.Deny:
 		if result.Reason != "" {
-			return fmt.Errorf("phase %q denied by policy: %s", p.Name, result.Reason)
+			return fmt.Errorf("phase %q denied by policy%s: %s", phaseName, qualifier, result.Reason)
 		}
-		return fmt.Errorf("phase %q denied by policy", p.Name)
+		return fmt.Errorf("phase %q denied by policy%s", phaseName, qualifier)
 	default:
 		if result.Reason != "" {
-			return fmt.Errorf("phase %q denied by policy: %s", p.Name, result.Reason)
+			return fmt.Errorf("phase %q denied by policy%s: %s", phaseName, qualifier, result.Reason)
 		}
-		return fmt.Errorf("phase %q denied by policy", p.Name)
+		return fmt.Errorf("phase %q denied by policy%s", phaseName, qualifier)
 	}
+}
+
+func indicatesGitCommit(rendered string) bool {
+	lower := strings.ToLower(rendered)
+	return strings.Contains(lower, "git commit") ||
+		strings.Contains(lower, "commit all changes") ||
+		strings.Contains(lower, "commit the changes")
+}
+
+func indicatesGitPush(rendered string) bool {
+	lower := strings.ToLower(rendered)
+	return strings.Contains(lower, "git push") ||
+		strings.Contains(lower, "push the branch") ||
+		strings.Contains(lower, "push branch")
+}
+
+func indicatesPRCreate(rendered string) bool {
+	lower := strings.ToLower(rendered)
+	return strings.Contains(lower, "gh pr create") ||
+		strings.Contains(lower, "create a pull request") ||
+		strings.Contains(lower, "create the pull request") ||
+		strings.Contains(lower, "create a pr")
+}
+
+func extractGitPushResource(rendered string) string {
+	fields := strings.Fields(rendered)
+	for i := 0; i < len(fields)-1; i++ {
+		if !strings.EqualFold(fields[i], "git") || !strings.EqualFold(fields[i+1], "push") {
+			continue
+		}
+
+		positional := make([]string, 0, 2)
+		for _, raw := range fields[i+2:] {
+			token := strings.Trim(strings.TrimSpace(raw), "\"'")
+			switch token {
+			case "", "&&", "||", ";", "|":
+				return "*"
+			}
+			if strings.HasPrefix(token, "-") {
+				continue
+			}
+			positional = append(positional, token)
+			if len(positional) == 2 {
+				return positional[1]
+			}
+		}
+		return "*"
+	}
+	return "*"
+}
+
+func extractRepoFlag(rendered, fallback string) string {
+	fields := strings.Fields(rendered)
+	for i := 0; i < len(fields); i++ {
+		token := strings.Trim(strings.TrimSpace(fields[i]), "\"'")
+		if strings.HasPrefix(token, "--repo=") {
+			if repo := strings.TrimPrefix(token, "--repo="); repo != "" {
+				return repo
+			}
+		}
+		if token == "--repo" && i+1 < len(fields) {
+			if repo := strings.Trim(strings.TrimSpace(fields[i+1]), "\"'"); repo != "" {
+				return repo
+			}
+		}
+	}
+	if strings.TrimSpace(fallback) != "" {
+		return fallback
+	}
+	return "*"
 }
 
 func (r *Runner) takeProtectedSurfaceSnapshot(worktreePath string) (surface.Snapshot, bool, error) {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -658,6 +658,74 @@ func TestPhaseActionType(t *testing.T) {
 	}
 }
 
+func TestPhasePolicyIntents_ClassifiesHighRiskCommandActions(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	r := New(cfg, nil, nil, nil)
+	vessel := queue.Vessel{
+		ID:       "issue-1",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Meta:     map[string]string{"config_source": "github"},
+	}
+	phaseDef := workflow.Phase{Name: "publish", Type: "command"}
+
+	intents := r.phasePolicyIntents(vessel, phaseDef, `git commit -m "ship" && git push origin feature-1 && gh pr create --repo owner/repo`, "")
+	require.Len(t, intents, 4)
+
+	assert.Equal(t, "external_command", intents[0].Action)
+	assert.Equal(t, "publish", intents[0].Resource)
+	assert.Equal(t, "git_commit", intents[1].Action)
+	assert.Equal(t, "*", intents[1].Resource)
+	assert.Equal(t, "git_push", intents[2].Action)
+	assert.Equal(t, "feature-1", intents[2].Resource)
+	assert.Equal(t, "pr_create", intents[3].Action)
+	assert.Equal(t, "owner/repo", intents[3].Resource)
+	assert.Equal(t, "command", intents[1].Metadata["classified_from"])
+}
+
+func TestPhasePolicyIntents_ClassifiesHighRiskPromptActions(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	r := New(cfg, nil, nil, nil)
+	vessel := queue.Vessel{
+		ID:       "issue-1",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Meta:     map[string]string{"config_source": "github"},
+	}
+	phaseDef := workflow.Phase{Name: "pr"}
+
+	intents := r.phasePolicyIntents(vessel, phaseDef, "", "Commit all changes with a clear commit message, push the branch, and create a pull request using gh pr create.")
+	require.Len(t, intents, 4)
+
+	assert.Equal(t, "phase_execute", intents[0].Action)
+	assert.Equal(t, "git_commit", intents[1].Action)
+	assert.Equal(t, "git_push", intents[2].Action)
+	assert.Equal(t, "*", intents[2].Resource)
+	assert.Equal(t, "pr_create", intents[3].Action)
+	assert.Equal(t, "owner/repo", intents[3].Resource)
+	assert.Equal(t, "prompt", intents[1].Metadata["classified_from"])
+}
+
+func TestPhasePolicyIntents_IgnoresHighRiskPhrasesFromRenderedPromptContext(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	r := New(cfg, nil, nil, nil)
+	vessel := queue.Vessel{
+		ID:       "issue-1",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Meta:     map[string]string{"config_source": "github"},
+	}
+	phaseDef := workflow.Phase{Name: "analyze"}
+
+	intents := r.phasePolicyIntents(vessel, phaseDef, "", "Analyze the following issue:\n\nIssue body:\n{{.Issue.Body}}\n")
+	require.Len(t, intents, 1)
+	assert.Equal(t, "phase_execute", intents[0].Action)
+	assert.Equal(t, "analyze", intents[0].Resource)
+}
+
 func TestSmoke_S1_PolicyDenialShortCircuitsBeforeSurfaceSnapshot(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)
@@ -4223,6 +4291,85 @@ func TestDrainPolicyBlocksPhaseBeforeExecution(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDrainCommandPhaseHighRiskActionRequiresApproval(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "push-command"))
+
+	writeWorkflowFile(t, dir, "push-command", []testPhase{
+		{name: "publish", phaseType: "command", run: "git push origin feature-1"},
+	})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{}
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, cfg.EffectiveAuditLogPath()))
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.AuditLog = auditLog
+	r.Intermediary = intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), auditLog, nil)
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+	assert.Equal(t, 0, countRunOutputCalls(cmdRunner, "sh"))
+
+	vessel := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, vessel.State)
+	assert.Contains(t, vessel.Error, "requires approval")
+	assert.Contains(t, vessel.Error, "git_push")
+
+	entries, err := auditLog.Entries()
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "external_command", entries[0].Intent.Action)
+	assert.Equal(t, intermediary.Allow, entries[0].Decision)
+	assert.Equal(t, "git_push", entries[1].Intent.Action)
+	assert.Equal(t, intermediary.RequireApproval, entries[1].Decision)
+	assert.Equal(t, "feature-1", entries[1].Intent.Resource)
+}
+
+func TestDrainPromptPhaseHighRiskActionRequiresApproval(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "pr-phase"))
+
+	writeWorkflowFile(t, dir, "pr-phase", []testPhase{
+		{name: "pr", promptContent: "Commit all changes with a clear commit message, push the branch, and create a pull request using gh pr create.", maxTurns: 5},
+	})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{}
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, cfg.EffectiveAuditLogPath()))
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.AuditLog = auditLog
+	r.Intermediary = intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), auditLog, nil)
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+	assert.Len(t, cmdRunner.phaseCalls, 0)
+
+	vessel := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, vessel.State)
+	assert.Contains(t, vessel.Error, "requires approval")
+	assert.Contains(t, vessel.Error, "git_push")
+
+	entries, err := auditLog.Entries()
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "phase_execute", entries[0].Intent.Action)
+	assert.Equal(t, intermediary.Allow, entries[0].Decision)
+	assert.Equal(t, "git_commit", entries[1].Intent.Action)
+	assert.Equal(t, intermediary.Allow, entries[1].Decision)
+	assert.Equal(t, "git_push", entries[2].Intent.Action)
+	assert.Equal(t, intermediary.RequireApproval, entries[2].Decision)
 }
 
 func TestDrainOrchestratedPolicyBlocksSinglePhaseWave(t *testing.T) {

--- a/cli/internal/worktree/worktree.go
+++ b/cli/internal/worktree/worktree.go
@@ -32,11 +32,35 @@ type Manager struct {
 	RepoRoot      string
 	Runner        CommandRunner
 	DefaultBranch string // if set, skip auto-detection
+
+	protectedSurfaces    []string
+	protectedSurfacesSet bool
 }
 
 // New creates a Manager for the given repository root.
 func New(repoRoot string, runner CommandRunner) *Manager {
 	return &Manager{RepoRoot: repoRoot, Runner: runner}
+}
+
+var defaultProtectedSurfaces = []string{
+	".xylem.yml",
+	".xylem/workflows/*.yaml",
+	".xylem/prompts/*/*.md",
+	".xylem/HARNESS.md",
+}
+
+// SetProtectedSurfaces overrides the default read-only worktree protections.
+// Passing a nil or empty slice disables the filesystem hardening layer.
+func (m *Manager) SetProtectedSurfaces(patterns []string) {
+	m.protectedSurfacesSet = true
+	m.protectedSurfaces = append([]string(nil), patterns...)
+}
+
+func (m *Manager) protectedSurfacePatterns() []string {
+	if m.protectedSurfacesSet {
+		return append([]string(nil), m.protectedSurfaces...)
+	}
+	return append([]string(nil), defaultProtectedSurfaces...)
 }
 
 // DetectDefaultBranch detects the repository's default branch.
@@ -144,9 +168,9 @@ func (m *Manager) Create(ctx context.Context, branchName string) (string, error)
 		fmt.Fprintf(os.Stderr, "warn: copy .claude/ config: %v\n", err)
 	}
 
-	// Mark .xylem/ protected surfaces as read-only to prevent agents from
+	// Mark protected control surfaces as read-only to prevent agents from
 	// accidentally deleting or modifying workflow/prompt definitions.
-	if err := protectXylemSurfaces(worktreePath); err != nil {
+	if err := protectXylemSurfaces(worktreePath, m.protectedSurfacePatterns()); err != nil {
 		fmt.Fprintf(os.Stderr, "warn: protect .xylem/ surfaces: %v\n", err)
 	}
 
@@ -254,19 +278,16 @@ func (m *Manager) copyClaudeConfig(worktreePath string) error {
 	return nil
 }
 
-// protectXylemSurfaces marks tracked .xylem/ files as read-only in the worktree
-// so agents running in the worktree cannot accidentally delete or modify them.
-// It also writes a .claude/rules/ file instructing Claude agents to leave them alone.
-func protectXylemSurfaces(worktreePath string) error {
-	// Glob patterns matching the default protected surfaces.
-	patterns := []string{
-		filepath.Join(worktreePath, ".xylem.yml"),
-		filepath.Join(worktreePath, ".xylem", "workflows", "*.yaml"),
-		filepath.Join(worktreePath, ".xylem", "prompts", "*", "*.md"),
-		filepath.Join(worktreePath, ".xylem", "HARNESS.md"),
+// protectXylemSurfaces marks configured protected files as read-only in the
+// worktree so agents cannot accidentally delete or modify them. It also writes
+// a .claude/rules/ file instructing agents to leave them alone.
+func protectXylemSurfaces(worktreePath string, patterns []string) error {
+	if len(patterns) == 0 {
+		return nil
 	}
 	for _, pattern := range patterns {
-		matches, err := filepath.Glob(pattern)
+		worktreePattern := filepath.Join(worktreePath, filepath.FromSlash(pattern))
+		matches, err := filepath.Glob(worktreePattern)
 		if err != nil {
 			continue
 		}
@@ -280,8 +301,10 @@ func protectXylemSurfaces(worktreePath string) error {
 	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
 		return err
 	}
-	rule := "Do not modify, delete, or move any files under .xylem/ or the .xylem.yml config file. " +
-		"These are protected workflow and prompt definitions managed by the xylem control plane.\n"
+	rule := "Do not modify, delete, or move the configured protected control surfaces managed by the xylem control plane:\n"
+	for _, pattern := range patterns {
+		rule += "- " + pattern + "\n"
+	}
 	return os.WriteFile(filepath.Join(rulesDir, "protected-surfaces.md"), []byte(rule), 0o644)
 }
 

--- a/cli/internal/worktree/worktree_test.go
+++ b/cli/internal/worktree/worktree_test.go
@@ -554,6 +554,75 @@ func TestCopyClaudeConfigSettingsLocal(t *testing.T) {
 	}
 }
 
+func TestProtectXylemSurfacesHonorsConfiguredPatterns(t *testing.T) {
+	worktreePath := t.TempDir()
+	protectedFile := filepath.Join(worktreePath, "docs", "control.txt")
+	unprotectedFile := filepath.Join(worktreePath, ".xylem.yml")
+	if err := os.MkdirAll(filepath.Dir(protectedFile), 0o755); err != nil {
+		t.Fatalf("MkdirAll(protected): %v", err)
+	}
+	if err := os.WriteFile(protectedFile, []byte("protected"), 0o644); err != nil {
+		t.Fatalf("WriteFile(protected): %v", err)
+	}
+	if err := os.WriteFile(unprotectedFile, []byte("config"), 0o644); err != nil {
+		t.Fatalf("WriteFile(unprotected): %v", err)
+	}
+
+	if err := protectXylemSurfaces(worktreePath, []string{"docs/*.txt"}); err != nil {
+		t.Fatalf("protectXylemSurfaces() error = %v", err)
+	}
+
+	protectedInfo, err := os.Stat(protectedFile)
+	if err != nil {
+		t.Fatalf("Stat(protected): %v", err)
+	}
+	if got := protectedInfo.Mode().Perm(); got != 0o444 {
+		t.Fatalf("protected file mode = %#o, want %#o", got, 0o444)
+	}
+
+	unprotectedInfo, err := os.Stat(unprotectedFile)
+	if err != nil {
+		t.Fatalf("Stat(unprotected): %v", err)
+	}
+	if got := unprotectedInfo.Mode().Perm(); got != 0o644 {
+		t.Fatalf("unprotected file mode = %#o, want %#o", got, 0o644)
+	}
+
+	ruleFile := filepath.Join(worktreePath, ".claude", "rules", "protected-surfaces.md")
+	ruleContent, err := os.ReadFile(ruleFile)
+	if err != nil {
+		t.Fatalf("ReadFile(rule): %v", err)
+	}
+	if !strings.Contains(string(ruleContent), "docs/*.txt") {
+		t.Fatalf("rule file = %q, want to mention configured pattern", string(ruleContent))
+	}
+}
+
+func TestProtectXylemSurfacesDisabledSkipsFilesystemHardening(t *testing.T) {
+	worktreePath := t.TempDir()
+	protectedFile := filepath.Join(worktreePath, ".xylem.yml")
+	if err := os.WriteFile(protectedFile, []byte("config"), 0o644); err != nil {
+		t.Fatalf("WriteFile(protected): %v", err)
+	}
+
+	if err := protectXylemSurfaces(worktreePath, nil); err != nil {
+		t.Fatalf("protectXylemSurfaces() error = %v", err)
+	}
+
+	info, err := os.Stat(protectedFile)
+	if err != nil {
+		t.Fatalf("Stat(protected): %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Fatalf("protected file mode = %#o, want %#o when protections disabled", got, 0o644)
+	}
+
+	ruleFile := filepath.Join(worktreePath, ".claude", "rules", "protected-surfaces.md")
+	if _, err := os.Stat(ruleFile); !os.IsNotExist(err) {
+		t.Fatalf("Stat(rule file) error = %v, want not exist", err)
+	}
+}
+
 func TestParsePorcelainBareWorktree(t *testing.T) {
 	// A bare worktree has "bare" instead of "branch"
 	porcelain := "worktree /home/user/repo.git\nHEAD abc123\nbare\n\n"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,6 +279,8 @@ The `daemon` section controls polling intervals when running `xylem daemon`.
 
 The `harness` section configures agent safety guardrails: protected file surfaces, policy rules, and audit logging.
 
+When `harness.policy.rules` is empty, xylem installs a default policy that denies writes to the protected control surfaces, requires approval for `git_push` and `pr_create`, and allows other actions. The runner classifies those high-risk actions from rendered command phases and from prompt phases that explicitly instruct an agent to push or open a pull request. The same `harness.protected_surfaces.paths` list also drives the worktree's read-only hardening and the runner's post-phase surface verification.
+
 | Field | Type | Default | Required | Description |
 |-------|------|---------|----------|-------------|
 | `harness.protected_surfaces.paths` | list of strings | `[".xylem/HARNESS.md", ".xylem.yml", ".xylem/workflows/*.yaml", ".xylem/prompts/*/*.md"]` | No | Glob patterns for files agents cannot modify. Set to `["none"]` to disable all surface protections. |
@@ -308,7 +310,10 @@ harness:
         effect: deny
       - action: "git_push"
         resource: "*"
-        effect: allow
+        effect: require_approval
+      - action: "pr_create"
+        resource: "*"
+        effect: require_approval
   audit_log: "audit.jsonl"
 ```
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -478,11 +478,11 @@ phases:
 1. **analyze** -- Reads the issue and the codebase to identify relevant files, the root cause, and constraints. If the output contains `XYLEM_NOOP`, the workflow completes early.
 2. **plan** -- Takes the analysis output and produces a step-by-step implementation plan: which files to change, in what order, what tests to update, and what risks exist.
 3. **implement** -- Executes the plan. After implementation, a command gate runs `make test`. If tests fail, the phase retries up to 2 times with the test output fed back via `{{.GateResult}}`.
-4. **pr** -- Commits changes, pushes the branch, and creates a pull request linking to the issue.
+4. **pr** -- Commits changes, pushes the branch, and creates a pull request linking to the issue. Under the default harness policy, `git_push` and `pr_create` are mediated high-risk actions and will stop here until your workflow or policy explicitly approves them.
 
 **When to use:** Assign this workflow to tasks triggered by `bug`-labeled GitHub issues. It works best for well-described bugs with clear reproduction steps.
 
-**Customization:** After running `xylem init`, edit the `run` field in the implement phase's gate to match your project's test command. The scaffolded default is `make test`, but you might need `go test ./...`, `npm test`, `pytest`, or something else.
+**Customization:** After running `xylem init`, edit the `run` field in the implement phase's gate to match your project's test command. The scaffolded default is `make test`, but you might need `go test ./...`, `npm test`, `pytest`, or something else. If you keep the scaffolded `pr` prompt phase, add an approval step before it or a policy rule that explicitly allows `git_push` and `pr_create` after review.
 
 ### implement-feature
 
@@ -521,11 +521,11 @@ phases:
 1. **analyze** -- Reads the issue and the codebase to identify requirements, affected modules, and existing patterns to follow.
 2. **plan** -- Produces an implementation plan with file changes, ordering, test strategy, and risk assessment. A label gate then waits for `plan-approved` before implementation continues.
 3. **implement** -- Executes the approved plan. Gated on `make test` with 2 retries in the scaffolded workflow.
-4. **pr** -- Commits, pushes, and creates a pull request.
+4. **pr** -- Commits, pushes, and creates a pull request. Under the default harness policy, `git_push` and `pr_create` are mediated high-risk actions and will stop here until your workflow or policy explicitly approves them.
 
 **When to use:** Assign this workflow to tasks triggered by `enhancement`-labeled issues that have been refined and marked as ready for autonomous implementation.
 
-**Customization:** After running `xylem init`, update the label gate and test command to match your process. For example, you might use a different approval label than `plan-approved`, or replace `make test` with `go test ./...`, `npm test`, or `pytest`.
+**Customization:** After running `xylem init`, update the label gate and test command to match your process. For example, you might use a different approval label than `plan-approved`, or replace `make test` with `go test ./...`, `npm test`, or `pytest`. If you keep the scaffolded `pr` prompt phase, add an approval step before it or a policy rule that explicitly allows `git_push` and `pr_create` after review.
 
 ### implement-harness (repo-specific)
 


### PR DESCRIPTION
## Summary
- classify high-risk phase intents before execution so default policy can require approval for `git_push` and `pr_create`
- deny prompt-file writes using the nested prompt glob and align worktree read-only hardening with configured `harness.protected_surfaces.paths`
- document the default approval boundary in scaffolded workflows and configuration/workflow docs

Closes https://github.com/nicholls-inc/xylem/issues/61