### PR TITLE
Establish recurring harness review reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ daemon:
   drain_interval: "30s"
 ```
 
-This example covers the most common fields. Additional configuration is available for per-source provider overrides (`llm`, `model`), agent safety guardrails (`harness`), OpenTelemetry tracing (`observability`), and token budget enforcement (`cost`). See the [Configuration Reference](docs/configuration.md) for all fields, defaults, and validation rules.
+This example covers the most common fields. Additional configuration is available for per-source provider overrides (`llm`, `model`), agent safety guardrails (`harness`), recurring harness reviews (`harness.review`), OpenTelemetry tracing (`observability`), and token budget enforcement (`cost`). See the [Configuration Reference](docs/configuration.md) for all fields, defaults, and validation rules.
 
 ## Workflows
 
@@ -139,6 +139,7 @@ See the [Workflows Guide](docs/workflows.md) for template variables, custom work
 | `xylem init` | Bootstrap config, workflows, prompts, and HARNESS.md |
 | `xylem scan` | Query sources and enqueue matching issues |
 | `xylem drain` | Dequeue pending vessels and launch sessions |
+| `xylem review` | Roll up failures, evals, and pruning signals into a harness review |
 | `xylem daemon` | Continuous scan-drain loop |
 | `xylem enqueue` | Manually enqueue a task |
 | `xylem retry` | Retry a failed vessel with failure context, or restart from scratch |
@@ -159,6 +160,8 @@ xylem dtu load --manifest cli/internal/dtu/testdata/issue-label-gate.yaml       
 xylem dtu materialize --manifest cli/internal/dtu/testdata/issue-label-gate.yaml # Prepare DTU runtime and shims
 xylem dtu run --manifest /path/to/universe.yaml --workdir "$PWD" -- scan         # Run xylem inside DTU from the current repo
 ```
+
+`xylem review` writes `.xylem/reviews/harness-review.json` and `.xylem/reviews/harness-review.md` by default. Enable recurring generation after drains with `harness.review` in `.xylem.yml`.
 
 See the [CLI Reference](docs/cli-reference.md) for all flags, examples, and exit codes.
 

--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -37,7 +37,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "dtu", "shim-dispatch", "scan", "drain", "status", "pause", "resume", "cancel", "cleanup", "enqueue", "daemon", "retry", "visualize"}
+	expected := []string{"init", "dtu", "shim-dispatch", "scan", "drain", "review", "status", "pause", "resume", "cancel", "cleanup", "enqueue", "daemon", "retry", "visualize"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -201,7 +201,11 @@ func runDrain(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *workt
 	cmdRunner := newCmdRunner(cfg)
 	r, cleanup := buildDrainRunner(cfg, q, wt, cmdRunner)
 	defer cleanup()
-	return r.Drain(ctx)
+	result, err := r.Drain(ctx)
+	if err == nil {
+		maybeAutoGenerateHarnessReview(cfg, result)
+	}
+	return result, err
 }
 
 func logTickSummary(q *queue.Queue) {

--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -53,6 +53,7 @@ func cmdDrain(cfg *config.Config, q *queue.Queue, wt *worktree.Manager, dryRun b
 	if err != nil {
 		return &exitError{code: 2, err: fmt.Errorf("drain error: %w", err)}
 	}
+	maybeAutoGenerateHarnessReview(cfg, result)
 	fmt.Printf("Completed %d, failed %d, skipped %d, waiting %d\n", result.Completed, result.Failed, result.Skipped, result.Waiting)
 	if result.Failed > 0 {
 		return &exitError{code: 1}

--- a/cli/cmd/xylem/review.go
+++ b/cli/cmd/xylem/review.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	reviewpkg "github.com/nicholls-inc/xylem/cli/internal/review"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+)
+
+var generateHarnessReview = func(cfg *config.Config) (*reviewpkg.Result, error) {
+	return reviewpkg.Generate(cfg.StateDir, reviewpkg.Options{
+		LookbackRuns: cfg.HarnessReviewLookbackRuns(),
+		MinSamples:   cfg.HarnessReviewMinSamples(),
+		OutputDir:    cfg.HarnessReviewOutputDir(),
+	})
+}
+
+func newReviewCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "review",
+		Short: "Aggregate recurring harness review inputs",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmdReview(deps.cfg)
+		},
+	}
+}
+
+func cmdReview(cfg *config.Config) error {
+	result, err := generateHarnessReview(cfg)
+	if err != nil {
+		return fmt.Errorf("generate harness review: %w", err)
+	}
+
+	fmt.Printf("Wrote %s and %s\n\n%s", result.JSONPath, result.MarkdownPath, result.Markdown)
+	return nil
+}
+
+func maybeAutoGenerateHarnessReview(cfg *config.Config, result runner.DrainResult) {
+	if result.Completed+result.Failed == 0 {
+		return
+	}
+
+	switch cfg.HarnessReviewCadence() {
+	case "manual":
+		return
+	case "every_drain":
+		// Always generate after a drain that processed at least one vessel.
+	case "every_n_runs":
+		totalRuns, err := reviewpkg.CountAvailableRuns(cfg.StateDir)
+		if err != nil {
+			log.Printf("warn: count harness review runs: %v", err)
+			return
+		}
+		latest, err := reviewpkg.LoadLatestReport(cfg.StateDir, cfg.HarnessReviewOutputDir())
+		if err != nil {
+			log.Printf("warn: load latest harness review: %v", err)
+			return
+		}
+		lastReviewed := 0
+		if latest != nil {
+			lastReviewed = latest.TotalRunsObserved
+		}
+		if totalRuns-lastReviewed < cfg.HarnessReviewEveryNRuns() {
+			return
+		}
+	default:
+		return
+	}
+
+	if _, err := generateHarnessReview(cfg); err != nil {
+		log.Printf("warn: generate harness review: %v", err)
+	}
+}

--- a/cli/cmd/xylem/review_test.go
+++ b/cli/cmd/xylem/review_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	reviewpkg "github.com/nicholls-inc/xylem/cli/internal/review"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+)
+
+func TestCmdReviewPrintsGeneratedReport(t *testing.T) {
+	cfg := &config.Config{StateDir: t.TempDir()}
+	original := generateHarnessReview
+	t.Cleanup(func() { generateHarnessReview = original })
+
+	generateHarnessReview = func(cfg *config.Config) (*reviewpkg.Result, error) {
+		return &reviewpkg.Result{
+			JSONPath:     cfg.StateDir + "/reviews/harness-review.json",
+			MarkdownPath: cfg.StateDir + "/reviews/harness-review.md",
+			Markdown:     "# Harness review\n",
+		}, nil
+	}
+
+	out := captureStdout(func() {
+		if err := cmdReview(cfg); err != nil {
+			t.Fatalf("cmdReview() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "harness-review.json") {
+		t.Fatalf("output = %q, want json path", out)
+	}
+	if !strings.Contains(out, "# Harness review") {
+		t.Fatalf("output = %q, want markdown body", out)
+	}
+}
+
+func TestReviewCommandSkipsToolingChecks(t *testing.T) {
+	t.Setenv("PATH", "")
+	stateDir := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	configYAML := fmt.Sprintf(`state_dir: %q
+repo: owner/repo
+tasks:
+  review:
+    labels: [bug]
+    workflow: fix-bug
+claude:
+  default_model: "claude-sonnet-4-6"
+`, stateDir)
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("WriteFile(config) error = %v", err)
+	}
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"--config", configPath, "review"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestMaybeAutoGenerateHarnessReviewRespectsCadence(t *testing.T) {
+	cfg := &config.Config{
+		StateDir: t.TempDir(),
+		Harness: config.HarnessConfig{
+			Review: config.HarnessReviewConfig{
+				Enabled:    true,
+				Cadence:    "every_n_runs",
+				EveryNRuns: 2,
+			},
+		},
+	}
+
+	result1, err := reviewpkg.Generate(cfg.StateDir, reviewpkg.Options{
+		OutputDir: cfg.HarnessReviewOutputDir(),
+		Now:       reviewTestTime(0),
+	})
+	if err != nil {
+		t.Fatalf("Generate() baseline error = %v", err)
+	}
+	if result1.Report.TotalRunsObserved != 0 {
+		t.Fatalf("initial total runs = %d, want 0", result1.Report.TotalRunsObserved)
+	}
+
+	writeReviewSummaryFixture(t, cfg.StateDir, "run-1", reviewTestTime(1))
+
+	calls := 0
+	original := generateHarnessReview
+	t.Cleanup(func() { generateHarnessReview = original })
+	generateHarnessReview = func(cfg *config.Config) (*reviewpkg.Result, error) {
+		calls++
+		return &reviewpkg.Result{}, nil
+	}
+
+	maybeAutoGenerateHarnessReview(cfg, runner.DrainResult{Completed: 1})
+	if calls != 0 {
+		t.Fatalf("generateHarnessReview calls = %d, want 0 before threshold", calls)
+	}
+
+	writeReviewSummaryFixture(t, cfg.StateDir, "run-2", reviewTestTime(2))
+	maybeAutoGenerateHarnessReview(cfg, runner.DrainResult{Completed: 1})
+	if calls != 1 {
+		t.Fatalf("generateHarnessReview calls = %d, want 1 at threshold", calls)
+	}
+}
+
+func writeReviewSummaryFixture(t *testing.T, stateDir, vesselID string, endedAt time.Time) {
+	t.Helper()
+	err := runner.SaveVesselSummary(stateDir, &runner.VesselSummary{
+		VesselID:   vesselID,
+		Source:     "manual",
+		Workflow:   "ad-hoc",
+		State:      "completed",
+		StartedAt:  endedAt.Add(-time.Minute),
+		EndedAt:    endedAt,
+		DurationMS: time.Minute.Milliseconds(),
+		Phases:     []runner.PhaseSummary{},
+		Note:       fmt.Sprintf("fixture %s", vesselID),
+	})
+	if err != nil {
+		t.Fatalf("SaveVesselSummary() error = %v", err)
+	}
+}
+
+func reviewTestTime(offsetMinutes int) time.Time {
+	return time.Date(2026, time.April, 8, 15, offsetMinutes, 0, 0, time.UTC)
+}

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -33,9 +33,9 @@ func newRootCmd() *cobra.Command {
 				return nil
 			}
 
-			// visualize is a read-only command that only parses config and
-			// workflow YAML; it doesn't shell out to git or gh.
-			skipTooling := cmd.Name() == "visualize"
+			// visualize and review are read-only commands that only parse config
+			// and local state; they don't shell out to git or gh.
+			skipTooling := cmd.Name() == "visualize" || cmd.Name() == "review"
 
 			if !skipTooling {
 				if _, err := exec.LookPath("git"); err != nil {
@@ -79,6 +79,7 @@ func newRootCmd() *cobra.Command {
 		newShimDispatchCmd(),
 		newScanCmd(),
 		newDrainCmd(),
+		newReviewCmd(),
 		newEnqueueCmd(),
 		newStatusCmd(),
 		newPauseCmd(),

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -116,6 +116,16 @@ type HarnessConfig struct {
 	ProtectedSurfaces ProtectedSurfacesConfig `yaml:"protected_surfaces,omitempty"`
 	Policy            PolicyConfig            `yaml:"policy,omitempty"`
 	AuditLog          string                  `yaml:"audit_log,omitempty"`
+	Review            HarnessReviewConfig     `yaml:"review,omitempty"`
+}
+
+type HarnessReviewConfig struct {
+	Enabled      bool   `yaml:"enabled,omitempty"`
+	Cadence      string `yaml:"cadence,omitempty"`
+	EveryNRuns   int    `yaml:"every_n_runs,omitempty"`
+	LookbackRuns int    `yaml:"lookback_runs,omitempty"`
+	MinSamples   int    `yaml:"min_samples,omitempty"`
+	OutputDir    string `yaml:"output_dir,omitempty"`
 }
 
 type ProtectedSurfacesConfig struct {
@@ -367,6 +377,48 @@ func (c *Config) EffectiveAuditLogPath() string {
 	return DefaultAuditLogPath
 }
 
+func (c *Config) HarnessReviewCadence() string {
+	if !c.Harness.Review.Enabled {
+		return "manual"
+	}
+	switch c.Harness.Review.Cadence {
+	case "", "manual":
+		return "manual"
+	case "every_drain", "every_n_runs":
+		return c.Harness.Review.Cadence
+	default:
+		return "manual"
+	}
+}
+
+func (c *Config) HarnessReviewEveryNRuns() int {
+	if c.Harness.Review.EveryNRuns > 0 {
+		return c.Harness.Review.EveryNRuns
+	}
+	return 10
+}
+
+func (c *Config) HarnessReviewLookbackRuns() int {
+	if c.Harness.Review.LookbackRuns > 0 {
+		return c.Harness.Review.LookbackRuns
+	}
+	return 50
+}
+
+func (c *Config) HarnessReviewMinSamples() int {
+	if c.Harness.Review.MinSamples > 0 {
+		return c.Harness.Review.MinSamples
+	}
+	return 3
+}
+
+func (c *Config) HarnessReviewOutputDir() string {
+	if strings.TrimSpace(c.Harness.Review.OutputDir) != "" {
+		return c.Harness.Review.OutputDir
+	}
+	return "reviews"
+}
+
 func (c *Config) ObservabilityEnabled() bool {
 	if c.Observability.Enabled == nil {
 		return true
@@ -453,6 +505,35 @@ func (c *Config) validateHarness() error {
 		case intermediary.Allow, intermediary.Deny, intermediary.RequireApproval:
 		default:
 			return fmt.Errorf("harness.policy.rules[%d]: invalid effect %q (must be allow, deny, or require_approval)", i, rule.Effect)
+		}
+	}
+
+	if cadence := c.Harness.Review.Cadence; cadence != "" {
+		switch cadence {
+		case "manual", "every_drain", "every_n_runs":
+		default:
+			return fmt.Errorf("harness.review.cadence: invalid value %q (must be manual, every_drain, or every_n_runs)", cadence)
+		}
+	}
+	if c.Harness.Review.EveryNRuns < 0 {
+		return fmt.Errorf("harness.review.every_n_runs must be non-negative")
+	}
+	if c.Harness.Review.MinSamples < 0 {
+		return fmt.Errorf("harness.review.min_samples must be non-negative")
+	}
+	if c.Harness.Review.LookbackRuns < 0 {
+		return fmt.Errorf("harness.review.lookback_runs must be non-negative")
+	}
+	if c.Harness.Review.Enabled && c.HarnessReviewCadence() == "every_n_runs" && c.HarnessReviewEveryNRuns() <= 0 {
+		return fmt.Errorf("harness.review.every_n_runs must be greater than 0 when cadence is every_n_runs")
+	}
+	if outputDir := strings.TrimSpace(c.Harness.Review.OutputDir); outputDir != "" {
+		if filepath.IsAbs(outputDir) {
+			return fmt.Errorf("harness.review.output_dir must be relative to state_dir")
+		}
+		cleaned := filepath.Clean(outputDir)
+		if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("harness.review.output_dir must stay within state_dir")
 		}
 	}
 

--- a/cli/internal/config/config_prop_test.go
+++ b/cli/internal/config/config_prop_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"pgregory.net/rapid"
@@ -108,6 +109,26 @@ func TestPropValidateHarnessAcceptsValidGlobs(t *testing.T) {
 
 		if err := cfg.validateHarness(); err != nil {
 			t.Fatalf("validateHarness() error for %q: %v", pattern, err)
+		}
+	})
+}
+
+func TestPropHarnessReviewOutputDirRejectsTraversal(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := Config{
+			Harness: HarnessConfig{
+				Review: HarnessReviewConfig{
+					OutputDir: "../" + rapid.StringMatching(`[A-Za-z0-9._-]{1,12}`).Draw(t, "segment"),
+				},
+			},
+		}
+
+		err := cfg.validateHarness()
+		if err == nil {
+			t.Fatal("validateHarness() error = nil, want traversal rejection")
+		}
+		if !strings.Contains(err.Error(), "harness.review.output_dir") {
+			t.Fatalf("validateHarness() error = %v, want harness.review.output_dir", err)
 		}
 	})
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -1273,6 +1273,11 @@ func TestSmoke_S2_NoHarnessSectionDefaultsActivate(t *testing.T) {
 
 	assert.Equal(t, DefaultProtectedSurfaces, cfg.EffectiveProtectedSurfaces())
 	assert.Equal(t, DefaultAuditLogPath, cfg.EffectiveAuditLogPath())
+	assert.Equal(t, "manual", cfg.HarnessReviewCadence())
+	assert.Equal(t, 10, cfg.HarnessReviewEveryNRuns())
+	assert.Equal(t, 50, cfg.HarnessReviewLookbackRuns())
+	assert.Equal(t, 3, cfg.HarnessReviewMinSamples())
+	assert.Equal(t, "reviews", cfg.HarnessReviewOutputDir())
 	assert.True(t, cfg.ObservabilityEnabled())
 	assert.Equal(t, 1.0, cfg.ObservabilitySampleRate())
 	assert.Nil(t, cfg.VesselBudget())
@@ -1404,6 +1409,51 @@ func TestSmoke_S32_NegativeMaxCostRejected(t *testing.T) {
 	_, err := Load(path)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cost.budget.max_cost_usd")
+}
+
+func TestSmoke_S33_HarnessReviewLoadsAndDefaults(t *testing.T) {
+	path := writeSmokeConfigFile(t, `harness:
+  review:
+    enabled: true
+    cadence: every_n_runs
+    every_n_runs: 7
+    lookback_runs: 12
+    min_samples: 4
+    output_dir: "insights"
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, "every_n_runs", cfg.HarnessReviewCadence())
+	assert.Equal(t, 7, cfg.HarnessReviewEveryNRuns())
+	assert.Equal(t, 12, cfg.HarnessReviewLookbackRuns())
+	assert.Equal(t, 4, cfg.HarnessReviewMinSamples())
+	assert.Equal(t, "insights", cfg.HarnessReviewOutputDir())
+}
+
+func TestSmoke_S34_HarnessReviewInvalidCadenceRejected(t *testing.T) {
+	path := writeSmokeConfigFile(t, `harness:
+  review:
+    enabled: true
+    cadence: hourly
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "harness.review.cadence")
+}
+
+func TestSmoke_S35_HarnessReviewRejectsAbsoluteOutputDir(t *testing.T) {
+	path := writeSmokeConfigFile(t, `harness:
+  review:
+    output_dir: "/tmp/reviews"
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "harness.review.output_dir")
 }
 
 func TestSourceTimeoutValid(t *testing.T) {

--- a/cli/internal/review/load.go
+++ b/cli/internal/review/load.go
@@ -1,0 +1,201 @@
+package review
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
+	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
+	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+)
+
+type loadedRun struct {
+	Summary      runner.VesselSummary
+	Evidence     *evidence.Manifest
+	CostReport   *cost.CostReport
+	BudgetAlerts []cost.BudgetAlert
+	EvalReport   *evaluator.LoopResult
+}
+
+func loadRuns(stateDir string, lookbackRuns int) ([]loadedRun, int, []string, error) {
+	phaseDir := filepath.Join(stateDir, "phases")
+	entries, err := os.ReadDir(phaseDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, 0, nil, nil
+		}
+		return nil, 0, nil, fmt.Errorf("load runs: read phase dir: %w", err)
+	}
+
+	type summaryRecord struct {
+		dirName string
+		summary runner.VesselSummary
+	}
+
+	summaries := make([]summaryRecord, 0, len(entries))
+	warnings := make([]string, 0)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		summary, err := loadSummaryFile(filepath.Join(phaseDir, entry.Name(), "summary.json"))
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			warnings = append(warnings, fmt.Sprintf("%s: %v", entry.Name(), err))
+			continue
+		}
+		summaries = append(summaries, summaryRecord{dirName: entry.Name(), summary: *summary})
+	}
+
+	sort.Slice(summaries, func(i, j int) bool {
+		return summaries[i].summary.EndedAt.After(summaries[j].summary.EndedAt)
+	})
+
+	total := len(summaries)
+	if lookbackRuns > 0 && len(summaries) > lookbackRuns {
+		summaries = summaries[:lookbackRuns]
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		return summaries[i].summary.EndedAt.Before(summaries[j].summary.EndedAt)
+	})
+
+	runs := make([]loadedRun, 0, len(summaries))
+	for _, record := range summaries {
+		run := loadedRun{Summary: record.summary}
+
+		if manifestPath := resolveArtifactPath(stateDir, record.summary.EvidenceManifestPath, reviewArtifactValue(record.summary.ReviewArtifacts, func(a *runner.ReviewArtifacts) string {
+			return a.EvidenceManifest
+		})); manifestPath != "" {
+			manifest, warning := loadOptionalManifest(stateDir, record.summary.VesselID, manifestPath)
+			run.Evidence = manifest
+			if warning != "" {
+				warnings = append(warnings, warning)
+			}
+		}
+
+		if costPath := resolveArtifactPath(stateDir, record.summary.CostReportPath, reviewArtifactValue(record.summary.ReviewArtifacts, func(a *runner.ReviewArtifacts) string {
+			return a.CostReport
+		})); costPath != "" {
+			report, warning := loadOptionalCostReport(costPath)
+			run.CostReport = report
+			if warning != "" {
+				warnings = append(warnings, warning)
+			}
+		}
+
+		if alertsPath := resolveArtifactPath(stateDir, record.summary.BudgetAlertsPath, reviewArtifactValue(record.summary.ReviewArtifacts, func(a *runner.ReviewArtifacts) string {
+			return a.BudgetAlerts
+		})); alertsPath != "" {
+			alerts, warning := loadOptionalBudgetAlerts(alertsPath)
+			run.BudgetAlerts = alerts
+			if warning != "" {
+				warnings = append(warnings, warning)
+			}
+		}
+
+		if evalPath := resolveArtifactPath(stateDir, record.summary.EvalReportPath, reviewArtifactValue(record.summary.ReviewArtifacts, func(a *runner.ReviewArtifacts) string {
+			return a.EvalReport
+		})); evalPath != "" {
+			report, warning := loadOptionalEvalReport(evalPath)
+			run.EvalReport = report
+			if warning != "" {
+				warnings = append(warnings, warning)
+			}
+		}
+
+		runs = append(runs, run)
+	}
+
+	return runs, total, warnings, nil
+}
+
+func CountAvailableRuns(stateDir string) (int, error) {
+	runs, total, _, err := loadRuns(stateDir, 0)
+	if err != nil {
+		return 0, err
+	}
+	if runs == nil {
+		return total, nil
+	}
+	return total, nil
+}
+
+func loadSummaryFile(path string) (*runner.VesselSummary, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read summary: %w", err)
+	}
+	var summary runner.VesselSummary
+	if err := json.Unmarshal(data, &summary); err != nil {
+		return nil, fmt.Errorf("unmarshal summary: %w", err)
+	}
+	return &summary, nil
+}
+
+func resolveArtifactPath(stateDir, legacyPath, reviewPath string) string {
+	rel := strings.TrimSpace(reviewPath)
+	if rel == "" {
+		rel = strings.TrimSpace(legacyPath)
+	}
+	if rel == "" {
+		return ""
+	}
+	return filepath.Join(stateDir, filepath.FromSlash(rel))
+}
+
+func reviewArtifactValue(artifacts *runner.ReviewArtifacts, selectPath func(*runner.ReviewArtifacts) string) string {
+	if artifacts == nil {
+		return ""
+	}
+	return selectPath(artifacts)
+}
+
+func loadOptionalManifest(stateDir, vesselID, path string) (*evidence.Manifest, string) {
+	manifest, err := evidence.LoadManifest(stateDir, vesselID)
+	if err == nil {
+		return manifest, ""
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, ""
+	}
+	return nil, fmt.Sprintf("%s: %v", filepath.Base(path), err)
+}
+
+func loadOptionalCostReport(path string) (*cost.CostReport, string) {
+	report, err := cost.LoadReport(path)
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return report, ""
+	}
+	return nil, fmt.Sprintf("%s: %v", filepath.Base(path), err)
+}
+
+func loadOptionalBudgetAlerts(path string) ([]cost.BudgetAlert, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ""
+		}
+		return nil, fmt.Sprintf("%s: %v", filepath.Base(path), err)
+	}
+	var alerts []cost.BudgetAlert
+	if err := json.Unmarshal(data, &alerts); err != nil {
+		return nil, fmt.Sprintf("%s: unmarshal budget alerts: %v", filepath.Base(path), err)
+	}
+	return alerts, ""
+}
+
+func loadOptionalEvalReport(path string) (*evaluator.LoopResult, string) {
+	report, err := evaluator.LoadReport(filepath.Dir(path))
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return report, ""
+	}
+	return nil, fmt.Sprintf("%s: %v", filepath.Base(path), err)
+}

--- a/cli/internal/review/recommend.go
+++ b/cli/internal/review/recommend.go
@@ -1,0 +1,59 @@
+package review
+
+import "fmt"
+
+type Recommendation string
+
+const (
+	RecommendationKeep             Recommendation = "keep"
+	RecommendationInvestigate      Recommendation = "investigate"
+	RecommendationPruneCandidate   Recommendation = "prune-candidate"
+	RecommendationInsufficientData Recommendation = "insufficient-data"
+)
+
+type aggregateStats struct {
+	Samples          int
+	FailureCount     int
+	BudgetAlertRuns  int
+	EvalIssueRuns    int
+	EvidenceFailures int
+	CostAnomalyRuns  int
+}
+
+func recommendGroup(stats aggregateStats, minSamples int) (Recommendation, []string) {
+	if stats.Samples < minSamples {
+		return RecommendationInsufficientData, []string{
+			fmt.Sprintf("only %d sample(s); need at least %d", stats.Samples, minSamples),
+		}
+	}
+
+	reasons := make([]string, 0, 5)
+	if stats.FailureCount > 0 {
+		reasons = append(reasons, fmt.Sprintf("%d failure(s) in reviewed runs", stats.FailureCount))
+	}
+	if stats.BudgetAlertRuns > 0 {
+		reasons = append(reasons, fmt.Sprintf("%d run(s) triggered budget alerts", stats.BudgetAlertRuns))
+	}
+	if stats.EvalIssueRuns > 0 {
+		reasons = append(reasons, fmt.Sprintf("%d run(s) had eval issues", stats.EvalIssueRuns))
+	}
+	if stats.EvidenceFailures > 0 {
+		reasons = append(reasons, fmt.Sprintf("%d failed evidence claim(s)", stats.EvidenceFailures))
+	}
+	if stats.CostAnomalyRuns > 0 {
+		reasons = append(reasons, fmt.Sprintf("%d run(s) showed cost anomalies", stats.CostAnomalyRuns))
+	}
+	if len(reasons) > 0 {
+		return RecommendationInvestigate, reasons
+	}
+
+	if stats.Samples >= minSamples*2 {
+		return RecommendationPruneCandidate, []string{
+			fmt.Sprintf("%d clean samples with no recurring failures, eval issues, or budget alerts", stats.Samples),
+		}
+	}
+
+	return RecommendationKeep, []string{
+		fmt.Sprintf("%d clean sample(s), but keep collecting evidence before pruning", stats.Samples),
+	}
+}

--- a/cli/internal/review/review.go
+++ b/cli/internal/review/review.go
@@ -1,0 +1,392 @@
+package review
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
+	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
+	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+)
+
+const (
+	defaultLookbackRuns = 50
+	defaultMinSamples   = 3
+	defaultOutputDir    = "reviews"
+	reportJSONName      = "harness-review.json"
+	reportMarkdownName  = "harness-review.md"
+	runPhaseName        = "[run]"
+)
+
+type Options struct {
+	LookbackRuns int
+	MinSamples   int
+	OutputDir    string
+	Now          time.Time
+}
+
+type Result struct {
+	Report       *Report
+	JSONPath     string
+	MarkdownPath string
+	Markdown     string
+}
+
+type Report struct {
+	GeneratedAt       time.Time     `json:"generated_at"`
+	LookbackRuns      int           `json:"lookback_runs"`
+	MinSamples        int           `json:"min_samples"`
+	TotalRunsObserved int           `json:"total_runs_observed"`
+	ReviewedRuns      int           `json:"reviewed_runs"`
+	Summary           Summary       `json:"summary"`
+	Groups            []GroupReview `json:"groups"`
+	CostAnomalies     []CostAnomaly `json:"cost_anomalies,omitempty"`
+	Warnings          []string      `json:"warnings,omitempty"`
+}
+
+type Summary struct {
+	KeepCount             int `json:"keep_count"`
+	InvestigateCount      int `json:"investigate_count"`
+	PruneCandidateCount   int `json:"prune_candidate_count"`
+	InsufficientDataCount int `json:"insufficient_data_count"`
+}
+
+type GroupReview struct {
+	Source            string         `json:"source"`
+	Workflow          string         `json:"workflow"`
+	Phase             string         `json:"phase"`
+	PhaseType         string         `json:"phase_type"`
+	Samples           int            `json:"samples"`
+	FailureCount      int            `json:"failure_count"`
+	BudgetAlertRuns   int            `json:"budget_alert_runs"`
+	EvalIssueRuns     int            `json:"eval_issue_runs"`
+	EvidenceFailures  int            `json:"evidence_failures"`
+	CostAnomalyRuns   int            `json:"cost_anomaly_runs"`
+	AverageCostUSDEst float64        `json:"average_cost_usd_est"`
+	Recommendation    Recommendation `json:"recommendation"`
+	Reasons           []string       `json:"reasons,omitempty"`
+}
+
+type CostAnomaly struct {
+	VesselID   string         `json:"vessel_id"`
+	Source     string         `json:"source"`
+	Workflow   string         `json:"workflow"`
+	DetectedAt time.Time      `json:"detected_at"`
+	Metrics    []cost.Anomaly `json:"metrics"`
+}
+
+type groupKey struct {
+	Source   string
+	Workflow string
+	Phase    string
+}
+
+type groupAccumulator struct {
+	GroupReview
+	totalCost float64
+}
+
+func Generate(stateDir string, opts Options) (*Result, error) {
+	if opts.LookbackRuns <= 0 {
+		opts.LookbackRuns = defaultLookbackRuns
+	}
+	if opts.MinSamples <= 0 {
+		opts.MinSamples = defaultMinSamples
+	}
+	if strings.TrimSpace(opts.OutputDir) == "" {
+		opts.OutputDir = defaultOutputDir
+	}
+	if opts.Now.IsZero() {
+		opts.Now = time.Now().UTC()
+	} else {
+		opts.Now = opts.Now.UTC()
+	}
+
+	runs, totalRuns, warnings, err := loadRuns(stateDir, opts.LookbackRuns)
+	if err != nil {
+		return nil, fmt.Errorf("generate review: %w", err)
+	}
+
+	report := &Report{
+		GeneratedAt:       opts.Now,
+		LookbackRuns:      opts.LookbackRuns,
+		MinSamples:        opts.MinSamples,
+		TotalRunsObserved: totalRuns,
+		ReviewedRuns:      len(runs),
+		Warnings:          append([]string(nil), warnings...),
+	}
+	report.Groups, report.CostAnomalies = buildGroupReviews(runs, opts.MinSamples)
+	report.Summary = summarizeRecommendations(report.Groups)
+
+	outputDir := filepath.Join(stateDir, opts.OutputDir)
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return nil, fmt.Errorf("generate review: create output dir: %w", err)
+	}
+
+	jsonPath := filepath.Join(outputDir, reportJSONName)
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("generate review: marshal report: %w", err)
+	}
+	if err := os.WriteFile(jsonPath, data, 0o644); err != nil {
+		return nil, fmt.Errorf("generate review: write json report: %w", err)
+	}
+
+	markdown := renderMarkdown(report)
+	markdownPath := filepath.Join(outputDir, reportMarkdownName)
+	if err := os.WriteFile(markdownPath, []byte(markdown), 0o644); err != nil {
+		return nil, fmt.Errorf("generate review: write markdown report: %w", err)
+	}
+
+	return &Result{
+		Report:       report,
+		JSONPath:     jsonPath,
+		MarkdownPath: markdownPath,
+		Markdown:     markdown,
+	}, nil
+}
+
+func LoadLatestReport(stateDir, outputDir string) (*Report, error) {
+	if strings.TrimSpace(outputDir) == "" {
+		outputDir = defaultOutputDir
+	}
+	path := filepath.Join(stateDir, outputDir, reportJSONName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("load latest report: read: %w", err)
+	}
+	var report Report
+	if err := json.Unmarshal(data, &report); err != nil {
+		return nil, fmt.Errorf("load latest report: unmarshal: %w", err)
+	}
+	return &report, nil
+}
+
+func buildGroupReviews(runs []loadedRun, minSamples int) ([]GroupReview, []CostAnomaly) {
+	groups := make(map[groupKey]*groupAccumulator)
+	costAnomalies := detectCostAnomalies(runs)
+	anomalousRuns := make(map[string]CostAnomaly, len(costAnomalies))
+	for _, anomaly := range costAnomalies {
+		anomalousRuns[anomaly.VesselID] = anomaly
+	}
+
+	for _, run := range runs {
+		runGroup := ensureGroup(groups, run.Summary.Source, run.Summary.Workflow, runPhaseName, "run")
+		runGroup.Samples++
+		runGroup.totalCost += run.Summary.TotalCostUSDEst
+		if run.Summary.State != "completed" {
+			runGroup.FailureCount++
+		}
+		if len(run.BudgetAlerts) > 0 {
+			runGroup.BudgetAlertRuns++
+		}
+		if evalHasIssues(run.EvalReport) {
+			runGroup.EvalIssueRuns++
+		}
+		if _, ok := anomalousRuns[run.Summary.VesselID]; ok {
+			runGroup.CostAnomalyRuns++
+		}
+
+		for _, claim := range manifestClaims(run.Evidence) {
+			if claim.Passed {
+				continue
+			}
+			phaseName := claim.Phase
+			phaseType := "run"
+			if phaseName == "" {
+				phaseName = runPhaseName
+			} else {
+				phaseType = phaseTypeFor(run.Summary, phaseName)
+			}
+			ensureGroup(groups, run.Summary.Source, run.Summary.Workflow, phaseName, phaseType).EvidenceFailures++
+		}
+
+		for _, phase := range run.Summary.Phases {
+			group := ensureGroup(groups, run.Summary.Source, run.Summary.Workflow, phase.Name, phase.Type)
+			group.Samples++
+			group.totalCost += phase.CostUSDEst
+			if phase.Status != "completed" && phase.Status != "no-op" {
+				group.FailureCount++
+			}
+			if phase.GatePassed != nil && !*phase.GatePassed {
+				group.FailureCount++
+			}
+		}
+	}
+
+	reviews := make([]GroupReview, 0, len(groups))
+	for _, group := range groups {
+		if group.Samples > 0 {
+			group.AverageCostUSDEst = group.totalCost / float64(group.Samples)
+		}
+		group.Recommendation, group.Reasons = recommendGroup(aggregateStats{
+			Samples:          group.Samples,
+			FailureCount:     group.FailureCount,
+			BudgetAlertRuns:  group.BudgetAlertRuns,
+			EvalIssueRuns:    group.EvalIssueRuns,
+			EvidenceFailures: group.EvidenceFailures,
+			CostAnomalyRuns:  group.CostAnomalyRuns,
+		}, minSamples)
+		reviews = append(reviews, group.GroupReview)
+	}
+
+	sort.Slice(reviews, func(i, j int) bool {
+		if reviews[i].Source != reviews[j].Source {
+			return reviews[i].Source < reviews[j].Source
+		}
+		if reviews[i].Workflow != reviews[j].Workflow {
+			return reviews[i].Workflow < reviews[j].Workflow
+		}
+		return reviews[i].Phase < reviews[j].Phase
+	})
+	sort.Slice(costAnomalies, func(i, j int) bool {
+		if costAnomalies[i].Source != costAnomalies[j].Source {
+			return costAnomalies[i].Source < costAnomalies[j].Source
+		}
+		if costAnomalies[i].Workflow != costAnomalies[j].Workflow {
+			return costAnomalies[i].Workflow < costAnomalies[j].Workflow
+		}
+		return costAnomalies[i].DetectedAt.Before(costAnomalies[j].DetectedAt)
+	})
+	return reviews, costAnomalies
+}
+
+func detectCostAnomalies(runs []loadedRun) []CostAnomaly {
+	historyByWorkflow := make(map[string][]*cost.CostReport)
+	anomalies := make([]CostAnomaly, 0)
+	for _, run := range runs {
+		if run.CostReport == nil {
+			continue
+		}
+		key := run.Summary.Source + "\x00" + run.Summary.Workflow
+		history := historyByWorkflow[key]
+		if detected := cost.DetectAnomalies(run.CostReport, history); len(detected) > 0 {
+			anomalies = append(anomalies, CostAnomaly{
+				VesselID:   run.Summary.VesselID,
+				Source:     run.Summary.Source,
+				Workflow:   run.Summary.Workflow,
+				DetectedAt: run.Summary.EndedAt,
+				Metrics:    detected,
+			})
+		}
+		historyByWorkflow[key] = append(historyByWorkflow[key], run.CostReport)
+	}
+	return anomalies
+}
+
+func ensureGroup(groups map[groupKey]*groupAccumulator, source, workflow, phase, phaseType string) *groupAccumulator {
+	key := groupKey{Source: source, Workflow: workflow, Phase: phase}
+	group, ok := groups[key]
+	if ok {
+		return group
+	}
+	group = &groupAccumulator{
+		GroupReview: GroupReview{
+			Source:    source,
+			Workflow:  workflow,
+			Phase:     phase,
+			PhaseType: phaseType,
+		},
+	}
+	groups[key] = group
+	return group
+}
+
+func phaseTypeFor(summary runner.VesselSummary, phaseName string) string {
+	for _, phase := range summary.Phases {
+		if phase.Name == phaseName {
+			return phase.Type
+		}
+	}
+	return "prompt"
+}
+
+func manifestClaims(manifest *evidence.Manifest) []evidence.Claim {
+	if manifest == nil {
+		return nil
+	}
+	return manifest.Claims
+}
+
+func evalHasIssues(result *evaluator.LoopResult) bool {
+	if result == nil || result.FinalResult == nil {
+		return false
+	}
+	return !result.FinalResult.Pass ||
+		len(result.FinalResult.Feedback) > 0 ||
+		len(result.FinalResult.Score.Issues) > 0
+}
+
+func summarizeRecommendations(groups []GroupReview) Summary {
+	var summary Summary
+	for _, group := range groups {
+		switch group.Recommendation {
+		case RecommendationKeep:
+			summary.KeepCount++
+		case RecommendationInvestigate:
+			summary.InvestigateCount++
+		case RecommendationPruneCandidate:
+			summary.PruneCandidateCount++
+		case RecommendationInsufficientData:
+			summary.InsufficientDataCount++
+		}
+	}
+	return summary
+}
+
+func renderMarkdown(report *Report) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Harness review\n\n")
+	fmt.Fprintf(&b, "- Generated: %s\n", report.GeneratedAt.Format(time.RFC3339))
+	fmt.Fprintf(&b, "- Reviewed runs: %d of %d available\n", report.ReviewedRuns, report.TotalRunsObserved)
+	fmt.Fprintf(&b, "- Recommendations: investigate=%d, prune-candidate=%d, keep=%d, insufficient-data=%d\n\n",
+		report.Summary.InvestigateCount,
+		report.Summary.PruneCandidateCount,
+		report.Summary.KeepCount,
+		report.Summary.InsufficientDataCount,
+	)
+
+	if len(report.Warnings) > 0 {
+		fmt.Fprintf(&b, "## Warnings\n\n")
+		for _, warning := range report.Warnings {
+			fmt.Fprintf(&b, "- %s\n", warning)
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+
+	fmt.Fprintf(&b, "## Group recommendations\n\n")
+	if len(report.Groups) == 0 {
+		fmt.Fprintf(&b, "No historical run summaries were available.\n")
+		return b.String()
+	}
+	for _, group := range report.Groups {
+		fmt.Fprintf(&b, "- `%s / %s / %s` → **%s**", group.Source, group.Workflow, group.Phase, group.Recommendation)
+		if len(group.Reasons) > 0 {
+			fmt.Fprintf(&b, " — %s", strings.Join(group.Reasons, "; "))
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+
+	if len(report.CostAnomalies) > 0 {
+		fmt.Fprintf(&b, "\n## Cost anomalies\n\n")
+		for _, anomaly := range report.CostAnomalies {
+			metrics := make([]string, 0, len(anomaly.Metrics))
+			for _, metric := range anomaly.Metrics {
+				metrics = append(metrics, fmt.Sprintf("%s %.2fx expected", metric.Metric, metric.Ratio))
+			}
+			fmt.Fprintf(&b, "- `%s / %s / %s` — %s\n",
+				anomaly.Source, anomaly.Workflow, anomaly.VesselID, strings.Join(metrics, ", "))
+		}
+	}
+
+	return b.String()
+}

--- a/cli/internal/review/review_prop_test.go
+++ b/cli/internal/review/review_prop_test.go
@@ -1,0 +1,24 @@
+package review
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropRecommendGroupCleanRunsAreMonotonic(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		minSamples := rapid.IntRange(1, 6).Draw(t, "minSamples")
+		samples := rapid.IntRange(0, minSamples*3).Draw(t, "samples")
+
+		got, _ := recommendGroup(aggregateStats{Samples: samples}, minSamples)
+		switch {
+		case samples < minSamples && got != RecommendationInsufficientData:
+			t.Fatalf("recommendGroup(%d,%d) = %q, want insufficient-data", samples, minSamples, got)
+		case samples >= minSamples*2 && got != RecommendationPruneCandidate:
+			t.Fatalf("recommendGroup(%d,%d) = %q, want prune-candidate", samples, minSamples, got)
+		case samples >= minSamples && samples < minSamples*2 && got != RecommendationKeep:
+			t.Fatalf("recommendGroup(%d,%d) = %q, want keep", samples, minSamples, got)
+		}
+	})
+}

--- a/cli/internal/review/review_test.go
+++ b/cli/internal/review/review_test.go
@@ -1,0 +1,293 @@
+package review
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
+	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
+	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+)
+
+func TestGenerateAggregatesReviewRecommendations(t *testing.T) {
+	stateDir := t.TempDir()
+	base := time.Date(2026, time.April, 8, 12, 0, 0, 0, time.UTC)
+
+	for i := range 6 {
+		writeRunArtifacts(t, stateDir, runFixture{
+			vesselID:  "stable-run-" + string(rune('a'+i)),
+			source:    "github-issue",
+			workflow:  "stable",
+			state:     "completed",
+			startedAt: base.Add(time.Duration(i) * time.Minute),
+			endedAt:   base.Add(time.Duration(i)*time.Minute + 30*time.Second),
+			phases: []runner.PhaseSummary{{
+				Name:       "implement",
+				Type:       "prompt",
+				Status:     "completed",
+				CostUSDEst: 0.15,
+			}},
+			totalCost: 0.15,
+			costReport: &cost.CostReport{
+				MissionID:    "stable",
+				TotalTokens:  100,
+				TotalCostUSD: 0.15,
+				GeneratedAt:  base,
+				ByRole:       map[cost.AgentRole]float64{cost.RoleGenerator: 0.15},
+				ByPurpose:    map[cost.Purpose]float64{cost.PurposeReasoning: 0.15},
+				ByModel:      map[string]float64{"claude-sonnet-4-6": 0.15},
+				RecordCount:  1,
+			},
+		})
+	}
+
+	for i := range 3 {
+		claimPhase := "implement"
+		writeRunArtifacts(t, stateDir, runFixture{
+			vesselID:  "broken-run-" + string(rune('a'+i)),
+			source:    "github-issue",
+			workflow:  "broken",
+			state:     "failed",
+			startedAt: base.Add(time.Duration(10+i) * time.Minute),
+			endedAt:   base.Add(time.Duration(10+i)*time.Minute + 30*time.Second),
+			phases: []runner.PhaseSummary{{
+				Name:       "implement",
+				Type:       "prompt",
+				Status:     "failed",
+				Error:      "gate failed",
+				CostUSDEst: 0.4,
+			}},
+			totalCost: 0.4,
+			manifest: &evidence.Manifest{
+				VesselID: "broken-run-" + string(rune('a'+i)),
+				Workflow: "broken",
+				Claims: []evidence.Claim{{
+					Claim:     "implementation gate",
+					Phase:     claimPhase,
+					Passed:    false,
+					Timestamp: base,
+				}},
+				CreatedAt: base,
+			},
+			evalReport: &evaluator.LoopResult{
+				FinalResult: &evaluator.EvalResult{Pass: false},
+				Iterations:  1,
+			},
+		})
+	}
+
+	writeRunArtifacts(t, stateDir, runFixture{
+		vesselID:  "costly-run-a",
+		source:    "github-issue",
+		workflow:  "costly",
+		state:     "completed",
+		startedAt: base.Add(20 * time.Minute),
+		endedAt:   base.Add(21 * time.Minute),
+		totalCost: 0.10,
+		costReport: &cost.CostReport{
+			MissionID:    "costly-a",
+			TotalTokens:  100,
+			TotalCostUSD: 0.10,
+			GeneratedAt:  base,
+			ByRole:       map[cost.AgentRole]float64{cost.RoleGenerator: 0.10},
+			ByPurpose:    map[cost.Purpose]float64{cost.PurposeReasoning: 0.10},
+			ByModel:      map[string]float64{"claude-sonnet-4-6": 0.10},
+			RecordCount:  1,
+		},
+	})
+	writeRunArtifacts(t, stateDir, runFixture{
+		vesselID:  "costly-run-b",
+		source:    "github-issue",
+		workflow:  "costly",
+		state:     "completed",
+		startedAt: base.Add(22 * time.Minute),
+		endedAt:   base.Add(23 * time.Minute),
+		totalCost: 0.12,
+		costReport: &cost.CostReport{
+			MissionID:    "costly-b",
+			TotalTokens:  120,
+			TotalCostUSD: 0.12,
+			GeneratedAt:  base,
+			ByRole:       map[cost.AgentRole]float64{cost.RoleGenerator: 0.12},
+			ByPurpose:    map[cost.Purpose]float64{cost.PurposeReasoning: 0.12},
+			ByModel:      map[string]float64{"claude-sonnet-4-6": 0.12},
+			RecordCount:  1,
+		},
+	})
+	writeRunArtifacts(t, stateDir, runFixture{
+		vesselID:  "costly-run-c",
+		source:    "github-issue",
+		workflow:  "costly",
+		state:     "completed",
+		startedAt: base.Add(24 * time.Minute),
+		endedAt:   base.Add(25 * time.Minute),
+		totalCost: 1.00,
+		costReport: &cost.CostReport{
+			MissionID:    "costly-c",
+			TotalTokens:  1500,
+			TotalCostUSD: 1.00,
+			GeneratedAt:  base,
+			ByRole:       map[cost.AgentRole]float64{cost.RoleGenerator: 1.00},
+			ByPurpose:    map[cost.Purpose]float64{cost.PurposeReasoning: 1.00},
+			ByModel:      map[string]float64{"claude-sonnet-4-6": 1.00},
+			RecordCount:  1,
+		},
+	})
+
+	result, err := Generate(stateDir, Options{LookbackRuns: 20, MinSamples: 3, OutputDir: "reviews", Now: base.Add(time.Hour)})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	stable := findGroup(t, result.Report.Groups, "github-issue", "stable", "implement")
+	if stable.Recommendation != RecommendationPruneCandidate {
+		t.Fatalf("stable recommendation = %q, want %q", stable.Recommendation, RecommendationPruneCandidate)
+	}
+
+	broken := findGroup(t, result.Report.Groups, "github-issue", "broken", "implement")
+	if broken.Recommendation != RecommendationInvestigate {
+		t.Fatalf("broken recommendation = %q, want %q", broken.Recommendation, RecommendationInvestigate)
+	}
+
+	costlyRun := findGroup(t, result.Report.Groups, "github-issue", "costly", runPhaseName)
+	if costlyRun.Recommendation != RecommendationInvestigate {
+		t.Fatalf("costly run recommendation = %q, want %q", costlyRun.Recommendation, RecommendationInvestigate)
+	}
+
+	if len(result.Report.CostAnomalies) == 0 {
+		t.Fatal("CostAnomalies = 0, want at least one anomaly")
+	}
+	if _, err := os.Stat(result.JSONPath); err != nil {
+		t.Fatalf("Stat(JSONPath) error = %v", err)
+	}
+	if _, err := os.Stat(result.MarkdownPath); err != nil {
+		t.Fatalf("Stat(MarkdownPath) error = %v", err)
+	}
+}
+
+func TestGenerateToleratesMissingOptionalArtifacts(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 8, 13, 0, 0, 0, time.UTC)
+	requireSummaryOnly(t, stateDir, runner.VesselSummary{
+		VesselID:   "summary-only",
+		Source:     "manual",
+		Workflow:   "ad-hoc",
+		State:      "completed",
+		StartedAt:  now,
+		EndedAt:    now.Add(time.Minute),
+		DurationMS: time.Minute.Milliseconds(),
+		Phases:     []runner.PhaseSummary{},
+		Note:       "test",
+	})
+
+	result, err := Generate(stateDir, Options{MinSamples: 2})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	group := findGroup(t, result.Report.Groups, "manual", "ad-hoc", runPhaseName)
+	if group.Recommendation != RecommendationInsufficientData {
+		t.Fatalf("recommendation = %q, want %q", group.Recommendation, RecommendationInsufficientData)
+	}
+}
+
+type runFixture struct {
+	vesselID     string
+	source       string
+	workflow     string
+	state        string
+	startedAt    time.Time
+	endedAt      time.Time
+	phases       []runner.PhaseSummary
+	totalCost    float64
+	manifest     *evidence.Manifest
+	costReport   *cost.CostReport
+	budgetAlerts []cost.BudgetAlert
+	evalReport   *evaluator.LoopResult
+}
+
+func writeRunArtifacts(t *testing.T, stateDir string, fixture runFixture) {
+	t.Helper()
+	summary := runner.VesselSummary{
+		VesselID:        fixture.vesselID,
+		Source:          fixture.source,
+		Workflow:        fixture.workflow,
+		State:           fixture.state,
+		StartedAt:       fixture.startedAt,
+		EndedAt:         fixture.endedAt,
+		DurationMS:      fixture.endedAt.Sub(fixture.startedAt).Milliseconds(),
+		Phases:          fixture.phases,
+		TotalCostUSDEst: fixture.totalCost,
+		Note:            "fixture",
+	}
+	artifacts := &runner.ReviewArtifacts{}
+	if fixture.manifest != nil {
+		if err := evidence.SaveManifest(stateDir, fixture.vesselID, fixture.manifest); err != nil {
+			t.Fatalf("SaveManifest() error = %v", err)
+		}
+		summary.EvidenceManifestPath = filepath.ToSlash(filepath.Join("phases", fixture.vesselID, "evidence-manifest.json"))
+		artifacts.EvidenceManifest = summary.EvidenceManifestPath
+	}
+	if fixture.costReport != nil {
+		reportPath := filepath.Join(stateDir, "phases", fixture.vesselID, "cost-report.json")
+		if err := os.MkdirAll(filepath.Dir(reportPath), 0o755); err != nil {
+			t.Fatalf("MkdirAll(reportPath) error = %v", err)
+		}
+		if err := cost.SaveReport(reportPath, fixture.costReport); err != nil {
+			t.Fatalf("SaveReport() error = %v", err)
+		}
+		summary.CostReportPath = filepath.ToSlash(filepath.Join("phases", fixture.vesselID, "cost-report.json"))
+		artifacts.CostReport = summary.CostReportPath
+	}
+	if fixture.evalReport != nil {
+		evalDir := filepath.Join(stateDir, "phases", fixture.vesselID)
+		if err := os.MkdirAll(evalDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(evalDir) error = %v", err)
+		}
+		if err := evaluator.SaveReport(evalDir, fixture.evalReport); err != nil {
+			t.Fatalf("SaveReport(eval) error = %v", err)
+		}
+		summary.EvalReportPath = filepath.ToSlash(filepath.Join("phases", fixture.vesselID, "quality-report.json"))
+		artifacts.EvalReport = summary.EvalReportPath
+	}
+	if len(fixture.budgetAlerts) > 0 {
+		alertPath := filepath.Join(stateDir, "phases", fixture.vesselID, "budget-alerts.json")
+		if err := os.MkdirAll(filepath.Dir(alertPath), 0o755); err != nil {
+			t.Fatalf("MkdirAll(alertPath) error = %v", err)
+		}
+		data, err := json.MarshalIndent(fixture.budgetAlerts, "", "  ")
+		if err != nil {
+			t.Fatalf("MarshalIndent() error = %v", err)
+		}
+		if err := os.WriteFile(alertPath, data, 0o644); err != nil {
+			t.Fatalf("WriteFile(alertPath) error = %v", err)
+		}
+		summary.BudgetAlertsPath = filepath.ToSlash(filepath.Join("phases", fixture.vesselID, "budget-alerts.json"))
+		artifacts.BudgetAlerts = summary.BudgetAlertsPath
+	}
+	if artifacts.EvidenceManifest != "" || artifacts.CostReport != "" || artifacts.BudgetAlerts != "" || artifacts.EvalReport != "" {
+		summary.ReviewArtifacts = artifacts
+	}
+	requireSummaryOnly(t, stateDir, summary)
+}
+
+func requireSummaryOnly(t *testing.T, stateDir string, summary runner.VesselSummary) {
+	t.Helper()
+	if err := runner.SaveVesselSummary(stateDir, &summary); err != nil {
+		t.Fatalf("SaveVesselSummary() error = %v", err)
+	}
+}
+
+func findGroup(t *testing.T, groups []GroupReview, source, workflow, phase string) GroupReview {
+	t.Helper()
+	for _, group := range groups {
+		if group.Source == source && group.Workflow == workflow && group.Phase == phase {
+			return group
+		}
+	}
+	t.Fatalf("group %s/%s/%s not found", source, workflow, phase)
+	return GroupReview{}
+}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -879,6 +879,7 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 	}
 
 	summary := vrs.buildSummary(state, now)
+	reviewArtifacts := &ReviewArtifacts{}
 	var manifest *evidence.Manifest
 	if len(claims) > 0 {
 		manifest = &evidence.Manifest{
@@ -891,7 +892,39 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 			log.Printf("warn: save evidence manifest: %v", err)
 		} else {
 			summary.EvidenceManifestPath = evidenceManifestRelativePath(vessel.ID)
+			reviewArtifacts.EvidenceManifest = summary.EvidenceManifestPath
 		}
+	}
+
+	if vrs.costTracker != nil {
+		reportPath := filepath.Join(r.Config.StateDir, "phases", vessel.ID, costReportFileName)
+		if err := os.MkdirAll(filepath.Dir(reportPath), 0o755); err != nil {
+			log.Printf("warn: save cost report: %v", fmt.Errorf("create dir: %w", err))
+		} else if err := cost.SaveReport(reportPath, vrs.costTracker.Report(vessel.ID)); err != nil {
+			log.Printf("warn: save cost report: %v", err)
+		} else {
+			summary.CostReportPath = costReportRelativePath(vessel.ID)
+			reviewArtifacts.CostReport = summary.CostReportPath
+		}
+
+		alertsPath := filepath.Join(r.Config.StateDir, "phases", vessel.ID, budgetAlertsFileName)
+		if err := saveJSONArtifact(alertsPath, vrs.costTracker.Alerts()); err != nil {
+			log.Printf("warn: save budget alerts: %v", err)
+		} else {
+			summary.BudgetAlertsPath = budgetAlertsRelativePath(vessel.ID)
+			reviewArtifacts.BudgetAlerts = summary.BudgetAlertsPath
+		}
+	}
+
+	evalPath := filepath.Join(r.Config.StateDir, "phases", vessel.ID, evalReportFileName)
+	if info, err := os.Stat(evalPath); err == nil && !info.IsDir() {
+		summary.EvalReportPath = evalReportRelativePath(vessel.ID)
+		reviewArtifacts.EvalReport = summary.EvalReportPath
+	}
+
+	if reviewArtifacts.EvidenceManifest != "" || reviewArtifacts.CostReport != "" ||
+		reviewArtifacts.BudgetAlerts != "" || reviewArtifacts.EvalReport != "" {
+		summary.ReviewArtifacts = reviewArtifacts
 	}
 
 	if err := SaveVesselSummary(r.Config.StateDir, summary); err != nil {
@@ -899,6 +932,20 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 	}
 
 	return manifest
+}
+
+func saveJSONArtifact(path string, value any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	return nil
 }
 
 // runVesselOrchestrated executes a workflow with explicit phase dependencies

--- a/cli/internal/runner/summary.go
+++ b/cli/internal/runner/summary.go
@@ -16,8 +16,11 @@ import (
 )
 
 const (
-	summaryFileName   = "summary.json"
-	summaryDisclaimer = "Token counts and costs are estimates (len/4 heuristic + static pricing). Not provider-reported values."
+	summaryFileName      = "summary.json"
+	costReportFileName   = "cost-report.json"
+	budgetAlertsFileName = "budget-alerts.json"
+	evalReportFileName   = "quality-report.json"
+	summaryDisclaimer    = "Token counts and costs are estimates (len/4 heuristic + static pricing). Not provider-reported values."
 )
 
 var safeSummaryPathComponent = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
@@ -44,9 +47,20 @@ type VesselSummary struct {
 	BudgetMaxTokens  *int     `json:"budget_max_tokens,omitempty"`
 	BudgetExceeded   bool     `json:"budget_exceeded"`
 
-	EvidenceManifestPath string `json:"evidence_manifest_path,omitempty"`
+	EvidenceManifestPath string           `json:"evidence_manifest_path,omitempty"`
+	CostReportPath       string           `json:"cost_report_path,omitempty"`
+	BudgetAlertsPath     string           `json:"budget_alerts_path,omitempty"`
+	EvalReportPath       string           `json:"eval_report_path,omitempty"`
+	ReviewArtifacts      *ReviewArtifacts `json:"review_artifacts,omitempty"`
 
 	Note string `json:"note"`
+}
+
+type ReviewArtifacts struct {
+	EvidenceManifest string `json:"evidence_manifest,omitempty"`
+	CostReport       string `json:"cost_report,omitempty"`
+	BudgetAlerts     string `json:"budget_alerts,omitempty"`
+	EvalReport       string `json:"eval_report,omitempty"`
 }
 
 // PhaseSummary records the outcome of a single phase.
@@ -243,6 +257,18 @@ func gatePassedPointer(passed bool) *bool {
 
 func evidenceManifestRelativePath(vesselID string) string {
 	return filepath.ToSlash(filepath.Join("phases", vesselID, "evidence-manifest.json"))
+}
+
+func costReportRelativePath(vesselID string) string {
+	return filepath.ToSlash(filepath.Join("phases", vesselID, costReportFileName))
+}
+
+func budgetAlertsRelativePath(vesselID string) string {
+	return filepath.ToSlash(filepath.Join("phases", vesselID, budgetAlertsFileName))
+}
+
+func evalReportRelativePath(vesselID string) string {
+	return filepath.ToSlash(filepath.Join("phases", vesselID, evalReportFileName))
 }
 
 func phaseArtifactRelativePath(vesselID, phaseName string) string {

--- a/cli/internal/runner/summary_test.go
+++ b/cli/internal/runner/summary_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
@@ -434,6 +435,68 @@ func TestSmoke_S18_EvidenceManifestPathIsEmptyInSummaryWhenNoClaimsProvided(t *t
 	raw := loadSummaryJSON(t, cfg.StateDir, vessel.ID)
 	_, ok := raw["evidence_manifest_path"]
 	assert.False(t, ok)
+}
+
+func TestSmoke_S18a_PersistRunArtifactsWritesCostAndBudgetReviewInputs(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem-state")
+	cfg.Cost.Budget = &config.BudgetConfig{MaxCostUSD: 1}
+
+	startedAt := time.Date(2026, time.April, 8, 20, 32, 30, 0, time.UTC)
+	vessel := runningSmokeVessel("vessel-cost-artifacts", "github", "fix-bug", startedAt)
+	vrs := newVesselRunState(cfg, vessel, startedAt)
+	require.NotNil(t, vrs.costTracker)
+
+	err := vrs.costTracker.Record(cost.UsageRecord{
+		MissionID:    vessel.ID,
+		AgentRole:    cost.RoleGenerator,
+		Purpose:      cost.PurposeReasoning,
+		Model:        "claude-sonnet-4-6",
+		InputTokens:  1000,
+		OutputTokens: 1000,
+		CostUSD:      1.2,
+		Timestamp:    startedAt.Add(time.Second),
+	})
+	require.NoError(t, err)
+
+	r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{}, &mockCmdRunner{})
+	r.persistRunArtifacts(vessel, string(queue.StateCompleted), vrs, nil, startedAt.Add(2*time.Second))
+
+	summary := loadSummary(t, cfg.StateDir, vessel.ID)
+	assert.Equal(t, costReportRelativePath(vessel.ID), summary.CostReportPath)
+	assert.Equal(t, budgetAlertsRelativePath(vessel.ID), summary.BudgetAlertsPath)
+	require.NotNil(t, summary.ReviewArtifacts)
+	assert.Equal(t, summary.CostReportPath, summary.ReviewArtifacts.CostReport)
+	assert.Equal(t, summary.BudgetAlertsPath, summary.ReviewArtifacts.BudgetAlerts)
+
+	report, err := cost.LoadReport(filepath.Join(cfg.StateDir, "phases", vessel.ID, costReportFileName))
+	require.NoError(t, err)
+	assert.Equal(t, vessel.ID, report.MissionID)
+
+	alertsData, err := os.ReadFile(filepath.Join(cfg.StateDir, "phases", vessel.ID, budgetAlertsFileName))
+	require.NoError(t, err)
+	assert.Contains(t, string(alertsData), `"type": "exceeded"`)
+}
+
+func TestSmoke_S18b_PersistRunArtifactsLinksExistingEvalReport(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem-state")
+
+	startedAt := time.Date(2026, time.April, 8, 20, 32, 45, 0, time.UTC)
+	vessel := runningSmokeVessel("vessel-eval-artifact", "github", "fix-bug", startedAt)
+	evalPath := filepath.Join(cfg.StateDir, "phases", vessel.ID, evalReportFileName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(evalPath), 0o755))
+	require.NoError(t, os.WriteFile(evalPath, []byte(`{"iterations":1}`), 0o644))
+
+	r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{}, &mockCmdRunner{})
+	r.persistRunArtifacts(vessel, string(queue.StateCompleted), newVesselRunState(cfg, vessel, startedAt), nil, startedAt.Add(time.Second))
+
+	summary := loadSummary(t, cfg.StateDir, vessel.ID)
+	assert.Equal(t, evalReportRelativePath(vessel.ID), summary.EvalReportPath)
+	require.NotNil(t, summary.ReviewArtifacts)
+	assert.Equal(t, summary.EvalReportPath, summary.ReviewArtifacts.EvalReport)
 }
 
 func TestSmoke_S19_FailurePathBuildsSummaryWithStateFailedAndCallsSaveVesselSummary(t *testing.T) {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -276,7 +276,8 @@ xylem drain [flags]
    - Executes workflow phases sequentially in the worktree. Prompt phases use the resolved provider (`claude` or `copilot`), and command phases run shell commands directly.
    - Runs quality gates between phases (command gates with retries, label gates with polling).
 4. Marks vessels as `completed`, `failed`, `waiting`, or `timed_out` based on outcome.
-5. Prints a summary line and exits.
+5. If `harness.review` is configured for automatic cadence, regenerates the latest harness review as a best-effort post-drain step.
+6. Prints a summary line and exits.
 
 **Graceful shutdown**: `drain` handles `SIGINT` and `SIGTERM`. When a signal is received, running sessions are allowed to finish, but no new pending vessels are started.
 
@@ -318,6 +319,41 @@ xylem scan && xylem drain
 
 ---
 
+## xylem review
+
+Aggregate persisted run artifacts into a recurring harness review report.
+
+### Usage
+
+```
+xylem review
+```
+
+### Flags
+
+None.
+
+### Behavior
+
+1. Scans historical vessel summaries under `<state_dir>/phases/`.
+2. Loads any linked evidence manifests, cost reports, budget alerts, and eval reports when present.
+3. Rolls those artifacts up by source, workflow, and phase into deterministic recommendations: `keep`, `investigate`, `prune-candidate`, or `insufficient-data`.
+4. Writes:
+   - `<state_dir>/<harness.review.output_dir>/harness-review.json`
+   - `<state_dir>/<harness.review.output_dir>/harness-review.md`
+5. Prints the latest markdown review to stdout.
+
+Missing historical artifacts from older runs are tolerated; the review degrades gracefully instead of failing.
+
+### Examples
+
+```bash
+# Generate the latest review report on demand
+xylem review
+```
+
+---
+
 ## xylem daemon
 
 Run a continuous scan-drain loop as a long-lived process.
@@ -346,6 +382,7 @@ The daemon uses the shorter of the two intervals as its tick interval and checks
 1. Parses scan and drain intervals from config (falling back to defaults).
 2. Enters a loop that alternates between scanning and draining based on elapsed time since each operation last ran.
 3. After each tick, logs a summary of the queue state (pending, running, completed, failed counts).
+4. Automatic harness review generation follows the same best-effort cadence as `xylem drain` because daemon draining uses the same post-drain hook.
 
 **Graceful shutdown**: Handles `SIGINT` and `SIGTERM`. On signal, the daemon logs a shutdown message and exits cleanly. Running sessions finish before the process terminates.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -284,6 +284,12 @@ The `harness` section configures agent safety guardrails: protected file surface
 | `harness.protected_surfaces.paths` | list of strings | `[".xylem/HARNESS.md", ".xylem.yml", ".xylem/workflows/*.yaml", ".xylem/prompts/*/*.md"]` | No | Glob patterns for files agents cannot modify. Set to `["none"]` to disable all surface protections. |
 | `harness.policy.rules` | list of objects | `[]` | No | Policy rules for action authorization. Each rule has `action`, `resource`, and `effect`. |
 | `harness.audit_log` | string | `"audit.jsonl"` | No | Path to the audit log file for policy decisions, relative to the state directory. |
+| `harness.review.enabled` | bool | `false` | No | Enables recurring harness review generation after drain runs. Manual `xylem review` works regardless. |
+| `harness.review.cadence` | string | `"manual"` | No | Automatic review cadence. Valid values: `manual`, `every_drain`, `every_n_runs`. |
+| `harness.review.every_n_runs` | integer | `10` | No | When cadence is `every_n_runs`, regenerate after this many new reviewed runs. |
+| `harness.review.lookback_runs` | integer | `50` | No | Maximum number of historical run summaries to include in each review. |
+| `harness.review.min_samples` | integer | `3` | No | Minimum samples required before xylem will recommend keeping or pruning a surface. |
+| `harness.review.output_dir` | string | `"reviews"` | No | Output directory for review reports, relative to the state directory. |
 
 **Policy rule fields:**
 
@@ -310,7 +316,16 @@ harness:
         resource: "*"
         effect: allow
   audit_log: "audit.jsonl"
+  review:
+    enabled: true
+    cadence: every_n_runs
+    every_n_runs: 10
+    lookback_runs: 50
+    min_samples: 3
+    output_dir: "reviews"
 ```
+
+`xylem review` writes `harness-review.json` and `harness-review.md` under `<state_dir>/<output_dir>/`. Automatic reviews are best-effort: failed review generation never fails `drain` or `daemon`.
 
 ### Observability settings
 

--- a/docs/design/xylem-harness-impl-spec.md
+++ b/docs/design/xylem-harness-impl-spec.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Date:** 2026-03-31
-**Scope:** Workstreams 1, 3, 4, 5 from the [SoTA Harness Plan](../plans/sota-harness-plan.md)
+**Scope:** Workstreams 1, 3, 4, 5, and the WS8 recurring harness review slice from the [SoTA Harness Plan](../plans/sota-harness-plan.md)
 **Inputs:** [SoTA Agent Harness Spec](sota-agent-harness-spec.md), [Harness Scorecard Report](../reports/harness-scorecard-report-2.md)
 
 ## 1. Purpose
@@ -17,8 +17,9 @@ This document provides implementation-level specifications for the first four wo
 | WS3 | Wire run-level observability and cost telemetry into the CLI path | 7.1 (1/2), 10.1 (1/2) |
 | WS4 | Formalize verification contracts and evidence levels | 6.2 (1/2), 6.4 (1/2) |
 | WS5 | Harness eval suite interface (types and schemas only) | 7.2-7.4 (0/2 each) |
+| WS8 | Recurring harness review from persisted run artifacts | 7.5 (0/2), 10.3-10.5 (partial) |
 
-**Out of scope:** WS2 (OS-level containment, egress policy, secret scoping) — deferred until WS1 and WS3 are measured. WS6-8 (context compilation, evaluator separation, agent-readable observability) — deferred until Phase 1 is complete.
+**Out of scope:** WS2 (OS-level containment, egress policy, secret scoping) — deferred until WS1 and WS3 are measured. WS6-7 and the routing/model-ladder slice of WS8 remain deferred until Phase 1 is complete.
 
 ### 1.2 Technical decisions
 
@@ -1777,6 +1778,83 @@ The following are **not implemented** by agents working from this spec:
 7. **Comparison tooling** — a lightweight script to diff `harbor analyze` JSON outputs across runs
 
 **What agents DO implement (Step 6):** the directory structure, `harbor.yaml`, `xylem_verify.py` helper module, `conftest.py`, one verification script template per category (workflow-execution and surface-protection), and the rubric TOML files. This creates the scaffolding that humans then populate with scenarios.
+
+---
+
+## 9A. WS8 recurring harness review
+
+This issue implements the WS8 review loop as a **read-only aggregation layer** over the artifacts already emitted by WS3-WS5. It does **not** auto-prune features or mutate workflows.
+
+### 9A.1 Config surface
+
+Add `harness.review` under `HarnessConfig`:
+
+```yaml
+harness:
+  review:
+    enabled: true
+    cadence: every_n_runs   # manual | every_drain | every_n_runs
+    every_n_runs: 10
+    lookback_runs: 50
+    min_samples: 3
+    output_dir: reviews
+```
+
+Rules:
+
+- `xylem review` always works, even when `enabled` is `false`.
+- Automatic generation is best-effort and never fails `drain` or `daemon`.
+- `output_dir` is relative to `state_dir` and must not escape it.
+
+### 9A.2 Artifact contract
+
+`summary.json` remains the index artifact for each vessel and now links the structured review inputs:
+
+- `evidence_manifest_path`
+- `cost_report_path`
+- `budget_alerts_path`
+- `eval_report_path`
+- `review_artifacts` (structured mirror of the same paths for future expansion)
+
+File locations for the first implementation:
+
+- `<state_dir>/phases/<vessel>/summary.json`
+- `<state_dir>/phases/<vessel>/evidence-manifest.json`
+- `<state_dir>/phases/<vessel>/cost-report.json`
+- `<state_dir>/phases/<vessel>/budget-alerts.json`
+- `<state_dir>/phases/<vessel>/quality-report.json` (optional, only when an eval report already exists)
+
+### 9A.3 Review output
+
+Add a new package `cli/internal/review/` and a new command `xylem review`.
+
+The package:
+
+1. scans historical summaries under `<state_dir>/phases/`,
+2. loads any linked evidence/cost/budget/eval artifacts that exist,
+3. rolls up recurring signals by `source + workflow + phase`,
+4. uses `cost.DetectAnomalies(...)` to flag abnormal cost spikes within a workflow history, and
+5. emits deterministic recommendations:
+   - `insufficient-data`
+   - `keep`
+   - `investigate`
+   - `prune-candidate`
+
+Outputs:
+
+- `<state_dir>/<output_dir>/harness-review.json`
+- `<state_dir>/<output_dir>/harness-review.md`
+
+### 9A.4 Recommendation rules
+
+The initial rules are intentionally conservative:
+
+- fewer than `min_samples` reviewed runs → `insufficient-data`
+- any recurring failure, failed evidence claim, eval issue, budget alert, or detected cost anomaly → `investigate`
+- at least `min_samples` clean samples but fewer than `2 * min_samples` → `keep`
+- at least `2 * min_samples` clean samples with no recurring negative signals → `prune-candidate`
+
+`prune-candidate` is advisory only. Operators must decide whether to simplify prompts, gates, or other advanced harness features.
 
 ---
 

--- a/docs/plans/sota-harness-plan.md
+++ b/docs/plans/sota-harness-plan.md
@@ -331,6 +331,8 @@ These are **validated quality multipliers**. They should follow immediately afte
 4. Summarize verbose tool output and gate failures into structured artifacts so context and cost stay bounded.
 5. Establish a recurring pruning review: compare advanced features (`ctxmgr`, evaluator loops, extra routing, sandbox modes) against actual eval and cost data, then remove or simplify what no longer pays for itself.
 
+**Implementation note:** the first slice should ship as a read-only review loop built on persisted run artifacts. Use `summary.json` as the index plus `evidence-manifest.json`, `cost-report.json`, `budget-alerts.json`, and optional `quality-report.json`, then expose the aggregate through `xylem review` and best-effort post-drain regeneration into `.xylem/reviews/harness-review.{json,md}`.
+
 **Dependencies**
 
 - Depends on Workstreams 3, 5, and 6. Budget/routing decisions are only useful once telemetry and eval data exist.


### PR DESCRIPTION
## Summary
- add harness review config defaults and validation, plus a new xylem review command
- persist cost, budget-alert, evidence, and optional eval artifacts into per-run summaries and aggregate them into recurring harness review reports
- document the review workflow, outputs, cadence, and recommendation model

Closes https://github.com/nicholls-inc/xylem/issues/62