### PR TITLE
feat: self-healing daemon with auto-upgrade, orphan recovery, and worktree recreation

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -13,6 +13,7 @@ sources:
         workflow: fix-bug
         status_labels:
           failed: xylem-failed
+          timed_out: xylem-failed
 
   features:
     type: github
@@ -25,6 +26,7 @@ sources:
         workflow: implement-feature
         status_labels:
           failed: xylem-failed
+          timed_out: xylem-failed
 
   triage:
     type: github
@@ -39,6 +41,7 @@ sources:
         workflow: triage
         status_labels:
           failed: xylem-failed
+          timed_out: xylem-failed
 
   refinement:
     type: github
@@ -50,6 +53,7 @@ sources:
         workflow: refine-issue
         status_labels:
           failed: xylem-failed
+          timed_out: xylem-failed
 
   # Harness implementation issues
   harness-impl:
@@ -64,6 +68,7 @@ sources:
         status_labels:
           running: in-progress
           failed: xylem-failed
+          timed_out: xylem-failed
 
   # PR review + CI failure monitoring for harness PRs
   # NOTE: review_submitted and checks_failed fire for ALL open PRs.

--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -28,10 +28,6 @@ import (
 // finish after receiving a shutdown signal before returning anyway.
 const drainShutdownTimeout = 30 * time.Second
 
-// defaultStaleTimeout is the fallback timeout for considering a running vessel
-// stale when no explicit timeout is configured.
-const defaultStaleTimeout = 2 * time.Hour
-
 func newDaemonCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "daemon",
@@ -54,12 +50,23 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	}
 	defer unlock()
 
-	// P0-2: Reconcile any vessels left in running state from a previous daemon.
-	var timeout time.Duration
-	if cfg.Timeout != "" {
-		timeout, _ = time.ParseDuration(cfg.Timeout)
+	// Auto-upgrade: pull latest main, rebuild, exec() if binary changed.
+	// Runs after PID lock (prevents concurrent upgrades) and before any vessel
+	// processing. If exec() fires, the new process re-acquires the lock.
+	if cfg.Daemon.AutoUpgrade {
+		execPath, execErr := os.Executable()
+		if execErr != nil {
+			log.Printf("daemon: auto-upgrade: resolve executable path: %v (skipping upgrade)", execErr)
+		} else {
+			repoDir := filepath.Dir(filepath.Dir(execPath))
+			selfUpgrade(repoDir, execPath)
+		}
 	}
-	reconcileStaleVessels(q, timeout)
+
+	// P0-2: Reconcile any vessels left in running state from a previous daemon.
+	// The singleton lock guarantees no other daemon is running, so all running
+	// vessels are definitionally orphaned.
+	reconcileStaleVessels(q, wt)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -218,40 +225,38 @@ func logTickSummary(q *queue.Queue) {
 		counts[queue.StateCompleted], counts[queue.StateFailed])
 }
 
-// reconcileStaleVessels transitions any running vessels that have exceeded the
-// given timeout to failed state. This cleans up orphaned vessels left behind
-// when a previous daemon was killed. If timeout is zero, defaultStaleTimeout
-// is used.
-func reconcileStaleVessels(q *queue.Queue, timeout time.Duration) {
-	if timeout == 0 {
-		timeout = defaultStaleTimeout
-	}
-
+// reconcileStaleVessels transitions ALL running vessels to timed_out. The
+// singleton daemon lock guarantees that no other daemon is executing vessels
+// when this runs, so every running vessel is orphaned by definition. The
+// timed_out state supports retry via `xylem retry`.
+func reconcileStaleVessels(q *queue.Queue, wt *worktree.Manager) {
 	vessels, err := q.List()
 	if err != nil {
 		log.Printf("daemon: reconcile: failed to list vessels: %v", err)
 		return
 	}
 
-	now := daemonNow()
+	var recovered int
 	for _, v := range vessels {
 		if v.State != queue.StateRunning {
 			continue
 		}
-		if v.StartedAt == nil {
-			// No start time recorded — treat as stale.
-			log.Printf("daemon: reconcile: vessel %s in running state with no start time, marking failed", v.ID)
-			if err := q.Update(v.ID, queue.StateFailed, "orphaned by daemon restart"); err != nil {
-				log.Printf("daemon: reconcile: failed to update vessel %s: %v", v.ID, err)
-			}
+		log.Printf("daemon: reconcile: vessel %s orphaned in running state, marking timed_out", v.ID)
+		if err := q.Update(v.ID, queue.StateTimedOut, "orphaned by daemon restart"); err != nil {
+			log.Printf("daemon: reconcile: failed to update vessel %s: %v", v.ID, err)
 			continue
 		}
-		if v.StartedAt.Add(timeout).Before(now) {
-			log.Printf("daemon: reconcile: vessel %s started at %s exceeded timeout %s, marking failed", v.ID, v.StartedAt.Format(time.RFC3339), timeout)
-			if err := q.Update(v.ID, queue.StateFailed, "orphaned by daemon restart"); err != nil {
-				log.Printf("daemon: reconcile: failed to update vessel %s: %v", v.ID, err)
+		recovered++
+
+		// Best-effort worktree cleanup.
+		if v.WorktreePath != "" && wt != nil {
+			if err := wt.Remove(context.Background(), v.WorktreePath); err != nil {
+				log.Printf("daemon: reconcile: failed to remove worktree for %s: %v", v.ID, err)
 			}
 		}
+	}
+	if recovered > 0 {
+		log.Printf("daemon: reconcile: recovered %d orphaned vessel(s)", recovered)
 	}
 }
 

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -326,38 +326,33 @@ func TestWS1S28DaemonPathWiresScaffolding(t *testing.T) {
 }
 
 func TestReconcileStaleVessels(t *testing.T) {
-	t.Run("stale running vessel transitions to failed", func(t *testing.T) {
+	t.Run("orphaned running vessel transitions to timed_out", func(t *testing.T) {
 		dir := t.TempDir()
 		q := queue.New(filepath.Join(dir, "queue.jsonl"))
 		now := time.Now().UTC()
-		staleStart := now.Add(-3 * time.Hour)
 
-		// Enqueue then dequeue to move to running state (sets StartedAt).
 		q.Enqueue(queue.Vessel{ID: "stale-1", Source: "manual", State: queue.StatePending, CreatedAt: now}) //nolint:errcheck
 		v, _ := q.Dequeue()
 		if v == nil {
 			t.Fatal("expected vessel from dequeue")
 			return
 		}
-		// Backdate StartedAt to make it stale.
-		v.StartedAt = &staleStart
-		q.UpdateVessel(*v) //nolint:errcheck
 
-		reconcileStaleVessels(q, 2*time.Hour)
+		reconcileStaleVessels(q, nil)
 
 		updated, err := q.FindByID("stale-1")
 		if err != nil {
 			t.Fatalf("failed to find vessel: %v", err)
 		}
-		if updated.State != queue.StateFailed {
-			t.Errorf("expected state %s, got %s", queue.StateFailed, updated.State)
+		if updated.State != queue.StateTimedOut {
+			t.Errorf("expected state %s, got %s", queue.StateTimedOut, updated.State)
 		}
 		if updated.Error != "orphaned by daemon restart" {
 			t.Errorf("expected error 'orphaned by daemon restart', got %q", updated.Error)
 		}
 	})
 
-	t.Run("recent running vessel is not reconciled", func(t *testing.T) {
+	t.Run("recently started running vessel is also recovered", func(t *testing.T) {
 		dir := t.TempDir()
 		q := queue.New(filepath.Join(dir, "queue.jsonl"))
 		now := time.Now().UTC()
@@ -368,16 +363,16 @@ func TestReconcileStaleVessels(t *testing.T) {
 			t.Fatal("expected vessel from dequeue")
 			return
 		}
-		// StartedAt is set to now by Dequeue — well within the timeout.
+		// StartedAt is set to now by Dequeue — singleton lock means it's still orphaned.
 
-		reconcileStaleVessels(q, 2*time.Hour)
+		reconcileStaleVessels(q, nil)
 
 		updated, err := q.FindByID("recent-1")
 		if err != nil {
 			t.Fatalf("failed to find vessel: %v", err)
 		}
-		if updated.State != queue.StateRunning {
-			t.Errorf("expected state %s, got %s", queue.StateRunning, updated.State)
+		if updated.State != queue.StateTimedOut {
+			t.Errorf("expected state %s, got %s", queue.StateTimedOut, updated.State)
 		}
 	})
 
@@ -389,7 +384,7 @@ func TestReconcileStaleVessels(t *testing.T) {
 		q.Enqueue(queue.Vessel{ID: "pending-1", Source: "manual", State: queue.StatePending, CreatedAt: now})    //nolint:errcheck
 		q.Enqueue(queue.Vessel{ID: "complete-1", Source: "manual", State: queue.StateCompleted, CreatedAt: now}) //nolint:errcheck
 
-		reconcileStaleVessels(q, 1*time.Millisecond)
+		reconcileStaleVessels(q, nil)
 
 		pending, _ := q.FindByID("pending-1")
 		if pending.State != queue.StatePending {
@@ -401,42 +396,21 @@ func TestReconcileStaleVessels(t *testing.T) {
 		}
 	})
 
-	t.Run("zero timeout uses default", func(t *testing.T) {
-		dir := t.TempDir()
-		q := queue.New(filepath.Join(dir, "queue.jsonl"))
-		now := time.Now().UTC()
-		// Started 1 hour ago — less than the 2-hour default.
-		recentStart := now.Add(-1 * time.Hour)
-
-		q.Enqueue(queue.Vessel{ID: "v1", Source: "manual", State: queue.StatePending, CreatedAt: now}) //nolint:errcheck
-		v, _ := q.Dequeue()
-		v.StartedAt = &recentStart
-		q.UpdateVessel(*v) //nolint:errcheck
-
-		reconcileStaleVessels(q, 0) // should use defaultStaleTimeout (2h)
-
-		updated, _ := q.FindByID("v1")
-		if updated.State != queue.StateRunning {
-			t.Errorf("expected vessel to remain running with default timeout, got %s", updated.State)
-		}
-	})
-
-	t.Run("running vessel with nil StartedAt is reconciled", func(t *testing.T) {
+	t.Run("running vessel with nil StartedAt is recovered", func(t *testing.T) {
 		dir := t.TempDir()
 		q := queue.New(filepath.Join(dir, "queue.jsonl"))
 		now := time.Now().UTC()
 
 		q.Enqueue(queue.Vessel{ID: "nil-start", Source: "manual", State: queue.StatePending, CreatedAt: now}) //nolint:errcheck
 		v, _ := q.Dequeue()
-		// Clear StartedAt to simulate a legacy/corrupt entry.
 		v.StartedAt = nil
 		q.UpdateVessel(*v) //nolint:errcheck
 
-		reconcileStaleVessels(q, 2*time.Hour)
+		reconcileStaleVessels(q, nil)
 
 		updated, _ := q.FindByID("nil-start")
-		if updated.State != queue.StateFailed {
-			t.Errorf("expected state failed for nil StartedAt, got %s", updated.State)
+		if updated.State != queue.StateTimedOut {
+			t.Errorf("expected state timed_out for nil StartedAt, got %s", updated.State)
 		}
 	})
 
@@ -514,18 +488,14 @@ func TestReconcileStaleVessels(t *testing.T) {
 			t.Fatalf("Stat(%q): %v", absWorktree, err)
 		}
 
-		if err := dtu.AdvanceRuntimeClock(time.Hour); err != nil {
-			t.Fatalf("AdvanceRuntimeClock() error = %v", err)
-		}
-
-		reconcileStaleVessels(q, 45*time.Minute)
+		reconcileStaleVessels(q, nil)
 
 		updated, err := q.FindByID("issue-4")
 		if err != nil {
 			t.Fatalf("FindByID(issue-4) error = %v", err)
 		}
-		if updated.State != queue.StateFailed {
-			t.Fatalf("updated.State = %q, want %q", updated.State, queue.StateFailed)
+		if updated.State != queue.StateTimedOut {
+			t.Fatalf("updated.State = %q, want %q", updated.State, queue.StateTimedOut)
 		}
 		if updated.Error != "orphaned by daemon restart" {
 			t.Fatalf("updated.Error = %q, want %q", updated.Error, "orphaned by daemon restart")
@@ -535,9 +505,6 @@ func TestReconcileStaleVessels(t *testing.T) {
 		}
 		if updated.StartedAt == nil {
 			t.Fatal("updated.StartedAt = nil, want start timestamp")
-		}
-		if updated.EndedAt.Sub(*updated.StartedAt) < time.Hour {
-			t.Fatalf("ended-started = %s, want at least 1h", updated.EndedAt.Sub(*updated.StartedAt))
 		}
 
 		assertLabelsEqual(t, readDaemonDTULabels(t, store, "owner/repo", 4), []string{"bug", "in-progress"})

--- a/cli/cmd/xylem/upgrade.go
+++ b/cli/cmd/xylem/upgrade.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+)
+
+// selfUpgrade pulls latest main, rebuilds the binary, and exec()s the new
+// binary if it changed. On success (binary changed), this function does not
+// return — the process image is replaced. On failure or no-change, it returns
+// normally so the daemon continues with the current binary.
+func selfUpgrade(repoDir, executablePath string) {
+	log.Println("daemon: auto-upgrade: pulling latest main")
+
+	if err := gitPull(repoDir); err != nil {
+		log.Printf("daemon: auto-upgrade: git pull failed: %v (continuing with current binary)", err)
+		return
+	}
+
+	oldHash, err := hashFile(executablePath)
+	if err != nil {
+		log.Printf("daemon: auto-upgrade: hash current binary: %v (continuing with current binary)", err)
+		return
+	}
+
+	// Build to a temp file to avoid corrupting the running binary on failure.
+	cliDir := filepath.Join(repoDir, "cli")
+	tmpBin := executablePath + ".upgrade"
+	if err := goBuild(cliDir, tmpBin); err != nil {
+		log.Printf("daemon: auto-upgrade: go build failed: %v (continuing with current binary)", err)
+		os.Remove(tmpBin) //nolint:errcheck
+		return
+	}
+
+	newHash, err := hashFile(tmpBin)
+	if err != nil {
+		log.Printf("daemon: auto-upgrade: hash new binary: %v (continuing with current binary)", err)
+		os.Remove(tmpBin) //nolint:errcheck
+		return
+	}
+
+	if oldHash == newHash {
+		log.Println("daemon: auto-upgrade: binary unchanged after rebuild")
+		os.Remove(tmpBin) //nolint:errcheck
+		return
+	}
+
+	// Atomic rename new binary over old (same filesystem).
+	if err := os.Rename(tmpBin, executablePath); err != nil {
+		log.Printf("daemon: auto-upgrade: rename failed: %v (continuing with current binary)", err)
+		os.Remove(tmpBin) //nolint:errcheck
+		return
+	}
+
+	log.Printf("daemon: auto-upgrade: binary changed (%s -> %s), exec()ing new binary", oldHash[:12], newHash[:12])
+	execErr := syscall.Exec(executablePath, os.Args, os.Environ())
+	// If we reach here, exec() failed.
+	log.Printf("daemon: auto-upgrade: exec() failed: %v (continuing with current binary)", execErr)
+}
+
+func gitPull(repoDir string) error {
+	fetch := exec.Command("git", "fetch", "origin", "main")
+	fetch.Dir = repoDir
+	if out, err := fetch.CombinedOutput(); err != nil {
+		return fmt.Errorf("git fetch: %w\n%s", err, out)
+	}
+
+	reset := exec.Command("git", "reset", "--hard", "origin/main")
+	reset.Dir = repoDir
+	if out, err := reset.CombinedOutput(); err != nil {
+		return fmt.Errorf("git reset: %w\n%s", err, out)
+	}
+
+	return nil
+}
+
+func goBuild(cliDir, outPath string) error {
+	cmd := exec.Command("go", "build", "-o", outPath, "./cmd/xylem")
+	cmd.Dir = cliDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("go build: %w\n%s", err, out)
+	}
+	return nil
+}
+
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -110,6 +110,7 @@ type CopilotConfig struct {
 type DaemonConfig struct {
 	ScanInterval  string `yaml:"scan_interval,omitempty"`
 	DrainInterval string `yaml:"drain_interval,omitempty"`
+	AutoUpgrade   bool   `yaml:"auto_upgrade,omitempty"`
 }
 
 type HarnessConfig struct {

--- a/cli/internal/dtu/scenario_daemon_test.go
+++ b/cli/internal/dtu/scenario_daemon_test.go
@@ -3,7 +3,6 @@ package dtu_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	dtu "github.com/nicholls-inc/xylem/cli/internal/dtu"
@@ -15,19 +14,12 @@ import (
 // reconcileStaleVesselsForTest replicates the daemon's stale-vessel
 // reconciliation logic (from cli/cmd/xylem/daemon.go) so the DTU scenario
 // test can exercise recovery without importing the main package.
-func reconcileStaleVesselsForTest(q *queue.Queue, timeout time.Duration) int {
-	if timeout == 0 {
-		timeout = 2 * time.Hour
-	}
-
+// The singleton daemon lock guarantees all running vessels are orphaned,
+// so no timeout heuristic is needed.
+func reconcileStaleVesselsForTest(q *queue.Queue) int {
 	vessels, err := q.List()
 	if err != nil {
 		return 0
-	}
-
-	now, err := dtu.RuntimeNow()
-	if err != nil {
-		now = time.Now().UTC()
 	}
 
 	reconciled := 0
@@ -35,15 +27,8 @@ func reconcileStaleVesselsForTest(q *queue.Queue, timeout time.Duration) int {
 		if v.State != queue.StateRunning {
 			continue
 		}
-		if v.StartedAt == nil {
-			q.Update(v.ID, queue.StateFailed, "orphaned by daemon restart") //nolint:errcheck
-			reconciled++
-			continue
-		}
-		if v.StartedAt.Add(timeout).Before(now) {
-			q.Update(v.ID, queue.StateFailed, "orphaned by daemon restart") //nolint:errcheck
-			reconciled++
-		}
+		q.Update(v.ID, queue.StateTimedOut, "orphaned by daemon restart") //nolint:errcheck
+		reconciled++
 	}
 	return reconciled
 }
@@ -110,24 +95,21 @@ func TestScenarioDaemonRecovery(t *testing.T) {
 		t.Fatal("vessel.StartedAt = nil after Dequeue()")
 	}
 
-	// --- Phase 3: Simulate daemon crash by advancing time past the timeout ---
-	if err := dtu.AdvanceRuntimeClock(time.Hour); err != nil {
-		t.Fatalf("AdvanceRuntimeClock() error = %v", err)
-	}
-
-	// --- Phase 4: Daemon restarts and reconciles stale vessels ---
-	reconciled := reconcileStaleVesselsForTest(env.queue, 45*time.Minute)
+	// --- Phase 3: Daemon restarts and reconciles orphaned vessels ---
+	// No need to advance time — the singleton lock means all running vessels
+	// are orphaned by definition.
+	reconciled := reconcileStaleVesselsForTest(env.queue)
 	if reconciled != 1 {
 		t.Fatalf("reconciled = %d, want 1", reconciled)
 	}
 
-	// Verify the stale vessel transitioned to failed.
+	// Verify the orphaned vessel transitioned to timed_out.
 	updated, err := env.queue.FindByID("issue-4")
 	if err != nil {
 		t.Fatalf("FindByID(issue-4) error = %v", err)
 	}
-	if updated.State != queue.StateFailed {
-		t.Fatalf("updated.State = %q, want %q", updated.State, queue.StateFailed)
+	if updated.State != queue.StateTimedOut {
+		t.Fatalf("updated.State = %q, want %q", updated.State, queue.StateTimedOut)
 	}
 	if updated.Error != "orphaned by daemon restart" {
 		t.Fatalf("updated.Error = %q, want %q", updated.Error, "orphaned by daemon restart")
@@ -186,7 +168,7 @@ func TestScenarioDaemonRecovery(t *testing.T) {
 		t.Fatalf("completed.State = %q, want %q", completed.State, queue.StateCompleted)
 	}
 
-	// Verify the full queue state: stale vessel still failed, new vessel completed.
+	// Verify the full queue state: orphaned vessel timed_out, new vessel completed.
 	vessels, err := env.queue.List()
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
@@ -195,8 +177,8 @@ func TestScenarioDaemonRecovery(t *testing.T) {
 	for _, v := range vessels {
 		states[v.ID] = v.State
 	}
-	if states["issue-4"] != queue.StateFailed {
-		t.Fatalf("queue[issue-4] = %q, want %q", states["issue-4"], queue.StateFailed)
+	if states["issue-4"] != queue.StateTimedOut {
+		t.Fatalf("queue[issue-4] = %q, want %q", states["issue-4"], queue.StateTimedOut)
 	}
 	if states["manual-recovery-1"] != queue.StateCompleted {
 		t.Fatalf("queue[manual-recovery-1] = %q, want %q", states["manual-recovery-1"], queue.StateCompleted)

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -260,9 +260,28 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 		r.persistRunArtifacts(vessel, string(queue.StateFailed), vrs, claims, r.runtimeNow())
 	}()
 
-	// Worktree: reuse if set (resuming from waiting), otherwise create
+	// Worktree: reuse if set (resuming from waiting), otherwise create.
+	// If set but missing on disk (e.g., retry after cleanup), recreate it.
 	worktreePath := vessel.WorktreePath
-	if worktreePath == "" {
+	if worktreePath != "" {
+		if _, statErr := os.Stat(worktreePath); os.IsNotExist(statErr) {
+			log.Printf("vessel %s: worktree %s missing on disk, recreating", vessel.ID, worktreePath)
+			branchName := src.BranchName(vessel)
+			recreated, recreateErr := r.Worktree.Create(ctx, branchName)
+			if recreateErr != nil {
+				r.failVessel(vessel.ID, fmt.Sprintf("recreate missing worktree: %v", recreateErr))
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
+				return "failed"
+			}
+			worktreePath = recreated
+			vessel.WorktreePath = worktreePath
+			if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
+				log.Printf("warn: failed to persist worktree path for %s: %v", vessel.ID, updateErr)
+			}
+		}
+	} else {
 		branchName := src.BranchName(vessel)
 		var err error
 		worktreePath, err = r.Worktree.Create(ctx, branchName)


### PR DESCRIPTION
## Summary
- **Auto-upgrade**: daemon pulls latest main and rebuilds itself on startup when `daemon.auto_upgrade: true`. If binary changed, exec()s the new binary (same PID, lock re-acquired).
- **Orphan recovery**: on startup, ALL running vessels transition to `timed_out` unconditionally. The singleton daemon lock guarantees no concurrent daemon — timeout heuristic removed.
- **Worktree recreation on retry**: runner recreates missing worktrees for retry vessels instead of failing with "chdir: no such file or directory".
- Adds `timed_out` status label mappings to `.xylem.yml`.

## Test plan
- [x] All existing tests updated and passing
- [x] `TestReconcileStaleVessels` — all subtests pass with new timed_out behavior
- [x] `TestScenarioDaemonRecovery` — DTU scenario test passes
- [x] Full `go test ./...` passes
- [x] `goimports`, `go vet`, `golangci-lint` all clean
- [ ] Manual: enable `daemon.auto_upgrade: true`, verify daemon rebuilds on code change
- [ ] Manual: kill daemon mid-vessel, restart, verify orphan recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)