### PR TITLE
Add agent-readable runtime artifacts and budget controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ daemon:
 
 This example covers the most common fields. Additional configuration is available for per-source provider overrides (`llm`, `model`), agent safety guardrails (`harness`), OpenTelemetry tracing (`observability`), and token budget enforcement (`cost`). See the [Configuration Reference](docs/configuration.md) for all fields, defaults, and validation rules.
 
+Each completed, failed, or approval-paused vessel now writes a canonical runtime index at `.xylem/phases/<vessel-id>/runtime.json`. That file links the compact `summary.json` to detailed per-vessel artifacts such as `cost-report.json`, `budget-events.json`, `audit-events.json`, `trace.json`, and `evidence-manifest.json` when present.
+
 ## Workflows
 
 Workflows are multi-phase execution plans defined in YAML. Prompt phases run against the configured LLM provider, and phases can have quality gates that must pass before the next phase begins.

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -140,12 +140,35 @@ type ObservabilityConfig struct {
 }
 
 type CostConfig struct {
-	Budget *BudgetConfig `yaml:"budget,omitempty"`
+	Budget      *BudgetConfig      `yaml:"budget,omitempty"`
+	ModelLadder *ModelLadderConfig `yaml:"model_ladder,omitempty"`
 }
 
 type BudgetConfig struct {
-	MaxCostUSD float64 `yaml:"max_cost_usd,omitempty"`
-	MaxTokens  int     `yaml:"max_tokens,omitempty"`
+	MaxCostUSD    float64 `yaml:"max_cost_usd,omitempty"`
+	MaxTokens     int     `yaml:"max_tokens,omitempty"`
+	OnExceeded    string  `yaml:"on_exceeded,omitempty"`
+	ApprovalLabel string  `yaml:"approval_label,omitempty"`
+}
+
+type ModelLadderConfig struct {
+	Planner   string `yaml:"planner,omitempty"`
+	Generator string `yaml:"generator,omitempty"`
+	Evaluator string `yaml:"evaluator,omitempty"`
+}
+
+type BudgetExceededAction string
+
+const (
+	BudgetExceededFail            BudgetExceededAction = "fail"
+	BudgetExceededWarn            BudgetExceededAction = "warn"
+	BudgetExceededRequireApproval BudgetExceededAction = "require_approval"
+	DefaultBudgetApprovalLabel                         = "budget-approved"
+)
+
+type BudgetPolicy struct {
+	Action        BudgetExceededAction
+	ApprovalLabel string
 }
 
 func Load(path string) (*Config, error) {
@@ -396,6 +419,42 @@ func (c *Config) VesselBudget() *cost.Budget {
 	}
 }
 
+func (c *Config) BudgetPolicy() BudgetPolicy {
+	policy := BudgetPolicy{
+		Action:        BudgetExceededFail,
+		ApprovalLabel: DefaultBudgetApprovalLabel,
+	}
+	if c == nil || c.Cost.Budget == nil {
+		return policy
+	}
+	if action := strings.TrimSpace(c.Cost.Budget.OnExceeded); action != "" {
+		policy.Action = BudgetExceededAction(action)
+	}
+	if label := strings.TrimSpace(c.Cost.Budget.ApprovalLabel); label != "" {
+		policy.ApprovalLabel = label
+	}
+	return policy
+}
+
+func (c *Config) ModelLadder() cost.ModelLadder {
+	ladder := cost.ModelLadder{
+		Roles: make(map[cost.AgentRole]string),
+	}
+	if c == nil || c.Cost.ModelLadder == nil {
+		return ladder
+	}
+	if model := strings.TrimSpace(c.Cost.ModelLadder.Planner); model != "" {
+		ladder.Roles[cost.RolePlanner] = model
+	}
+	if model := strings.TrimSpace(c.Cost.ModelLadder.Generator); model != "" {
+		ladder.Roles[cost.RoleGenerator] = model
+	}
+	if model := strings.TrimSpace(c.Cost.ModelLadder.Evaluator); model != "" {
+		ladder.Roles[cost.RoleEvaluator] = model
+	}
+	return ladder
+}
+
 func (c *Config) BuildIntermediaryPolicies() []intermediary.Policy {
 	if len(c.Harness.Policy.Rules) == 0 {
 		return []intermediary.Policy{DefaultPolicy()}
@@ -468,13 +527,31 @@ func (c *Config) validateObservability() error {
 
 func (c *Config) validateCost() error {
 	if c.Cost.Budget == nil {
-		return nil
+		goto validateLadder
 	}
 	if c.Cost.Budget.MaxCostUSD < 0 {
 		return fmt.Errorf("cost.budget.max_cost_usd must be non-negative")
 	}
 	if c.Cost.Budget.MaxTokens < 0 {
 		return fmt.Errorf("cost.budget.max_tokens must be non-negative")
+	}
+	switch BudgetExceededAction(strings.TrimSpace(c.Cost.Budget.OnExceeded)) {
+	case "", BudgetExceededFail, BudgetExceededWarn, BudgetExceededRequireApproval:
+	default:
+		return fmt.Errorf("cost.budget.on_exceeded must be one of fail, warn, or require_approval")
+	}
+	if c.Cost.Budget.ApprovalLabel != "" && strings.TrimSpace(c.Cost.Budget.ApprovalLabel) == "" {
+		return fmt.Errorf("cost.budget.approval_label must not be blank")
+	}
+
+validateLadder:
+	if c.Cost.ModelLadder == nil {
+		return nil
+	}
+	if strings.TrimSpace(c.Cost.ModelLadder.Planner) == "" &&
+		strings.TrimSpace(c.Cost.ModelLadder.Generator) == "" &&
+		strings.TrimSpace(c.Cost.ModelLadder.Evaluator) == "" {
+		return fmt.Errorf("cost.model_ladder must configure at least one role")
 	}
 	return nil
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1385,6 +1386,32 @@ func TestSmoke_S30_CostBudgetLoadsCorrectly(t *testing.T) {
 	assert.Equal(t, 500000, budget.TokenLimit)
 }
 
+func TestSmoke_S30b_CostBudgetPolicyAndModelLadderLoadCorrectly(t *testing.T) {
+	path := writeSmokeConfigFile(t, `cost:
+  budget:
+    max_cost_usd: 5.0
+    max_tokens: 500000
+    on_exceeded: require_approval
+    approval_label: budget-greenlight
+  model_ladder:
+    planner: claude-opus-4.6
+    generator: claude-sonnet-4.6
+    evaluator: claude-haiku-4.5
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+
+	policy := cfg.BudgetPolicy()
+	assert.Equal(t, BudgetExceededRequireApproval, policy.Action)
+	assert.Equal(t, "budget-greenlight", policy.ApprovalLabel)
+
+	ladder := cfg.ModelLadder()
+	assert.Equal(t, "claude-opus-4.6", ladder.Roles[cost.RolePlanner])
+	assert.Equal(t, "claude-sonnet-4.6", ladder.Roles[cost.RoleGenerator])
+	assert.Equal(t, "claude-haiku-4.5", ladder.Roles[cost.RoleEvaluator])
+}
+
 func TestSmoke_S31_NegativeSampleRateRejected(t *testing.T) {
 	path := writeSmokeConfigFile(t, `observability:
   sample_rate: -0.5
@@ -1404,6 +1431,17 @@ func TestSmoke_S32_NegativeMaxCostRejected(t *testing.T) {
 	_, err := Load(path)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cost.budget.max_cost_usd")
+}
+
+func TestSmoke_S32b_InvalidBudgetActionRejected(t *testing.T) {
+	path := writeSmokeConfigFile(t, `cost:
+  budget:
+    on_exceeded: maybe
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cost.budget.on_exceeded")
 }
 
 func TestSourceTimeoutValid(t *testing.T) {

--- a/cli/internal/intermediary/intermediary.go
+++ b/cli/internal/intermediary/intermediary.go
@@ -82,9 +82,20 @@ func NewAuditLog(path string) *AuditLog {
 	}
 }
 
+func (a *AuditLog) Path() string {
+	if a == nil {
+		return ""
+	}
+	return a.path
+}
+
 // Append writes a single audit entry to the log file under an exclusive lock.
 // INV: Every Append call adds exactly one JSONL line.
 func (a *AuditLog) Append(entry AuditEntry) error {
+	if err := os.MkdirAll(filepath.Dir(a.path), 0o755); err != nil {
+		return fmt.Errorf("create audit log dir: %w", err)
+	}
+
 	lock := flock.New(a.lockPath)
 	if err := lock.Lock(); err != nil {
 		return fmt.Errorf("acquire audit log lock: %w", err)

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -257,7 +257,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 		if outcome != "failed" {
 			return
 		}
-		r.persistRunArtifacts(vessel, string(queue.StateFailed), vrs, claims, r.runtimeNow())
+		r.persistRunArtifacts(ctx, vessel, string(queue.StateFailed), vrs, claims, r.runtimeNow())
 	}()
 
 	// Worktree: reuse if set (resuming from waiting), otherwise create
@@ -564,7 +564,8 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 			recordedAt := r.runtimeNow()
 			inputTokensEst, outputTokensEst, costUSDEst := vrs.recordPhaseTokens(p, model, promptForCost, string(output), recordedAt)
-			if vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() {
+			budgetExceeded := vrs.costTracker != nil && vrs.costTracker.BudgetExceeded()
+			if budgetExceeded && r.budgetPolicy().Action == config.BudgetExceededFail {
 				errMsg := fmt.Sprintf("budget exceeded after phase %q: estimated cost $%.4f, estimated tokens %d",
 					p.Name, vrs.costTracker.TotalCost(), vrs.costTracker.TotalTokens())
 				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg))
@@ -609,6 +610,24 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			if issueNum > 0 && r.Reporter != nil {
 				r.logReporterError("post phase-complete comment", vessel.ID,
 					r.Reporter.PhaseComplete(ctx, issueNum, p.Name, phaseDuration, string(output)))
+			}
+
+			if budgetExceeded && r.budgetPolicy().Action == config.BudgetExceededRequireApproval {
+				errMsg := fmt.Sprintf("budget exceeded after phase %q: estimated cost $%.4f, estimated tokens %d; waiting for approval label %q",
+					p.Name, vrs.costTracker.TotalCost(), vrs.costTracker.TotalTokens(), r.budgetPolicy().ApprovalLabel)
+				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, ""))
+				if err := r.moveVesselToBudgetApproval(&vessel, p.Name); err != nil {
+					finishCurrentPhaseSpan(err)
+					r.failVessel(vessel.ID, err.Error())
+					if failErr := src.OnFail(ctx, vessel); failErr != nil {
+						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, failErr)
+					}
+					return "failed"
+				}
+				log.Printf("%s%s", vesselLabel(vessel), errMsg)
+				r.persistRunArtifacts(ctx, vessel, string(queue.StateWaiting), vrs, claims, r.runtimeNow())
+				finishCurrentPhaseSpan(nil)
+				return "waiting"
 			}
 
 			if phaseStatus == "no-op" {
@@ -793,7 +812,7 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 	recordedAt := r.runtimeNow()
 	if vrs != nil {
 		vrs.recordPromptOnlyUsage(model, prompt, string(output), recordedAt)
-		if vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() {
+		if vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() && r.budgetPolicy().Action == config.BudgetExceededFail {
 			errMsg := fmt.Sprintf("budget exceeded: estimated cost $%.4f, estimated tokens %d",
 				vrs.costTracker.TotalCost(), vrs.costTracker.TotalTokens())
 			r.failVessel(vessel.ID, errMsg)
@@ -801,6 +820,17 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
 			}
 			return "failed"
+		}
+		if vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() && r.budgetPolicy().Action == config.BudgetExceededRequireApproval {
+			if err := r.moveVesselToBudgetApproval(&vessel, "prompt-only"); err != nil {
+				r.failVessel(vessel.ID, err.Error())
+				if failErr := src.OnFail(ctx, vessel); failErr != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, failErr)
+				}
+				return "failed"
+			}
+			r.persistRunArtifacts(ctx, vessel, string(queue.StateWaiting), vrs, nil, r.runtimeNow())
+			return "waiting"
 		}
 	}
 
@@ -853,12 +883,40 @@ func (r *Runner) failVessel(id string, errMsg string) {
 	}
 }
 
+func (r *Runner) budgetPolicy() config.BudgetPolicy {
+	if r.Config == nil {
+		return config.BudgetPolicy{
+			Action:        config.BudgetExceededFail,
+			ApprovalLabel: config.DefaultBudgetApprovalLabel,
+		}
+	}
+	return r.Config.BudgetPolicy()
+}
+
+func (r *Runner) moveVesselToBudgetApproval(vessel *queue.Vessel, phaseName string) error {
+	if vessel == nil {
+		return fmt.Errorf("persist budget approval wait: vessel must not be nil")
+	}
+	if r.parseIssueNum(*vessel) == 0 || r.resolveRepo(*vessel) == "" {
+		return fmt.Errorf("persist budget approval wait: budget approval requires a GitHub-backed issue or PR vessel")
+	}
+	now := r.runtimeNow()
+	vessel.State = queue.StateWaiting
+	vessel.WaitingSince = &now
+	vessel.WaitingFor = r.budgetPolicy().ApprovalLabel
+	vessel.FailedPhase = phaseName
+	if err := r.Queue.UpdateVessel(*vessel); err != nil {
+		return fmt.Errorf("persist budget approval wait: %w", err)
+	}
+	return nil
+}
+
 func (r *Runner) completeVessel(ctx context.Context, vessel queue.Vessel, worktreePath string, phaseResults []reporter.PhaseResult, vrs *vesselRunState, claims []evidence.Claim) string {
 	if updateErr := r.Queue.Update(vessel.ID, queue.StateCompleted, ""); updateErr != nil {
 		log.Printf("warn: failed to update vessel %s state: %v", vessel.ID, updateErr)
 	}
 
-	manifest := r.persistRunArtifacts(vessel, string(queue.StateCompleted), vrs, claims, r.runtimeNow())
+	manifest := r.persistRunArtifacts(ctx, vessel, string(queue.StateCompleted), vrs, claims, r.runtimeNow())
 
 	// Clean up worktree (best-effort)
 	r.removeWorktree(worktreePath, vessel.ID)
@@ -873,7 +931,7 @@ func (r *Runner) completeVessel(ctx context.Context, vessel queue.Vessel, worktr
 	return "completed"
 }
 
-func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *vesselRunState, claims []evidence.Claim, now time.Time) *evidence.Manifest {
+func (r *Runner) persistRunArtifacts(ctx context.Context, vessel queue.Vessel, state string, vrs *vesselRunState, claims []evidence.Claim, now time.Time) *evidence.Manifest {
 	if vrs == nil {
 		vrs = newVesselRunState(r.Config, vessel, now)
 	}
@@ -893,6 +951,8 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 			summary.EvidenceManifestPath = evidenceManifestRelativePath(vessel.ID)
 		}
 	}
+
+	persistRuntimeArtifacts(ctx, r.Config, r.AuditLog, summary, manifest, vrs, now)
 
 	if err := SaveVesselSummary(r.Config.StateDir, summary); err != nil {
 		log.Printf("warn: save vessel summary: %v", err)
@@ -1031,6 +1091,11 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 			return "failed"
 		}
 		if waveWaiting {
+			var currentClaims []evidence.Claim
+			if claims != nil {
+				currentClaims = append(currentClaims, (*claims)...)
+			}
+			r.persistRunArtifacts(ctx, vessel, string(queue.StateWaiting), vrs, currentClaims, r.runtimeNow())
 			return "waiting"
 		}
 		if waveNoOp {
@@ -1045,7 +1110,7 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 			return r.completeVessel(ctx, vessel, worktreePath, allPhaseResults, vrs, completedClaims)
 		}
 
-		if waveIdx < len(graph.waves)-1 && vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() {
+		if waveIdx < len(graph.waves)-1 && vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() && r.budgetPolicy().Action == config.BudgetExceededFail {
 			errMsg := fmt.Sprintf("budget exceeded after concurrent wave: estimated cost $%.4f, estimated tokens %d",
 				vrs.costTracker.TotalCost(), vrs.costTracker.TotalTokens())
 			r.failVessel(vessel.ID, errMsg)
@@ -1058,6 +1123,21 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 					r.Reporter.VesselFailed(ctx, issueNum, "", errMsg, ""))
 			}
 			return "failed"
+		}
+		if waveIdx < len(graph.waves)-1 && vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() && r.budgetPolicy().Action == config.BudgetExceededRequireApproval {
+			if err := r.moveVesselToBudgetApproval(&vessel, "concurrent-wave"); err != nil {
+				r.failVessel(vessel.ID, err.Error())
+				if failErr := src.OnFail(ctx, vessel); failErr != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, failErr)
+				}
+				return "failed"
+			}
+			var currentClaims []evidence.Claim
+			if claims != nil {
+				currentClaims = append(currentClaims, (*claims)...)
+			}
+			r.persistRunArtifacts(ctx, vessel, string(queue.StateWaiting), vrs, currentClaims, r.runtimeNow())
+			return "waiting"
 		}
 	}
 
@@ -1321,7 +1401,8 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 
 		recordedAt := r.runtimeNow()
 		inputTokensEst, outputTokensEst, costUSDEst := vrs.recordPhaseTokens(p, model, promptForCost, string(output), recordedAt)
-		if enforceBudget && vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() {
+		budgetExceeded := enforceBudget && vrs.costTracker != nil && vrs.costTracker.BudgetExceeded()
+		if budgetExceeded && r.budgetPolicy().Action == config.BudgetExceededFail {
 			errMsg := fmt.Sprintf("budget exceeded after phase %q: estimated cost $%.4f, estimated tokens %d",
 				p.Name, vrs.costTracker.TotalCost(), vrs.costTracker.TotalTokens())
 			vessel.FailedPhase = p.Name
@@ -1339,6 +1420,28 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				status:       "failed",
 				duration:     phaseDuration,
 				phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg),
+			}
+		}
+		if budgetExceeded && r.budgetPolicy().Action == config.BudgetExceededRequireApproval {
+			if err := r.moveVesselToBudgetApproval(&vessel, p.Name); err != nil {
+				finishCurrentPhaseSpan(err)
+				r.failVessel(vessel.ID, err.Error())
+				if failErr := src.OnFail(ctx, vessel); failErr != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, failErr)
+				}
+				return singlePhaseResult{
+					status:       "failed",
+					duration:     phaseDuration,
+					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, err.Error()),
+				}
+			}
+			finishCurrentPhaseSpan(nil)
+			return singlePhaseResult{
+				output:        string(output),
+				status:        "waiting",
+				duration:      phaseDuration,
+				phaseSummary:  vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, ""),
+				evidenceClaim: nil,
 			}
 		}
 
@@ -2265,7 +2368,7 @@ func resolveProvider(cfg *config.Config, srcCfg *config.SourceConfig, wf *workfl
 }
 
 // resolveModel determines the model string for a phase invocation.
-// Resolution order: Phase.Model > Workflow.Model > Source.Model > provider's DefaultModel.
+// Resolution order: Phase.Model > Workflow.Model > Source.Model > configured model ladder > provider's DefaultModel.
 // The provider's DefaultModel ensures the fallback is always compatible with the
 // resolved provider, avoiding cross-provider model leaks (e.g. gpt-* sent to claude).
 func resolveModel(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, provider string) string {
@@ -2281,11 +2384,36 @@ func resolveModel(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.
 	if cfg == nil {
 		return ""
 	}
+	if ladderModel := cfg.ModelLadder().Roles[phaseCostRole(p)]; ladderModel != "" {
+		return ladderModel
+	}
 	switch provider {
 	case "copilot":
 		return cfg.Copilot.DefaultModel
 	default:
 		return cfg.Claude.DefaultModel
+	}
+}
+
+func phaseCostRole(p *workflow.Phase) cost.AgentRole {
+	if p == nil {
+		return cost.RoleGenerator
+	}
+	name := strings.ToLower(p.Name)
+	switch {
+	case strings.Contains(name, "plan"),
+		strings.Contains(name, "analy"),
+		strings.Contains(name, "triage"),
+		strings.Contains(name, "design"):
+		return cost.RolePlanner
+	case strings.Contains(name, "verify"),
+		strings.Contains(name, "test"),
+		strings.Contains(name, "review"),
+		strings.Contains(name, "check"),
+		strings.Contains(name, "qa"):
+		return cost.RoleEvaluator
+	default:
+		return cost.RoleGenerator
 	}
 }
 

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -328,6 +328,14 @@ func setBudget(cfg *config.Config, maxCostUSD float64, maxTokens int) {
 	}
 }
 
+func setBudgetAction(cfg *config.Config, action, approvalLabel string) {
+	if cfg.Cost.Budget == nil {
+		cfg.Cost.Budget = &config.BudgetConfig{}
+	}
+	cfg.Cost.Budget.OnExceeded = action
+	cfg.Cost.Budget.ApprovalLabel = approvalLabel
+}
+
 func setPricedModel(cfg *config.Config) {
 	cfg.Claude.DefaultModel = "claude-sonnet-4"
 }
@@ -1699,6 +1707,133 @@ func TestSmoke_S29_NilBudgetMeansNoEnforcement(t *testing.T) {
 	assert.False(t, summary.BudgetExceeded)
 }
 
+func TestSmoke_S29b_BudgetWarnAllowsCompletionWhileRecordingExceededBudget(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	setPricedModel(cfg)
+	setBudget(cfg, 0.0001, 0)
+	setBudgetAction(cfg, string(config.BudgetExceededWarn), "")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "budget-warn"))
+
+	writeWorkflowFile(t, dir, "budget-warn", []testPhase{
+		{name: "implement", promptContent: "Budget warn path", maxTurns: 5},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Budget warn path": []byte(strings.Repeat("w", 4000)),
+		},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
+
+	vessels, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, queue.StateCompleted, vessels[0].State)
+
+	summary := loadSummary(t, cfg.StateDir, "issue-1")
+	assert.Equal(t, "completed", summary.State)
+	assert.True(t, summary.BudgetExceeded)
+	assert.Equal(t, string(config.BudgetExceededWarn), summary.BudgetAction)
+}
+
+func TestSmoke_S29c_BudgetRequireApprovalMovesVesselToWaiting(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	setPricedModel(cfg)
+	setBudget(cfg, 0.0001, 0)
+	setBudgetAction(cfg, string(config.BudgetExceededRequireApproval), "budget-greenlight")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "budget-approval"))
+
+	writeWorkflowFile(t, dir, "budget-approval", []testPhase{
+		{name: "implement", promptContent: "Budget approval path", maxTurns: 5},
+		{name: "verify", promptContent: "Should not run until approved", maxTurns: 5},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Budget approval path": []byte(strings.Repeat("a", 4000)),
+		},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Waiting)
+
+	vessels, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, queue.StateWaiting, vessels[0].State)
+	assert.Equal(t, "budget-greenlight", vessels[0].WaitingFor)
+	assert.Equal(t, 1, vessels[0].CurrentPhase)
+
+	summary := loadSummary(t, cfg.StateDir, "issue-1")
+	assert.Equal(t, "waiting", summary.State)
+	assert.True(t, summary.BudgetExceeded)
+	assert.Equal(t, string(config.BudgetExceededRequireApproval), summary.BudgetAction)
+	assert.Equal(t, runtimeArtifactRelativePath("issue-1"), summary.RuntimePath)
+}
+
+func TestSmoke_S29d_BudgetRequireApprovalFailsForManualPromptOnlyVessel(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	setPricedModel(cfg)
+	setBudget(cfg, 0.0001, 0)
+	setBudgetAction(cfg, string(config.BudgetExceededRequireApproval), "budget-greenlight")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makePromptVessel(1, "Manual budget approval path"))
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Manual budget approval path": []byte(strings.Repeat("m", 4000)),
+		},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+	assert.Zero(t, result.Waiting)
+
+	vessels, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, queue.StateFailed, vessels[0].State)
+	assert.Contains(t, vessels[0].Error, "budget approval requires a GitHub-backed issue or PR vessel")
+
+	summary := loadSummary(t, cfg.StateDir, "prompt-1")
+	assert.Equal(t, "failed", summary.State)
+	assert.True(t, summary.BudgetExceeded)
+	assert.Equal(t, string(config.BudgetExceededRequireApproval), summary.BudgetAction)
+}
+
 func TestSmoke_WS6_S5_BudgetExceededShortCircuitsBeforeGate(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)
@@ -3007,6 +3142,38 @@ func TestResolveModel(t *testing.T) {
 			got := resolveModel(cfg, nil, wf, p, tt.provider)
 			if got != tt.want {
 				t.Errorf("resolveModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveModelFallsBackToConfiguredModelLadder(t *testing.T) {
+	cfg := &config.Config{
+		Claude: config.ClaudeConfig{DefaultModel: "claude-default"},
+		Cost: config.CostConfig{
+			ModelLadder: &config.ModelLadderConfig{
+				Planner:   "planner-model",
+				Generator: "generator-model",
+				Evaluator: "evaluator-model",
+			},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		phase *workflow.Phase
+		want  string
+	}{
+		{name: "planner phase", phase: &workflow.Phase{Name: "analyze"}, want: "planner-model"},
+		{name: "generator phase", phase: &workflow.Phase{Name: "implement"}, want: "generator-model"},
+		{name: "evaluator phase", phase: &workflow.Phase{Name: "verify"}, want: "evaluator-model"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveModel(cfg, nil, &workflow.Workflow{}, tt.phase, "claude")
+			if got != tt.want {
+				t.Fatalf("resolveModel() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/cli/internal/runner/runtime_artifacts.go
+++ b/cli/internal/runner/runtime_artifacts.go
@@ -1,0 +1,273 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
+	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+const runtimeArtifactSchemaVersion = "xylem.runtime.v1"
+
+type RuntimeArtifacts struct {
+	SchemaVersion string                `json:"schema_version"`
+	VesselID      string                `json:"vessel_id"`
+	Source        string                `json:"source"`
+	Workflow      string                `json:"workflow,omitempty"`
+	State         string                `json:"state"`
+	GeneratedAt   time.Time             `json:"generated_at"`
+	SummaryPath   string                `json:"summary_path"`
+	Artifacts     RuntimeArtifactPaths  `json:"artifacts"`
+	Trace         TraceArtifact         `json:"trace"`
+	Budget        BudgetEventsArtifact  `json:"budget"`
+	Audit         AuditEventsArtifact   `json:"audit"`
+	Evidence      RuntimeEvidenceStatus `json:"evidence"`
+	Phases        []PhaseArtifact       `json:"phases"`
+}
+
+type RuntimeArtifactPaths struct {
+	CostReport       string `json:"cost_report"`
+	BudgetEvents     string `json:"budget_events"`
+	AuditEvents      string `json:"audit_events"`
+	Trace            string `json:"trace"`
+	EvidenceManifest string `json:"evidence_manifest,omitempty"`
+}
+
+type RuntimeEvidenceStatus struct {
+	ManifestPath   string `json:"manifest_path,omitempty"`
+	ClaimCount     int    `json:"claim_count"`
+	StrongestLevel string `json:"strongest_level,omitempty"`
+}
+
+type PhaseArtifact struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Status      string `json:"status"`
+	PromptPath  string `json:"prompt_path,omitempty"`
+	CommandPath string `json:"command_path,omitempty"`
+	OutputPath  string `json:"output_path,omitempty"`
+}
+
+type BudgetEventsArtifact struct {
+	VesselID       string             `json:"vessel_id"`
+	GeneratedAt    time.Time          `json:"generated_at"`
+	Action         string             `json:"action"`
+	ApprovalLabel  string             `json:"approval_label,omitempty"`
+	BudgetExceeded bool               `json:"budget_exceeded"`
+	MaxCostUSD     *float64           `json:"max_cost_usd,omitempty"`
+	MaxTokens      *int               `json:"max_tokens,omitempty"`
+	Alerts         []cost.BudgetAlert `json:"alerts"`
+}
+
+type AuditEventsArtifact struct {
+	VesselID    string                    `json:"vessel_id"`
+	GeneratedAt time.Time                 `json:"generated_at"`
+	SourcePath  string                    `json:"source_path,omitempty"`
+	EntryCount  int                       `json:"entry_count"`
+	Entries     []intermediary.AuditEntry `json:"entries"`
+}
+
+type TraceArtifact struct {
+	VesselID          string    `json:"vessel_id"`
+	GeneratedAt       time.Time `json:"generated_at"`
+	Enabled           bool      `json:"enabled"`
+	CollectorEndpoint string    `json:"collector_endpoint,omitempty"`
+	TraceID           string    `json:"trace_id,omitempty"`
+	SpanID            string    `json:"span_id,omitempty"`
+	Traceparent       string    `json:"traceparent,omitempty"`
+}
+
+func persistRuntimeArtifacts(ctx context.Context, cfg *config.Config, auditLog *intermediary.AuditLog, summary *VesselSummary, manifest *evidence.Manifest, vrs *vesselRunState, now time.Time) {
+	if cfg == nil || summary == nil || vrs == nil {
+		return
+	}
+
+	costReport := vrs.costTracker.Report(vrs.vesselID)
+	costReportPath := filepath.Join(cfg.StateDir, "phases", vrs.vesselID, costReportFileName)
+	if err := os.MkdirAll(filepath.Dir(costReportPath), 0o755); err != nil {
+		log.Printf("warn: create cost report dir: %v", err)
+	} else if err := cost.SaveReport(costReportPath, costReport); err != nil {
+		log.Printf("warn: save cost report: %v", err)
+	}
+	summary.CostReportPath = costReportRelativePath(vrs.vesselID)
+
+	budgetArtifact := buildBudgetEventsArtifact(summary, vrs, now)
+	budgetPath := filepath.Join(cfg.StateDir, "phases", vrs.vesselID, budgetEventsFileName)
+	if err := saveRuntimeArtifact(budgetPath, budgetArtifact); err != nil {
+		log.Printf("warn: save budget events: %v", err)
+	} else {
+		summary.BudgetEventsPath = budgetEventsRelativePath(vrs.vesselID)
+	}
+
+	auditArtifact, err := buildAuditEventsArtifact(auditLog, vrs.vesselID, now)
+	if err != nil {
+		log.Printf("warn: build audit events: %v", err)
+	} else {
+		auditPath := filepath.Join(cfg.StateDir, "phases", vrs.vesselID, auditEventsFileName)
+		if err := saveRuntimeArtifact(auditPath, auditArtifact); err != nil {
+			log.Printf("warn: save audit events: %v", err)
+		} else {
+			summary.AuditEventsPath = auditEventsRelativePath(vrs.vesselID)
+		}
+	}
+
+	traceArtifact := buildTraceArtifact(ctx, cfg, vrs.vesselID, now)
+	tracePath := filepath.Join(cfg.StateDir, "phases", vrs.vesselID, traceFileName)
+	if err := saveRuntimeArtifact(tracePath, traceArtifact); err != nil {
+		log.Printf("warn: save trace artifact: %v", err)
+	} else {
+		summary.TracePath = traceArtifactRelativePath(vrs.vesselID)
+	}
+
+	runtimeArtifact := RuntimeArtifacts{
+		SchemaVersion: runtimeArtifactSchemaVersion,
+		VesselID:      summary.VesselID,
+		Source:        summary.Source,
+		Workflow:      summary.Workflow,
+		State:         summary.State,
+		GeneratedAt:   now.UTC(),
+		SummaryPath:   filepath.ToSlash(filepath.Join("phases", vrs.vesselID, summaryFileName)),
+		Artifacts: RuntimeArtifactPaths{
+			CostReport:       summary.CostReportPath,
+			BudgetEvents:     summary.BudgetEventsPath,
+			AuditEvents:      summary.AuditEventsPath,
+			Trace:            summary.TracePath,
+			EvidenceManifest: summary.EvidenceManifestPath,
+		},
+		Trace:  traceArtifact,
+		Budget: budgetArtifact,
+		Evidence: RuntimeEvidenceStatus{
+			ManifestPath: summary.EvidenceManifestPath,
+		},
+		Phases: buildPhaseArtifacts(vrs.vesselID, summary.Phases),
+	}
+	if manifest != nil {
+		runtimeArtifact.Evidence.ClaimCount = len(manifest.Claims)
+		runtimeArtifact.Evidence.StrongestLevel = manifest.StrongestLevel().String()
+	}
+	if auditArtifact.VesselID != "" || auditArtifact.EntryCount > 0 {
+		runtimeArtifact.Audit = auditArtifact
+	}
+	runtimePath := filepath.Join(cfg.StateDir, "phases", vrs.vesselID, runtimeFileName)
+	if err := saveRuntimeArtifact(runtimePath, runtimeArtifact); err != nil {
+		log.Printf("warn: save runtime artifact index: %v", err)
+	} else {
+		summary.RuntimePath = runtimeArtifactRelativePath(vrs.vesselID)
+	}
+}
+
+func saveRuntimeArtifact(path string, value any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create artifact dir: %w", err)
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal artifact: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write artifact: %w", err)
+	}
+	return nil
+}
+
+func buildPhaseArtifacts(vesselID string, phases []PhaseSummary) []PhaseArtifact {
+	artifacts := make([]PhaseArtifact, 0, len(phases))
+	for _, phase := range phases {
+		artifact := PhaseArtifact{
+			Name:       phase.Name,
+			Type:       phase.Type,
+			Status:     phase.Status,
+			OutputPath: phaseArtifactRelativePath(vesselID, phase.Name),
+		}
+		switch phase.Type {
+		case "command":
+			artifact.CommandPath = filepath.ToSlash(filepath.Join("phases", vesselID, phase.Name+".command"))
+		default:
+			artifact.PromptPath = filepath.ToSlash(filepath.Join("phases", vesselID, phase.Name+".prompt"))
+		}
+		artifacts = append(artifacts, artifact)
+	}
+	return artifacts
+}
+
+func buildBudgetEventsArtifact(summary *VesselSummary, vrs *vesselRunState, now time.Time) BudgetEventsArtifact {
+	artifact := BudgetEventsArtifact{
+		VesselID:       summary.VesselID,
+		GeneratedAt:    now.UTC(),
+		BudgetExceeded: summary.BudgetExceeded,
+		Alerts:         []cost.BudgetAlert{},
+	}
+	if summary.BudgetMaxCostUSD != nil || summary.BudgetMaxTokens != nil {
+		artifact.Action = string(vrs.budgetPolicy.Action)
+	}
+	if artifact.Action != "" && vrs.budgetPolicy.Action == config.BudgetExceededRequireApproval {
+		artifact.ApprovalLabel = vrs.budgetPolicy.ApprovalLabel
+	}
+	if summary.BudgetMaxCostUSD != nil {
+		v := *summary.BudgetMaxCostUSD
+		artifact.MaxCostUSD = &v
+	}
+	if summary.BudgetMaxTokens != nil {
+		v := *summary.BudgetMaxTokens
+		artifact.MaxTokens = &v
+	}
+	if vrs.costTracker != nil {
+		artifact.Alerts = vrs.costTracker.Alerts()
+	}
+	return artifact
+}
+
+func buildAuditEventsArtifact(auditLog *intermediary.AuditLog, vesselID string, now time.Time) (AuditEventsArtifact, error) {
+	artifact := AuditEventsArtifact{
+		VesselID:    vesselID,
+		GeneratedAt: now.UTC(),
+		Entries:     []intermediary.AuditEntry{},
+	}
+	if auditLog == nil {
+		return artifact, nil
+	}
+
+	entries, err := auditLog.Entries()
+	if err != nil {
+		return artifact, fmt.Errorf("read audit log: %w", err)
+	}
+
+	filtered := make([]intermediary.AuditEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Intent.AgentID == vesselID {
+			filtered = append(filtered, entry)
+		}
+	}
+	artifact.SourcePath = filepath.ToSlash(auditLog.Path())
+	artifact.EntryCount = len(filtered)
+	artifact.Entries = filtered
+	return artifact, nil
+}
+
+func buildTraceArtifact(ctx context.Context, cfg *config.Config, vesselID string, now time.Time) TraceArtifact {
+	artifact := TraceArtifact{
+		VesselID:    vesselID,
+		GeneratedAt: now.UTC(),
+	}
+	if cfg != nil {
+		artifact.CollectorEndpoint = cfg.Observability.Endpoint
+	}
+	spanCtx := oteltrace.SpanContextFromContext(ctx)
+	if !spanCtx.IsValid() {
+		return artifact
+	}
+	artifact.Enabled = true
+	artifact.TraceID = spanCtx.TraceID().String()
+	artifact.SpanID = spanCtx.SpanID().String()
+	artifact.Traceparent = fmt.Sprintf("00-%s-%s-%02x", artifact.TraceID, artifact.SpanID, spanCtx.TraceFlags())
+	return artifact
+}

--- a/cli/internal/runner/summary.go
+++ b/cli/internal/runner/summary.go
@@ -16,8 +16,13 @@ import (
 )
 
 const (
-	summaryFileName   = "summary.json"
-	summaryDisclaimer = "Token counts and costs are estimates (len/4 heuristic + static pricing). Not provider-reported values."
+	summaryFileName      = "summary.json"
+	runtimeFileName      = "runtime.json"
+	costReportFileName   = "cost-report.json"
+	budgetEventsFileName = "budget-events.json"
+	auditEventsFileName  = "audit-events.json"
+	traceFileName        = "trace.json"
+	summaryDisclaimer    = "Token counts and costs are estimates (len/4 heuristic + static pricing). Not provider-reported values."
 )
 
 var safeSummaryPathComponent = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
@@ -43,8 +48,14 @@ type VesselSummary struct {
 	BudgetMaxCostUSD *float64 `json:"budget_max_cost_usd,omitempty"`
 	BudgetMaxTokens  *int     `json:"budget_max_tokens,omitempty"`
 	BudgetExceeded   bool     `json:"budget_exceeded"`
+	BudgetAction     string   `json:"budget_action,omitempty"`
 
 	EvidenceManifestPath string `json:"evidence_manifest_path,omitempty"`
+	RuntimePath          string `json:"runtime_path,omitempty"`
+	CostReportPath       string `json:"cost_report_path,omitempty"`
+	BudgetEventsPath     string `json:"budget_events_path,omitempty"`
+	AuditEventsPath      string `json:"audit_events_path,omitempty"`
+	TracePath            string `json:"trace_path,omitempty"`
 
 	Note string `json:"note"`
 }
@@ -69,11 +80,12 @@ type vesselRunState struct {
 	startedAt time.Time
 	phases    []PhaseSummary
 
-	costTracker *cost.Tracker
-	vesselID    string
-	source      string
-	workflow    string
-	ref         string
+	costTracker  *cost.Tracker
+	vesselID     string
+	source       string
+	workflow     string
+	ref          string
+	budgetPolicy config.BudgetPolicy
 
 	budgetMaxCostUSD *float64
 	budgetMaxTokens  *int
@@ -85,20 +97,24 @@ type vesselRunState struct {
 
 func newVesselRunState(cfg *config.Config, vessel queue.Vessel, startedAt time.Time) *vesselRunState {
 	s := &vesselRunState{
-		startedAt: startedAt.UTC(),
-		phases:    make([]PhaseSummary, 0),
-		vesselID:  vessel.ID,
-		source:    vessel.Source,
-		workflow:  vessel.Workflow,
-		ref:       vessel.Ref,
+		startedAt:    startedAt.UTC(),
+		phases:       make([]PhaseSummary, 0),
+		vesselID:     vessel.ID,
+		source:       vessel.Source,
+		workflow:     vessel.Workflow,
+		ref:          vessel.Ref,
+		budgetPolicy: config.BudgetPolicy{Action: config.BudgetExceededFail, ApprovalLabel: config.DefaultBudgetApprovalLabel},
 	}
 
 	if cfg == nil {
+		s.costTracker = cost.NewTracker(nil)
 		return s
 	}
 
-	if budget := cfg.VesselBudget(); budget != nil {
-		s.costTracker = cost.NewTracker(budget)
+	s.budgetPolicy = cfg.BudgetPolicy()
+	budget := cfg.VesselBudget()
+	s.costTracker = cost.NewTracker(budget)
+	if budget != nil {
 		if budget.CostLimitUSD > 0 {
 			v := budget.CostLimitUSD
 			s.budgetMaxCostUSD = &v
@@ -139,6 +155,9 @@ func (s *vesselRunState) buildSummary(state string, endedAt time.Time) *VesselSu
 		BudgetMaxCostUSD: s.budgetMaxCostUSD,
 		BudgetMaxTokens:  s.budgetMaxTokens,
 		Note:             summaryDisclaimer,
+	}
+	if s.budgetMaxCostUSD != nil || s.budgetMaxTokens != nil {
+		summary.BudgetAction = string(s.budgetPolicy.Action)
 	}
 
 	for _, p := range s.phases {
@@ -243,6 +262,26 @@ func gatePassedPointer(passed bool) *bool {
 
 func evidenceManifestRelativePath(vesselID string) string {
 	return filepath.ToSlash(filepath.Join("phases", vesselID, "evidence-manifest.json"))
+}
+
+func runtimeArtifactRelativePath(vesselID string) string {
+	return filepath.ToSlash(filepath.Join("phases", vesselID, runtimeFileName))
+}
+
+func costReportRelativePath(vesselID string) string {
+	return filepath.ToSlash(filepath.Join("phases", vesselID, costReportFileName))
+}
+
+func budgetEventsRelativePath(vesselID string) string {
+	return filepath.ToSlash(filepath.Join("phases", vesselID, budgetEventsFileName))
+}
+
+func auditEventsRelativePath(vesselID string) string {
+	return filepath.ToSlash(filepath.Join("phases", vesselID, auditEventsFileName))
+}
+
+func traceArtifactRelativePath(vesselID string) string {
+	return filepath.ToSlash(filepath.Join("phases", vesselID, traceFileName))
 }
 
 func phaseArtifactRelativePath(vesselID, phaseName string) string {

--- a/cli/internal/runner/summary_test.go
+++ b/cli/internal/runner/summary_test.go
@@ -15,12 +15,14 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 var standardLoggerMu sync.Mutex
@@ -434,6 +436,74 @@ func TestSmoke_S18_EvidenceManifestPathIsEmptyInSummaryWhenNoClaimsProvided(t *t
 	raw := loadSummaryJSON(t, cfg.StateDir, vessel.ID)
 	_, ok := raw["evidence_manifest_path"]
 	assert.False(t, ok)
+}
+
+func TestSmoke_S18b_RuntimeArtifactsAreWrittenAndLinkedFromSummary(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem-state")
+	setPricedModel(cfg)
+
+	startedAt := time.Date(2026, time.April, 8, 20, 32, 30, 0, time.UTC)
+	vessel := runningSmokeVessel("vessel-runtime-artifacts", "github", "fix-bug", startedAt)
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	r.AuditLog = intermediary.NewAuditLog(filepath.Join(cfg.StateDir, cfg.EffectiveAuditLogPath()))
+	require.NoError(t, r.AuditLog.Append(intermediary.AuditEntry{
+		Intent: intermediary.Intent{
+			Action:   "phase_execute",
+			Resource: "implement",
+			AgentID:  vessel.ID,
+		},
+		Decision:  intermediary.Allow,
+		Timestamp: startedAt.Add(time.Second),
+	}))
+
+	vrs := newVesselRunState(cfg, vessel, startedAt)
+	vrs.addPhase(PhaseSummary{Name: "implement", Type: "prompt", Status: "completed"})
+	claims := []evidence.Claim{{
+		Claim:     "Implementation verified",
+		Level:     evidence.BehaviorallyChecked,
+		Checker:   "go test ./...",
+		Phase:     "implement",
+		Passed:    true,
+		Timestamp: startedAt.Add(2 * time.Second),
+	}}
+
+	spanCtx := oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    oteltrace.TraceID{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+		SpanID:     oteltrace.SpanID{2, 2, 2, 2, 2, 2, 2, 2},
+		TraceFlags: oteltrace.FlagsSampled,
+		Remote:     false,
+	})
+	ctx := oteltrace.ContextWithSpanContext(context.Background(), spanCtx)
+
+	outcome := r.completeVessel(ctx, vessel, "", nil, vrs, claims)
+	assert.Equal(t, "completed", outcome)
+
+	summary := loadSummary(t, cfg.StateDir, vessel.ID)
+	assert.Equal(t, runtimeArtifactRelativePath(vessel.ID), summary.RuntimePath)
+	assert.Equal(t, costReportRelativePath(vessel.ID), summary.CostReportPath)
+	assert.Equal(t, budgetEventsRelativePath(vessel.ID), summary.BudgetEventsPath)
+	assert.Equal(t, auditEventsRelativePath(vessel.ID), summary.AuditEventsPath)
+	assert.Equal(t, traceArtifactRelativePath(vessel.ID), summary.TracePath)
+
+	runtimeJSON := loadRuntimeJSON(t, cfg.StateDir, vessel.ID)
+	assert.Equal(t, runtimeArtifactSchemaVersion, runtimeJSON["schema_version"])
+	artifacts := runtimeJSON["artifacts"].(map[string]any)
+	assert.Equal(t, summary.CostReportPath, artifacts["cost_report"])
+	assert.Equal(t, summary.BudgetEventsPath, artifacts["budget_events"])
+	assert.Equal(t, summary.AuditEventsPath, artifacts["audit_events"])
+	assert.Equal(t, summary.TracePath, artifacts["trace"])
+	traceData := runtimeJSON["trace"].(map[string]any)
+	assert.Equal(t, spanCtx.TraceID().String(), traceData["trace_id"])
+	assert.Equal(t, spanCtx.SpanID().String(), traceData["span_id"])
+	auditData := runtimeJSON["audit"].(map[string]any)
+	assert.EqualValues(t, 1, auditData["entry_count"])
 }
 
 func TestSmoke_S19_FailurePathBuildsSummaryWithStateFailedAndCallsSaveVesselSummary(t *testing.T) {
@@ -861,7 +931,7 @@ func TestSmoke_WS6S6_EvidenceCollectionFailureIsNonFatal(t *testing.T) {
 	}}
 	vrs := newVesselRunState(cfg, vessel, now)
 
-	r.persistRunArtifacts(vessel, string(queue.StateCompleted), vrs, claims, now)
+	r.persistRunArtifacts(context.Background(), vessel, string(queue.StateCompleted), vrs, claims, now)
 
 	if !strings.Contains(buf.String(), "warn: save evidence manifest:") {
 		t.Fatalf("expected warning log for evidence manifest save failure, got %q", buf.String())
@@ -892,7 +962,7 @@ func TestSmoke_WS6S7_SummaryWriteFailureIsNonFatal(t *testing.T) {
 	now := time.Date(2026, time.April, 2, 10, 0, 0, 0, time.UTC)
 	vrs := newVesselRunState(cfg, vessel, now)
 
-	r.persistRunArtifacts(vessel, string(queue.StateCompleted), vrs, nil, now)
+	r.persistRunArtifacts(context.Background(), vessel, string(queue.StateCompleted), vrs, nil, now)
 
 	if !strings.Contains(buf.String(), "warn: save vessel summary:") {
 		t.Fatalf("expected warning log for summary write failure, got %q", buf.String())
@@ -1329,6 +1399,17 @@ func readSummaryBytes(t *testing.T, stateDir, vesselID string) []byte {
 	require.NoError(t, err)
 
 	return data
+}
+
+func loadRuntimeJSON(t *testing.T, stateDir, vesselID string) map[string]any {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(stateDir, "phases", vesselID, runtimeFileName))
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	return raw
 }
 
 func queueVesselByID(t *testing.T, q *queue.Queue, vesselID string) queue.Vessel {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,6 +98,20 @@ copilot:
 daemon:
   scan_interval: "60s"   # how often the daemon scans for new work
   drain_interval: "30s"  # how often the daemon drains pending vessels
+
+# ---------------------------------------------------------------------------
+# Runtime cost controls
+# ---------------------------------------------------------------------------
+cost:
+  budget:
+    max_cost_usd: 5.0              # optional estimated USD ceiling
+    max_tokens: 500000             # optional estimated token ceiling
+    on_exceeded: require_approval  # fail, warn, or require_approval
+    approval_label: budget-approved # label that resumes waiting GitHub vessels
+  model_ladder:
+    planner: claude-opus-4.6
+    generator: claude-sonnet-4.6
+    evaluator: claude-haiku-4.5
 ```
 
 ## Field reference
@@ -349,6 +363,32 @@ The `cost` section configures token budget enforcement for agent sessions.
 |-------|------|---------|----------|-------------|
 | `cost.budget.max_cost_usd` | float | `0` | No | Maximum cost in USD. Must be >= 0. Set to 0 to disable cost-based limits. |
 | `cost.budget.max_tokens` | integer | `0` | No | Maximum total tokens. Must be >= 0. Set to 0 to disable token-based limits. |
+| `cost.budget.on_exceeded` | string | `"fail"` | No | Action when an estimated budget is exceeded. Valid values: `fail`, `warn`, `require_approval`. |
+| `cost.budget.approval_label` | string | `"budget-approved"` | No | Label checked on GitHub-backed waiting vessels when `on_exceeded: require_approval`. |
+| `cost.model_ladder.planner` | string | `""` | No | Optional fallback model for planning-style phases such as `analyze`, `plan`, or `design` when no explicit model override is set. |
+| `cost.model_ladder.generator` | string | `""` | No | Optional fallback model for implementation-style phases when no explicit model override is set. |
+| `cost.model_ladder.evaluator` | string | `""` | No | Optional fallback model for evaluation-style phases such as `verify`, `test`, `review`, or `check` when no explicit model override is set. |
+
+Budget behavior:
+
+- `fail` keeps the current behavior: the vessel fails immediately once the estimate crosses the configured limit.
+- `warn` lets the vessel continue, but the run artifacts record both warning and exceeded events.
+- `require_approval` moves GitHub-backed issue/PR vessels to `waiting` and automatically resumes them when the configured `approval_label` appears. Non-GitHub vessels fail immediately with a clear error because there is no label-driven approval path to satisfy.
+
+### Runtime artifact contract
+
+Each vessel writes a canonical runtime index at `<state_dir>/phases/<vessel-id>/runtime.json`. Agents should read this file first rather than inferring paths from filenames.
+
+The per-vessel artifact directory contains:
+
+- `summary.json` — compact execution summary with links to detailed artifacts
+- `runtime.json` — canonical index for the run
+- `cost-report.json` — aggregated token/cost totals by model, purpose, and role
+- `budget-events.json` — warning/exceeded events and the configured budget action
+- `audit-events.json` — audit entries filtered to the current vessel
+- `trace.json` — trace IDs and collector metadata for linking into Jaeger/OTLP tooling
+- `evidence-manifest.json` — verification claims (only when evidence was collected)
+- `<phase>.prompt`, `<phase>.command`, `<phase>.output` — raw per-phase artifacts when that phase type emitted them
 
 ## Duration strings
 
@@ -593,3 +633,4 @@ The following rules are enforced when loading `.xylem.yml`. If any rule fails, `
 | `observability.sample_rate` must be in [0.0, 1.0] | `observability.sample_rate must be in [0.0, 1.0]` |
 | `cost.budget.max_cost_usd` must be >= 0 | `cost.budget.max_cost_usd must be non-negative` |
 | `cost.budget.max_tokens` must be >= 0 | `cost.budget.max_tokens must be non-negative` |
+| `cost.budget.on_exceeded` must be `fail`, `warn`, or `require_approval` | `cost.budget.on_exceeded must be one of fail, warn, or require_approval` |


### PR DESCRIPTION
## Summary
- add a canonical per-vessel runtime artifact index that links summary, cost, budget, audit, trace, evidence, and phase outputs
- enforce configurable budget actions (fail, warn, require approval) and add model ladder fallbacks for planning/generation/evaluation phases
- document the runtime artifact contract and budget behavior, and extend runner/config tests around artifact surfaces and budget flows

Closes https://github.com/nicholls-inc/xylem/issues/59