### PR TITLE
Integrate structured runner context, handoffs, and retention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,14 @@ Key types:
 - **Workflow** (`workflow` package) — YAML-defined multi-phase execution plan loaded from `.xylem/workflows/`
 - **Gate** (`gate` package) — inter-phase quality checks: `command` (run shell command) or `label` (poll GitHub for label, vessel enters `waiting` state)
 
-The `runner` drives phase execution: renders Go templates into prompts, pipes them to `claude -p` via stdin, persists outputs to `.xylem/phases/<id>/`, and handles gate retries and label-wait suspension.
+The `runner` drives phase execution: renders Go templates into prompts, compiles a structured context window for each phase, pipes prompts to `claude -p` via stdin, persists artifacts to `.xylem/phases/<id>/`, and handles gate retries and label-wait suspension.
+
+Structured runner artifacts now include:
+- `<phase>.context.json` — inspectable compiled-context manifest for a phase
+- `progress_<vessel>.json` — phase progress state used across resumes
+- `handoff_<vessel>_latest.json` plus snapshot handoffs — structured resume state
+
+Retention follows `cleanup_after`: historical handoff snapshots and context manifests are expirable, while the latest handoff, progress file, raw prompt/output artifacts, and summary remain durable so waiting/resumed vessels keep their state.
 
 ### Agent harness library (`cli/internal/`)
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,20 @@ Use `noop.match` on a phase to let that phase complete the workflow early when i
 
 See the [Workflows Guide](docs/workflows.md) for template variables, custom workflows, and prompt authoring tips.
 
+## Runner artifacts
+
+Each vessel writes durable artifacts under `.xylem/phases/<vessel-id>/` so long-running and resumed workflows can rebuild state deliberately instead of relying only on raw prompt/output files.
+
+| Artifact | Purpose |
+|----------|---------|
+| `<phase>.context.json` | Inspectable compiled context manifest showing selected inputs, compaction strategy, and the final context window used for that phase |
+| `progress_<vessel>.json` | Structured per-phase progress state used across retries, waiting states, and resume |
+| `handoff_<vessel>_latest.json` | Latest structured handoff with plan, checkpoints, unresolved items, verification state, approvals, and phase outputs |
+| `handoff_<vessel>_<snapshot>.json` | Historical handoff snapshots written at meaningful state transitions |
+| `summary.json` | Final vessel summary with per-phase telemetry, artifact links, and retention metadata |
+
+The latest handoff, progress file, rendered prompts, raw outputs, and summary stay durable. Historical handoff snapshots and compiled context manifests are expirable and follow `cleanup_after` from `.xylem.yml`.
+
 ## Commands
 
 | Command | Description |

--- a/cli/internal/memory/memory.go
+++ b/cli/internal/memory/memory.go
@@ -306,13 +306,27 @@ func (s *Store) Delete(memType MemoryType, key string) error {
 // HandoffArtifact captures session outcome for structured handoff between
 // sessions.
 type HandoffArtifact struct {
-	MissionID  string    `json:"mission_id"`
-	SessionID  string    `json:"session_id"`
-	Completed  []string  `json:"completed,omitempty"`
-	Failed     []string  `json:"failed,omitempty"`
-	Unresolved []string  `json:"unresolved,omitempty"`
-	NextSteps  []string  `json:"next_steps,omitempty"`
-	CreatedAt  time.Time `json:"created_at"`
+	MissionID    string             `json:"mission_id"`
+	SessionID    string             `json:"session_id"`
+	CurrentPhase int                `json:"current_phase,omitempty"`
+	Plan         []string           `json:"plan,omitempty"`
+	Checkpoints  []string           `json:"checkpoints,omitempty"`
+	Completed    []string           `json:"completed,omitempty"`
+	Failed       []string           `json:"failed,omitempty"`
+	Unresolved   []string           `json:"unresolved,omitempty"`
+	NextSteps    []string           `json:"next_steps,omitempty"`
+	PhaseOutputs map[string]string  `json:"phase_outputs,omitempty"`
+	Verification map[string]string  `json:"verification,omitempty"`
+	Approvals    []OperatorApproval `json:"approvals,omitempty"`
+	CreatedAt    time.Time          `json:"created_at"`
+}
+
+// OperatorApproval records the last known approval state for a workflow phase.
+type OperatorApproval struct {
+	Phase      string    `json:"phase"`
+	Status     string    `json:"status"`
+	Reason     string    `json:"reason,omitempty"`
+	RecordedAt time.Time `json:"recorded_at"`
 }
 
 // NewHandoff creates a HandoffArtifact stamped with the current time.

--- a/cli/internal/phase/phase.go
+++ b/cli/internal/phase/phase.go
@@ -8,11 +8,12 @@ import (
 
 // Truncation limits (constants, not configurable).
 const (
-	MaxPreviousOutputLen = 16000
-	MaxGateResultLen     = 8000
-	MaxIssueBodyLen      = 32000
-	MaxReporterOutputLen = 64000
-	TruncationSuffix     = "\n\n[... output truncated at %d characters]"
+	MaxPreviousOutputLen  = 16000
+	MaxGateResultLen      = 8000
+	MaxIssueBodyLen       = 32000
+	MaxCompiledContextLen = 24000
+	MaxReporterOutputLen  = 64000
+	TruncationSuffix      = "\n\n[... output truncated at %d characters]"
 )
 
 // TemplateData holds all data available to phase prompt templates.
@@ -21,7 +22,16 @@ type TemplateData struct {
 	Phase           PhaseData
 	PreviousOutputs map[string]string // phase name → output text
 	GateResult      string            // most recent gate command output
+	Context         ContextData
 	Vessel          VesselData
+}
+
+// ContextData exposes the runner-compiled context view for the current phase.
+type ContextData struct {
+	ManifestPath string
+	Strategy     string
+	Compiled     string
+	Resumed      bool
 }
 
 // IssueData describes the issue being worked on.
@@ -67,6 +77,7 @@ func prepareData(data TemplateData) TemplateData {
 	}
 
 	out.GateResult = TruncateOutput(data.GateResult, MaxGateResultLen)
+	out.Context.Compiled = TruncateOutput(data.Context.Compiled, MaxCompiledContextLen)
 	out.Issue.Body = TruncateOutput(data.Issue.Body, MaxIssueBodyLen)
 
 	return out

--- a/cli/internal/runner/context.go
+++ b/cli/internal/runner/context.go
@@ -1,0 +1,762 @@
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/ctxmgr"
+	"github.com/nicholls-inc/xylem/cli/internal/memory"
+	"github.com/nicholls-inc/xylem/cli/internal/phase"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
+)
+
+const (
+	defaultContextWindowTokens = 4000
+	latestHandoffSessionID     = "latest"
+	contextManifestSuffix      = ".context.json"
+)
+
+type resumeArtifacts struct {
+	Handoff         *memory.HandoffArtifact
+	Progress        *memory.ProgressFile
+	PreviousOutputs map[string]string
+	Resumed         bool
+}
+
+type structuredState struct {
+	mu        sync.Mutex
+	vesselID  string
+	phasesDir string
+	workflow  *workflow.Workflow
+	progress  *memory.ProgressFile
+	handoff   *memory.HandoffArtifact
+}
+
+type structuredSnapshot struct {
+	Progress *memory.ProgressFile
+	Handoff  *memory.HandoffArtifact
+}
+
+type PhaseContextManifest struct {
+	Version                 string                  `json:"version"`
+	VesselID                string                  `json:"vessel_id"`
+	PhaseName               string                  `json:"phase_name"`
+	PhaseIndex              int                     `json:"phase_index"`
+	CreatedAt               time.Time               `json:"created_at"`
+	Resumed                 bool                    `json:"resumed"`
+	Strategy                string                  `json:"strategy"`
+	Inputs                  ContextInputs           `json:"inputs"`
+	Metrics                 ctxmgr.Metrics          `json:"metrics"`
+	Compaction              ContextCompaction       `json:"compaction"`
+	Window                  ctxmgr.Window           `json:"window"`
+	SelectedPreviousOutputs map[string]string       `json:"selected_previous_outputs,omitempty"`
+	Progress                *memory.ProgressFile    `json:"progress,omitempty"`
+	Handoff                 *memory.HandoffArtifact `json:"handoff,omitempty"`
+}
+
+type ContextInputs struct {
+	DependencyOutputs []string `json:"dependency_outputs,omitempty"`
+	HasIssue          bool     `json:"has_issue"`
+	HasGateResult     bool     `json:"has_gate_result"`
+	HasProgress       bool     `json:"has_progress"`
+	HasHandoff        bool     `json:"has_handoff"`
+	HasApprovals      bool     `json:"has_approvals"`
+}
+
+type ContextCompaction struct {
+	Applied           bool    `json:"applied"`
+	Threshold         float64 `json:"threshold"`
+	UtilizationBefore float64 `json:"utilization_before"`
+	UtilizationAfter  float64 `json:"utilization_after"`
+}
+
+type compiledPhaseContext struct {
+	TemplateData phase.TemplateData
+	PromptPrefix string
+}
+
+func (r *Runner) phasesDir(vesselID string) (string, error) {
+	if err := validateSummaryPathComponent(vesselID); err != nil {
+		return "", fmt.Errorf("phases dir: invalid vessel ID: %w", err)
+	}
+	return filepath.Join(r.Config.StateDir, "phases", vesselID), nil
+}
+
+func (r *Runner) prepareStructuredState(vessel queue.Vessel, wf *workflow.Workflow) (*structuredState, resumeArtifacts, error) {
+	phasesDir, err := r.phasesDir(vessel.ID)
+	if err != nil {
+		return nil, resumeArtifacts{}, err
+	}
+	if err := os.MkdirAll(phasesDir, 0o755); err != nil {
+		return nil, resumeArtifacts{}, fmt.Errorf("create phases dir: %w", err)
+	}
+
+	if err := cleanupExpiredStructuredArtifacts(r.Config.StateDir, r.runtimeNow(), r.Config.CleanupAfterDuration()); err != nil {
+		log.Printf("warn: cleanup structured artifacts: %v", err)
+	}
+
+	resume, err := r.loadResumeArtifacts(phasesDir, vessel, wf)
+	if err != nil {
+		return nil, resumeArtifacts{}, err
+	}
+
+	progress, err := ensureProgressFile(vessel.ID, wf, phasesDir, resume.Progress)
+	if err != nil {
+		return nil, resumeArtifacts{}, err
+	}
+	resume.Progress = progress
+
+	handoff := resume.Handoff
+	if handoff == nil {
+		handoff = memory.NewHandoff(vessel.ID, latestHandoffSessionID)
+	}
+	handoff.MissionID = vessel.ID
+	handoff.SessionID = latestHandoffSessionID
+	handoff.Plan = workflowPhaseNames(wf)
+	if handoff.PhaseOutputs == nil {
+		handoff.PhaseOutputs = make(map[string]string)
+	}
+	if handoff.Verification == nil {
+		handoff.Verification = make(map[string]string)
+	}
+
+	state := &structuredState{
+		vesselID:  vessel.ID,
+		phasesDir: phasesDir,
+		workflow:  wf,
+		progress:  progress,
+		handoff:   handoff,
+	}
+	if err := state.persistHandoff("bootstrap"); err != nil {
+		return nil, resumeArtifacts{}, err
+	}
+	return state, resume, nil
+}
+
+func (r *Runner) loadResumeArtifacts(phasesDir string, vessel queue.Vessel, wf *workflow.Workflow) (resumeArtifacts, error) {
+	ctx, err := memory.StartSession(vessel.ID, latestHandoffSessionID, phasesDir)
+	if err != nil {
+		return resumeArtifacts{}, fmt.Errorf("load resume artifacts: %w", err)
+	}
+
+	resume := resumeArtifacts{
+		Handoff:  ctx.Handoff,
+		Progress: ctx.Progress,
+	}
+	if ctx.Handoff != nil && len(ctx.Handoff.PhaseOutputs) > 0 {
+		resume.PreviousOutputs = cloneStringMap(ctx.Handoff.PhaseOutputs)
+		resume.Resumed = true
+		return resume, nil
+	}
+
+	resume.PreviousOutputs = r.rebuildPreviousOutputs(vessel.ID, wf)
+	resume.Resumed = len(resume.PreviousOutputs) > 0 || ctx.Progress != nil
+	return resume, nil
+}
+
+func ensureProgressFile(vesselID string, wf *workflow.Workflow, phasesDir string, existing *memory.ProgressFile) (*memory.ProgressFile, error) {
+	if existing != nil {
+		return existing, nil
+	}
+
+	progress, err := memory.LoadProgress(vesselID, phasesDir)
+	if err == nil {
+		return progress, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("load progress: %w", err)
+	}
+
+	progress, err = memory.CreateProgress(vesselID, workflowPhaseNames(wf), phasesDir)
+	if err != nil {
+		return nil, fmt.Errorf("create progress: %w", err)
+	}
+	return progress, nil
+}
+
+func (s *structuredState) snapshot() structuredSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return structuredSnapshot{
+		Progress: cloneProgressFile(s.progress),
+		Handoff:  cloneHandoffArtifact(s.handoff),
+	}
+}
+
+func (s *structuredState) markPhaseInProgress(phaseName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := memory.UpdateProgress(s.vesselID, phaseName, "in_progress", s.phasesDir); err != nil {
+		return fmt.Errorf("mark phase in progress: %w", err)
+	}
+	progress, err := memory.LoadProgress(s.vesselID, s.phasesDir)
+	if err != nil {
+		return fmt.Errorf("reload progress: %w", err)
+	}
+	s.progress = progress
+	s.refreshDerivedState()
+	return s.persistHandoff(phaseName + "-start")
+}
+
+func (s *structuredState) recordApproval(phaseName, status, reason string, recordedAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var approvals []memory.OperatorApproval
+	for _, approval := range s.handoff.Approvals {
+		if approval.Phase != phaseName {
+			approvals = append(approvals, approval)
+		}
+	}
+	approvals = append(approvals, memory.OperatorApproval{
+		Phase:      phaseName,
+		Status:     status,
+		Reason:     reason,
+		RecordedAt: recordedAt.UTC(),
+	})
+	sort.SliceStable(approvals, func(i, j int) bool {
+		return approvals[i].Phase < approvals[j].Phase
+	})
+	s.handoff.Approvals = approvals
+	return s.persistHandoff(phaseName + "-approval")
+}
+
+func (s *structuredState) recordPhaseOutcome(phaseName string, phaseIdx int, output, status, verification string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	progressStatus := "completed"
+	if status == "failed" {
+		progressStatus = "failed"
+	}
+	if err := memory.UpdateProgress(s.vesselID, phaseName, progressStatus, s.phasesDir); err != nil {
+		return fmt.Errorf("record phase outcome: %w", err)
+	}
+	progress, err := memory.LoadProgress(s.vesselID, s.phasesDir)
+	if err != nil {
+		return fmt.Errorf("reload progress: %w", err)
+	}
+	s.progress = progress
+
+	if output != "" {
+		if s.handoff.PhaseOutputs == nil {
+			s.handoff.PhaseOutputs = make(map[string]string)
+		}
+		s.handoff.PhaseOutputs[phaseName] = output
+	}
+	if verification != "" {
+		if s.handoff.Verification == nil {
+			s.handoff.Verification = make(map[string]string)
+		}
+		s.handoff.Verification[phaseName] = verification
+	}
+
+	s.handoff.CurrentPhase = phaseIdx + 1
+	s.refreshDerivedState()
+	return s.persistHandoff(phaseName + "-" + status)
+}
+
+func (s *structuredState) refreshDerivedState() {
+	s.handoff.Plan = workflowPhaseNames(s.workflow)
+	s.handoff.Checkpoints = progressPhaseNames(s.progress, "completed")
+	s.handoff.Completed = progressPhaseNames(s.progress, "completed")
+	s.handoff.Failed = progressPhaseNames(s.progress, "failed")
+	s.handoff.NextSteps = append(progressPhaseNames(s.progress, "in_progress"), progressPhaseNames(s.progress, "pending")...)
+	s.handoff.Unresolved = unresolvedFromState(s.progress, s.handoff.Verification)
+}
+
+func (s *structuredState) persistHandoff(sessionID string) error {
+	latest := cloneHandoffArtifact(s.handoff)
+	latest.SessionID = latestHandoffSessionID
+	if err := latest.Save(s.phasesDir); err != nil {
+		return fmt.Errorf("save latest handoff: %w", err)
+	}
+
+	if strings.TrimSpace(sessionID) == "" {
+		return nil
+	}
+	snapshot := cloneHandoffArtifact(s.handoff)
+	snapshot.SessionID = sanitizeSessionID(sessionID)
+	if err := snapshot.Save(s.phasesDir); err != nil {
+		return fmt.Errorf("save handoff snapshot: %w", err)
+	}
+	return nil
+}
+
+func (r *Runner) compilePhaseContext(vessel queue.Vessel, p workflow.Phase, phaseIdx int, issueData phase.IssueData, previousOutputs map[string]string, gateResult string, snapshot structuredSnapshot, resumed bool) (*compiledPhaseContext, error) {
+	phasesDir, err := r.phasesDir(vessel.ID)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(phasesDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create phases dir: %w", err)
+	}
+
+	inputs := ContextInputs{
+		DependencyOutputs: sortedKeys(previousOutputs),
+		HasIssue:          issueData.Number != 0 || issueData.Title != "" || issueData.Body != "",
+		HasGateResult:     gateResult != "",
+		HasProgress:       snapshot.Progress != nil,
+		HasHandoff:        snapshot.Handoff != nil,
+	}
+	if snapshot.Handoff != nil && len(snapshot.Handoff.Approvals) > 0 {
+		inputs.HasApprovals = true
+	}
+
+	processors := []ctxmgr.Processor{
+		{
+			Name:     "resume_handoff",
+			Priority: 10,
+			Fn: func(step ctxmgr.StepContext) []ctxmgr.Segment {
+				if snapshot.Handoff == nil {
+					return nil
+				}
+				content := formatHandoffSegment(snapshot.Handoff)
+				if strings.TrimSpace(content) == "" {
+					return nil
+				}
+				return []ctxmgr.Segment{{
+					Name:     "resume_handoff",
+					Content:  content,
+					Tokens:   ctxmgr.EstimateTokens(content),
+					Durable:  true,
+					Source:   "handoff",
+					Priority: 10,
+				}}
+			},
+		},
+		{
+			Name:     "progress",
+			Priority: 20,
+			Fn: func(step ctxmgr.StepContext) []ctxmgr.Segment {
+				if snapshot.Progress == nil {
+					return nil
+				}
+				content := formatProgressSegment(snapshot.Progress)
+				if strings.TrimSpace(content) == "" {
+					return nil
+				}
+				return []ctxmgr.Segment{{
+					Name:     "progress",
+					Content:  content,
+					Tokens:   ctxmgr.EstimateTokens(content),
+					Durable:  true,
+					Source:   "progress",
+					Priority: 20,
+				}}
+			},
+		},
+		{
+			Name:     "issue",
+			Priority: 30,
+			Fn: func(step ctxmgr.StepContext) []ctxmgr.Segment {
+				content := formatIssueSegment(issueData)
+				if strings.TrimSpace(content) == "" {
+					return nil
+				}
+				return []ctxmgr.Segment{{
+					Name:     "issue",
+					Content:  content,
+					Tokens:   ctxmgr.EstimateTokens(content),
+					Durable:  true,
+					Source:   "issue",
+					Priority: 30,
+				}}
+			},
+		},
+		{
+			Name:     "dependencies",
+			Priority: 40,
+			Fn: func(step ctxmgr.StepContext) []ctxmgr.Segment {
+				keys := sortedKeys(previousOutputs)
+				segments := make([]ctxmgr.Segment, 0, len(keys))
+				for _, key := range keys {
+					content := previousOutputs[key]
+					segments = append(segments, ctxmgr.Segment{
+						Name:     "previous_output:" + key,
+						Content:  content,
+						Tokens:   ctxmgr.EstimateTokens(content),
+						Durable:  false,
+						Source:   "previous_output:" + key,
+						Priority: 40,
+					})
+				}
+				return segments
+			},
+		},
+		{
+			Name:     "gate_result",
+			Priority: 50,
+			Fn: func(step ctxmgr.StepContext) []ctxmgr.Segment {
+				if strings.TrimSpace(gateResult) == "" {
+					return nil
+				}
+				return []ctxmgr.Segment{{
+					Name:     "gate_result",
+					Content:  gateResult,
+					Tokens:   ctxmgr.EstimateTokens(gateResult),
+					Durable:  false,
+					Source:   "gate_result",
+					Priority: 50,
+				}}
+			},
+		},
+	}
+
+	pipeline := ctxmgr.NewPipeline(processors...)
+	window := pipeline.Assemble(ctxmgr.StepContext{
+		StepName:        p.Name,
+		Phase:           p.Name,
+		AvailableTokens: defaultContextWindowTokens,
+		Metadata: map[string]string{
+			"vessel_id": vessel.ID,
+			"phase":     p.Name,
+		},
+	}, defaultContextWindowTokens)
+
+	utilBefore := window.Utilization()
+	strategy := ctxmgr.SelectStrategy(utilBefore, window.DurableTokens() > 0, phaseComplexity(p, len(previousOutputs)))
+	compaction := ContextCompaction{
+		Threshold:         ctxmgr.DefaultCompactionThreshold,
+		UtilizationBefore: utilBefore,
+		UtilizationAfter:  utilBefore,
+	}
+	if strategy == ctxmgr.StrategyCompress {
+		window = ctxmgr.Compact(window, ctxmgr.CompactionConfig{
+			Threshold:       ctxmgr.DefaultCompactionThreshold,
+			PreserveDurable: true,
+		})
+		compaction.Applied = true
+		compaction.UtilizationAfter = window.Utilization()
+	}
+
+	selectedOutputs := selectedPreviousOutputs(window)
+	manifestPath := filepath.Join(phasesDir, p.Name+contextManifestSuffix)
+	manifest := PhaseContextManifest{
+		Version:                 "v1",
+		VesselID:                vessel.ID,
+		PhaseName:               p.Name,
+		PhaseIndex:              phaseIdx,
+		CreatedAt:               r.runtimeNow(),
+		Resumed:                 resumed,
+		Strategy:                string(strategy),
+		Inputs:                  inputs,
+		Metrics:                 pipeline.Metrics(),
+		Compaction:              compaction,
+		Window:                  *window,
+		SelectedPreviousOutputs: cloneStringMap(selectedOutputs),
+		Progress:                cloneProgressFile(snapshot.Progress),
+		Handoff:                 cloneHandoffArtifact(snapshot.Handoff),
+	}
+	if err := saveJSONFile(manifestPath, manifest); err != nil {
+		return nil, fmt.Errorf("save context manifest: %w", err)
+	}
+
+	return &compiledPhaseContext{
+		TemplateData: phase.TemplateData{
+			Issue: issueData,
+			Phase: phase.PhaseData{
+				Name:  p.Name,
+				Index: phaseIdx,
+			},
+			PreviousOutputs: selectedOutputs,
+			GateResult:      gateResult,
+			Context: phase.ContextData{
+				ManifestPath: filepath.ToSlash(filepath.Join("phases", vessel.ID, filepath.Base(manifestPath))),
+				Strategy:     string(strategy),
+				Compiled:     renderCompiledContext(window),
+				Resumed:      resumed,
+			},
+			Vessel: phase.VesselData{
+				ID:     vessel.ID,
+				Source: vessel.Source,
+			},
+		},
+		PromptPrefix: renderCompiledContext(window),
+	}, nil
+}
+
+func workflowPhaseNames(wf *workflow.Workflow) []string {
+	if wf == nil {
+		return nil
+	}
+	out := make([]string, 0, len(wf.Phases))
+	for _, p := range wf.Phases {
+		out = append(out, p.Name)
+	}
+	return out
+}
+
+func progressPhaseNames(progress *memory.ProgressFile, status string) []string {
+	if progress == nil {
+		return nil
+	}
+	var out []string
+	for _, item := range progress.Items {
+		if item.Status == status {
+			out = append(out, item.Task)
+		}
+	}
+	return out
+}
+
+func unresolvedFromState(progress *memory.ProgressFile, verification map[string]string) []string {
+	var unresolved []string
+	for _, task := range progressPhaseNames(progress, "failed") {
+		unresolved = append(unresolved, fmt.Sprintf("phase %s failed", task))
+	}
+	keys := sortedKeys(verification)
+	for _, key := range keys {
+		status := verification[key]
+		if strings.Contains(status, "failed") || strings.Contains(status, "waiting") || strings.Contains(status, "required") {
+			unresolved = append(unresolved, fmt.Sprintf("%s: %s", key, status))
+		}
+	}
+	return unresolved
+}
+
+func formatHandoffSegment(h *memory.HandoffArtifact) string {
+	if h == nil {
+		return ""
+	}
+	var b strings.Builder
+	if len(h.Plan) > 0 {
+		fmt.Fprintf(&b, "Plan: %s\n", strings.Join(h.Plan, ", "))
+	}
+	if len(h.Checkpoints) > 0 {
+		fmt.Fprintf(&b, "Checkpoints complete: %s\n", strings.Join(h.Checkpoints, ", "))
+	}
+	if len(h.Unresolved) > 0 {
+		fmt.Fprintf(&b, "Unresolved: %s\n", strings.Join(h.Unresolved, " | "))
+	}
+	if len(h.NextSteps) > 0 {
+		fmt.Fprintf(&b, "Next steps: %s\n", strings.Join(h.NextSteps, ", "))
+	}
+	if len(h.Verification) > 0 {
+		fmt.Fprintf(&b, "Verification: %s\n", formatStringMap(h.Verification))
+	}
+	if len(h.Approvals) > 0 {
+		parts := make([]string, 0, len(h.Approvals))
+		for _, approval := range h.Approvals {
+			if approval.Reason != "" {
+				parts = append(parts, fmt.Sprintf("%s=%s (%s)", approval.Phase, approval.Status, approval.Reason))
+				continue
+			}
+			parts = append(parts, fmt.Sprintf("%s=%s", approval.Phase, approval.Status))
+		}
+		fmt.Fprintf(&b, "Approvals: %s\n", strings.Join(parts, ", "))
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func formatProgressSegment(progress *memory.ProgressFile) string {
+	if progress == nil {
+		return ""
+	}
+	parts := make([]string, 0, len(progress.Items))
+	for _, item := range progress.Items {
+		parts = append(parts, fmt.Sprintf("%s=%s", item.Task, item.Status))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "Progress: " + strings.Join(parts, ", ")
+}
+
+func formatIssueSegment(issueData phase.IssueData) string {
+	if issueData.Title == "" && issueData.Body == "" && issueData.URL == "" {
+		return ""
+	}
+	var parts []string
+	if issueData.Number != 0 {
+		parts = append(parts, fmt.Sprintf("Issue #%d", issueData.Number))
+	}
+	if issueData.Title != "" {
+		parts = append(parts, issueData.Title)
+	}
+	if issueData.URL != "" {
+		parts = append(parts, issueData.URL)
+	}
+	if len(issueData.Labels) > 0 {
+		parts = append(parts, "labels="+strings.Join(issueData.Labels, ","))
+	}
+	return strings.Join(parts, " | ")
+}
+
+func renderCompiledContext(window *ctxmgr.Window) string {
+	if window == nil || len(window.Segments) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Structured context\n")
+	for _, segment := range window.Segments {
+		fmt.Fprintf(&b, "\n[%s]\n%s\n", segment.Name, segment.Content)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func selectedPreviousOutputs(window *ctxmgr.Window) map[string]string {
+	selected := make(map[string]string)
+	if window == nil {
+		return selected
+	}
+	for _, segment := range window.Segments {
+		if !strings.HasPrefix(segment.Source, "previous_output:") {
+			continue
+		}
+		phaseName := strings.TrimPrefix(segment.Source, "previous_output:")
+		selected[phaseName] = segment.Content
+	}
+	return selected
+}
+
+func withCompiledContext(prefix, rendered string) string {
+	if strings.TrimSpace(prefix) == "" {
+		return rendered
+	}
+	if strings.TrimSpace(rendered) == "" {
+		return prefix
+	}
+	return prefix + "\n\nPhase instructions\n" + rendered
+}
+
+func phaseComplexity(p workflow.Phase, dependencyCount int) string {
+	if p.MaxTurns >= 20 || dependencyCount >= 3 {
+		return "high"
+	}
+	return "medium"
+}
+
+func saveJSONFile(path string, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal json: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func cleanupExpiredStructuredArtifacts(stateDir string, now time.Time, retainFor time.Duration) error {
+	phasesRoot := filepath.Join(stateDir, "phases")
+	entries, err := os.ReadDir(phasesRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read phases root: %w", err)
+	}
+
+	cutoff := now.Add(-retainFor)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dirPath := filepath.Join(phasesRoot, entry.Name())
+		files, err := os.ReadDir(dirPath)
+		if err != nil {
+			return fmt.Errorf("read vessel phase dir %s: %w", entry.Name(), err)
+		}
+		for _, file := range files {
+			if file.IsDir() || !isExpirableStructuredArtifact(file.Name()) {
+				continue
+			}
+			info, err := file.Info()
+			if err != nil {
+				return fmt.Errorf("stat structured artifact %s: %w", file.Name(), err)
+			}
+			if info.ModTime().After(cutoff) {
+				continue
+			}
+			if err := os.Remove(filepath.Join(dirPath, file.Name())); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove structured artifact %s: %w", file.Name(), err)
+			}
+		}
+	}
+	return nil
+}
+
+func isExpirableStructuredArtifact(name string) bool {
+	if strings.HasSuffix(name, contextManifestSuffix) {
+		return true
+	}
+	if strings.HasPrefix(name, "handoff_") && !strings.HasSuffix(name, "_latest.json") {
+		return true
+	}
+	return false
+}
+
+func sanitizeSessionID(sessionID string) string {
+	replacer := strings.NewReplacer("/", "-", "\\", "-", " ", "-")
+	cleaned := replacer.Replace(strings.TrimSpace(sessionID))
+	if cleaned == "" {
+		return "session"
+	}
+	return cleaned
+}
+
+func cloneStringMap(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func cloneProgressFile(progress *memory.ProgressFile) *memory.ProgressFile {
+	if progress == nil {
+		return nil
+	}
+	cloned := *progress
+	cloned.Items = append([]memory.ProgressItem(nil), progress.Items...)
+	return &cloned
+}
+
+func cloneHandoffArtifact(h *memory.HandoffArtifact) *memory.HandoffArtifact {
+	if h == nil {
+		return nil
+	}
+	cloned := *h
+	cloned.Plan = append([]string(nil), h.Plan...)
+	cloned.Checkpoints = append([]string(nil), h.Checkpoints...)
+	cloned.Completed = append([]string(nil), h.Completed...)
+	cloned.Failed = append([]string(nil), h.Failed...)
+	cloned.Unresolved = append([]string(nil), h.Unresolved...)
+	cloned.NextSteps = append([]string(nil), h.NextSteps...)
+	cloned.PhaseOutputs = cloneStringMap(h.PhaseOutputs)
+	cloned.Verification = cloneStringMap(h.Verification)
+	cloned.Approvals = append([]memory.OperatorApproval(nil), h.Approvals...)
+	return &cloned
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func formatStringMap(m map[string]string) string {
+	keys := sortedKeys(m)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", key, m[key]))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -319,14 +319,22 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 	// Read harness file
 	harnessContent := r.readHarness()
 
+	structuredState, resume, err := r.prepareStructuredState(vessel, sk)
+	if err != nil {
+		r.failVessel(vessel.ID, fmt.Sprintf("prepare structured state: %v", err))
+		if err := src.OnFail(ctx, vessel); err != nil {
+			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+		}
+		return "failed"
+	}
+
 	// Orchestrator-driven execution for workflows with explicit phase dependencies.
 	// This enables parallel phase execution within waves and context firewalls.
 	if sk.HasDependencies() {
-		return r.runVesselOrchestrated(ctx, vessel, sk, issueData, harnessContent, worktreePath, src, vrs, &claims)
+		return r.runVesselOrchestrated(ctx, vessel, sk, issueData, harnessContent, worktreePath, src, vrs, &claims, structuredState, resume.Resumed)
 	}
 
-	// Rebuild previousOutputs from .xylem/phases/<id>/*.output (for resume)
-	previousOutputs := r.rebuildPreviousOutputs(vessel.ID, sk)
+	previousOutputs := cloneStringMap(resume.PreviousOutputs)
 	srcCfg := r.sourceConfigFromMeta(vessel)
 
 	// Execute phases sequentially (no explicit dependencies)
@@ -341,30 +349,33 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 		}
 
 		// Gate retry loop: may re-run the same phase with gate output appended
+		if err := structuredState.markPhaseInProgress(p.Name); err != nil {
+			r.failVessel(vessel.ID, fmt.Sprintf("mark phase %s in progress: %v", p.Name, err))
+			if err := src.OnFail(ctx, vessel); err != nil {
+				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+			}
+			return "failed"
+		}
 		for {
 			log.Printf("%sphase %q starting (%d/%d)", vesselLabel(vessel), p.Name, i+1, len(sk.Phases))
 			phaseStart := r.runtimeNow()
 
-			// Build template data
-			td := phase.TemplateData{
-				Issue: issueData,
-				Phase: phase.PhaseData{
-					Name:  p.Name,
-					Index: i,
-				},
-				PreviousOutputs: previousOutputs,
-				GateResult:      gateResult,
-				Vessel: phase.VesselData{
-					ID:     vessel.ID,
-					Source: vessel.Source,
-				},
+			compiledCtx, err := r.compilePhaseContext(vessel, p, i, issueData, previousOutputs, gateResult, structuredState.snapshot(), resume.Resumed)
+			if err != nil {
+				r.failVessel(vessel.ID, fmt.Sprintf("compile context for phase %s: %v", p.Name, err))
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
+				return "failed"
 			}
+			td := compiledCtx.TemplateData
 
 			var output []byte
 			var runErr error
 			var beforeSnapshot surface.Snapshot
 			var checkProtectedSurfaces bool
 			var promptForCost string
+			contextManifestPath := td.Context.ManifestPath
 			provider := resolveProvider(r.Config, srcCfg, sk, &p)
 			model := resolveModel(r.Config, srcCfg, sk, &p, provider)
 			retryAttempt := 0
@@ -421,6 +432,11 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if policyErr := r.enforcePhasePolicy(vessel, p); policyErr != nil {
 					finishCurrentPhaseSpan(policyErr)
 					log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
+					if structuredState != nil && strings.Contains(policyErr.Error(), "requires approval") {
+						if err := structuredState.recordApproval(p.Name, "required", policyErr.Error(), r.runtimeNow()); err != nil {
+							log.Printf("warn: record approval state for %s/%s: %v", vessel.ID, p.Name, err)
+						}
+					}
 					vessel.FailedPhase = p.Name
 					r.failVessel(vessel.ID, policyErr.Error())
 					if err := src.OnFail(ctx, vessel); err != nil {
@@ -471,6 +487,8 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					}
 					return "failed"
 				}
+				contextManifestPath = td.Context.ManifestPath
+				rendered = withCompiledContext(compiledCtx.PromptPrefix, rendered)
 				promptForCost = rendered
 				if harnessContent != "" {
 					promptForCost = harnessContent + "\n\n" + rendered
@@ -482,6 +500,11 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if policyErr := r.enforcePhasePolicy(vessel, p); policyErr != nil {
 					finishCurrentPhaseSpan(policyErr)
 					log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
+					if structuredState != nil && strings.Contains(policyErr.Error(), "requires approval") {
+						if err := structuredState.recordApproval(p.Name, "required", policyErr.Error(), r.runtimeNow()); err != nil {
+							log.Printf("warn: record approval state for %s/%s: %v", vessel.ID, p.Name, err)
+						}
+					}
 					vessel.FailedPhase = p.Name
 					r.failVessel(vessel.ID, policyErr.Error())
 					if err := src.OnFail(ctx, vessel); err != nil {
@@ -529,7 +552,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			if runErr != nil {
 				finishCurrentPhaseSpan(runErr)
 				log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
-				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()))
+				vrs.addPhase(vrs.phaseSummaryWithContext(r.Config, srcCfg, sk, p, harnessContent, contextManifestPath, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()))
+				if err := structuredState.recordPhaseOutcome(p.Name, i, string(output), "failed", "phase:failed:"+runErr.Error()); err != nil {
+					log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+				}
 				vessel.FailedPhase = p.Name
 				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, runErr))
 				if err := src.OnFail(ctx, vessel); err != nil {
@@ -547,7 +573,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if err := r.verifyProtectedSurfaces(vessel, p, worktreePath, beforeSnapshot); err != nil {
 					finishCurrentPhaseSpan(err)
 					log.Printf("%sphase %q violated protected surfaces: %v", vesselLabel(vessel), p.Name, err)
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error()))
+					vrs.addPhase(vrs.phaseSummaryWithContext(r.Config, srcCfg, sk, p, harnessContent, contextManifestPath, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error()))
+					if err := structuredState.recordPhaseOutcome(p.Name, i, string(output), "failed", "phase:failed:"+err.Error()); err != nil {
+						log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+					}
 					vessel.FailedPhase = p.Name
 					r.failVessel(vessel.ID, err.Error())
 					if err := src.OnFail(ctx, vessel); err != nil {
@@ -567,7 +596,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			if vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() {
 				errMsg := fmt.Sprintf("budget exceeded after phase %q: estimated cost $%.4f, estimated tokens %d",
 					p.Name, vrs.costTracker.TotalCost(), vrs.costTracker.TotalTokens())
-				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg))
+				vrs.addPhase(vrs.phaseSummaryWithContext(r.Config, srcCfg, sk, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg))
+				if err := structuredState.recordPhaseOutcome(p.Name, i, string(output), "failed", "budget:"+errMsg); err != nil {
+					log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+				}
 				vessel.FailedPhase = p.Name
 				r.failVessel(vessel.ID, errMsg)
 				if err := src.OnFail(ctx, vessel); err != nil {
@@ -612,7 +644,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			}
 
 			if phaseStatus == "no-op" {
-				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, ""))
+				vrs.addPhase(vrs.phaseSummaryWithContext(r.Config, srcCfg, sk, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, ""))
+				if err := structuredState.recordPhaseOutcome(p.Name, i, string(output), phaseStatus, ""); err != nil {
+					log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+				}
 				log.Printf("%sphase %q triggered no-op; completing workflow early", vesselLabel(vessel), p.Name)
 				finishCurrentPhaseSpan(nil)
 				return r.completeVessel(ctx, vessel, worktreePath, phaseResults, vrs, claims)
@@ -620,7 +655,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 			// Handle gate
 			if p.Gate == nil {
-				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, ""))
+				vrs.addPhase(vrs.phaseSummaryWithContext(r.Config, srcCfg, sk, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, ""))
+				if err := structuredState.recordPhaseOutcome(p.Name, i, string(output), phaseStatus, ""); err != nil {
+					log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+				}
 				finishCurrentPhaseSpan(nil)
 				break // no gate, proceed to next phase
 			}
@@ -635,7 +673,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					RetryAttempt: retryAttempt,
 				}, gateErr)
 				if gateErr != nil {
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error()))
+					vrs.addPhase(vrs.phaseSummaryWithContext(r.Config, srcCfg, sk, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error()))
+					if err := structuredState.recordPhaseOutcome(p.Name, i, string(output), "failed", "command:error:"+gateErr.Error()); err != nil {
+						log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+					}
 					finishCurrentPhaseSpan(nil)
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate error: %v", p.Name, gateErr))
 					if err := src.OnFail(ctx, vessel); err != nil {
@@ -645,7 +686,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				}
 				if passed {
 					log.Printf("%sgate passed for phase %q", vesselLabel(vessel), p.Name)
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, gatePassedPointer(true), ""))
+					vrs.addPhase(vrs.phaseSummaryWithContext(r.Config, srcCfg, sk, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, gatePassedPointer(true), ""))
+					if err := structuredState.recordPhaseOutcome(p.Name, i, string(output), phaseStatus, "command:passed"); err != nil {
+						log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+					}
 					gateRecordedAt := r.runtimeNow()
 					claims = append(claims, buildGateClaim(p, true, phaseArtifactRelativePath(vessel.ID, p.Name), gateRecordedAt))
 					finishCurrentPhaseSpan(nil)
@@ -662,7 +706,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 				if vessel.GateRetries <= 0 {
 					log.Printf("%sgate failed for phase %q, retries exhausted", vesselLabel(vessel), p.Name)
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted"))
+					vrs.addPhase(vrs.phaseSummaryWithContext(r.Config, srcCfg, sk, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted"))
+					if err := structuredState.recordPhaseOutcome(p.Name, i, string(output), "failed", "command:failed"); err != nil {
+						log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+					}
 					finishCurrentPhaseSpan(nil)
 					vessel.FailedPhase = p.Name
 					vessel.GateOutput = gateOut
@@ -687,9 +734,12 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				gateResult = fmt.Sprintf("The following gate check failed after the previous phase. Fix the issues and try again:\n\n%s", gateOut)
 
 				if err := r.runtimeSleep(ctx, retryDelay); err != nil {
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error()))
+					vrs.addPhase(vrs.phaseSummaryWithContext(r.Config, srcCfg, sk, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error()))
 					finishCurrentPhaseSpan(err)
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate retry interrupted: %v", p.Name, err))
+					if stateErr := structuredState.recordPhaseOutcome(p.Name, i, string(output), "failed", "command:retry_interrupted:"+err.Error()); stateErr != nil {
+						log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, stateErr)
+					}
 					if failErr := src.OnFail(ctx, vessel); failErr != nil {
 						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, failErr)
 					}
@@ -713,6 +763,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				vessel.WaitingSince = &now
 				vessel.CurrentPhase = i + 1
 				vessel.State = queue.StateWaiting
+				if err := structuredState.recordPhaseOutcome(p.Name, i, string(output), "completed", "label:waiting:"+p.Gate.WaitFor); err != nil {
+					log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+				}
 				if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
 					log.Printf("warn: persist waiting state for %s: %v", vessel.ID, updateErr)
 					finishCurrentPhaseSpan(updateErr)
@@ -877,6 +930,20 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 	if vrs == nil {
 		vrs = newVesselRunState(r.Config, vessel, now)
 	}
+	if vessel.Workflow != "" {
+		if phasesDir, err := r.phasesDir(vessel.ID); err == nil {
+			progressPath := filepath.Join(phasesDir, fmt.Sprintf("progress_%s.json", vessel.ID))
+			if _, err := os.Stat(progressPath); err == nil {
+				vrs.progressPath = filepath.ToSlash(filepath.Join("phases", vessel.ID, filepath.Base(progressPath)))
+			}
+			handoffPath := filepath.Join(phasesDir, fmt.Sprintf("handoff_%s_%s.json", vessel.ID, latestHandoffSessionID))
+			if _, err := os.Stat(handoffPath); err == nil {
+				vrs.handoffPath = filepath.ToSlash(filepath.Join("phases", vessel.ID, filepath.Base(handoffPath)))
+			}
+		} else {
+			log.Printf("warn: resolve phases dir for %s: %v", vessel.ID, err)
+		}
+	}
 
 	summary := vrs.buildSummary(state, now)
 	var manifest *evidence.Manifest
@@ -905,7 +972,7 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 // using the orchestrator for tracking and wave-based parallel execution.
 // Phases within the same wave (no dependencies between them) run concurrently.
 // Context firewalls ensure each phase only sees outputs from its declared dependencies.
-func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel, wf *workflow.Workflow, issueData phase.IssueData, harnessContent, worktreePath string, src source.Source, vrs *vesselRunState, claims *[]evidence.Claim) string {
+func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel, wf *workflow.Workflow, issueData phase.IssueData, harnessContent, worktreePath string, src source.Source, vrs *vesselRunState, claims *[]evidence.Claim, structuredState *structuredState, resumed bool) string {
 	graph, err := buildPhaseGraph(wf)
 	if err != nil {
 		r.failVessel(vessel.ID, fmt.Sprintf("build phase graph: %v", err))
@@ -915,8 +982,15 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 		return "failed"
 	}
 
-	// Rebuild previous outputs for resume.
-	allOutputs := r.rebuildPreviousOutputs(vessel.ID, wf)
+	allOutputs := map[string]string{}
+	if structuredState != nil {
+		if snapshot := structuredState.snapshot(); snapshot.Handoff != nil {
+			allOutputs = cloneStringMap(snapshot.Handoff.PhaseOutputs)
+		}
+	}
+	if len(allOutputs) == 0 {
+		allOutputs = r.rebuildPreviousOutputs(vessel.ID, wf)
+	}
 
 	// Mark already-completed phases in orchestrator.
 	for phaseName, output := range allOutputs {
@@ -954,7 +1028,7 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 			// Single phase: run inline (no goroutine overhead).
 			idx := pending[0]
 			depOutputs := graph.dependencyOutputs(idx, allOutputs)
-			res := r.runSinglePhase(ctx, vessel, wf, idx, depOutputs, issueData, harnessContent, worktreePath, src, vrs, true)
+			res := r.runSinglePhaseWithState(ctx, vessel, wf, idx, depOutputs, issueData, harnessContent, worktreePath, src, vrs, true, structuredState, resumed)
 			results[0] = waveResult{phaseIdx: idx, result: res}
 		} else {
 			// Multiple phases: run concurrently.
@@ -973,7 +1047,7 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 					_ = graph.orch.UpdateAgent(wf.Phases[idx].Name, orchestrator.StatusRunning, 0, 0, "")
 					mu.Unlock()
 
-					res := r.runSinglePhase(ctx, vessel, wf, idx, depOutputs, issueData, harnessContent, worktreePath, src, vrs, false)
+					res := r.runSinglePhaseWithState(ctx, vessel, wf, idx, depOutputs, issueData, harnessContent, worktreePath, src, vrs, false, structuredState, resumed)
 
 					mu.Lock()
 					results[ri] = waveResult{phaseIdx: idx, result: res}
@@ -1087,6 +1161,10 @@ type singlePhaseResult struct {
 // gate evaluation and retries. It returns the outcome without mutating the
 // vessel's queue state directly (the caller handles that).
 func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *workflow.Workflow, phaseIdx int, previousOutputs map[string]string, issueData phase.IssueData, harnessContent, worktreePath string, src source.Source, vrs *vesselRunState, enforceBudget bool) singlePhaseResult {
+	return r.runSinglePhaseWithState(ctx, vessel, wf, phaseIdx, previousOutputs, issueData, harnessContent, worktreePath, src, vrs, enforceBudget, nil, false)
+}
+
+func (r *Runner) runSinglePhaseWithState(ctx context.Context, vessel queue.Vessel, wf *workflow.Workflow, phaseIdx int, previousOutputs map[string]string, issueData phase.IssueData, harnessContent, worktreePath string, src source.Source, vrs *vesselRunState, enforceBudget bool, structuredState *structuredState, resumed bool) singlePhaseResult {
 	p := wf.Phases[phaseIdx]
 	gateResult := ""
 	gateRetries := 0
@@ -1095,30 +1173,46 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 	}
 
 	srcCfg := r.sourceConfigFromMeta(vessel)
+	if structuredState != nil {
+		if err := structuredState.markPhaseInProgress(p.Name); err != nil {
+			r.failVessel(vessel.ID, fmt.Sprintf("mark phase %s in progress: %v", p.Name, err))
+			if err := src.OnFail(ctx, vessel); err != nil {
+				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+			}
+			return singlePhaseResult{
+				status:       "failed",
+				phaseSummary: vrs.phaseSummaryWithContext(r.Config, srcCfg, wf, p, harnessContent, "", 0, 0, 0.0, 0, "failed", nil, err.Error()),
+			}
+		}
+	}
 
 	for {
 		log.Printf("%sphase %q starting (orchestrated)", vesselLabel(vessel), p.Name)
 		phaseStart := r.runtimeNow()
 
-		td := phase.TemplateData{
-			Issue: issueData,
-			Phase: phase.PhaseData{
-				Name:  p.Name,
-				Index: phaseIdx,
-			},
-			PreviousOutputs: previousOutputs,
-			GateResult:      gateResult,
-			Vessel: phase.VesselData{
-				ID:     vessel.ID,
-				Source: vessel.Source,
-			},
+		var snapshot structuredSnapshot
+		if structuredState != nil {
+			snapshot = structuredState.snapshot()
 		}
+		compiledCtx, err := r.compilePhaseContext(vessel, p, phaseIdx, issueData, previousOutputs, gateResult, snapshot, resumed)
+		if err != nil {
+			r.failVessel(vessel.ID, fmt.Sprintf("compile context for phase %s: %v", p.Name, err))
+			if err := src.OnFail(ctx, vessel); err != nil {
+				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+			}
+			return singlePhaseResult{
+				status:       "failed",
+				phaseSummary: vrs.phaseSummaryWithContext(r.Config, srcCfg, wf, p, harnessContent, "", 0, 0, 0.0, 0, "failed", nil, err.Error()),
+			}
+		}
+		td := compiledCtx.TemplateData
 
 		var output []byte
 		var runErr error
 		var beforeSnapshot surface.Snapshot
 		var checkProtectedSurfaces bool
 		var promptForCost string
+		contextManifestPath := td.Context.ManifestPath
 		provider := resolveProvider(r.Config, srcCfg, wf, &p)
 		model := resolveModel(r.Config, srcCfg, wf, &p, provider)
 		retryAttempt := 0
@@ -1173,6 +1267,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if policyErr := r.enforcePhasePolicy(vessel, p); policyErr != nil {
 				finishCurrentPhaseSpan(policyErr)
 				log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
+				if structuredState != nil && strings.Contains(policyErr.Error(), "requires approval") {
+					if err := structuredState.recordApproval(p.Name, "required", policyErr.Error(), r.runtimeNow()); err != nil {
+						log.Printf("warn: record approval state for %s/%s: %v", vessel.ID, p.Name, err)
+					}
+				}
 				vessel.FailedPhase = p.Name
 				r.failVessel(vessel.ID, policyErr.Error())
 				if err := src.OnFail(ctx, vessel); err != nil {
@@ -1222,6 +1321,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				}
 				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
 			}
+			rendered = withCompiledContext(compiledCtx.PromptPrefix, rendered)
 			promptForCost = rendered
 			if harnessContent != "" {
 				promptForCost = harnessContent + "\n\n" + rendered
@@ -1233,6 +1333,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if policyErr := r.enforcePhasePolicy(vessel, p); policyErr != nil {
 				finishCurrentPhaseSpan(policyErr)
 				log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
+				if structuredState != nil && strings.Contains(policyErr.Error(), "requires approval") {
+					if err := structuredState.recordApproval(p.Name, "required", policyErr.Error(), r.runtimeNow()); err != nil {
+						log.Printf("warn: record approval state for %s/%s: %v", vessel.ID, p.Name, err)
+					}
+				}
 				vessel.FailedPhase = p.Name
 				r.failVessel(vessel.ID, policyErr.Error())
 				if err := src.OnFail(ctx, vessel); err != nil {
@@ -1293,7 +1398,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			return singlePhaseResult{
 				status:       "failed",
 				duration:     phaseDuration,
-				phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()),
+				phaseSummary: vrs.phaseSummaryWithContext(r.Config, srcCfg, wf, p, harnessContent, contextManifestPath, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()),
 			}
 		}
 
@@ -1314,7 +1419,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				return singlePhaseResult{
 					status:       "failed",
 					duration:     phaseDuration,
-					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error()),
+					phaseSummary: vrs.phaseSummaryWithContext(r.Config, srcCfg, wf, p, harnessContent, contextManifestPath, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error()),
 				}
 			}
 		}
@@ -1338,7 +1443,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			return singlePhaseResult{
 				status:       "failed",
 				duration:     phaseDuration,
-				phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg),
+				phaseSummary: vrs.phaseSummaryWithContext(r.Config, srcCfg, wf, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg),
 			}
 		}
 
@@ -1354,7 +1459,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				output:        string(output),
 				status:        "no-op",
 				duration:      phaseDuration,
-				phaseSummary:  vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "no-op", nil, ""),
+				phaseSummary:  vrs.phaseSummaryWithContext(r.Config, srcCfg, wf, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "no-op", nil, ""),
 				evidenceClaim: nil,
 			}
 		}
@@ -1371,7 +1476,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				output:        string(output),
 				status:        "completed",
 				duration:      phaseDuration,
-				phaseSummary:  vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, ""),
+				phaseSummary:  vrs.phaseSummaryWithContext(r.Config, srcCfg, wf, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, ""),
 				evidenceClaim: nil,
 			}
 		}
@@ -1395,7 +1500,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					status:       "failed",
 					duration:     phaseDuration,
 					gateOut:      gateOut,
-					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error()),
+					phaseSummary: vrs.phaseSummaryWithContext(r.Config, srcCfg, wf, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error()),
 				}
 			}
 			if passed {
@@ -1407,7 +1512,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					output:        string(output),
 					status:        "completed",
 					duration:      phaseDuration,
-					phaseSummary:  vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", gatePassedPointer(true), ""),
+					phaseSummary:  vrs.phaseSummaryWithContext(r.Config, srcCfg, wf, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", gatePassedPointer(true), ""),
 					evidenceClaim: &claim,
 				}
 			}
@@ -1436,7 +1541,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					status:       "failed",
 					duration:     phaseDuration,
 					gateOut:      gateOut,
-					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted"),
+					phaseSummary: vrs.phaseSummaryWithContext(r.Config, srcCfg, wf, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted"),
 				}
 			}
 			gateRetries--
@@ -1452,7 +1557,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					status:       "failed",
 					duration:     phaseDuration,
 					gateOut:      gateOut,
-					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error()),
+					phaseSummary: vrs.phaseSummaryWithContext(r.Config, srcCfg, wf, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error()),
 				}
 			}
 			finishCurrentPhaseSpan(nil)
@@ -1478,7 +1583,12 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
 			}
 			finishCurrentPhaseSpan(nil)
-			return singlePhaseResult{output: string(output), status: "waiting", duration: r.runtimeSince(phaseStart)}
+			return singlePhaseResult{
+				output:       string(output),
+				status:       "waiting",
+				duration:     r.runtimeSince(phaseStart),
+				phaseSummary: vrs.phaseSummaryWithContext(r.Config, srcCfg, wf, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, ""),
+			}
 		}
 
 		// Unknown gate type: treat as passed.
@@ -1487,7 +1597,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			output:        string(output),
 			status:        "completed",
 			duration:      phaseDuration,
-			phaseSummary:  vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, ""),
+			phaseSummary:  vrs.phaseSummaryWithContext(r.Config, srcCfg, wf, p, harnessContent, contextManifestPath, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, ""),
 			evidenceClaim: nil,
 		}
 	}

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+	"github.com/nicholls-inc/xylem/cli/internal/memory"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
@@ -2578,6 +2580,174 @@ func TestDrainPreviousOutputsAvailable(t *testing.T) {
 	if !strings.Contains(secondPrompt, "found root cause in auth.go") {
 		t.Errorf("expected previous output in second phase prompt, got: %s", secondPrompt)
 	}
+}
+
+func TestDrainWritesStructuredContextArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "artifact-context"))
+
+	writeWorkflowFile(t, dir, "artifact-context", []testPhase{
+		{name: "analyze", promptContent: "Analyze issue", maxTurns: 5},
+		{name: "implement", promptContent: "Implement {{.PreviousOutputs.analyze}}", maxTurns: 5},
+	})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Analyze issue":      []byte("analysis ready"),
+			"Implement analysis": []byte("implemented"),
+		},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Completed)
+
+	manifestPath := filepath.Join(cfg.StateDir, "phases", "issue-1", "implement"+contextManifestSuffix)
+	data, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+
+	var manifest PhaseContextManifest
+	require.NoError(t, json.Unmarshal(data, &manifest))
+	assert.Equal(t, "issue-1", manifest.VesselID)
+	assert.Equal(t, "implement", manifest.PhaseName)
+	assert.Equal(t, "v1", manifest.Version)
+	assert.Contains(t, manifest.SelectedPreviousOutputs["analyze"], "analysis ready")
+	assert.True(t, manifest.Inputs.HasProgress)
+	assert.True(t, manifest.Inputs.HasHandoff)
+
+	handoff, err := memory.LoadHandoff("issue-1", latestHandoffSessionID, filepath.Join(cfg.StateDir, "phases", "issue-1"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"analyze", "implement"}, handoff.Plan)
+	assert.Contains(t, handoff.Checkpoints, "analyze")
+	assert.Equal(t, "implemented", handoff.PhaseOutputs["implement"])
+
+	progress, err := memory.LoadProgress("issue-1", filepath.Join(cfg.StateDir, "phases", "issue-1"))
+	require.NoError(t, err)
+	require.Len(t, progress.Items, 2)
+	assert.Equal(t, "completed", progress.Items[0].Status)
+	assert.Equal(t, "completed", progress.Items[1].Status)
+}
+
+func TestDrainResumeUsesStructuredHandoffBeforeRawOutputs(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	vessel := makeVessel(1, "resume-context")
+	vessel.CurrentPhase = 1
+	_, _ = q.Enqueue(vessel)
+
+	writeWorkflowFile(t, dir, "resume-context", []testPhase{
+		{name: "analyze", promptContent: "Analyze issue", maxTurns: 5},
+		{name: "implement", promptContent: "Implement using {{.PreviousOutputs.analyze}}", maxTurns: 5},
+	})
+	withTestWorkingDir(t, dir)
+
+	phasesDir := filepath.Join(cfg.StateDir, "phases", "issue-1")
+	require.NoError(t, os.MkdirAll(phasesDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(phasesDir, "analyze.output"), []byte("raw output should not be used"), 0o644))
+
+	handoff := memory.NewHandoff("issue-1", latestHandoffSessionID)
+	handoff.Plan = []string{"analyze", "implement"}
+	handoff.Checkpoints = []string{"analyze"}
+	handoff.PhaseOutputs = map[string]string{"analyze": "handoff output should win"}
+	require.NoError(t, handoff.Save(phasesDir))
+
+	progress, err := memory.CreateProgress("issue-1", []string{"analyze", "implement"}, phasesDir)
+	require.NoError(t, err)
+	_ = progress
+	require.NoError(t, memory.UpdateProgress("issue-1", "analyze", "in_progress", phasesDir))
+	require.NoError(t, memory.UpdateProgress("issue-1", "analyze", "completed", phasesDir))
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Implement using handoff output should win": []byte("implemented"),
+		},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Completed)
+	require.Len(t, cmdRunner.phaseCalls, 1)
+	assert.Contains(t, cmdRunner.phaseCalls[0].prompt, "handoff output should win")
+	assert.NotContains(t, cmdRunner.phaseCalls[0].prompt, "raw output should not be used")
+}
+
+func TestCompilePhaseContextCompactsLargePreviousOutputs(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{path: dir}, &mockCmdRunner{})
+	vessel := makeVessel(1, "compact")
+	p := workflow.Phase{Name: "implement", MaxTurns: 5}
+	largeOutput := strings.Repeat("dependency output ", 1500)
+
+	compiled, err := r.compilePhaseContext(vessel, p, 1, phase.IssueData{Title: "Issue title"}, map[string]string{"analyze": largeOutput}, "", structuredSnapshot{
+		Progress: &memory.ProgressFile{
+			MissionID: "issue-1",
+			Items: []memory.ProgressItem{
+				{Task: "analyze", Status: "completed"},
+				{Task: "implement", Status: "pending"},
+			},
+		},
+		Handoff: &memory.HandoffArtifact{
+			MissionID:   "issue-1",
+			SessionID:   latestHandoffSessionID,
+			Plan:        []string{"analyze", "implement"},
+			Checkpoints: []string{"analyze"},
+		},
+	}, false)
+	require.NoError(t, err)
+	assert.Empty(t, compiled.TemplateData.PreviousOutputs["analyze"])
+
+	manifestPath := filepath.Join(cfg.StateDir, "phases", "issue-1", "implement"+contextManifestSuffix)
+	data, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+
+	var manifest PhaseContextManifest
+	require.NoError(t, json.Unmarshal(data, &manifest))
+	assert.True(t, manifest.Compaction.Applied)
+	assert.Empty(t, manifest.SelectedPreviousOutputs)
+	assert.NotEmpty(t, manifest.Window.Segments)
+}
+
+func TestCleanupExpiredStructuredArtifactsRemovesSnapshotsOnly(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+	phasesDir := filepath.Join(stateDir, "phases", "issue-1")
+	require.NoError(t, os.MkdirAll(phasesDir, 0o755))
+
+	oldContext := filepath.Join(phasesDir, "implement"+contextManifestSuffix)
+	oldSnapshot := filepath.Join(phasesDir, "handoff_issue-1_completed.json")
+	latest := filepath.Join(phasesDir, "handoff_issue-1_latest.json")
+	progress := filepath.Join(phasesDir, "progress_issue-1.json")
+	for _, path := range []string{oldContext, oldSnapshot, latest, progress} {
+		require.NoError(t, os.WriteFile(path, []byte("{}"), 0o644))
+	}
+
+	oldTime := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(oldContext, oldTime, oldTime))
+	require.NoError(t, os.Chtimes(oldSnapshot, oldTime, oldTime))
+
+	require.NoError(t, cleanupExpiredStructuredArtifacts(stateDir, time.Now(), time.Hour))
+
+	_, err := os.Stat(oldContext)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(oldSnapshot)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(latest)
+	assert.NoError(t, err)
+	_, err = os.Stat(progress)
+	assert.NoError(t, err)
 }
 
 func TestBranchPrefixSelection(t *testing.T) {

--- a/cli/internal/runner/summary.go
+++ b/cli/internal/runner/summary.go
@@ -22,6 +22,30 @@ const (
 
 var safeSummaryPathComponent = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
+// ArtifactRetention records the retention policy for structured runner artifacts.
+type ArtifactRetention struct {
+	CleanupAfter string   `json:"cleanup_after"`
+	Preserved    []string `json:"preserved"`
+	Expiring     []string `json:"expiring"`
+}
+
+func defaultArtifactRetention() ArtifactRetention {
+	return ArtifactRetention{
+		CleanupAfter: "168h",
+		Preserved: []string{
+			"progress_<vessel>.json",
+			"handoff_<vessel>_latest.json",
+			"summary.json",
+			"*.output",
+			"*.prompt",
+		},
+		Expiring: []string{
+			"*" + contextManifestSuffix,
+			"handoff_<vessel>_<snapshot>.json",
+		},
+	}
+}
+
 // VesselSummary is the JSON artifact written after vessel completion or failure.
 type VesselSummary struct {
 	VesselID   string    `json:"vessel_id"`
@@ -44,25 +68,29 @@ type VesselSummary struct {
 	BudgetMaxTokens  *int     `json:"budget_max_tokens,omitempty"`
 	BudgetExceeded   bool     `json:"budget_exceeded"`
 
-	EvidenceManifestPath string `json:"evidence_manifest_path,omitempty"`
+	EvidenceManifestPath string            `json:"evidence_manifest_path,omitempty"`
+	ProgressPath         string            `json:"progress_path,omitempty"`
+	HandoffPath          string            `json:"handoff_path,omitempty"`
+	Retention            ArtifactRetention `json:"retention"`
 
 	Note string `json:"note"`
 }
 
 // PhaseSummary records the outcome of a single phase.
 type PhaseSummary struct {
-	Name            string  `json:"name"`
-	Type            string  `json:"type"`
-	Provider        string  `json:"provider,omitempty"`
-	Model           string  `json:"model,omitempty"`
-	DurationMS      int64   `json:"duration_ms"`
-	Status          string  `json:"status"`
-	InputTokensEst  int     `json:"input_tokens_est"`
-	OutputTokensEst int     `json:"output_tokens_est"`
-	CostUSDEst      float64 `json:"cost_usd_est"`
-	GateType        string  `json:"gate_type,omitempty"`
-	GatePassed      *bool   `json:"gate_passed,omitempty"`
-	Error           string  `json:"error,omitempty"`
+	Name                string  `json:"name"`
+	Type                string  `json:"type"`
+	Provider            string  `json:"provider,omitempty"`
+	Model               string  `json:"model,omitempty"`
+	DurationMS          int64   `json:"duration_ms"`
+	Status              string  `json:"status"`
+	InputTokensEst      int     `json:"input_tokens_est"`
+	OutputTokensEst     int     `json:"output_tokens_est"`
+	CostUSDEst          float64 `json:"cost_usd_est"`
+	GateType            string  `json:"gate_type,omitempty"`
+	GatePassed          *bool   `json:"gate_passed,omitempty"`
+	ContextManifestPath string  `json:"context_manifest_path,omitempty"`
+	Error               string  `json:"error,omitempty"`
 }
 
 type vesselRunState struct {
@@ -81,6 +109,10 @@ type vesselRunState struct {
 	extraInputTokensEst  int
 	extraOutputTokensEst int
 	extraCostUSDEst      float64
+
+	progressPath string
+	handoffPath  string
+	retention    ArtifactRetention
 }
 
 func newVesselRunState(cfg *config.Config, vessel queue.Vessel, startedAt time.Time) *vesselRunState {
@@ -91,10 +123,15 @@ func newVesselRunState(cfg *config.Config, vessel queue.Vessel, startedAt time.T
 		source:    vessel.Source,
 		workflow:  vessel.Workflow,
 		ref:       vessel.Ref,
+		retention: defaultArtifactRetention(),
 	}
 
 	if cfg == nil {
 		return s
+	}
+
+	if cfg.CleanupAfter != "" {
+		s.retention.CleanupAfter = cfg.CleanupAfter
 	}
 
 	if budget := cfg.VesselBudget(); budget != nil {
@@ -138,6 +175,9 @@ func (s *vesselRunState) buildSummary(state string, endedAt time.Time) *VesselSu
 		Phases:           phases,
 		BudgetMaxCostUSD: s.budgetMaxCostUSD,
 		BudgetMaxTokens:  s.budgetMaxTokens,
+		ProgressPath:     s.progressPath,
+		HandoffPath:      s.handoffPath,
+		Retention:        s.retention,
 		Note:             summaryDisclaimer,
 	}
 
@@ -201,12 +241,17 @@ func (s *vesselRunState) recordPhaseTokens(
 }
 
 func (s *vesselRunState) phaseSummary(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p workflow.Phase, harnessContent string, inputTokensEst, outputTokensEst int, costUSDEst float64, duration time.Duration, status string, gatePassed *bool, errMsg string) PhaseSummary {
+	return s.phaseSummaryWithContext(cfg, srcCfg, wf, p, harnessContent, "", inputTokensEst, outputTokensEst, costUSDEst, duration, status, gatePassed, errMsg)
+}
+
+func (s *vesselRunState) phaseSummaryWithContext(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p workflow.Phase, harnessContent, contextManifestPath string, inputTokensEst, outputTokensEst int, costUSDEst float64, duration time.Duration, status string, gatePassed *bool, errMsg string) PhaseSummary {
 	summary := PhaseSummary{
-		Name:       p.Name,
-		Type:       phaseTypeLabel(p),
-		DurationMS: duration.Milliseconds(),
-		Status:     status,
-		Error:      errMsg,
+		Name:                p.Name,
+		Type:                phaseTypeLabel(p),
+		DurationMS:          duration.Milliseconds(),
+		Status:              status,
+		ContextManifestPath: contextManifestPath,
+		Error:               errMsg,
 	}
 
 	if p.Gate != nil {
@@ -266,6 +311,9 @@ func SaveVesselSummary(stateDir string, summary *VesselSummary) error {
 	summary.Note = summaryDisclaimer
 	if summary.Phases == nil {
 		summary.Phases = []PhaseSummary{}
+	}
+	if summary.Retention.CleanupAfter == "" {
+		summary.Retention = defaultArtifactRetention()
 	}
 	data, err := json.MarshalIndent(summary, "", "  ")
 	if err != nil {


### PR DESCRIPTION
## Summary
- compile an inspectable context manifest for each phase and thread the compiled context into prompt assembly
- persist structured progress and handoff artifacts so resumed vessels rebuild state from durable runner artifacts
- record retention metadata in vessel summaries and document which artifacts expire versus remain durable
- extend runner tests to cover compaction, structured resume reconstruction, and artifact cleanup

Closes https://github.com/nicholls-inc/xylem/issues/60