### PR TITLE
Add runtime containment, network policy, and scoped secret handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ daemon:
 
 This example covers the most common fields. Additional configuration is available for per-source provider overrides (`llm`, `model`), agent safety guardrails (`harness`), OpenTelemetry tracing (`observability`), and token budget enforcement (`cost`). See the [Configuration Reference](docs/configuration.md) for all fields, defaults, and validation rules.
 
+Runtime containment now defaults to a workspace-scoped execution profile for autonomous phases: xylem rewrites `HOME`, `TMPDIR`, and XDG state into worktree-local directories, injects only phase-scoped secrets, and applies a deny-by-default network environment for command/gate phases unless you opt back into inherited network behavior.
+
 ## Workflows
 
 Workflows are multi-phase execution plans defined in YAML. Prompt phases run against the configured LLM provider, and phases can have quality gates that must pass before the next phase begins.

--- a/cli/cmd/xylem/exec.go
+++ b/cli/cmd/xylem/exec.go
@@ -183,8 +183,9 @@ func (hostRuntime) Apply(cmd *exec.Cmd, req containment.Request) error {
 }
 
 func buildContainedEnv(base []string, req containment.Request) ([]string, error) {
-	env := filterRuntimeBaseEnv(base)
+	env := append([]string(nil), base...)
 	if req.Isolation == containment.IsolationWorkspace {
+		env = filterRuntimeBaseEnv(base)
 		homeDir := filepath.Join(req.RuntimeDir, "home")
 		tmpDir := filepath.Join(req.RuntimeDir, "tmp")
 		cacheDir := filepath.Join(req.RuntimeDir, "xdg", "cache")

--- a/cli/cmd/xylem/exec.go
+++ b/cli/cmd/xylem/exec.go
@@ -7,9 +7,12 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/containment"
 )
 
 // maxStderrBytes is the maximum amount of stderr captured from a phase subprocess.
@@ -70,25 +73,19 @@ func (lw *limitedWriter) Len() int {
 }
 
 type realCmdRunner struct {
-	// extraEnv holds additional KEY=VALUE pairs merged into the subprocess
-	// environment. Populated from claude.env and copilot.env in config.
-	extraEnv []string
+	runtime executionRuntime
 }
 
-// newCmdRunner creates a realCmdRunner with extra env vars merged from
-// claude.env and copilot.env config sections.
+type executionRuntime interface {
+	Apply(cmd *exec.Cmd, req containment.Request) error
+}
+
+type hostRuntime struct{}
+
+// newCmdRunner creates a realCmdRunner for real subprocess execution.
 func newCmdRunner(cfg *config.Config) *realCmdRunner {
-	if cfg == nil {
-		return &realCmdRunner{}
-	}
-	var env []string
-	for k, v := range cfg.Claude.Env {
-		env = append(env, k+"="+os.ExpandEnv(v))
-	}
-	for k, v := range cfg.Copilot.Env {
-		env = append(env, k+"="+os.ExpandEnv(v))
-	}
-	return &realCmdRunner{extraEnv: env}
+	_ = cfg
+	return &realCmdRunner{runtime: hostRuntime{}}
 }
 
 func (r *realCmdRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
@@ -96,11 +93,18 @@ func (r *realCmdRunner) Run(ctx context.Context, name string, args ...string) ([
 }
 
 func (r *realCmdRunner) RunOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+	cmd, err := r.commandWithRequest(ctx, name, args...)
+	if err != nil {
+		return nil, err
+	}
+	return cmd.CombinedOutput()
 }
 
 func (r *realCmdRunner) RunProcess(ctx context.Context, dir string, name string, args ...string) error {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd, err := r.commandWithRequest(ctx, name, args...)
+	if err != nil {
+		return err
+	}
 	cmd.Dir = dir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -113,25 +117,157 @@ func (r *realCmdRunner) RunProcessWithEnv(ctx context.Context, dir string, extra
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = append(os.Environ(), extraEnv...)
+	if err := r.applyRequest(ctx, cmd); err != nil {
+		return err
+	}
 	return cmd.Run()
 }
 
 func (r *realCmdRunner) RunPhase(ctx context.Context, dir string, stdin io.Reader, name string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd, err := r.commandWithRequest(ctx, name, args...)
+	if err != nil {
+		return nil, err
+	}
 	cmd.Dir = dir
 	cmd.Stdin = stdin
-	if len(r.extraEnv) > 0 {
-		cmd.Env = append(os.Environ(), r.extraEnv...)
-	}
 
 	var stdout bytes.Buffer
 	stderr := newLimitedWriter(maxStderrBytes)
 	cmd.Stdout = &stdout
 	cmd.Stderr = stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil && stderr.Len() > 0 {
 		return stdout.Bytes(), fmt.Errorf("%w\nstderr: %s", err, stderr.String())
 	}
 	return stdout.Bytes(), err
+}
+
+func (r *realCmdRunner) applyRequest(ctx context.Context, cmd *exec.Cmd) error {
+	if r.runtime == nil {
+		return nil
+	}
+	req, ok := containment.RequestFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	if err := r.runtime.Apply(cmd, req); err != nil {
+		return fmt.Errorf("apply runtime containment: %w", err)
+	}
+	return nil
+}
+
+func (r *realCmdRunner) commandWithRequest(ctx context.Context, name string, args ...string) (*exec.Cmd, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if err := r.applyRequest(ctx, cmd); err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}
+
+func (hostRuntime) Apply(cmd *exec.Cmd, req containment.Request) error {
+	if req.Isolation == containment.IsolationOff && req.Network == containment.NetworkInherit && len(req.Env) == 0 {
+		return nil
+	}
+
+	baseEnv := os.Environ()
+	if len(cmd.Env) > 0 {
+		baseEnv = cmd.Env
+	}
+	env, err := buildContainedEnv(baseEnv, req)
+	if err != nil {
+		return err
+	}
+	cmd.Env = env
+	return nil
+}
+
+func buildContainedEnv(base []string, req containment.Request) ([]string, error) {
+	env := filterRuntimeBaseEnv(base)
+	if req.Isolation == containment.IsolationWorkspace {
+		homeDir := filepath.Join(req.RuntimeDir, "home")
+		tmpDir := filepath.Join(req.RuntimeDir, "tmp")
+		cacheDir := filepath.Join(req.RuntimeDir, "xdg", "cache")
+		configDir := filepath.Join(req.RuntimeDir, "xdg", "config")
+		dataDir := filepath.Join(req.RuntimeDir, "xdg", "data")
+		for _, dir := range []string{homeDir, tmpDir, cacheDir, configDir, dataDir} {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return nil, fmt.Errorf("create runtime dir %q: %w", dir, err)
+			}
+		}
+		env = upsertEnv(env, "HOME", homeDir)
+		env = upsertEnv(env, "TMPDIR", tmpDir)
+		env = upsertEnv(env, "XDG_CACHE_HOME", cacheDir)
+		env = upsertEnv(env, "XDG_CONFIG_HOME", configDir)
+		env = upsertEnv(env, "XDG_DATA_HOME", dataDir)
+		env = upsertEnv(env, "GIT_CONFIG_GLOBAL", os.DevNull)
+		env = upsertEnv(env, "GIT_CONFIG_NOSYSTEM", "1")
+	}
+
+	switch req.Network {
+	case containment.NetworkDeny:
+		env = applyDeniedNetworkEnv(env)
+	case containment.NetworkInherit:
+		// Preserve proxy-related env from the filtered base set.
+	}
+
+	for _, entry := range req.Env {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		env = upsertEnv(env, name, value)
+	}
+	env = upsertEnv(env, "XYLEM_RUNTIME_NETWORK", string(req.Network))
+	env = upsertEnv(env, "XYLEM_RUNTIME_ISOLATION", string(req.Isolation))
+	return env, nil
+}
+
+func filterRuntimeBaseEnv(base []string) []string {
+	allowed := map[string]struct{}{
+		"PATH": {}, "LANG": {}, "LC_ALL": {}, "LC_CTYPE": {}, "TERM": {}, "COLORTERM": {},
+		"NO_COLOR": {}, "CI": {}, "TZ": {}, "SSL_CERT_FILE": {}, "SSL_CERT_DIR": {},
+		"http_proxy": {}, "https_proxy": {}, "all_proxy": {}, "no_proxy": {},
+		"HTTP_PROXY": {}, "HTTPS_PROXY": {}, "ALL_PROXY": {}, "NO_PROXY": {},
+	}
+	var filtered []string
+	for _, entry := range base {
+		name, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if _, ok := allowed[name]; ok {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
+}
+
+func upsertEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	replaced := false
+	for i, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			env[i] = prefix + value
+			replaced = true
+		}
+	}
+	if !replaced {
+		env = append(env, prefix+value)
+	}
+	return env
+}
+
+func applyDeniedNetworkEnv(env []string) []string {
+	blockedHTTP := "http://127.0.0.1:9"
+	blockedSOCKS := "socks5://127.0.0.1:9"
+	env = upsertEnv(env, "http_proxy", blockedHTTP)
+	env = upsertEnv(env, "https_proxy", blockedHTTP)
+	env = upsertEnv(env, "all_proxy", blockedSOCKS)
+	env = upsertEnv(env, "HTTP_PROXY", blockedHTTP)
+	env = upsertEnv(env, "HTTPS_PROXY", blockedHTTP)
+	env = upsertEnv(env, "ALL_PROXY", blockedSOCKS)
+	env = upsertEnv(env, "NO_PROXY", "127.0.0.1,localhost,::1")
+	env = upsertEnv(env, "no_proxy", "127.0.0.1,localhost,::1")
+	return env
 }

--- a/cli/cmd/xylem/exec_test.go
+++ b/cli/cmd/xylem/exec_test.go
@@ -72,6 +72,38 @@ func TestBuildContainedEnvInheritPreservesProxy(t *testing.T) {
 	}
 }
 
+func TestBuildContainedEnvOffPreservesAmbientEnvWithScopedSecrets(t *testing.T) {
+	env, err := buildContainedEnv([]string{
+		"PATH=/usr/bin",
+		"HOME=/Users/example",
+		"SECRET=ambient",
+		"CUSTOM=ambient",
+	}, containment.Request{
+		Isolation: containment.IsolationOff,
+		Network:   containment.NetworkDeny,
+		Env:       []string{"TOKEN=scoped", "SECRET=scoped"},
+	})
+	if err != nil {
+		t.Fatalf("buildContainedEnv() error = %v", err)
+	}
+
+	if got := envValue(env, "CUSTOM"); got != "ambient" {
+		t.Fatalf("CUSTOM = %q, want ambient", got)
+	}
+	if got := envValue(env, "HOME"); got != "/Users/example" {
+		t.Fatalf("HOME = %q, want inherited home", got)
+	}
+	if got := envValue(env, "TOKEN"); got != "scoped" {
+		t.Fatalf("TOKEN = %q, want scoped", got)
+	}
+	if got := envValue(env, "SECRET"); got != "scoped" {
+		t.Fatalf("SECRET = %q, want scoped", got)
+	}
+	if got := envValue(env, "HTTP_PROXY"); got != "http://127.0.0.1:9" {
+		t.Fatalf("HTTP_PROXY = %q, want deny proxy", got)
+	}
+}
+
 func TestCommandWithRequestAppliesContainment(t *testing.T) {
 	runtimeDir := t.TempDir()
 	runner := &realCmdRunner{runtime: hostRuntime{}}

--- a/cli/cmd/xylem/exec_test.go
+++ b/cli/cmd/xylem/exec_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/containment"
+)
+
+func envValue(env []string, key string) string {
+	tok := key + "="
+	for _, entry := range env {
+		if len(entry) > len(tok) && entry[:len(tok)] == tok {
+			return entry[len(tok):]
+		}
+	}
+	return ""
+}
+
+func TestBuildContainedEnvWorkspaceIsolation(t *testing.T) {
+	runtimeDir := t.TempDir()
+
+	env, err := buildContainedEnv([]string{
+		"PATH=/usr/bin",
+		"HOME=/Users/example",
+		"SECRET=ambient",
+	}, containment.Request{
+		Isolation:  containment.IsolationWorkspace,
+		Network:    containment.NetworkDeny,
+		RuntimeDir: runtimeDir,
+		Env:        []string{"TOKEN=scoped"},
+	})
+	if err != nil {
+		t.Fatalf("buildContainedEnv() error = %v", err)
+	}
+
+	if got := envValue(env, "HOME"); got != filepath.Join(runtimeDir, "home") {
+		t.Fatalf("HOME = %q, want %q", got, filepath.Join(runtimeDir, "home"))
+	}
+	if got := envValue(env, "TMPDIR"); got != filepath.Join(runtimeDir, "tmp") {
+		t.Fatalf("TMPDIR = %q, want %q", got, filepath.Join(runtimeDir, "tmp"))
+	}
+	if got := envValue(env, "TOKEN"); got != "scoped" {
+		t.Fatalf("TOKEN = %q, want scoped", got)
+	}
+	if got := envValue(env, "SECRET"); got != "" {
+		t.Fatalf("SECRET = %q, want empty", got)
+	}
+	if got := envValue(env, "HTTP_PROXY"); got != "http://127.0.0.1:9" {
+		t.Fatalf("HTTP_PROXY = %q, want deny proxy", got)
+	}
+	if got := envValue(env, "GIT_CONFIG_NOSYSTEM"); got != "1" {
+		t.Fatalf("GIT_CONFIG_NOSYSTEM = %q, want 1", got)
+	}
+}
+
+func TestBuildContainedEnvInheritPreservesProxy(t *testing.T) {
+	env, err := buildContainedEnv([]string{
+		"PATH=/usr/bin",
+		"HTTP_PROXY=http://proxy.internal:8080",
+	}, containment.Request{
+		Isolation: containment.IsolationOff,
+		Network:   containment.NetworkInherit,
+	})
+	if err != nil {
+		t.Fatalf("buildContainedEnv() error = %v", err)
+	}
+
+	if got := envValue(env, "HTTP_PROXY"); got != "http://proxy.internal:8080" {
+		t.Fatalf("HTTP_PROXY = %q, want inherited proxy", got)
+	}
+}
+
+func TestCommandWithRequestAppliesContainment(t *testing.T) {
+	runtimeDir := t.TempDir()
+	runner := &realCmdRunner{runtime: hostRuntime{}}
+	ctx := containment.WithRequest(context.Background(), containment.Request{
+		Isolation:  containment.IsolationWorkspace,
+		Network:    containment.NetworkDeny,
+		RuntimeDir: runtimeDir,
+		Env:        []string{"TOKEN=scoped"},
+	})
+
+	cmd, err := runner.commandWithRequest(ctx, "env")
+	if err != nil {
+		t.Fatalf("commandWithRequest() error = %v", err)
+	}
+
+	if got := envValue(cmd.Env, "TOKEN"); got != "scoped" {
+		t.Fatalf("cmd env TOKEN = %q, want scoped", got)
+	}
+	if got := envValue(cmd.Env, "HTTP_PROXY"); got != "http://127.0.0.1:9" {
+		t.Fatalf("cmd env HTTP_PROXY = %q, want deny proxy", got)
+	}
+	if got := envValue(cmd.Env, "HOME"); got != filepath.Join(runtimeDir, "home") {
+		t.Fatalf("cmd env HOME = %q, want %q", got, filepath.Join(runtimeDir, "home"))
+	}
+}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -16,6 +16,13 @@ const minTimeout = 30 * time.Second
 
 const DefaultAuditLogPath = "audit.jsonl"
 
+const (
+	RuntimeIsolationWorkspace = "workspace"
+	RuntimeIsolationOff       = "off"
+	RuntimeNetworkInherit     = "inherit"
+	RuntimeNetworkDeny        = "deny"
+)
+
 var DefaultProtectedSurfaces = []string{
 	".xylem/HARNESS.md",
 	".xylem.yml",
@@ -117,6 +124,7 @@ type HarnessConfig struct {
 	ProtectedSurfaces ProtectedSurfacesConfig `yaml:"protected_surfaces,omitempty"`
 	Policy            PolicyConfig            `yaml:"policy,omitempty"`
 	AuditLog          string                  `yaml:"audit_log,omitempty"`
+	Runtime           RuntimeConfig           `yaml:"runtime,omitempty"`
 }
 
 type ProtectedSurfacesConfig struct {
@@ -131,6 +139,37 @@ type PolicyRuleConfig struct {
 	Action   string `yaml:"action"`
 	Resource string `yaml:"resource"`
 	Effect   string `yaml:"effect"`
+}
+
+type RuntimeConfig struct {
+	Isolation string                `yaml:"isolation,omitempty"`
+	Network   RuntimeNetworkConfig  `yaml:"network,omitempty"`
+	Secrets   []RuntimeSecretConfig `yaml:"secrets,omitempty"`
+}
+
+type RuntimeNetworkConfig struct {
+	Default string `yaml:"default,omitempty"`
+	Prompt  string `yaml:"prompt,omitempty"`
+	Command string `yaml:"command,omitempty"`
+	Gate    string `yaml:"gate,omitempty"`
+}
+
+type RuntimeSecretConfig struct {
+	Name       string   `yaml:"name"`
+	Value      string   `yaml:"value"`
+	Providers  []string `yaml:"providers,omitempty"`
+	Workflows  []string `yaml:"workflows,omitempty"`
+	Phases     []string `yaml:"phases,omitempty"`
+	Operations []string `yaml:"operations,omitempty"`
+}
+
+type ResolvedRuntimeSecret struct {
+	Name       string
+	Value      string
+	Providers  []string
+	Workflows  []string
+	Phases     []string
+	Operations []string
 }
 
 type ObservabilityConfig struct {
@@ -368,6 +407,84 @@ func (c *Config) EffectiveAuditLogPath() string {
 	return DefaultAuditLogPath
 }
 
+func (c *Config) EffectiveRuntimeIsolation() string {
+	switch c.Harness.Runtime.Isolation {
+	case "", RuntimeIsolationWorkspace:
+		return RuntimeIsolationWorkspace
+	case RuntimeIsolationOff:
+		return RuntimeIsolationOff
+	default:
+		return RuntimeIsolationWorkspace
+	}
+}
+
+func (c *Config) EffectiveRuntimeNetworkMode(operation string) string {
+	var value string
+	switch operation {
+	case "prompt", "prompt_only":
+		value = c.Harness.Runtime.Network.Prompt
+	case "command":
+		value = c.Harness.Runtime.Network.Command
+	case "gate":
+		value = c.Harness.Runtime.Network.Gate
+	}
+	if strings.TrimSpace(value) == "" {
+		value = c.Harness.Runtime.Network.Default
+	}
+	if strings.TrimSpace(value) == "" {
+		switch operation {
+		case "prompt", "prompt_only":
+			return RuntimeNetworkInherit
+		default:
+			return RuntimeNetworkDeny
+		}
+	}
+	switch value {
+	case RuntimeNetworkInherit:
+		return RuntimeNetworkInherit
+	case RuntimeNetworkDeny:
+		return RuntimeNetworkDeny
+	default:
+		switch operation {
+		case "prompt", "prompt_only":
+			return RuntimeNetworkInherit
+		default:
+			return RuntimeNetworkDeny
+		}
+	}
+}
+
+func (c *Config) RuntimeSecrets() []ResolvedRuntimeSecret {
+	var resolved []ResolvedRuntimeSecret
+	for name, value := range c.Claude.Env {
+		resolved = append(resolved, ResolvedRuntimeSecret{
+			Name:       name,
+			Value:      os.ExpandEnv(value),
+			Providers:  []string{"claude"},
+			Operations: []string{"prompt", "prompt_only"},
+		})
+	}
+	for name, value := range c.Copilot.Env {
+		resolved = append(resolved, ResolvedRuntimeSecret{
+			Name:       name,
+			Value:      os.ExpandEnv(value),
+			Providers:  []string{"copilot"},
+			Operations: []string{"prompt", "prompt_only"},
+		})
+	}
+	for _, secret := range c.Harness.Runtime.Secrets {
+		resolved = append(resolved, ResolvedRuntimeSecret{
+			Name:       secret.Name,
+			Value:      os.ExpandEnv(secret.Value),
+			Providers:  append([]string(nil), secret.Providers...),
+			Workflows:  append([]string(nil), secret.Workflows...),
+			Phases:     append([]string(nil), secret.Phases...),
+			Operations: append([]string(nil), secret.Operations...),
+		})
+	}
+	return resolved
+}
+
 func (c *Config) ObservabilityEnabled() bool {
 	if c.Observability.Enabled == nil {
 		return true
@@ -457,7 +574,69 @@ func (c *Config) validateHarness() error {
 		}
 	}
 
+	if err := validateRuntimeIsolation(c.Harness.Runtime.Isolation); err != nil {
+		return fmt.Errorf("harness.runtime.isolation: %w", err)
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{"default", c.Harness.Runtime.Network.Default},
+		{"prompt", c.Harness.Runtime.Network.Prompt},
+		{"command", c.Harness.Runtime.Network.Command},
+		{"gate", c.Harness.Runtime.Network.Gate},
+	} {
+		if err := validateRuntimeNetworkMode(field.value); err != nil {
+			return fmt.Errorf("harness.runtime.network.%s: %w", field.name, err)
+		}
+	}
+	seenNames := make(map[string]struct{}, len(c.Harness.Runtime.Secrets))
+	for i, secret := range c.Harness.Runtime.Secrets {
+		if strings.TrimSpace(secret.Name) == "" {
+			return fmt.Errorf("harness.runtime.secrets[%d]: name is required", i)
+		}
+		if strings.TrimSpace(secret.Value) == "" {
+			return fmt.Errorf("harness.runtime.secrets[%d]: value is required", i)
+		}
+		if _, ok := seenNames[secret.Name]; ok {
+			return fmt.Errorf("harness.runtime.secrets[%d]: duplicate name %q", i, secret.Name)
+		}
+		seenNames[secret.Name] = struct{}{}
+		for _, provider := range secret.Providers {
+			switch provider {
+			case "claude", "copilot":
+			default:
+				return fmt.Errorf("harness.runtime.secrets[%d]: invalid provider %q", i, provider)
+			}
+		}
+		for _, operation := range secret.Operations {
+			switch operation {
+			case "prompt", "prompt_only", "command", "gate":
+			default:
+				return fmt.Errorf("harness.runtime.secrets[%d]: invalid operation %q", i, operation)
+			}
+		}
+	}
+
 	return nil
+}
+
+func validateRuntimeIsolation(value string) error {
+	switch strings.TrimSpace(value) {
+	case "", RuntimeIsolationWorkspace, RuntimeIsolationOff:
+		return nil
+	default:
+		return fmt.Errorf("must be %q or %q", RuntimeIsolationWorkspace, RuntimeIsolationOff)
+	}
+}
+
+func validateRuntimeNetworkMode(value string) error {
+	switch strings.TrimSpace(value) {
+	case "", RuntimeNetworkInherit, RuntimeNetworkDeny:
+		return nil
+	default:
+		return fmt.Errorf("must be %q or %q", RuntimeNetworkInherit, RuntimeNetworkDeny)
+	}
 }
 
 func (c *Config) validateObservability() error {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -332,6 +332,61 @@ func TestValidateTimeoutTooLow(t *testing.T) {
 	requireErrorContains(t, err, "timeout must be at least")
 }
 
+func TestValidateRuntimeIsolationRejectedWhenUnknown(t *testing.T) {
+	cfg := validConfig()
+	cfg.Harness.Runtime.Isolation = "container"
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, "harness.runtime.isolation")
+}
+
+func TestValidateRuntimeSecretRejectedWhenOperationUnknown(t *testing.T) {
+	cfg := validConfig()
+	cfg.Harness.Runtime.Secrets = []RuntimeSecretConfig{{
+		Name:       "GH_TOKEN",
+		Value:      "secret",
+		Operations: []string{"deploy"},
+	}}
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, "invalid operation")
+}
+
+func TestRuntimeSecretsIncludeLegacyProviderEnv(t *testing.T) {
+	cfg := validConfig()
+	cfg.Claude.Env = map[string]string{"ANTHROPIC_API_KEY": "${TEST_ANTHROPIC_KEY}"}
+	cfg.Copilot.Env = map[string]string{"GITHUB_TOKEN": "${TEST_COPILOT_KEY}"}
+	cfg.Harness.Runtime.Secrets = []RuntimeSecretConfig{{
+		Name:       "GH_TOKEN",
+		Value:      "${TEST_GH_TOKEN}",
+		Operations: []string{"command"},
+	}}
+	t.Setenv("TEST_ANTHROPIC_KEY", "anthropic-secret")
+	t.Setenv("TEST_COPILOT_KEY", "copilot-secret")
+	t.Setenv("TEST_GH_TOKEN", "gh-secret")
+
+	got := cfg.RuntimeSecrets()
+
+	require.Len(t, got, 3)
+	assert.Contains(t, got, ResolvedRuntimeSecret{
+		Name:       "ANTHROPIC_API_KEY",
+		Value:      "anthropic-secret",
+		Providers:  []string{"claude"},
+		Operations: []string{"prompt", "prompt_only"},
+	})
+	assert.Contains(t, got, ResolvedRuntimeSecret{
+		Name:       "GITHUB_TOKEN",
+		Value:      "copilot-secret",
+		Providers:  []string{"copilot"},
+		Operations: []string{"prompt", "prompt_only"},
+	})
+	assert.Contains(t, got, ResolvedRuntimeSecret{
+		Name:       "GH_TOKEN",
+		Value:      "gh-secret",
+		Operations: []string{"command"},
+	})
+}
+
 func TestValidateMalformedRepo(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cli/internal/containment/containment.go
+++ b/cli/internal/containment/containment.go
@@ -1,0 +1,74 @@
+package containment
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type IsolationMode string
+
+const (
+	IsolationWorkspace IsolationMode = "workspace"
+	IsolationOff       IsolationMode = "off"
+)
+
+type NetworkMode string
+
+const (
+	NetworkInherit NetworkMode = "inherit"
+	NetworkDeny    NetworkMode = "deny"
+)
+
+type Request struct {
+	Isolation  IsolationMode
+	Network    NetworkMode
+	RuntimeDir string
+	Env        []string
+	Metadata   map[string]string
+}
+
+var safePathComponent = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+type contextKey struct{}
+
+func WithRequest(ctx context.Context, req Request) context.Context {
+	return context.WithValue(ctx, contextKey{}, req)
+}
+
+func RequestFromContext(ctx context.Context) (Request, bool) {
+	req, ok := ctx.Value(contextKey{}).(Request)
+	return req, ok
+}
+
+func BuildRuntimeDir(worktreePath, vesselID, operation, phaseName string) (string, error) {
+	for _, component := range []struct {
+		name  string
+		value string
+	}{
+		{name: "vessel ID", value: vesselID},
+		{name: "operation", value: operation},
+		{name: "phase", value: phaseName},
+	} {
+		if err := validatePathComponent(component.value); err != nil {
+			return "", fmt.Errorf("%s: %w", component.name, err)
+		}
+	}
+
+	return filepath.Join(worktreePath, ".xylem", "runtime", vesselID, operation, phaseName), nil
+}
+
+func validatePathComponent(value string) error {
+	if value == "" {
+		return fmt.Errorf("path component must not be empty")
+	}
+	if strings.Contains(value, "..") {
+		return fmt.Errorf("path component must not contain %q", "..")
+	}
+	if !safePathComponent.MatchString(value) {
+		return fmt.Errorf("path component %q contains invalid characters (allowed: a-zA-Z0-9._-)", value)
+	}
+	return nil
+}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -8,12 +8,14 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/containment"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/dtu"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
@@ -467,7 +469,16 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					}
 					return "failed"
 				}
-				cmdOut, cmdErr := gate.RunCommand(ctx, r.Runner, worktreePath, rendered)
+				execCtx, execErr := r.executionContext(ctx, worktreePath, vessel, sk, &p, "", executionCommand)
+				if execErr != nil {
+					finishCurrentPhaseSpan(execErr)
+					r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, execErr))
+					if err := src.OnFail(ctx, vessel); err != nil {
+						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+					}
+					return "failed"
+				}
+				cmdOut, cmdErr := gate.RunCommand(execCtx, r.Runner, worktreePath, rendered)
 				output = []byte(cmdOut)
 				runErr = cmdErr
 			} else {
@@ -534,7 +545,16 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if phaseStdin != nil {
 					stdinContent = rendered
 				}
-				output, runErr = r.runPhaseWithRateLimitRetry(ctx, worktreePath, stdinContent, cmd, args)
+				execCtx, execErr := r.executionContext(ctx, worktreePath, vessel, sk, &p, provider, executionPrompt)
+				if execErr != nil {
+					finishCurrentPhaseSpan(execErr)
+					r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, execErr))
+					if err := src.OnFail(ctx, vessel); err != nil {
+						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+					}
+					return "failed"
+				}
+				output, runErr = r.runPhaseWithRateLimitRetry(execCtx, worktreePath, stdinContent, cmd, args)
 			}
 
 			// Shared: Write phase output
@@ -647,7 +667,17 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			switch p.Gate.Type {
 			case "command":
 				gateSpan := startGateSpan(r.Tracer, phaseSpan, ctx, p.Gate.Type)
-				gateOut, passed, gateErr := gate.RunCommandGate(ctx, r.Runner, worktreePath, p.Gate.Run)
+				gateCtx, gateCtxErr := r.executionContext(ctx, worktreePath, vessel, sk, &p, "", executionGate)
+				if gateCtxErr != nil {
+					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateCtxErr.Error()))
+					finishCurrentPhaseSpan(gateCtxErr)
+					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate error: %v", p.Name, gateCtxErr))
+					if err := src.OnFail(ctx, vessel); err != nil {
+						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+					}
+					return "failed"
+				}
+				gateOut, passed, gateErr := gate.RunCommandGate(gateCtx, r.Runner, worktreePath, p.Gate.Run)
 				finishGateSpan(r.Tracer, gateSpan, observability.GateSpanData{
 					Type:         p.Gate.Type,
 					Passed:       passed,
@@ -792,7 +822,15 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 		return "failed"
 	}
 
-	output, runErr := r.runPhaseWithRateLimitRetry(ctx, worktreePath, prompt, cmd, args)
+	execCtx, execErr := r.executionContext(ctx, worktreePath, vessel, nil, nil, provider, executionPromptOnly)
+	if execErr != nil {
+		r.failVessel(vessel.ID, execErr.Error())
+		if err := src.OnFail(ctx, vessel); err != nil {
+			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+		}
+		return "failed"
+	}
+	output, runErr := r.runPhaseWithRateLimitRetry(execCtx, worktreePath, prompt, cmd, args)
 	if runErr != nil {
 		r.failVessel(vessel.ID, runErr.Error())
 		if err := src.OnFail(ctx, vessel); err != nil {
@@ -1219,7 +1257,16 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				}
 				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
 			}
-			cmdOut, cmdErr := gate.RunCommand(ctx, r.Runner, worktreePath, rendered)
+			execCtx, execErr := r.executionContext(ctx, worktreePath, vessel, wf, &p, "", executionCommand)
+			if execErr != nil {
+				finishCurrentPhaseSpan(execErr)
+				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, execErr))
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
+				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
+			}
+			cmdOut, cmdErr := gate.RunCommand(execCtx, r.Runner, worktreePath, rendered)
 			output = []byte(cmdOut)
 			runErr = cmdErr
 		} else {
@@ -1285,7 +1332,16 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if phaseStdin != nil {
 				stdinContent = rendered
 			}
-			output, runErr = r.runPhaseWithRateLimitRetry(ctx, worktreePath, stdinContent, cmd, args)
+			execCtx, execErr := r.executionContext(ctx, worktreePath, vessel, wf, &p, provider, executionPrompt)
+			if execErr != nil {
+				finishCurrentPhaseSpan(execErr)
+				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, execErr))
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
+				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
+			}
+			output, runErr = r.runPhaseWithRateLimitRetry(execCtx, worktreePath, stdinContent, cmd, args)
 		}
 
 		// Write output file.
@@ -1398,7 +1454,16 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		switch p.Gate.Type {
 		case "command":
 			gateSpan := startGateSpan(r.Tracer, phaseSpan, ctx, p.Gate.Type)
-			gateOut, passed, gateErr := gate.RunCommandGate(ctx, r.Runner, worktreePath, p.Gate.Run)
+			gateCtx, gateCtxErr := r.executionContext(ctx, worktreePath, vessel, wf, &p, "", executionGate)
+			if gateCtxErr != nil {
+				finishCurrentPhaseSpan(gateCtxErr)
+				return singlePhaseResult{
+					status:       "failed",
+					duration:     phaseDuration,
+					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateCtxErr.Error()),
+				}
+			}
+			gateOut, passed, gateErr := gate.RunCommandGate(gateCtx, r.Runner, worktreePath, p.Gate.Run)
 			finishGateSpan(r.Tracer, gateSpan, observability.GateSpanData{
 				Type:         p.Gate.Type,
 				Passed:       passed,
@@ -1626,6 +1691,130 @@ func phaseActionType(p *workflow.Phase) string {
 		return "external_command"
 	}
 	return "phase_execute"
+}
+
+type executionOperation string
+
+const (
+	executionPrompt     executionOperation = "prompt"
+	executionPromptOnly executionOperation = "prompt_only"
+	executionCommand    executionOperation = "command"
+	executionGate       executionOperation = "gate"
+)
+
+func (r *Runner) executionContext(
+	ctx context.Context,
+	worktreePath string,
+	vessel queue.Vessel,
+	wf *workflow.Workflow,
+	p *workflow.Phase,
+	provider string,
+	operation executionOperation,
+) (context.Context, error) {
+	req, err := r.buildExecutionRequest(worktreePath, vessel, wf, p, provider, operation)
+	if err != nil {
+		return nil, err
+	}
+	return containment.WithRequest(ctx, req), nil
+}
+
+func (r *Runner) buildExecutionRequest(
+	worktreePath string,
+	vessel queue.Vessel,
+	wf *workflow.Workflow,
+	p *workflow.Phase,
+	provider string,
+	operation executionOperation,
+) (containment.Request, error) {
+	networkMode := r.Config.EffectiveRuntimeNetworkMode(string(operation))
+	if p != nil && p.Runtime != nil && p.Runtime.Network != "" {
+		networkMode = p.Runtime.Network
+	}
+
+	env, err := r.executionEnv(vessel, p, provider, operation)
+	if err != nil {
+		return containment.Request{}, err
+	}
+
+	phaseName := string(operation)
+	if p != nil && p.Name != "" {
+		phaseName = p.Name
+	}
+
+	runtimeDir, err := containment.BuildRuntimeDir(worktreePath, vessel.ID, string(operation), phaseName)
+	if err != nil {
+		return containment.Request{}, fmt.Errorf("build runtime dir: %w", err)
+	}
+
+	return containment.Request{
+		Isolation:  containment.IsolationMode(r.Config.EffectiveRuntimeIsolation()),
+		Network:    containment.NetworkMode(networkMode),
+		RuntimeDir: runtimeDir,
+		Env:        env,
+		Metadata: map[string]string{
+			"provider":  provider,
+			"operation": string(operation),
+			"phase":     phaseName,
+			"workflow":  vessel.Workflow,
+			"vessel_id": vessel.ID,
+		},
+	}, nil
+}
+
+func (r *Runner) executionEnv(
+	vessel queue.Vessel,
+	p *workflow.Phase,
+	provider string,
+	operation executionOperation,
+) ([]string, error) {
+	var allowedNames []string
+	if p != nil && p.Runtime != nil && len(p.Runtime.Secrets) > 0 {
+		allowedNames = append(allowedNames, p.Runtime.Secrets...)
+	}
+
+	var env []string
+	seen := make(map[string]struct{})
+	for _, secret := range r.Config.RuntimeSecrets() {
+		if !secretMatches(secret, vessel.Workflow, phaseName(p), provider, string(operation)) {
+			continue
+		}
+		if len(allowedNames) > 0 && !slices.Contains(allowedNames, secret.Name) {
+			continue
+		}
+		seen[secret.Name] = struct{}{}
+		env = append(env, fmt.Sprintf("%s=%s", secret.Name, secret.Value))
+	}
+	if len(allowedNames) > 0 {
+		for _, name := range allowedNames {
+			if _, ok := seen[name]; !ok {
+				return nil, fmt.Errorf("phase %q references unknown runtime secret %q", phaseName(p), name)
+			}
+		}
+	}
+	return env, nil
+}
+
+func secretMatches(secret config.ResolvedRuntimeSecret, workflowName, phaseName, provider, operation string) bool {
+	if len(secret.Providers) > 0 && (provider == "" || !slices.Contains(secret.Providers, provider)) {
+		return false
+	}
+	if len(secret.Workflows) > 0 && (workflowName == "" || !slices.Contains(secret.Workflows, workflowName)) {
+		return false
+	}
+	if len(secret.Phases) > 0 && (phaseName == "" || !slices.Contains(secret.Phases, phaseName)) {
+		return false
+	}
+	if len(secret.Operations) > 0 && !slices.Contains(secret.Operations, operation) {
+		return false
+	}
+	return true
+}
+
+func phaseName(p *workflow.Phase) string {
+	if p == nil {
+		return ""
+	}
+	return p.Name
 }
 
 func (r *Runner) enforcePhasePolicy(vessel queue.Vessel, p workflow.Phase) error {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/containment"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
@@ -54,6 +55,8 @@ type mockCmdRunner struct {
 	// Track calls for assertion
 	phaseCalls []phaseCall
 	outputArgs [][]string
+	outputCtxs []context.Context
+	phaseCtxs  []context.Context
 	lastBody   string
 }
 
@@ -69,9 +72,10 @@ type phaseCall struct {
 	args   []string
 }
 
-func (m *mockCmdRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+func (m *mockCmdRunner) RunOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
 	m.mu.Lock()
 	m.outputArgs = append(m.outputArgs, append([]string{name}, args...))
+	m.outputCtxs = append(m.outputCtxs, ctx)
 	for i, arg := range args {
 		if arg == "--body" && i+1 < len(args) {
 			m.lastBody = args[i+1]
@@ -108,7 +112,7 @@ func (m *mockCmdRunner) RunProcess(_ context.Context, _ string, _ string, _ ...s
 	return m.processErr
 }
 
-func (m *mockCmdRunner) RunPhase(_ context.Context, dir string, stdin io.Reader, name string, args ...string) ([]byte, error) {
+func (m *mockCmdRunner) RunPhase(ctx context.Context, dir string, stdin io.Reader, name string, args ...string) ([]byte, error) {
 	prompt, _ := io.ReadAll(stdin)
 	m.mu.Lock()
 	m.phaseCalls = append(m.phaseCalls, phaseCall{
@@ -117,6 +121,7 @@ func (m *mockCmdRunner) RunPhase(_ context.Context, dir string, stdin io.Reader,
 		name:   name,
 		args:   args,
 	})
+	m.phaseCtxs = append(m.phaseCtxs, ctx)
 	m.mu.Unlock()
 	atomic.AddInt32(&m.started, 1)
 
@@ -317,6 +322,64 @@ func loadSingleVessel(t *testing.T, q *queue.Queue) queue.Vessel {
 	require.NoError(t, err)
 	require.Len(t, vessels, 1)
 	return vessels[0]
+}
+
+func TestBuildExecutionRequestScopesSecretsAndNetwork(t *testing.T) {
+	cfg := makeTestConfig(t.TempDir(), 1)
+	cfg.Claude.Env = map[string]string{"ANTHROPIC_API_KEY": "anthropic-secret"}
+	cfg.Harness.Runtime.Secrets = []config.RuntimeSecretConfig{{
+		Name:       "GH_TOKEN",
+		Value:      "gh-secret",
+		Operations: []string{"command"},
+		Phases:     []string{"publish"},
+	}}
+
+	r := &Runner{Config: cfg}
+	vessel := makeVessel(1, "fix-bug")
+
+	promptReq, err := r.buildExecutionRequest("/tmp/worktree", vessel, nil, &workflow.Phase{Name: "implement"}, "claude", executionPrompt)
+	require.NoError(t, err)
+	assert.Equal(t, containment.NetworkInherit, promptReq.Network)
+	assert.Equal(t, containment.IsolationWorkspace, promptReq.Isolation)
+	assert.Contains(t, promptReq.Env, "ANTHROPIC_API_KEY=anthropic-secret")
+	assert.NotContains(t, promptReq.Env, "GH_TOKEN=gh-secret")
+
+	commandReq, err := r.buildExecutionRequest("/tmp/worktree", vessel, nil, &workflow.Phase{
+		Name: "publish",
+		Runtime: &workflow.Runtime{
+			Secrets: []string{"GH_TOKEN"},
+		},
+	}, "", executionCommand)
+	require.NoError(t, err)
+	assert.Equal(t, containment.NetworkDeny, commandReq.Network)
+	assert.Equal(t, []string{"GH_TOKEN=gh-secret"}, commandReq.Env)
+}
+
+func TestBuildExecutionRequestRejectsUnknownPhaseSecret(t *testing.T) {
+	cfg := makeTestConfig(t.TempDir(), 1)
+	r := &Runner{Config: cfg}
+	vessel := makeVessel(1, "fix-bug")
+
+	_, err := r.buildExecutionRequest("/tmp/worktree", vessel, nil, &workflow.Phase{
+		Name: "publish",
+		Runtime: &workflow.Runtime{
+			Secrets: []string{"GH_TOKEN"},
+		},
+	}, "", executionCommand)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown runtime secret "GH_TOKEN"`)
+}
+
+func TestBuildExecutionRequestRejectsUnsafeVesselID(t *testing.T) {
+	cfg := makeTestConfig(t.TempDir(), 1)
+	r := &Runner{Config: cfg}
+	vessel := makeVessel(1, "fix-bug")
+	vessel.ID = "../escape"
+
+	_, err := r.buildExecutionRequest("/tmp/worktree", vessel, nil, &workflow.Phase{Name: "implement"}, "claude", executionPrompt)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `build runtime dir`)
+	assert.Contains(t, err.Error(), `vessel ID`)
 }
 
 func setBudget(cfg *config.Config, maxCostUSD float64, maxTokens int) {

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"gopkg.in/yaml.v3"
 )
@@ -38,7 +39,13 @@ type Phase struct {
 	NoOp         *NoOp    `yaml:"noop,omitempty"`
 	Gate         *Gate    `yaml:"gate,omitempty"`
 	AllowedTools *string  `yaml:"allowed_tools,omitempty"`
+	Runtime      *Runtime `yaml:"runtime,omitempty"`
 	DependsOn    []string `yaml:"depends_on,omitempty"`
+}
+
+type Runtime struct {
+	Network string   `yaml:"network,omitempty"`
+	Secrets []string `yaml:"secrets,omitempty"`
 }
 
 // NoOp defines an early-success completion rule for a phase.
@@ -165,6 +172,12 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 			return fmt.Errorf("phase %q: allowed_tools must not be empty when specified", p.Name)
 		}
 
+		if p.Runtime != nil {
+			if err := validateRuntime(p.Name, p.Runtime); err != nil {
+				return err
+			}
+		}
+
 		if err := validateLLM(p.LLM, fmt.Sprintf("phase %q", p.Name)); err != nil {
 			return err
 		}
@@ -262,6 +275,33 @@ func validateNoOp(phaseName string, n *NoOp) error {
 		return fmt.Errorf("phase %q: noop: match is required", phaseName)
 	}
 	return nil
+}
+
+func validateRuntime(phaseName string, rt *Runtime) error {
+	if err := validateRuntimeNetwork(rt.Network); err != nil {
+		return fmt.Errorf("phase %q: runtime.network: %w", phaseName, err)
+	}
+	seen := make(map[string]struct{}, len(rt.Secrets))
+	for _, secret := range rt.Secrets {
+		trimmed := strings.TrimSpace(secret)
+		if trimmed == "" {
+			return fmt.Errorf("phase %q: runtime.secrets must not contain empty entries", phaseName)
+		}
+		if _, ok := seen[trimmed]; ok {
+			return fmt.Errorf("phase %q: runtime.secrets contains duplicate entry %q", phaseName, trimmed)
+		}
+		seen[trimmed] = struct{}{}
+	}
+	return nil
+}
+
+func validateRuntimeNetwork(value string) error {
+	switch strings.TrimSpace(value) {
+	case "", config.RuntimeNetworkInherit, config.RuntimeNetworkDeny:
+		return nil
+	default:
+		return fmt.Errorf("must be %q or %q", config.RuntimeNetworkInherit, config.RuntimeNetworkDeny)
+	}
 }
 
 func validateGate(phaseName string, g *Gate) error {

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -523,6 +523,42 @@ phases:
 	}
 }
 
+func TestLoadRejectsInvalidRuntimeNetwork(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+    runtime:
+      network: allowlist
+`)
+
+	_, err := Load(path)
+	requireErrorContains(t, err, `runtime.network`)
+}
+
+func TestLoadRejectsDuplicateRuntimeSecrets(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+    runtime:
+      secrets: [GH_TOKEN, GH_TOKEN]
+`)
+
+	_, err := Load(path)
+	requireErrorContains(t, err, `runtime.secrets contains duplicate entry`)
+}
+
 func TestLoadFileNotFound(t *testing.T) {
 	_, err := Load(filepath.Join(t.TempDir(), "missing.yaml"))
 	if err == nil {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ Sources                     xylem scan            Queue
 
 4. **Worktree creation** -- The runner asks the source for a branch name (e.g. `fix/issue-42-login-crash`), then creates an isolated git worktree at `.claude/worktrees/<branch>` branched from `origin/<default-branch>`. Provider config files (`.claude/settings.json`, rules) are copied into the worktree.
 
-5. **Phase execution** -- The runner loads the workflow YAML, reads `.xylem/HARNESS.md`, then iterates through phases. Prompt phases render a Go template with issue data and previous phase outputs, then invoke the resolved provider (`claude` or `copilot`). Command phases render and run a shell command directly in the worktree. Phase outputs are persisted to `.xylem/phases/<vessel-id>/<phase>.output`.
+5. **Phase execution** -- The runner loads the workflow YAML, reads `.xylem/HARNESS.md`, then iterates through phases. Before autonomous execution it applies runtime containment: prompt and command subprocesses run with workspace-local `HOME`/`TMPDIR`/XDG state, provider and operator secrets are injected only when the phase selectors match, and network defaults are narrower for command/gate execution than for prompt-provider calls. Prompt phases render a Go template with issue data and previous phase outputs, then invoke the resolved provider (`claude` or `copilot`). Command phases render and run a shell command directly in the worktree. Phase outputs are persisted to `.xylem/phases/<vessel-id>/<phase>.output`.
 
 6. **Gate evaluation** -- After each phase, if a gate is defined:
    - **Command gate**: runs a shell command (e.g. `make test`). On failure, the same phase re-runs with gate output appended to the prompt, up to `retries` times.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,22 @@ copilot:
   env: {}                                     # parsed config map for Copilot-related environment values
 
 # ---------------------------------------------------------------------------
+# Harness runtime containment
+# ---------------------------------------------------------------------------
+harness:
+  runtime:
+    isolation: workspace                      # workspace (default) or off
+    network:
+      prompt: inherit                         # prompt + prompt-only phases default to inherit
+      command: deny                           # command phases default to deny
+      gate: deny                              # command gates default to deny
+    secrets:
+      - name: GH_TOKEN
+        value: "${GH_TOKEN}"
+        operations: [command, gate]
+        phases: [publish]
+
+# ---------------------------------------------------------------------------
 # Daemon mode intervals
 # ---------------------------------------------------------------------------
 daemon:
@@ -284,6 +300,7 @@ The `harness` section configures agent safety guardrails: protected file surface
 | `harness.protected_surfaces.paths` | list of strings | `[".xylem/HARNESS.md", ".xylem.yml", ".xylem/workflows/*.yaml", ".xylem/prompts/*/*.md"]` | No | Glob patterns for files agents cannot modify. Set to `["none"]` to disable all surface protections. |
 | `harness.policy.rules` | list of objects | `[]` | No | Policy rules for action authorization. Each rule has `action`, `resource`, and `effect`. |
 | `harness.audit_log` | string | `"audit.jsonl"` | No | Path to the audit log file for policy decisions, relative to the state directory. |
+| `harness.runtime` | object | see below | No | Execution-time containment settings: workspace-local home/tmp, network policy, and scoped secret injection. |
 
 **Policy rule fields:**
 
@@ -310,7 +327,41 @@ harness:
         resource: "*"
         effect: allow
   audit_log: "audit.jsonl"
+  runtime:
+    isolation: workspace
+    network:
+      command: deny
+      gate: deny
+    secrets:
+      - name: GH_TOKEN
+        value: "${GH_TOKEN}"
+        operations: [command, gate]
+        phases: [publish]
 ```
+
+**Runtime fields:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `harness.runtime.isolation` | string | `workspace` | `workspace` rewrites `HOME`, `TMPDIR`, XDG dirs, and git config paths into worktree-local runtime directories for autonomous execution. `off` disables that containment layer. |
+| `harness.runtime.network.default` | string | operation-specific | Fallback network mode. Valid values: `inherit`, `deny`. `deny` applies the filtered runtime environment plus loopback blackhole proxy settings; it is not an OS-level firewall. |
+| `harness.runtime.network.prompt` | string | `inherit` | Network mode for prompt and prompt-only runs. |
+| `harness.runtime.network.command` | string | `deny` | Network mode for command phases. `deny` keeps the constrained runtime environment and points common proxy variables at loopback blackholes. |
+| `harness.runtime.network.gate` | string | `deny` | Network mode for command gates. `deny` keeps the constrained runtime environment and points common proxy variables at loopback blackholes. |
+| `harness.runtime.secrets` | list | `[]` | Additional secret bindings that are injected only when their selectors match the provider, workflow, phase, and operation. |
+
+**Runtime secret fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Environment variable name exposed to the matched subprocess. |
+| `value` | string | Yes | Value to inject. Shell variable expansion via `${VAR}` is supported at config load time. |
+| `providers` | list | No | Optional provider selector (`claude`, `copilot`). |
+| `workflows` | list | No | Optional workflow-name selector. |
+| `phases` | list | No | Optional phase-name selector. |
+| `operations` | list | No | Optional execution-kind selector. Valid values: `prompt`, `prompt_only`, `command`, `gate`. |
+
+Provider env blocks (`claude.env`, `copilot.env`) are now treated as prompt-scoped secret bindings rather than being ambient across every subprocess. That preserves existing provider authentication behavior while narrowing secret exposure for command phases and gates.
 
 ### Observability settings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -344,10 +344,10 @@ harness:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `harness.runtime.isolation` | string | `workspace` | `workspace` rewrites `HOME`, `TMPDIR`, XDG dirs, and git config paths into worktree-local runtime directories for autonomous execution. `off` disables that containment layer. |
-| `harness.runtime.network.default` | string | operation-specific | Fallback network mode. Valid values: `inherit`, `deny`. `deny` applies the filtered runtime environment plus loopback blackhole proxy settings; it is not an OS-level firewall. |
+| `harness.runtime.network.default` | string | operation-specific | Fallback network mode. Valid values: `inherit`, `deny`. `deny` rewrites common proxy variables to loopback blackholes; when workspace isolation is enabled the base env also stays filtered, but `off` isolation preserves the ambient env. It is not an OS-level firewall. |
 | `harness.runtime.network.prompt` | string | `inherit` | Network mode for prompt and prompt-only runs. |
-| `harness.runtime.network.command` | string | `deny` | Network mode for command phases. `deny` keeps the constrained runtime environment and points common proxy variables at loopback blackholes. |
-| `harness.runtime.network.gate` | string | `deny` | Network mode for command gates. `deny` keeps the constrained runtime environment and points common proxy variables at loopback blackholes. |
+| `harness.runtime.network.command` | string | `deny` | Network mode for command phases. `deny` points common proxy variables at loopback blackholes, while any workspace isolation settings still control whether the base env is filtered or ambient. |
+| `harness.runtime.network.gate` | string | `deny` | Network mode for command gates. `deny` points common proxy variables at loopback blackholes, while any workspace isolation settings still control whether the base env is filtered or ambient. |
 | `harness.runtime.secrets` | list | `[]` | Additional secret bindings that are injected only when their selectors match the provider, workflow, phase, and operation. |
 
 **Runtime secret fields:**

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -65,6 +65,8 @@ phases:
     prompt_file: .xylem/prompts/fix-bug/implement.md
     max_turns: 15
     allowed_tools: "Bash, Read, Edit, Write, Grep, Glob"  # Optional tool restriction
+    runtime:
+      network: inherit
     gate:                                          # Optional quality gate
       type: command                                # "command" or "label"
       run: "make test"                             # Shell command to execute
@@ -78,6 +80,9 @@ phases:
   - name: smoke_test
     type: command                                  # Optional shell-command phase
     run: "make smoke-test"
+    runtime:
+      secrets: [GH_TOKEN]
+      network: deny
 ```
 
 ### Field reference
@@ -105,6 +110,7 @@ phases:
 | `model` | No | Model override for this prompt phase. Provider-specific string. |
 | `noop` | No | Early-success completion rule checked against the phase output before any gate runs. |
 | `allowed_tools` | No | Tool restriction string for prompt phases. Passed through to the provider CLI. Use this instead of top-level `claude.allowed_tools`, which is rejected by config validation. |
+| `runtime` | No | Runtime containment override for this phase. Lets you override the per-operation network mode and explicitly opt this phase into configured secret bindings. |
 | `gate` | No | Quality gate that must pass after this phase completes. |
 | `depends_on` | No | List of phase names this phase depends on. Enables parallel execution -- phases without dependency relationships can execute concurrently. Validated for duplicate entries, self-references, references to unknown phase names, and dependency cycles. |
 
@@ -113,6 +119,13 @@ phases:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `match` | Yes | Substring marker that, when present in successful phase output, completes the workflow early. |
+
+**Runtime fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `runtime.network` | No | Overrides the effective network mode for this phase. Valid values: `inherit`, `deny`. Prompt phases default to `inherit`; command phases and command gates default to `deny`. |
+| `runtime.secrets` | No | List of configured `harness.runtime.secrets` names this phase is allowed to receive. If omitted, all matching secret bindings are eligible; if set, unmatched names fail the phase early. |
 
 **Gate fields (when `type: command`):**
 
@@ -174,10 +187,11 @@ Provider resolution for prompt phases is: `phase.llm` -> `workflow.llm` -> `.xyl
 
 1. The runner builds `TemplateData` for the current phase (issue details, previous phase outputs, gate results, vessel metadata).
 2. If the phase is `prompt`, the runner reads `prompt_file`, renders it, writes `.xylem/phases/<vessel-id>/<phase>.prompt`, then invokes the resolved provider CLI in the worktree.
-3. If the phase is `command`, the runner renders `run`, writes `.xylem/phases/<vessel-id>/<phase>.command`, then executes the rendered shell command in the worktree.
-4. The phase output is captured and persisted to `.xylem/phases/<vessel-id>/<phase>.output`.
-5. If the phase has a `noop` rule and the successful phase output contains `noop.match`, the vessel is marked `completed`, remaining phases are skipped, and no gate is evaluated for that phase.
-6. Otherwise, if the phase has a gate, the gate is evaluated. If it fails and retries remain, the phase re-executes with the gate failure output injected into the template via `{{.GateResult}}`.
+3. Before autonomous execution, xylem applies runtime containment: workspace-local `HOME`/`TMPDIR`/XDG directories, operation-specific network policy, and secret injection scoped to the matched provider/workflow/phase/operation selectors.
+4. If the phase is `command`, the runner renders `run`, writes `.xylem/phases/<vessel-id>/<phase>.command`, then executes the rendered shell command in the worktree.
+5. The phase output is captured and persisted to `.xylem/phases/<vessel-id>/<phase>.output`.
+6. If the phase has a `noop` rule and the successful phase output contains `noop.match`, the vessel is marked `completed`, remaining phases are skipped, and no gate is evaluated for that phase.
+7. Otherwise, if the phase has a gate, the gate is evaluated. If it fails and retries remain, the phase re-executes with the gate failure output injected into the template via `{{.GateResult}}`.
 
 ### Output persistence
 


### PR DESCRIPTION
## Summary
- add a runtime containment model with workspace-local execution state, per-operation network defaults, and scoped secret bindings under harness.runtime
- wire containment through runner execution contexts for prompt phases, command phases, command gates, and prompt-only execution, including the direct subprocess path used by RunOutput
- validate and document phase-level runtime overrides, plus add tests covering config resolution, workflow validation, runner secret scoping, and contained subprocess env construction

Closes https://github.com/nicholls-inc/xylem/issues/58
