### PR TITLE
Integrate structured runner context and handoffs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,15 @@ Key types:
 - **Workflow** (`workflow` package) — YAML-defined multi-phase execution plan loaded from `.xylem/workflows/`
 - **Gate** (`gate` package) — inter-phase quality checks: `command` (run shell command) or `label` (poll GitHub for label, vessel enters `waiting` state)
 
-The `runner` drives phase execution: renders Go templates into prompts, pipes them to `claude -p` via stdin, persists outputs to `.xylem/phases/<id>/`, and handles gate retries and label-wait suspension.
+The `runner` drives phase execution: renders Go templates into prompts, compiles a structured context view for each phase via `ctxmgr`, pipes prompts to `claude -p` via stdin, persists outputs to `.xylem/phases/<id>/`, and handles gate retries and label-wait suspension.
+
+Structured runner artifacts include:
+- `<phase>.context.json` — compiled context manifest showing selected inputs, strategy, and compaction outcome
+- `progress_<vessel>.json` — durable per-vessel state (plan, checkpoints, unresolved items, verification, approvals, phase output paths)
+- `handoff_<vessel>_latest.json` plus timestamped handoff snapshots — structured resume state for waiting/resumed vessels
+- `summary.json` — terminal summary, including retention metadata and durable artifact paths
+
+Retention follows `cleanup_after`: `summary.json`, `progress_<vessel>.json`, `handoff_<vessel>_latest.json`, and raw prompt/output/command artifacts are durable; historical handoff snapshots and `*.context.json` files expire once they age past the configured window.
 
 ### Agent harness library (`cli/internal/`)
 

--- a/cli/internal/memory/memory.go
+++ b/cli/internal/memory/memory.go
@@ -303,16 +303,29 @@ func (s *Store) Delete(memType MemoryType, key string) error {
 	return nil
 }
 
+// OperatorApproval records an operator decision that should survive resumes.
+type OperatorApproval struct {
+	ApprovedBy string    `json:"approved_by"`
+	Reason     string    `json:"reason,omitempty"`
+	ApprovedAt time.Time `json:"approved_at"`
+}
+
 // HandoffArtifact captures session outcome for structured handoff between
 // sessions.
 type HandoffArtifact struct {
-	MissionID  string    `json:"mission_id"`
-	SessionID  string    `json:"session_id"`
-	Completed  []string  `json:"completed,omitempty"`
-	Failed     []string  `json:"failed,omitempty"`
-	Unresolved []string  `json:"unresolved,omitempty"`
-	NextSteps  []string  `json:"next_steps,omitempty"`
-	CreatedAt  time.Time `json:"created_at"`
+	MissionID    string             `json:"mission_id"`
+	SessionID    string             `json:"session_id"`
+	CurrentPhase string             `json:"current_phase,omitempty"`
+	Completed    []string           `json:"completed,omitempty"`
+	Failed       []string           `json:"failed,omitempty"`
+	Unresolved   []string           `json:"unresolved,omitempty"`
+	NextSteps    []string           `json:"next_steps,omitempty"`
+	Plan         string             `json:"plan,omitempty"`
+	Checkpoints  []string           `json:"checkpoints,omitempty"`
+	PhaseOutputs map[string]string  `json:"phase_outputs,omitempty"`
+	Verification []string           `json:"verification,omitempty"`
+	Approvals    []OperatorApproval `json:"approvals,omitempty"`
+	CreatedAt    time.Time          `json:"created_at"`
 }
 
 // NewHandoff creates a HandoffArtifact stamped with the current time.

--- a/cli/internal/memory/memory_test.go
+++ b/cli/internal/memory/memory_test.go
@@ -425,10 +425,20 @@ func TestStorePathTraversal(t *testing.T) {
 func TestHandoffSaveLoad(t *testing.T) {
 	dir := t.TempDir()
 	h := NewHandoff("m1", "s1")
+	h.CurrentPhase = "implement"
 	h.Completed = []string{"task-a"}
 	h.Failed = []string{"task-b"}
 	h.Unresolved = []string{"task-c"}
 	h.NextSteps = []string{"retry task-b"}
+	h.Plan = "1. inspect\n2. patch\n3. verify"
+	h.Checkpoints = []string{"plan complete"}
+	h.PhaseOutputs = map[string]string{"plan": "plan.output"}
+	h.Verification = []string{"go test ./..."}
+	h.Approvals = []OperatorApproval{{
+		ApprovedBy: "operator",
+		Reason:     "manual gate release",
+		ApprovedAt: time.Now().UTC(),
+	}}
 
 	if err := h.Save(dir); err != nil {
 		t.Fatalf("save: %v", err)
@@ -442,6 +452,9 @@ func TestHandoffSaveLoad(t *testing.T) {
 	if loaded.MissionID != "m1" || loaded.SessionID != "s1" {
 		t.Fatalf("id mismatch: %+v", loaded)
 	}
+	if loaded.CurrentPhase != "implement" {
+		t.Fatalf("current phase mismatch: %q", loaded.CurrentPhase)
+	}
 	if len(loaded.Completed) != 1 || loaded.Completed[0] != "task-a" {
 		t.Fatalf("completed mismatch: %v", loaded.Completed)
 	}
@@ -453,6 +466,21 @@ func TestHandoffSaveLoad(t *testing.T) {
 	}
 	if len(loaded.Unresolved) != 1 || loaded.Unresolved[0] != "task-c" {
 		t.Fatalf("unresolved mismatch: %v", loaded.Unresolved)
+	}
+	if loaded.Plan != "1. inspect\n2. patch\n3. verify" {
+		t.Fatalf("plan mismatch: %q", loaded.Plan)
+	}
+	if len(loaded.Checkpoints) != 1 || loaded.Checkpoints[0] != "plan complete" {
+		t.Fatalf("checkpoints mismatch: %v", loaded.Checkpoints)
+	}
+	if loaded.PhaseOutputs["plan"] != "plan.output" {
+		t.Fatalf("phase_outputs mismatch: %v", loaded.PhaseOutputs)
+	}
+	if len(loaded.Verification) != 1 || loaded.Verification[0] != "go test ./..." {
+		t.Fatalf("verification mismatch: %v", loaded.Verification)
+	}
+	if len(loaded.Approvals) != 1 || loaded.Approvals[0].ApprovedBy != "operator" {
+		t.Fatalf("approvals mismatch: %v", loaded.Approvals)
 	}
 	if loaded.CreatedAt.IsZero() {
 		t.Fatal("expected non-zero CreatedAt")

--- a/cli/internal/phase/phase.go
+++ b/cli/internal/phase/phase.go
@@ -8,11 +8,12 @@ import (
 
 // Truncation limits (constants, not configurable).
 const (
-	MaxPreviousOutputLen = 16000
-	MaxGateResultLen     = 8000
-	MaxIssueBodyLen      = 32000
-	MaxReporterOutputLen = 64000
-	TruncationSuffix     = "\n\n[... output truncated at %d characters]"
+	MaxPreviousOutputLen  = 16000
+	MaxGateResultLen      = 8000
+	MaxIssueBodyLen       = 32000
+	MaxReporterOutputLen  = 64000
+	MaxCompiledContextLen = 16000
+	TruncationSuffix      = "\n\n[... output truncated at %d characters]"
 )
 
 // TemplateData holds all data available to phase prompt templates.
@@ -21,7 +22,16 @@ type TemplateData struct {
 	Phase           PhaseData
 	PreviousOutputs map[string]string // phase name → output text
 	GateResult      string            // most recent gate command output
+	Context         ContextData
 	Vessel          VesselData
+}
+
+// ContextData describes the compiled context artifact prepared for a phase.
+type ContextData struct {
+	ManifestPath string `json:"manifest_path,omitempty"`
+	Strategy     string `json:"strategy,omitempty"`
+	Compiled     string `json:"compiled,omitempty"`
+	Resumed      bool   `json:"resumed,omitempty"`
 }
 
 // IssueData describes the issue being worked on.
@@ -68,6 +78,7 @@ func prepareData(data TemplateData) TemplateData {
 
 	out.GateResult = TruncateOutput(data.GateResult, MaxGateResultLen)
 	out.Issue.Body = TruncateOutput(data.Issue.Body, MaxIssueBodyLen)
+	out.Context.Compiled = TruncateOutput(data.Context.Compiled, MaxCompiledContextLen)
 
 	return out
 }

--- a/cli/internal/phase/phase_test.go
+++ b/cli/internal/phase/phase_test.go
@@ -132,6 +132,19 @@ func TestRenderPrompt(t *testing.T) {
 			want: "Vessel: issue-42 from github",
 		},
 		{
+			name:     "renders compiled context data",
+			template: "Context: {{.Context.Strategy}} {{.Context.ManifestPath}} {{.Context.Resumed}} {{.Context.Compiled}}",
+			data: TemplateData{
+				Context: ContextData{
+					ManifestPath: "phases/issue-42/plan.context.json",
+					Strategy:     "compress",
+					Compiled:     "context block",
+					Resumed:      true,
+				},
+			},
+			want: "Context: compress phases/issue-42/plan.context.json true context block",
+		},
+		{
 			name:     "template syntax error",
 			template: "{{.BadSyntax",
 			data:     TemplateData{},
@@ -242,6 +255,22 @@ func TestRenderPromptTruncation(t *testing.T) {
 		}
 	})
 
+	t.Run("Compiled context exceeding limit is truncated", func(t *testing.T) {
+		data := TemplateData{
+			Context: ContextData{
+				Compiled: longString(MaxCompiledContextLen + 200),
+			},
+		}
+		got, err := RenderPrompt("{{.Context.Compiled}}", data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		suffix := fmt.Sprintf(TruncationSuffix, MaxCompiledContextLen)
+		if !strings.HasSuffix(got, suffix) {
+			t.Fatalf("expected truncation suffix")
+		}
+	})
+
 	t.Run("only large PreviousOutputs value is truncated", func(t *testing.T) {
 		shortVal := "short output"
 		longVal := longString(MaxPreviousOutputLen + 100)
@@ -279,11 +308,13 @@ func TestPrepareDataDoesNotMutateOriginal(t *testing.T) {
 			"analyze": strings.Repeat("x", MaxPreviousOutputLen+100),
 		},
 		GateResult: strings.Repeat("y", MaxGateResultLen+100),
+		Context:    ContextData{Compiled: strings.Repeat("w", MaxCompiledContextLen+100)},
 		Issue:      IssueData{Body: strings.Repeat("z", MaxIssueBodyLen+100)},
 	}
 
 	originalAnalyzeLen := len(original.PreviousOutputs["analyze"])
 	originalGateLen := len(original.GateResult)
+	originalContextLen := len(original.Context.Compiled)
 	originalBodyLen := len(original.Issue.Body)
 
 	_ = prepareData(original)
@@ -293,6 +324,9 @@ func TestPrepareDataDoesNotMutateOriginal(t *testing.T) {
 	}
 	if len(original.GateResult) != originalGateLen {
 		t.Fatal("prepareData mutated original GateResult")
+	}
+	if len(original.Context.Compiled) != originalContextLen {
+		t.Fatal("prepareData mutated original Context.Compiled")
 	}
 	if len(original.Issue.Body) != originalBodyLen {
 		t.Fatal("prepareData mutated original Issue.Body")

--- a/cli/internal/runner/context.go
+++ b/cli/internal/runner/context.go
@@ -1,0 +1,771 @@
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/ctxmgr"
+	"github.com/nicholls-inc/xylem/cli/internal/memory"
+	"github.com/nicholls-inc/xylem/cli/internal/phase"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
+)
+
+const (
+	structuredProgressPrefix   = "progress_"
+	structuredProgressSuffix   = ".json"
+	latestHandoffSessionID     = "latest"
+	compiledContextTokenBudget = 4096
+)
+
+type resumeArtifacts struct {
+	Progress        *structuredProgressFile
+	Handoff         *memory.HandoffArtifact
+	PreviousOutputs map[string]string
+}
+
+type structuredState struct {
+	cfg      *config.Config
+	vessel   queue.Vessel
+	workflow *workflow.Workflow
+
+	phasesDir        string
+	progressPath     string
+	latestHandoffRel string
+
+	resume   resumeArtifacts
+	progress structuredProgressFile
+}
+
+type structuredProgressFile struct {
+	VesselID       string                    `json:"vessel_id"`
+	Workflow       string                    `json:"workflow,omitempty"`
+	CurrentPhase   int                       `json:"current_phase"`
+	Plan           string                    `json:"plan,omitempty"`
+	Unresolved     []string                  `json:"unresolved,omitempty"`
+	Checkpoints    []string                  `json:"checkpoints,omitempty"`
+	Verification   []string                  `json:"verification,omitempty"`
+	Approvals      []memory.OperatorApproval `json:"approvals,omitempty"`
+	LastGateResult string                    `json:"last_gate_result,omitempty"`
+	PhaseOutputs   map[string]string         `json:"phase_outputs,omitempty"`
+	Phases         []structuredSnapshot      `json:"phases,omitempty"`
+	UpdatedAt      time.Time                 `json:"updated_at"`
+}
+
+type structuredSnapshot struct {
+	Name       string    `json:"name"`
+	Index      int       `json:"index"`
+	Status     string    `json:"status"`
+	OutputPath string    `json:"output_path,omitempty"`
+	Detail     string    `json:"detail,omitempty"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+type PhaseContextManifest struct {
+	VesselID     string            `json:"vessel_id"`
+	Workflow     string            `json:"workflow,omitempty"`
+	Phase        string            `json:"phase"`
+	ManifestPath string            `json:"manifest_path"`
+	Strategy     ctxmgr.Strategy   `json:"strategy"`
+	Resumed      bool              `json:"resumed"`
+	Inputs       ContextInputs     `json:"inputs"`
+	Compaction   ContextCompaction `json:"compaction"`
+	Window       *ctxmgr.Window    `json:"window"`
+	Compiled     string            `json:"compiled"`
+	CreatedAt    time.Time         `json:"created_at"`
+}
+
+type ContextInputs struct {
+	IssuePresent     bool     `json:"issue_present"`
+	GateResult       bool     `json:"gate_result"`
+	PreviousOutputs  []string `json:"previous_outputs,omitempty"`
+	DurableSections  []string `json:"durable_sections,omitempty"`
+	DependencyScoped bool     `json:"dependency_scoped"`
+}
+
+type ContextCompaction struct {
+	Applied       bool    `json:"applied"`
+	Threshold     float64 `json:"threshold"`
+	BeforeTokens  int     `json:"before_tokens"`
+	AfterTokens   int     `json:"after_tokens"`
+	DurableTokens int     `json:"durable_tokens"`
+}
+
+func prepareStructuredState(cfg *config.Config, vessel queue.Vessel, wf *workflow.Workflow) (*structuredState, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("prepare structured state: config must not be nil")
+	}
+	if err := validateSummaryPathComponent(vessel.ID); err != nil {
+		return nil, fmt.Errorf("prepare structured state: invalid vessel ID: %w", err)
+	}
+
+	phasesDir := filepath.Join(cfg.StateDir, "phases", vessel.ID)
+	if err := os.MkdirAll(phasesDir, 0o755); err != nil {
+		return nil, fmt.Errorf("prepare structured state: create phases dir: %w", err)
+	}
+
+	state := &structuredState{
+		cfg:              cfg,
+		vessel:           vessel,
+		workflow:         wf,
+		phasesDir:        phasesDir,
+		progressPath:     filepath.Join(phasesDir, progressFileName(vessel.ID)),
+		latestHandoffRel: latestHandoffRelativePath(vessel.ID),
+	}
+
+	resume, err := loadResumeArtifacts(phasesDir, vessel.ID)
+	if err != nil {
+		return nil, fmt.Errorf("prepare structured state: %w", err)
+	}
+	state.resume = resume
+
+	if err := state.ensureProgressFile(); err != nil {
+		return nil, fmt.Errorf("prepare structured state: ensure progress file: %w", err)
+	}
+
+	if err := cleanupExpiredStructuredArtifacts(cfg, vessel.ID, time.Now().UTC()); err != nil {
+		return nil, fmt.Errorf("prepare structured state: cleanup expired structured artifacts: %w", err)
+	}
+
+	return state, nil
+}
+
+func loadResumeArtifacts(phasesDir, vesselID string) (resumeArtifacts, error) {
+	var resume resumeArtifacts
+
+	progress, err := readStructuredProgress(filepath.Join(phasesDir, progressFileName(vesselID)))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return resume, fmt.Errorf("load resume artifacts: read progress: %w", err)
+		}
+	} else {
+		resume.Progress = progress
+	}
+
+	handoff, err := memory.LoadHandoff(vesselID, latestHandoffSessionID, phasesDir)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return resume, fmt.Errorf("load resume artifacts: read handoff: %w", err)
+		}
+	} else {
+		resume.Handoff = handoff
+		resume.PreviousOutputs = cloneStringMap(handoff.PhaseOutputs)
+	}
+	if len(resume.PreviousOutputs) == 0 && resume.Progress != nil {
+		resume.PreviousOutputs = readPhaseOutputContents(phasesDir, resume.Progress.PhaseOutputs)
+	}
+
+	return resume, nil
+}
+
+func readStructuredProgress(path string) (*structuredProgressFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var progress structuredProgressFile
+	if err := json.Unmarshal(data, &progress); err != nil {
+		return nil, fmt.Errorf("unmarshal progress %s: %w", path, err)
+	}
+	return &progress, nil
+}
+
+func progressFileName(vesselID string) string {
+	return structuredProgressPrefix + vesselID + structuredProgressSuffix
+}
+
+func latestHandoffRelativePath(vesselID string) string {
+	return filepath.ToSlash(filepath.Join("phases", vesselID, "handoff_"+vesselID+"_"+latestHandoffSessionID+".json"))
+}
+
+func (s *structuredState) ensureProgressFile() error {
+	if s.resume.Progress != nil {
+		s.progress = cloneStructuredProgress(*s.resume.Progress)
+	} else {
+		s.progress = structuredProgressFile{
+			VesselID:     s.vessel.ID,
+			Workflow:     s.vessel.Workflow,
+			CurrentPhase: s.vessel.CurrentPhase,
+			PhaseOutputs: make(map[string]string),
+		}
+	}
+
+	if s.progress.PhaseOutputs == nil {
+		s.progress.PhaseOutputs = make(map[string]string)
+	}
+
+	if s.resume.Handoff != nil {
+		s.mergeHandoff(*s.resume.Handoff)
+	}
+
+	s.progress.VesselID = s.vessel.ID
+	if s.progress.Workflow == "" {
+		s.progress.Workflow = s.vessel.Workflow
+	}
+	if s.progress.CurrentPhase < s.vessel.CurrentPhase {
+		s.progress.CurrentPhase = s.vessel.CurrentPhase
+	}
+
+	s.progress.Phases = ensurePhaseSnapshots(s.progress.Phases, s.workflow)
+	s.progress.UpdatedAt = time.Now().UTC()
+
+	return s.persist(false)
+}
+
+func (s *structuredState) mergeHandoff(h memory.HandoffArtifact) {
+	if s.progress.Plan == "" {
+		s.progress.Plan = h.Plan
+	}
+	if s.progress.CurrentPhase == 0 && h.CurrentPhase != "" && s.workflow != nil {
+		for idx, p := range s.workflow.Phases {
+			if p.Name == h.CurrentPhase {
+				s.progress.CurrentPhase = idx
+				break
+			}
+		}
+	}
+	s.progress.Unresolved = mergeUniqueStrings(s.progress.Unresolved, h.Unresolved)
+	s.progress.Checkpoints = mergeUniqueStrings(s.progress.Checkpoints, h.Checkpoints)
+	s.progress.Verification = mergeUniqueStrings(s.progress.Verification, h.Verification)
+	s.progress.Approvals = mergeApprovals(s.progress.Approvals, h.Approvals)
+}
+
+func ensurePhaseSnapshots(existing []structuredSnapshot, wf *workflow.Workflow) []structuredSnapshot {
+	indexed := make(map[string]structuredSnapshot, len(existing))
+	for _, item := range existing {
+		indexed[item.Name] = item
+	}
+
+	snapshots := make([]structuredSnapshot, 0)
+	if wf == nil {
+		snapshots = append(snapshots, existing...)
+		sort.SliceStable(snapshots, func(i, j int) bool { return snapshots[i].Index < snapshots[j].Index })
+		return snapshots
+	}
+
+	for idx, p := range wf.Phases {
+		item, ok := indexed[p.Name]
+		if !ok {
+			item = structuredSnapshot{Name: p.Name, Index: idx, Status: "pending"}
+		}
+		item.Name = p.Name
+		item.Index = idx
+		if item.Status == "" {
+			item.Status = "pending"
+		}
+		snapshots = append(snapshots, item)
+	}
+	return snapshots
+}
+
+func (s *structuredState) recordPhaseOutcome(phaseName string, phaseIdx int, output, status, detail string) error {
+	now := time.Now().UTC()
+	item := structuredSnapshot{
+		Name:       phaseName,
+		Index:      phaseIdx,
+		Status:     status,
+		OutputPath: phaseArtifactRelativePath(s.vessel.ID, phaseName),
+		Detail:     detail,
+		UpdatedAt:  now,
+	}
+
+	replaced := false
+	for i := range s.progress.Phases {
+		if s.progress.Phases[i].Name == phaseName {
+			s.progress.Phases[i] = item
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		s.progress.Phases = append(s.progress.Phases, item)
+		sort.SliceStable(s.progress.Phases, func(i, j int) bool { return s.progress.Phases[i].Index < s.progress.Phases[j].Index })
+	}
+
+	s.progress.CurrentPhase = maxInt(s.progress.CurrentPhase, phaseIdx+1)
+	s.progress.PhaseOutputs[phaseName] = item.OutputPath
+	if output != "" && (phaseName == "plan" || strings.Contains(phaseName, "plan")) {
+		s.progress.Plan = phase.TruncateOutput(output, phase.MaxCompiledContextLen)
+	}
+	if status == "completed" || status == "no-op" {
+		s.progress.Checkpoints = appendUniqueString(s.progress.Checkpoints, phaseName)
+	}
+	if status == "failed" && detail != "" {
+		s.progress.Unresolved = appendUniqueString(s.progress.Unresolved, phaseName+": "+detail)
+	}
+	if detail != "" && (strings.Contains(detail, "command:") || strings.Contains(detail, "label:") || strings.Contains(detail, "gate")) {
+		s.progress.Verification = appendUniqueString(s.progress.Verification, phaseName+": "+detail)
+	}
+	if detail != "" && (strings.Contains(detail, "command:") || strings.Contains(detail, "label:")) {
+		s.progress.LastGateResult = detail
+	}
+	s.progress.UpdatedAt = now
+
+	return s.persist(true)
+}
+
+func (s *structuredState) recordApproval(approval memory.OperatorApproval) error {
+	s.progress.Approvals = mergeApprovals(s.progress.Approvals, []memory.OperatorApproval{approval})
+	s.progress.UpdatedAt = time.Now().UTC()
+	return s.persist(true)
+}
+
+func (s *structuredState) persist(writeSnapshot bool) error {
+	if err := s.writeProgress(); err != nil {
+		return err
+	}
+	if err := s.writeHandoff(latestHandoffSessionID); err != nil {
+		return err
+	}
+	if !writeSnapshot {
+		return nil
+	}
+	return s.writeHandoff(time.Now().UTC().Format("20060102T150405Z"))
+}
+
+func (s *structuredState) writeProgress() error {
+	data, err := json.MarshalIndent(s.progress, "", "  ")
+	if err != nil {
+		return fmt.Errorf("write progress: marshal: %w", err)
+	}
+	if err := os.WriteFile(s.progressPath, data, 0o644); err != nil {
+		return fmt.Errorf("write progress: write: %w", err)
+	}
+	return nil
+}
+
+func (s *structuredState) writeHandoff(sessionID string) error {
+	handoff := memory.NewHandoff(s.vessel.ID, sessionID)
+	if s.workflow != nil {
+		if s.progress.CurrentPhase >= 0 && s.progress.CurrentPhase < len(s.workflow.Phases) {
+			handoff.CurrentPhase = s.workflow.Phases[s.progress.CurrentPhase].Name
+		} else if len(s.workflow.Phases) > 0 {
+			handoff.CurrentPhase = s.workflow.Phases[len(s.workflow.Phases)-1].Name
+		}
+	}
+	handoff.Plan = s.progress.Plan
+	handoff.Unresolved = cloneStrings(s.progress.Unresolved)
+	handoff.Checkpoints = cloneStrings(s.progress.Checkpoints)
+	handoff.Verification = cloneStrings(s.progress.Verification)
+	handoff.Approvals = cloneApprovals(s.progress.Approvals)
+	handoff.PhaseOutputs = readPhaseOutputContents(s.phasesDir, s.progress.PhaseOutputs)
+	for _, item := range s.progress.Phases {
+		switch item.Status {
+		case "completed", "no-op":
+			handoff.Completed = append(handoff.Completed, item.Name)
+		case "failed":
+			handoff.Failed = append(handoff.Failed, item.Name)
+		}
+	}
+	for _, item := range s.progress.Phases {
+		if item.Status == "pending" || item.Status == "in_progress" {
+			handoff.NextSteps = append(handoff.NextSteps, item.Name)
+		}
+	}
+	if err := handoff.Save(s.phasesDir); err != nil {
+		return fmt.Errorf("write handoff: %w", err)
+	}
+	return nil
+}
+
+func (s *structuredState) compilePhaseContext(p workflow.Phase, phaseIdx int, issueData phase.IssueData, previousOutputs map[string]string, gateResult string, dependencyScoped bool) (*PhaseContextManifest, error) {
+	processors := make([]ctxmgr.Processor, 0)
+	durableSections := make([]string, 0)
+
+	if section := strings.TrimSpace(renderIssueContext(issueData)); section != "" {
+		processors = append(processors, staticContextProcessor("issue", 10, section, true, "issue"))
+		durableSections = append(durableSections, "issue")
+	}
+	if s.progress.Plan != "" {
+		processors = append(processors, staticContextProcessor("plan", 20, s.progress.Plan, true, "progress.plan"))
+		durableSections = append(durableSections, "plan")
+	}
+	if len(s.progress.Checkpoints) > 0 {
+		processors = append(processors, staticContextProcessor("checkpoints", 30, strings.Join(s.progress.Checkpoints, "\n"), true, "progress.checkpoints"))
+		durableSections = append(durableSections, "checkpoints")
+	}
+	if len(s.progress.Unresolved) > 0 {
+		processors = append(processors, staticContextProcessor("unresolved", 40, strings.Join(s.progress.Unresolved, "\n"), true, "progress.unresolved"))
+		durableSections = append(durableSections, "unresolved")
+	}
+	if len(s.progress.Verification) > 0 {
+		processors = append(processors, staticContextProcessor("verification", 50, strings.Join(s.progress.Verification, "\n"), true, "progress.verification"))
+		durableSections = append(durableSections, "verification")
+	}
+	if approvals := renderApprovals(s.progress.Approvals); approvals != "" {
+		processors = append(processors, staticContextProcessor("approvals", 60, approvals, true, "progress.approvals"))
+		durableSections = append(durableSections, "approvals")
+	}
+	if gateResult != "" {
+		processors = append(processors, staticContextProcessor("gate_result", 70, gateResult, false, "gate"))
+	}
+	for priority, name := range sortedMapKeys(previousOutputs) {
+		processors = append(processors, staticContextProcessor("output:"+name, 100+priority, previousOutputs[name], false, "phase."+name))
+	}
+
+	pipeline := ctxmgr.NewPipeline(processors...)
+	window := pipeline.Assemble(ctxmgr.StepContext{
+		StepName:        p.Name,
+		Phase:           p.Name,
+		AvailableTokens: compiledContextTokenBudget,
+		Metadata: map[string]string{
+			"workflow":    s.vessel.Workflow,
+			"vessel_id":   s.vessel.ID,
+			"phase_index": fmt.Sprintf("%d", phaseIdx),
+		},
+	}, compiledContextTokenBudget)
+
+	hasDurableState := len(durableSections) > 0
+	complexity := "normal"
+	strategy := ctxmgr.SelectStrategy(window.Utilization(), hasDurableState, complexity)
+	selectedWindow := window
+	compaction := ContextCompaction{
+		Threshold:     ctxmgr.DefaultCompactionThreshold,
+		BeforeTokens:  window.UsedTokens(),
+		DurableTokens: window.DurableTokens(),
+	}
+	if strategy == ctxmgr.StrategyCompress {
+		selectedWindow = ctxmgr.Compact(window, ctxmgr.CompactionConfig{
+			Threshold:       ctxmgr.DefaultCompactionThreshold,
+			PreserveDurable: true,
+		})
+		compaction.Applied = true
+	}
+	compaction.AfterTokens = selectedWindow.UsedTokens()
+
+	manifest := &PhaseContextManifest{
+		VesselID:     s.vessel.ID,
+		Workflow:     s.vessel.Workflow,
+		Phase:        p.Name,
+		ManifestPath: filepath.ToSlash(filepath.Join("phases", s.vessel.ID, p.Name+".context.json")),
+		Strategy:     strategy,
+		Resumed:      s.resume.Progress != nil || s.resume.Handoff != nil,
+		Inputs: ContextInputs{
+			IssuePresent:     issueData.Number != 0 || issueData.Title != "" || issueData.Body != "",
+			GateResult:       gateResult != "",
+			PreviousOutputs:  sortedMapKeys(previousOutputs),
+			DurableSections:  durableSections,
+			DependencyScoped: dependencyScoped,
+		},
+		Compaction: compaction,
+		Window: &ctxmgr.Window{
+			Segments:  cloneSegments(selectedWindow.Segments),
+			MaxTokens: selectedWindow.MaxTokens,
+		},
+		Compiled:  renderCompiledContext(selectedWindow),
+		CreatedAt: time.Now().UTC(),
+	}
+
+	if err := s.writeContextManifest(p.Name, manifest); err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func (s *structuredState) writeContextManifest(phaseName string, manifest *PhaseContextManifest) error {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("write context manifest %s: marshal: %w", phaseName, err)
+	}
+	path := filepath.Join(s.phasesDir, phaseName+".context.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write context manifest %s: write: %w", phaseName, err)
+	}
+	return nil
+}
+
+func renderCompiledContext(window *ctxmgr.Window) string {
+	if window == nil || len(window.Segments) == 0 {
+		return ""
+	}
+
+	var parts []string
+	for _, segment := range window.Segments {
+		parts = append(parts, fmt.Sprintf("[%s]\n%s", segment.Name, segment.Content))
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func withCompiledContext(rendered, compiled string) string {
+	if strings.TrimSpace(compiled) == "" {
+		return rendered
+	}
+	return compiled + "\n\n---\n\n" + rendered
+}
+
+func renderIssueContext(issueData phase.IssueData) string {
+	var parts []string
+	if issueData.Number != 0 {
+		parts = append(parts, fmt.Sprintf("Number: %d", issueData.Number))
+	}
+	if issueData.Title != "" {
+		parts = append(parts, "Title: "+issueData.Title)
+	}
+	if issueData.URL != "" {
+		parts = append(parts, "URL: "+issueData.URL)
+	}
+	if len(issueData.Labels) > 0 {
+		parts = append(parts, "Labels: "+strings.Join(issueData.Labels, ", "))
+	}
+	if issueData.Body != "" {
+		parts = append(parts, "Body:\n"+phase.TruncateOutput(issueData.Body, phase.MaxIssueBodyLen))
+	}
+	return strings.Join(parts, "\n")
+}
+
+func renderApprovals(approvals []memory.OperatorApproval) string {
+	if len(approvals) == 0 {
+		return ""
+	}
+
+	lines := make([]string, 0, len(approvals))
+	for _, approval := range approvals {
+		line := approval.ApprovedBy
+		if approval.Reason != "" {
+			line += ": " + approval.Reason
+		}
+		if !approval.ApprovedAt.IsZero() {
+			line += " (" + approval.ApprovedAt.UTC().Format(time.RFC3339) + ")"
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func staticContextProcessor(name string, priority int, content string, durable bool, source string) ctxmgr.Processor {
+	return ctxmgr.Processor{
+		Name:     name,
+		Priority: priority,
+		Fn: func(_ ctxmgr.StepContext) []ctxmgr.Segment {
+			if strings.TrimSpace(content) == "" {
+				return nil
+			}
+			return []ctxmgr.Segment{{
+				Name:     name,
+				Content:  content,
+				Tokens:   ctxmgr.EstimateTokens(content),
+				Durable:  durable,
+				Source:   source,
+				Priority: priority,
+			}}
+		},
+	}
+}
+
+func cleanupExpiredStructuredArtifacts(cfg *config.Config, vesselID string, now time.Time) error {
+	if cfg == nil || cfg.CleanupAfter == "" {
+		return nil
+	}
+	cleanupAfter, err := time.ParseDuration(cfg.CleanupAfter)
+	if err != nil {
+		return fmt.Errorf("parse cleanup_after: %w", err)
+	}
+
+	phasesDir := filepath.Join(cfg.StateDir, "phases", vesselID)
+	entries, err := os.ReadDir(phasesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read phases dir: %w", err)
+	}
+
+	cutoff := now.Add(-cleanupAfter)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		expirableContext := strings.HasSuffix(name, ".context.json")
+		expirableHandoff := strings.HasPrefix(name, "handoff_"+vesselID+"_") && !strings.HasSuffix(name, "_"+latestHandoffSessionID+".json")
+		if !expirableContext && !expirableHandoff {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", name, err)
+		}
+		if info.ModTime().After(cutoff) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(phasesDir, name)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove expired artifact %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func (s *structuredState) applySummary(summary *VesselSummary) {
+	if summary == nil {
+		return
+	}
+	summary.ProgressPath = filepath.ToSlash(filepath.Join("phases", s.vessel.ID, progressFileName(s.vessel.ID)))
+	summary.HandoffPath = s.latestHandoffRel
+	summary.Retention = &ArtifactRetention{
+		CleanupAfter: s.cfg.CleanupAfter,
+		Durable: []string{
+			filepath.ToSlash(filepath.Join("phases", s.vessel.ID, summaryFileName)),
+			summary.ProgressPath,
+			summary.HandoffPath,
+			filepath.ToSlash(filepath.Join("phases", s.vessel.ID, "*.prompt")),
+			filepath.ToSlash(filepath.Join("phases", s.vessel.ID, "*.output")),
+			filepath.ToSlash(filepath.Join("phases", s.vessel.ID, "*.command")),
+		},
+		Expirable: []string{
+			filepath.ToSlash(filepath.Join("phases", s.vessel.ID, "*.context.json")),
+			filepath.ToSlash(filepath.Join("phases", s.vessel.ID, "handoff_"+s.vessel.ID+"_*.json (except latest)")),
+		},
+	}
+}
+
+func cloneStructuredProgress(progress structuredProgressFile) structuredProgressFile {
+	return structuredProgressFile{
+		VesselID:       progress.VesselID,
+		Workflow:       progress.Workflow,
+		CurrentPhase:   progress.CurrentPhase,
+		Plan:           progress.Plan,
+		Unresolved:     cloneStrings(progress.Unresolved),
+		Checkpoints:    cloneStrings(progress.Checkpoints),
+		Verification:   cloneStrings(progress.Verification),
+		Approvals:      cloneApprovals(progress.Approvals),
+		LastGateResult: progress.LastGateResult,
+		PhaseOutputs:   cloneStringMap(progress.PhaseOutputs),
+		Phases:         cloneSnapshots(progress.Phases),
+		UpdatedAt:      progress.UpdatedAt,
+	}
+}
+
+func readPhaseOutputContents(phasesDir string, outputs map[string]string) map[string]string {
+	if len(outputs) == 0 {
+		return nil
+	}
+
+	contents := make(map[string]string, len(outputs))
+	for phaseName, relPath := range outputs {
+		if strings.TrimSpace(relPath) == "" {
+			continue
+		}
+
+		path := relPath
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(slashBase(phasesDir), filepath.FromSlash(strings.TrimPrefix(relPath, "phases/")))
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		contents[phaseName] = string(data)
+	}
+	if len(contents) == 0 {
+		return nil
+	}
+	return contents
+}
+
+func slashBase(phasesDir string) string {
+	return filepath.Dir(filepath.Dir(filepath.Clean(phasesDir)))
+}
+
+func cloneSnapshots(in []structuredSnapshot) []structuredSnapshot {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]structuredSnapshot, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneSegments(in []ctxmgr.Segment) []ctxmgr.Segment {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ctxmgr.Segment, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneApprovals(in []memory.OperatorApproval) []memory.OperatorApproval {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]memory.OperatorApproval, len(in))
+	copy(out, in)
+	return out
+}
+
+func mergeUniqueStrings(base, add []string) []string {
+	for _, item := range add {
+		base = appendUniqueString(base, item)
+	}
+	return base
+}
+
+func appendUniqueString(items []string, value string) []string {
+	for _, existing := range items {
+		if existing == value {
+			return items
+		}
+	}
+	return append(items, value)
+}
+
+func mergeApprovals(base, add []memory.OperatorApproval) []memory.OperatorApproval {
+	for _, approval := range add {
+		found := false
+		for _, existing := range base {
+			if existing.ApprovedBy == approval.ApprovedBy && existing.Reason == approval.Reason && existing.ApprovedAt.Equal(approval.ApprovedAt) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			base = append(base, approval)
+		}
+	}
+	return base
+}
+
+func sortedMapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/cli/internal/runner/context_test.go
+++ b/cli/internal/runner/context_test.go
@@ -1,0 +1,188 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/ctxmgr"
+	"github.com/nicholls-inc/xylem/cli/internal/memory"
+	"github.com/nicholls-inc/xylem/cli/internal/phase"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareStructuredStateReconstructsResumeArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = dir
+
+	vessel := queue.Vessel{ID: "issue-60", Workflow: "fix-bug", CurrentPhase: 1}
+	wf := &workflow.Workflow{
+		Name: "fix-bug",
+		Phases: []workflow.Phase{
+			{Name: "plan"},
+			{Name: "implement"},
+		},
+	}
+
+	phasesDir := filepath.Join(dir, "phases", vessel.ID)
+	require.NoError(t, os.MkdirAll(phasesDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(phasesDir, "plan.output"), []byte("plan output from file"), 0o644))
+	progress := structuredProgressFile{
+		VesselID:     vessel.ID,
+		Workflow:     vessel.Workflow,
+		CurrentPhase: 1,
+		Plan:         "existing plan",
+		Checkpoints:  []string{"plan"},
+		Verification: []string{"go test ./..."},
+		Approvals: []memory.OperatorApproval{{
+			ApprovedBy: "operator",
+			Reason:     "resume",
+			ApprovedAt: time.Now().UTC(),
+		}},
+		PhaseOutputs: map[string]string{"plan": "phases/issue-60/plan.output"},
+		Phases: []structuredSnapshot{{
+			Name:      "plan",
+			Index:     0,
+			Status:    "completed",
+			UpdatedAt: time.Now().UTC(),
+		}},
+		UpdatedAt: time.Now().UTC(),
+	}
+	progressData, err := json.MarshalIndent(progress, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(phasesDir, progressFileName(vessel.ID)), progressData, 0o644))
+
+	handoff := memory.NewHandoff(vessel.ID, latestHandoffSessionID)
+	handoff.CurrentPhase = "implement"
+	handoff.Plan = "existing plan"
+	handoff.Checkpoints = []string{"plan"}
+	handoff.Unresolved = []string{"implement: still open"}
+	handoff.PhaseOutputs = map[string]string{"plan": "plan output from handoff"}
+	require.NoError(t, handoff.Save(phasesDir))
+
+	state, err := prepareStructuredState(cfg, vessel, wf)
+	require.NoError(t, err)
+
+	assert.Equal(t, "existing plan", state.progress.Plan)
+	assert.Equal(t, 1, state.progress.CurrentPhase)
+	assert.Contains(t, state.progress.Checkpoints, "plan")
+	assert.Contains(t, state.progress.Unresolved, "implement: still open")
+	assert.Equal(t, "phases/issue-60/plan.output", state.progress.PhaseOutputs["plan"])
+	assert.Equal(t, "plan output from handoff", state.resume.PreviousOutputs["plan"])
+	require.Len(t, state.progress.Phases, 2)
+	assert.Equal(t, "implement", state.progress.Phases[1].Name)
+}
+
+func TestCompilePhaseContextCompactsWorkingOutputsAtThreshold(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = dir
+	cfg.CleanupAfter = "24h"
+
+	vessel := queue.Vessel{ID: "issue-60", Workflow: "fix-bug"}
+	wf := &workflow.Workflow{
+		Name: "fix-bug",
+		Phases: []workflow.Phase{
+			{Name: "plan"},
+		},
+	}
+
+	state, err := prepareStructuredState(cfg, vessel, wf)
+	require.NoError(t, err)
+	state.progress.Plan = "durable plan"
+
+	manifest, err := state.compilePhaseContext(
+		workflow.Phase{Name: "plan"},
+		0,
+		phase.IssueData{},
+		map[string]string{"previous": strings.Repeat("x", compiledContextTokenBudget*8)},
+		"",
+		false,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, ctxmgr.StrategyCompress, manifest.Strategy)
+	assert.True(t, manifest.Compaction.Applied)
+	assert.Equal(t, manifest.Compaction.DurableTokens, manifest.Compaction.AfterTokens)
+	require.Len(t, manifest.Window.Segments, 1)
+	assert.Equal(t, "plan", manifest.Window.Segments[0].Name)
+
+	manifestPath := filepath.Join(dir, manifest.ManifestPath)
+	data, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	var persisted PhaseContextManifest
+	require.NoError(t, json.Unmarshal(data, &persisted))
+	assert.Equal(t, manifest.Phase, persisted.Phase)
+	assert.Equal(t, manifest.ManifestPath, persisted.ManifestPath)
+}
+
+func TestCleanupExpiredStructuredArtifactsKeepsDurableFiles(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = dir
+	cfg.CleanupAfter = "1h"
+
+	vesselID := "issue-60"
+	phasesDir := filepath.Join(dir, "phases", vesselID)
+	require.NoError(t, os.MkdirAll(phasesDir, 0o755))
+
+	oldTime := time.Now().Add(-2 * time.Hour)
+	newTime := time.Now()
+	oldFiles := []string{
+		filepath.Join(phasesDir, "plan.context.json"),
+		filepath.Join(phasesDir, "handoff_"+vesselID+"_20260408T202500Z.json"),
+	}
+	keptFiles := []string{
+		filepath.Join(phasesDir, "handoff_"+vesselID+"_"+latestHandoffSessionID+".json"),
+		filepath.Join(phasesDir, progressFileName(vesselID)),
+		filepath.Join(phasesDir, summaryFileName),
+		filepath.Join(phasesDir, "plan.output"),
+	}
+
+	for _, path := range oldFiles {
+		require.NoError(t, os.WriteFile(path, []byte("{}"), 0o644))
+		require.NoError(t, os.Chtimes(path, oldTime, oldTime))
+	}
+	for _, path := range keptFiles {
+		require.NoError(t, os.WriteFile(path, []byte("{}"), 0o644))
+		require.NoError(t, os.Chtimes(path, newTime, newTime))
+	}
+
+	require.NoError(t, cleanupExpiredStructuredArtifacts(cfg, vesselID, newTime))
+
+	for _, path := range oldFiles {
+		_, err := os.Stat(path)
+		assert.Error(t, err)
+	}
+	for _, path := range keptFiles {
+		_, err := os.Stat(path)
+		assert.NoError(t, err)
+	}
+}
+
+func TestApplySummaryIncludesStructuredRetention(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = dir
+
+	state := &structuredState{
+		cfg:              cfg,
+		vessel:           queue.Vessel{ID: "issue-60"},
+		latestHandoffRel: latestHandoffRelativePath("issue-60"),
+	}
+	summary := &VesselSummary{}
+
+	state.applySummary(summary)
+
+	assert.Equal(t, "phases/issue-60/"+progressFileName("issue-60"), summary.ProgressPath)
+	assert.Equal(t, latestHandoffRelativePath("issue-60"), summary.HandoffPath)
+	require.NotNil(t, summary.Retention)
+	assert.Contains(t, summary.Retention.Expirable, "phases/issue-60/*.context.json")
+}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"github.com/nicholls-inc/xylem/cli/internal/gate"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+	"github.com/nicholls-inc/xylem/cli/internal/memory"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/orchestrator"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
@@ -338,14 +339,26 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 	// Read harness file
 	harnessContent := r.readHarness()
 
+	structuredState, err := prepareStructuredState(r.Config, vessel, sk)
+	if err != nil {
+		r.failVessel(vessel.ID, fmt.Sprintf("prepare structured state: %v", err))
+		if err := src.OnFail(ctx, vessel); err != nil {
+			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+		}
+		return "failed"
+	}
+	vrs.structured = structuredState
+
 	// Orchestrator-driven execution for workflows with explicit phase dependencies.
 	// This enables parallel phase execution within waves and context firewalls.
 	if sk.HasDependencies() {
 		return r.runVesselOrchestrated(ctx, vessel, sk, issueData, harnessContent, worktreePath, src, vrs, &claims)
 	}
 
-	// Rebuild previousOutputs from .xylem/phases/<id>/*.output (for resume)
-	previousOutputs := r.rebuildPreviousOutputs(vessel.ID, sk)
+	previousOutputs := cloneStringMap(structuredState.resume.PreviousOutputs)
+	if len(previousOutputs) == 0 {
+		previousOutputs = r.rebuildPreviousOutputs(vessel.ID, sk)
+	}
 	srcCfg := r.sourceConfigFromMeta(vessel)
 
 	// Execute phases sequentially (no explicit dependencies)
@@ -364,6 +377,24 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			log.Printf("%sphase %q starting (%d/%d)", vesselLabel(vessel), p.Name, i+1, len(sk.Phases))
 			phaseStart := r.runtimeNow()
 
+			contextData := phase.ContextData{}
+			if vrs.structured != nil {
+				manifest, err := vrs.structured.compilePhaseContext(p, i, issueData, previousOutputs, gateResult, false)
+				if err != nil {
+					r.failVessel(vessel.ID, fmt.Sprintf("compile phase context for %s: %v", p.Name, err))
+					if err := src.OnFail(ctx, vessel); err != nil {
+						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+					}
+					return "failed"
+				}
+				contextData = phase.ContextData{
+					ManifestPath: manifest.ManifestPath,
+					Strategy:     string(manifest.Strategy),
+					Compiled:     manifest.Compiled,
+					Resumed:      manifest.Resumed,
+				}
+			}
+
 			// Build template data
 			td := phase.TemplateData{
 				Issue: issueData,
@@ -373,6 +404,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				},
 				PreviousOutputs: previousOutputs,
 				GateResult:      gateResult,
+				Context:         contextData,
 				Vessel: phase.VesselData{
 					ID:     vessel.ID,
 					Source: vessel.Source,
@@ -440,6 +472,15 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if policyErr := r.enforcePhasePolicy(vessel, p); policyErr != nil {
 					finishCurrentPhaseSpan(policyErr)
 					log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
+					if vrs.structured != nil && strings.Contains(policyErr.Error(), "requires approval") {
+						if err := vrs.structured.recordApproval(memory.OperatorApproval{
+							ApprovedBy: p.Name,
+							Reason:     policyErr.Error(),
+							ApprovedAt: r.runtimeNow(),
+						}); err != nil {
+							log.Printf("warn: record approval for %s/%s: %v", vessel.ID, p.Name, err)
+						}
+					}
 					vessel.FailedPhase = p.Name
 					r.failVessel(vessel.ID, policyErr.Error())
 					if err := src.OnFail(ctx, vessel); err != nil {
@@ -490,6 +531,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					}
 					return "failed"
 				}
+				rendered = withCompiledContext(rendered, td.Context.Compiled)
 				promptForCost = rendered
 				if harnessContent != "" {
 					promptForCost = harnessContent + "\n\n" + rendered
@@ -501,6 +543,15 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if policyErr := r.enforcePhasePolicy(vessel, p); policyErr != nil {
 					finishCurrentPhaseSpan(policyErr)
 					log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
+					if vrs.structured != nil && strings.Contains(policyErr.Error(), "requires approval") {
+						if err := vrs.structured.recordApproval(memory.OperatorApproval{
+							ApprovedBy: p.Name,
+							Reason:     policyErr.Error(),
+							ApprovedAt: r.runtimeNow(),
+						}); err != nil {
+							log.Printf("warn: record approval for %s/%s: %v", vessel.ID, p.Name, err)
+						}
+					}
 					vessel.FailedPhase = p.Name
 					r.failVessel(vessel.ID, policyErr.Error())
 					if err := src.OnFail(ctx, vessel); err != nil {
@@ -550,6 +601,11 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
 				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()))
 				vessel.FailedPhase = p.Name
+				if vrs.structured != nil {
+					if err := vrs.structured.recordPhaseOutcome(p.Name, i, string(output), "failed", "phase:failed:"+runErr.Error()); err != nil {
+						log.Printf("warn: update structured progress for %s/%s: %v", vessel.ID, p.Name, err)
+					}
+				}
 				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, runErr))
 				if err := src.OnFail(ctx, vessel); err != nil {
 					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
@@ -568,6 +624,11 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					log.Printf("%sphase %q violated protected surfaces: %v", vesselLabel(vessel), p.Name, err)
 					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error()))
 					vessel.FailedPhase = p.Name
+					if vrs.structured != nil {
+						if stateErr := vrs.structured.recordPhaseOutcome(p.Name, i, string(output), "failed", "phase:failed:"+err.Error()); stateErr != nil {
+							log.Printf("warn: update structured progress for %s/%s: %v", vessel.ID, p.Name, stateErr)
+						}
+					}
 					r.failVessel(vessel.ID, err.Error())
 					if err := src.OnFail(ctx, vessel); err != nil {
 						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
@@ -588,6 +649,11 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					p.Name, vrs.costTracker.TotalCost(), vrs.costTracker.TotalTokens())
 				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg))
 				vessel.FailedPhase = p.Name
+				if vrs.structured != nil {
+					if err := vrs.structured.recordPhaseOutcome(p.Name, i, string(output), "failed", "budget:"+errMsg); err != nil {
+						log.Printf("warn: update structured progress for %s/%s: %v", vessel.ID, p.Name, err)
+					}
+				}
 				r.failVessel(vessel.ID, errMsg)
 				if err := src.OnFail(ctx, vessel); err != nil {
 					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
@@ -632,6 +698,11 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 			if phaseStatus == "no-op" {
 				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, ""))
+				if vrs.structured != nil {
+					if err := vrs.structured.recordPhaseOutcome(p.Name, i, string(output), "no-op", ""); err != nil {
+						log.Printf("warn: update structured progress for %s/%s: %v", vessel.ID, p.Name, err)
+					}
+				}
 				log.Printf("%sphase %q triggered no-op; completing workflow early", vesselLabel(vessel), p.Name)
 				finishCurrentPhaseSpan(nil)
 				return r.completeVessel(ctx, vessel, worktreePath, phaseResults, vrs, claims)
@@ -640,6 +711,11 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			// Handle gate
 			if p.Gate == nil {
 				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, ""))
+				if vrs.structured != nil {
+					if err := vrs.structured.recordPhaseOutcome(p.Name, i, string(output), phaseStatus, ""); err != nil {
+						log.Printf("warn: update structured progress for %s/%s: %v", vessel.ID, p.Name, err)
+					}
+				}
 				finishCurrentPhaseSpan(nil)
 				break // no gate, proceed to next phase
 			}
@@ -655,6 +731,11 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				}, gateErr)
 				if gateErr != nil {
 					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error()))
+					if vrs.structured != nil {
+						if err := vrs.structured.recordPhaseOutcome(p.Name, i, string(output), "failed", "command:error:"+gateErr.Error()); err != nil {
+							log.Printf("warn: update structured progress for %s/%s: %v", vessel.ID, p.Name, err)
+						}
+					}
 					finishCurrentPhaseSpan(nil)
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate error: %v", p.Name, gateErr))
 					if err := src.OnFail(ctx, vessel); err != nil {
@@ -665,6 +746,11 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if passed {
 					log.Printf("%sgate passed for phase %q", vesselLabel(vessel), p.Name)
 					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, gatePassedPointer(true), ""))
+					if vrs.structured != nil {
+						if err := vrs.structured.recordPhaseOutcome(p.Name, i, string(output), phaseStatus, "command:passed"); err != nil {
+							log.Printf("warn: update structured progress for %s/%s: %v", vessel.ID, p.Name, err)
+						}
+					}
 					gateRecordedAt := r.runtimeNow()
 					claims = append(claims, buildGateClaim(p, true, phaseArtifactRelativePath(vessel.ID, p.Name), gateRecordedAt))
 					finishCurrentPhaseSpan(nil)
@@ -682,6 +768,11 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if vessel.GateRetries <= 0 {
 					log.Printf("%sgate failed for phase %q, retries exhausted", vesselLabel(vessel), p.Name)
 					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted"))
+					if vrs.structured != nil {
+						if err := vrs.structured.recordPhaseOutcome(p.Name, i, string(output), "failed", "command:failed"); err != nil {
+							log.Printf("warn: update structured progress for %s/%s: %v", vessel.ID, p.Name, err)
+						}
+					}
 					finishCurrentPhaseSpan(nil)
 					vessel.FailedPhase = p.Name
 					vessel.GateOutput = gateOut
@@ -707,6 +798,11 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 				if err := r.runtimeSleep(ctx, retryDelay); err != nil {
 					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error()))
+					if vrs.structured != nil {
+						if stateErr := vrs.structured.recordPhaseOutcome(p.Name, i, string(output), "failed", "command:retry_interrupted:"+err.Error()); stateErr != nil {
+							log.Printf("warn: update structured progress for %s/%s: %v", vessel.ID, p.Name, stateErr)
+						}
+					}
 					finishCurrentPhaseSpan(err)
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate retry interrupted: %v", p.Name, err))
 					if failErr := src.OnFail(ctx, vessel); failErr != nil {
@@ -732,6 +828,11 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				vessel.WaitingSince = &now
 				vessel.CurrentPhase = i + 1
 				vessel.State = queue.StateWaiting
+				if vrs.structured != nil {
+					if err := vrs.structured.recordPhaseOutcome(p.Name, i, string(output), "waiting", "label:waiting:"+p.Gate.WaitFor); err != nil {
+						log.Printf("warn: update structured progress for %s/%s: %v", vessel.ID, p.Name, err)
+					}
+				}
 				if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
 					log.Printf("warn: persist waiting state for %s: %v", vessel.ID, updateErr)
 					finishCurrentPhaseSpan(updateErr)
@@ -898,6 +999,9 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 	}
 
 	summary := vrs.buildSummary(state, now)
+	if vrs.structured != nil {
+		vrs.structured.applySummary(summary)
+	}
 	var manifest *evidence.Manifest
 	if len(claims) > 0 {
 		manifest = &evidence.Manifest{
@@ -915,6 +1019,11 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 
 	if err := SaveVesselSummary(r.Config.StateDir, summary); err != nil {
 		log.Printf("warn: save vessel summary: %v", err)
+	}
+	if vrs.structured != nil {
+		if err := cleanupExpiredStructuredArtifacts(r.Config, vessel.ID, now.UTC()); err != nil {
+			log.Printf("warn: cleanup structured artifacts: %v", err)
+		}
 	}
 
 	return manifest
@@ -934,8 +1043,13 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 		return "failed"
 	}
 
-	// Rebuild previous outputs for resume.
-	allOutputs := r.rebuildPreviousOutputs(vessel.ID, wf)
+	var allOutputs map[string]string
+	if vrs.structured != nil {
+		allOutputs = cloneStringMap(vrs.structured.resume.PreviousOutputs)
+	}
+	if len(allOutputs) == 0 {
+		allOutputs = r.rebuildPreviousOutputs(vessel.ID, wf)
+	}
 
 	// Mark already-completed phases in orchestrator.
 	for phaseName, output := range allOutputs {
@@ -1109,6 +1223,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 	p := wf.Phases[phaseIdx]
 	gateResult := ""
 	gateRetries := 0
+	structuredState := vrs.structured
 	if p.Gate != nil && p.Gate.Type == "command" && p.Gate.Retries > 0 {
 		gateRetries = p.Gate.Retries
 	}
@@ -1119,6 +1234,24 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		log.Printf("%sphase %q starting (orchestrated)", vesselLabel(vessel), p.Name)
 		phaseStart := r.runtimeNow()
 
+		contextData := phase.ContextData{}
+		if structuredState != nil {
+			manifest, err := structuredState.compilePhaseContext(p, phaseIdx, issueData, previousOutputs, gateResult, len(p.DependsOn) > 0)
+			if err != nil {
+				r.failVessel(vessel.ID, fmt.Sprintf("compile phase context for %s: %v", p.Name, err))
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
+				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
+			}
+			contextData = phase.ContextData{
+				ManifestPath: manifest.ManifestPath,
+				Strategy:     string(manifest.Strategy),
+				Compiled:     manifest.Compiled,
+				Resumed:      manifest.Resumed,
+			}
+		}
+
 		td := phase.TemplateData{
 			Issue: issueData,
 			Phase: phase.PhaseData{
@@ -1127,6 +1260,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			},
 			PreviousOutputs: previousOutputs,
 			GateResult:      gateResult,
+			Context:         contextData,
 			Vessel: phase.VesselData{
 				ID:     vessel.ID,
 				Source: vessel.Source,
@@ -1192,6 +1326,15 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if policyErr := r.enforcePhasePolicy(vessel, p); policyErr != nil {
 				finishCurrentPhaseSpan(policyErr)
 				log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
+				if structuredState != nil && strings.Contains(policyErr.Error(), "requires approval") {
+					if err := structuredState.recordApproval(memory.OperatorApproval{
+						ApprovedBy: p.Name,
+						Reason:     policyErr.Error(),
+						ApprovedAt: r.runtimeNow(),
+					}); err != nil {
+						log.Printf("warn: record approval for %s/%s: %v", vessel.ID, p.Name, err)
+					}
+				}
 				vessel.FailedPhase = p.Name
 				r.failVessel(vessel.ID, policyErr.Error())
 				if err := src.OnFail(ctx, vessel); err != nil {
@@ -1241,6 +1384,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				}
 				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
 			}
+			rendered = withCompiledContext(rendered, td.Context.Compiled)
 			promptForCost = rendered
 			if harnessContent != "" {
 				promptForCost = harnessContent + "\n\n" + rendered
@@ -1252,6 +1396,15 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if policyErr := r.enforcePhasePolicy(vessel, p); policyErr != nil {
 				finishCurrentPhaseSpan(policyErr)
 				log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
+				if structuredState != nil && strings.Contains(policyErr.Error(), "requires approval") {
+					if err := structuredState.recordApproval(memory.OperatorApproval{
+						ApprovedBy: p.Name,
+						Reason:     policyErr.Error(),
+						ApprovedAt: r.runtimeNow(),
+					}); err != nil {
+						log.Printf("warn: record approval for %s/%s: %v", vessel.ID, p.Name, err)
+					}
+				}
 				vessel.FailedPhase = p.Name
 				r.failVessel(vessel.ID, policyErr.Error())
 				if err := src.OnFail(ctx, vessel); err != nil {
@@ -1300,6 +1453,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			finishCurrentPhaseSpan(runErr)
 			log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
 			vessel.FailedPhase = p.Name
+			if structuredState != nil {
+				if err := structuredState.recordPhaseOutcome(p.Name, phaseIdx, string(output), "failed", "phase:failed:"+runErr.Error()); err != nil {
+					log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+				}
+			}
 			r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, runErr))
 			if err := src.OnFail(ctx, vessel); err != nil {
 				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
@@ -1321,6 +1479,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				finishCurrentPhaseSpan(err)
 				log.Printf("%sphase %q violated protected surfaces: %v", vesselLabel(vessel), p.Name, err)
 				vessel.FailedPhase = p.Name
+				if structuredState != nil {
+					if stateErr := structuredState.recordPhaseOutcome(p.Name, phaseIdx, string(output), "failed", "phase:failed:"+err.Error()); stateErr != nil {
+						log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, stateErr)
+					}
+				}
 				r.failVessel(vessel.ID, err.Error())
 				if err := src.OnFail(ctx, vessel); err != nil {
 					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
@@ -1344,6 +1507,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			errMsg := fmt.Sprintf("budget exceeded after phase %q: estimated cost $%.4f, estimated tokens %d",
 				p.Name, vrs.costTracker.TotalCost(), vrs.costTracker.TotalTokens())
 			vessel.FailedPhase = p.Name
+			if structuredState != nil {
+				if err := structuredState.recordPhaseOutcome(p.Name, phaseIdx, string(output), "failed", "budget:"+errMsg); err != nil {
+					log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+				}
+			}
 			r.failVessel(vessel.ID, errMsg)
 			if err := src.OnFail(ctx, vessel); err != nil {
 				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
@@ -1364,6 +1532,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		// Report phase completion.
 		issueNum := r.parseIssueNum(vessel)
 		if phaseMatchedNoOp(&p, string(output)) {
+			if structuredState != nil {
+				if err := structuredState.recordPhaseOutcome(p.Name, phaseIdx, string(output), "no-op", ""); err != nil {
+					log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+				}
+			}
 			if issueNum > 0 && r.Reporter != nil {
 				r.logReporterError("post phase-complete comment", vessel.ID,
 					r.Reporter.PhaseComplete(ctx, issueNum, p.Name, phaseDuration, string(output)))
@@ -1385,6 +1558,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 
 		// Handle gate.
 		if p.Gate == nil {
+			if structuredState != nil {
+				if err := structuredState.recordPhaseOutcome(p.Name, phaseIdx, string(output), "completed", ""); err != nil {
+					log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+				}
+			}
 			finishCurrentPhaseSpan(nil)
 			return singlePhaseResult{
 				output:        string(output),
@@ -1405,6 +1583,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				RetryAttempt: retryAttempt,
 			}, gateErr)
 			if gateErr != nil {
+				if structuredState != nil {
+					if err := structuredState.recordPhaseOutcome(p.Name, phaseIdx, string(output), "failed", "command:error:"+gateErr.Error()); err != nil {
+						log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+					}
+				}
 				r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate error: %v", p.Name, gateErr))
 				if err := src.OnFail(ctx, vessel); err != nil {
 					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
@@ -1421,6 +1604,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				log.Printf("%sgate passed for phase %q", vesselLabel(vessel), p.Name)
 				gateRecordedAt := r.runtimeNow()
 				claim := buildGateClaim(p, true, phaseArtifactRelativePath(vessel.ID, p.Name), gateRecordedAt)
+				if structuredState != nil {
+					if err := structuredState.recordPhaseOutcome(p.Name, phaseIdx, string(output), "completed", "command:passed"); err != nil {
+						log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+					}
+				}
 				finishCurrentPhaseSpan(nil)
 				return singlePhaseResult{
 					output:        string(output),
@@ -1442,6 +1630,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				log.Printf("%sgate failed for phase %q, retries exhausted", vesselLabel(vessel), p.Name)
 				vessel.FailedPhase = p.Name
 				vessel.GateOutput = gateOut
+				if structuredState != nil {
+					if err := structuredState.recordPhaseOutcome(p.Name, phaseIdx, string(output), "failed", "command:failed"); err != nil {
+						log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+					}
+				}
 				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: gate failed, retries exhausted", p.Name))
 				if err := src.OnFail(ctx, vessel); err != nil {
 					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
@@ -1463,6 +1656,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			gateResult = fmt.Sprintf("The following gate check failed after the previous phase. Fix the issues and try again:\n\n%s", gateOut)
 			if err := r.runtimeSleep(ctx, retryDelay); err != nil {
 				r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate retry interrupted: %v", p.Name, err))
+				if structuredState != nil {
+					if stateErr := structuredState.recordPhaseOutcome(p.Name, phaseIdx, string(output), "failed", "command:retry_interrupted:"+err.Error()); stateErr != nil {
+						log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, stateErr)
+					}
+				}
 				if failErr := src.OnFail(ctx, vessel); failErr != nil {
 					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, failErr)
 				}
@@ -1491,6 +1689,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			vessel.WaitingSince = &now
 			vessel.State = queue.StateWaiting
 			vessel.CurrentPhase = phaseIdx + 1
+			if structuredState != nil {
+				if err := structuredState.recordPhaseOutcome(p.Name, phaseIdx, string(output), "completed", "label:waiting:"+p.Gate.WaitFor); err != nil {
+					log.Printf("warn: update progress for %s/%s: %v", vessel.ID, p.Name, err)
+				}
+			}
 			if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
 				log.Printf("warn: persist waiting state for %s: %v", vessel.ID, updateErr)
 				finishCurrentPhaseSpan(updateErr)

--- a/cli/internal/runner/summary.go
+++ b/cli/internal/runner/summary.go
@@ -44,9 +44,18 @@ type VesselSummary struct {
 	BudgetMaxTokens  *int     `json:"budget_max_tokens,omitempty"`
 	BudgetExceeded   bool     `json:"budget_exceeded"`
 
-	EvidenceManifestPath string `json:"evidence_manifest_path,omitempty"`
+	EvidenceManifestPath string             `json:"evidence_manifest_path,omitempty"`
+	ProgressPath         string             `json:"progress_path,omitempty"`
+	HandoffPath          string             `json:"handoff_path,omitempty"`
+	Retention            *ArtifactRetention `json:"retention,omitempty"`
 
 	Note string `json:"note"`
+}
+
+type ArtifactRetention struct {
+	CleanupAfter string   `json:"cleanup_after,omitempty"`
+	Durable      []string `json:"durable,omitempty"`
+	Expirable    []string `json:"expirable,omitempty"`
 }
 
 // PhaseSummary records the outcome of a single phase.
@@ -70,6 +79,7 @@ type vesselRunState struct {
 	phases    []PhaseSummary
 
 	costTracker *cost.Tracker
+	structured  *structuredState
 	vesselID    string
 	source      string
 	workflow    string


### PR DESCRIPTION
## Summary
- integrate compiled context manifests and structured resume artifacts into the runner
- persist progress, handoff, and retention metadata for sequential and orchestrated workflows
- add tests and docs for resume reconstruction, compaction, and artifact retention

Closes https://github.com/nicholls-inc/xylem/issues/60