### PR TITLE
Wire cost telemetry and per-vessel cost reports into CLI

### DIFF
--- a/cli/cmd/xylem/status.go
+++ b/cli/cmd/xylem/status.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
 
@@ -20,7 +22,7 @@ func newStatusCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			jsonMode, _ := cmd.Flags().GetBool("json")
 			stateFilter, _ := cmd.Flags().GetString("state")
-			return cmdStatus(deps.q, jsonMode, stateFilter)
+			return cmdStatusWithStateDir(deps.q, deps.cfg.StateDir, jsonMode, stateFilter)
 		},
 	}
 	cmd.Flags().Bool("json", false, "Output as JSON")
@@ -29,6 +31,10 @@ func newStatusCmd() *cobra.Command {
 }
 
 func cmdStatus(q *queue.Queue, jsonMode bool, stateFilter string) error {
+	return cmdStatusWithStateDir(q, "", jsonMode, stateFilter)
+}
+
+func cmdStatusWithStateDir(q *queue.Queue, stateDir string, jsonMode bool, stateFilter string) error {
 	var vessels []queue.Vessel
 	var err error
 	if stateFilter != "" {
@@ -77,7 +83,7 @@ func cmdStatus(q *queue.Queue, jsonMode bool, stateFilter string) error {
 		if wf == "" {
 			wf = "(prompt)"
 		}
-		info := vesselInfo(j)
+		info := vesselInfo(stateDir, j)
 		fmt.Printf("%-14s  %-14s  %-20s  %-10s  %-30s  %-12s  %s\n",
 			j.ID, j.Source, wf, string(j.State), info, started, duration)
 	}
@@ -91,7 +97,7 @@ func cmdStatus(q *queue.Queue, jsonMode bool, stateFilter string) error {
 }
 
 // vesselInfo returns additional context for the Info column based on vessel state.
-func vesselInfo(v queue.Vessel) string {
+func vesselInfo(stateDir string, v queue.Vessel) string {
 	if v.State == queue.StateWaiting && v.WaitingFor != "" {
 		elapsed := "unknown"
 		if v.WaitingSince != nil {
@@ -99,7 +105,42 @@ func vesselInfo(v queue.Vessel) string {
 		}
 		return fmt.Sprintf("waiting for %q (%s)", v.WaitingFor, elapsed)
 	}
-	return ""
+	if stateDir == "" {
+		return ""
+	}
+	report, err := cost.LoadReport(filepath.Join(stateDir, "phases", v.ID, cost.ReportFileName))
+	if err != nil {
+		return ""
+	}
+	return formatStatusCostInfo(report)
+}
+
+func formatStatusCostInfo(report *cost.CostReport) string {
+	if report == nil {
+		return ""
+	}
+	parts := []string{fmt.Sprintf("$%.4f", report.TotalCostUSD)}
+	if report.TotalTokens > 0 {
+		parts = append(parts, fmt.Sprintf("%dt", report.TotalTokens))
+	}
+	if report.UsageSource != "" {
+		parts = append(parts, string(report.UsageSource))
+	}
+	if report.BudgetExceeded {
+		parts = append(parts, "budget exceeded")
+	} else {
+		for _, alert := range report.Alerts {
+			if alert.Type == "warning" {
+				parts = append(parts, "warning")
+				break
+			}
+		}
+	}
+	info := strings.Join(parts, ", ")
+	if report.UsageUnavailableReason != "" {
+		info += ": " + report.UsageUnavailableReason
+	}
+	return info
 }
 
 func pauseMarkerPath(cfg *config.Config) string {

--- a/cli/cmd/xylem/status_test.go
+++ b/cli/cmd/xylem/status_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
 
@@ -350,5 +351,45 @@ func TestStatusJSONIncludesWaitingFields(t *testing.T) {
 	}
 	if v.WaitingSince == nil {
 		t.Error("expected waiting_since to be set")
+	}
+}
+
+func TestStatusShowsCostReportInfo(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	q.Enqueue(testStatusVessel("issue-55", queue.StateCompleted)) //nolint:errcheck
+
+	reportDir := filepath.Join(stateDir, "phases", "issue-55")
+	if err := os.MkdirAll(reportDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := cost.SaveReport(filepath.Join(reportDir, cost.ReportFileName), &cost.CostReport{
+		VesselID:               "issue-55",
+		TotalTokens:            420,
+		TotalCostUSD:           0.0123,
+		UsageSource:            cost.UsageSourceEstimated,
+		UsageUnavailableReason: "provider output did not include structured usage metadata",
+		Alerts:                 []cost.BudgetAlert{{Type: "warning", Metric: "tokens", Current: 420, Limit: 500}},
+	}); err != nil {
+		t.Fatalf("SaveReport() error = %v", err)
+	}
+
+	var err error
+	out := captureStdout(func() { err = cmdStatusWithStateDir(q, stateDir, false, "") })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "$0.0123") {
+		t.Fatalf("expected cost in output, got: %s", out)
+	}
+	if !strings.Contains(out, "420t") {
+		t.Fatalf("expected tokens in output, got: %s", out)
+	}
+	if !strings.Contains(out, "estimated") {
+		t.Fatalf("expected usage source in output, got: %s", out)
+	}
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("expected warning in output, got: %s", out)
 	}
 }

--- a/cli/internal/cost/cost.go
+++ b/cli/internal/cost/cost.go
@@ -53,21 +53,74 @@ type Budget struct {
 // BudgetAlert records a budget threshold event.
 type BudgetAlert struct {
 	Type      string    `json:"type"` // "warning" or "exceeded"
+	Metric    string    `json:"metric,omitempty"`
 	Current   float64   `json:"current"`
 	Limit     float64   `json:"limit"`
 	Timestamp time.Time `json:"timestamp"`
 }
 
-// CostReport summarises cost data for a mission.
+// UsageSource identifies how a usage value was obtained.
+type UsageSource string
+
+const (
+	UsageSourceReported    UsageSource = "reported"
+	UsageSourceEstimated   UsageSource = "estimated"
+	UsageSourceUnavailable UsageSource = "unavailable"
+	UsageSourceMixed       UsageSource = "mixed"
+)
+
+// PhaseCostBreakdown describes usage and cost for a single vessel phase.
+type PhaseCostBreakdown struct {
+	Name                   string      `json:"name"`
+	Type                   string      `json:"type,omitempty"`
+	Provider               string      `json:"provider,omitempty"`
+	Model                  string      `json:"model,omitempty"`
+	Status                 string      `json:"status,omitempty"`
+	DurationMS             int64       `json:"duration_ms,omitempty"`
+	ArtifactPath           string      `json:"artifact_path,omitempty"`
+	InputTokens            int         `json:"input_tokens,omitempty"`
+	OutputTokens           int         `json:"output_tokens,omitempty"`
+	TotalTokens            int         `json:"total_tokens,omitempty"`
+	CostUSD                float64     `json:"cost_usd,omitempty"`
+	UsageSource            UsageSource `json:"usage_source,omitempty"`
+	UsageUnavailableReason string      `json:"usage_unavailable_reason,omitempty"`
+}
+
+// ArtifactJoin records stable fields used to join cost artifacts to traces and evidence.
+type ArtifactJoin struct {
+	TraceID              string `json:"trace_id,omitempty"`
+	SpanID               string `json:"span_id,omitempty"`
+	SummaryPath          string `json:"summary_path,omitempty"`
+	EvidenceManifestPath string `json:"evidence_manifest_path,omitempty"`
+}
+
+const ReportFileName = "cost-report.json"
+
+// CostReport summarises cost data for a mission or vessel.
 type CostReport struct {
-	MissionID    string                `json:"mission_id"`
-	TotalTokens  int                   `json:"total_tokens"`
-	TotalCostUSD float64               `json:"total_cost_usd"`
-	ByRole       map[AgentRole]float64 `json:"by_role"`
-	ByPurpose    map[Purpose]float64   `json:"by_purpose"`
-	ByModel      map[string]float64    `json:"by_model"`
-	RecordCount  int                   `json:"record_count"`
-	GeneratedAt  time.Time             `json:"generated_at"`
+	MissionID              string                `json:"mission_id"`
+	VesselID               string                `json:"vessel_id,omitempty"`
+	Source                 string                `json:"source,omitempty"`
+	Workflow               string                `json:"workflow,omitempty"`
+	Ref                    string                `json:"ref,omitempty"`
+	State                  string                `json:"state,omitempty"`
+	TotalInputTokens       int                   `json:"total_input_tokens,omitempty"`
+	TotalOutputTokens      int                   `json:"total_output_tokens,omitempty"`
+	TotalTokens            int                   `json:"total_tokens"`
+	TotalCostUSD           float64               `json:"total_cost_usd"`
+	ByRole                 map[AgentRole]float64 `json:"by_role"`
+	ByPurpose              map[Purpose]float64   `json:"by_purpose"`
+	ByModel                map[string]float64    `json:"by_model"`
+	RecordCount            int                   `json:"record_count"`
+	GeneratedAt            time.Time             `json:"generated_at"`
+	UsageSource            UsageSource           `json:"usage_source,omitempty"`
+	UsageUnavailableReason string                `json:"usage_unavailable_reason,omitempty"`
+	Phases                 []PhaseCostBreakdown  `json:"phases,omitempty"`
+	Alerts                 []BudgetAlert         `json:"alerts,omitempty"`
+	BudgetExceeded         bool                  `json:"budget_exceeded,omitempty"`
+	BudgetMaxCostUSD       *float64              `json:"budget_max_cost_usd,omitempty"`
+	BudgetMaxTokens        *int                  `json:"budget_max_tokens,omitempty"`
+	Join                   ArtifactJoin          `json:"join,omitempty"`
 }
 
 // ModelLadder maps each agent role to a preferred model name.
@@ -160,6 +213,7 @@ func (t *Tracker) Record(record UsageRecord) error {
 			t.exceeded = true
 			t.alerts = append(t.alerts, BudgetAlert{
 				Type:      "exceeded",
+				Metric:    "cost_usd",
 				Current:   totalCost,
 				Limit:     t.budget.CostLimitUSD,
 				Timestamp: record.Timestamp,
@@ -167,6 +221,7 @@ func (t *Tracker) Record(record UsageRecord) error {
 		} else if utilization >= warningThreshold && !t.exceeded && !alertsHaveWarningForLimit(t.alerts, t.budget.CostLimitUSD) {
 			t.alerts = append(t.alerts, BudgetAlert{
 				Type:      "warning",
+				Metric:    "cost_usd",
 				Current:   totalCost,
 				Limit:     t.budget.CostLimitUSD,
 				Timestamp: record.Timestamp,
@@ -181,6 +236,7 @@ func (t *Tracker) Record(record UsageRecord) error {
 			t.exceeded = true
 			t.alerts = append(t.alerts, BudgetAlert{
 				Type:      "exceeded",
+				Metric:    "tokens",
 				Current:   float64(totalTokens),
 				Limit:     float64(t.budget.TokenLimit),
 				Timestamp: record.Timestamp,
@@ -188,6 +244,7 @@ func (t *Tracker) Record(record UsageRecord) error {
 		} else if utilization >= warningThreshold && !t.exceeded && !alertsHaveWarningForLimit(t.alerts, float64(t.budget.TokenLimit)) {
 			t.alerts = append(t.alerts, BudgetAlert{
 				Type:      "warning",
+				Metric:    "tokens",
 				Current:   float64(totalTokens),
 				Limit:     float64(t.budget.TokenLimit),
 				Timestamp: record.Timestamp,
@@ -292,6 +349,8 @@ func (t *Tracker) Report(missionID string) *CostReport {
 	}
 
 	for _, r := range t.records {
+		report.TotalInputTokens += r.InputTokens
+		report.TotalOutputTokens += r.OutputTokens
 		report.TotalTokens += r.InputTokens + r.OutputTokens
 		report.TotalCostUSD += r.CostUSD
 		report.ByRole[r.AgentRole] += r.CostUSD
@@ -301,6 +360,54 @@ func (t *Tracker) Report(missionID string) *CostReport {
 	}
 
 	return report
+}
+
+// DeriveUsageSource returns the aggregate usage source across phases.
+func DeriveUsageSource(phases []PhaseCostBreakdown) UsageSource {
+	var seenReported bool
+	var seenEstimated bool
+	var seenUnavailable bool
+
+	for _, phase := range phases {
+		switch phase.UsageSource {
+		case UsageSourceReported:
+			seenReported = true
+		case UsageSourceEstimated:
+			seenEstimated = true
+		case UsageSourceUnavailable:
+			seenUnavailable = true
+		}
+	}
+
+	count := 0
+	for _, seen := range []bool{seenReported, seenEstimated, seenUnavailable} {
+		if seen {
+			count++
+		}
+	}
+	if count > 1 {
+		return UsageSourceMixed
+	}
+	switch {
+	case seenReported:
+		return UsageSourceReported
+	case seenEstimated:
+		return UsageSourceEstimated
+	case seenUnavailable:
+		return UsageSourceUnavailable
+	default:
+		return ""
+	}
+}
+
+// FirstUsageUnavailableReason returns the first non-empty unavailable reason across phases.
+func FirstUsageUnavailableReason(phases []PhaseCostBreakdown) string {
+	for _, phase := range phases {
+		if phase.UsageUnavailableReason != "" {
+			return phase.UsageUnavailableReason
+		}
+	}
+	return ""
 }
 
 // DefaultModelLadder returns a sensible default model assignment per role.
@@ -393,6 +500,9 @@ func DetectAnomalies(current *CostReport, history []*CostReport) []Anomaly {
 
 // SaveReport writes a CostReport as JSON to the given file path.
 func SaveReport(path string, report *CostReport) error {
+	if report == nil {
+		return fmt.Errorf("marshal report: report must not be nil")
+	}
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal report: %w", err)
@@ -484,6 +594,7 @@ func (wt *WindowedTracker) Record(record UsageRecord) error {
 			wt.exceeded = true
 			wt.alerts = append(wt.alerts, BudgetAlert{
 				Type:      "exceeded",
+				Metric:    "cost_usd",
 				Current:   wt.windowCost,
 				Limit:     wt.budget.CostLimitUSD,
 				Timestamp: record.Timestamp,
@@ -491,6 +602,7 @@ func (wt *WindowedTracker) Record(record UsageRecord) error {
 		} else if utilization >= warningThreshold && !wt.exceeded && !alertsHaveWarningForLimit(wt.alerts, wt.budget.CostLimitUSD) {
 			wt.alerts = append(wt.alerts, BudgetAlert{
 				Type:      "warning",
+				Metric:    "cost_usd",
 				Current:   wt.windowCost,
 				Limit:     wt.budget.CostLimitUSD,
 				Timestamp: record.Timestamp,
@@ -505,6 +617,7 @@ func (wt *WindowedTracker) Record(record UsageRecord) error {
 			wt.exceeded = true
 			wt.alerts = append(wt.alerts, BudgetAlert{
 				Type:      "exceeded",
+				Metric:    "tokens",
 				Current:   float64(wt.windowTokens),
 				Limit:     float64(wt.budget.TokenLimit),
 				Timestamp: record.Timestamp,
@@ -512,6 +625,7 @@ func (wt *WindowedTracker) Record(record UsageRecord) error {
 		} else if utilization >= warningThreshold && !wt.exceeded && !alertsHaveWarningForLimit(wt.alerts, float64(wt.budget.TokenLimit)) {
 			wt.alerts = append(wt.alerts, BudgetAlert{
 				Type:      "warning",
+				Metric:    "tokens",
 				Current:   float64(wt.windowTokens),
 				Limit:     float64(wt.budget.TokenLimit),
 				Timestamp: record.Timestamp,

--- a/cli/internal/cost/cost_test.go
+++ b/cli/internal/cost/cost_test.go
@@ -618,9 +618,14 @@ func TestSaveAndLoadReport(t *testing.T) {
 	path := filepath.Join(dir, "report.json")
 
 	original := &CostReport{
-		MissionID:    "m-42",
-		TotalTokens:  1500,
-		TotalCostUSD: 2.75,
+		MissionID:         "m-42",
+		VesselID:          "issue-55",
+		Workflow:          "fix-bug",
+		State:             "completed",
+		TotalInputTokens:  1200,
+		TotalOutputTokens: 300,
+		TotalTokens:       1500,
+		TotalCostUSD:      2.75,
 		ByRole: map[AgentRole]float64{
 			RolePlanner:   1.00,
 			RoleGenerator: 1.75,
@@ -632,8 +637,36 @@ func TestSaveAndLoadReport(t *testing.T) {
 		ByModel: map[string]float64{
 			"sonnet": 2.75,
 		},
-		RecordCount: 5,
-		GeneratedAt: time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
+		RecordCount:            5,
+		GeneratedAt:            time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
+		UsageSource:            UsageSourceMixed,
+		UsageUnavailableReason: "provider output did not include structured usage metadata",
+		Phases: []PhaseCostBreakdown{{
+			Name:                   "implement",
+			Type:                   "prompt",
+			Model:                  "sonnet",
+			InputTokens:            1200,
+			OutputTokens:           300,
+			TotalTokens:            1500,
+			CostUSD:                2.75,
+			UsageSource:            UsageSourceReported,
+			UsageUnavailableReason: "",
+		}},
+		Alerts: []BudgetAlert{{
+			Type:    "warning",
+			Metric:  "tokens",
+			Current: 1500,
+			Limit:   2000,
+		}},
+		BudgetMaxTokens: func() *int {
+			v := 2000
+			return &v
+		}(),
+		Join: ArtifactJoin{
+			TraceID:     "trace-123",
+			SpanID:      "span-456",
+			SummaryPath: "phases/issue-55/summary.json",
+		},
 	}
 
 	if err := SaveReport(path, original); err != nil {
@@ -657,9 +690,43 @@ func TestSaveAndLoadReport(t *testing.T) {
 	if loaded.RecordCount != original.RecordCount {
 		t.Fatalf("RecordCount = %d, want %d", loaded.RecordCount, original.RecordCount)
 	}
+	if loaded.VesselID != original.VesselID {
+		t.Fatalf("VesselID = %s, want %s", loaded.VesselID, original.VesselID)
+	}
+	if loaded.UsageSource != original.UsageSource {
+		t.Fatalf("UsageSource = %s, want %s", loaded.UsageSource, original.UsageSource)
+	}
+	if loaded.Join.TraceID != original.Join.TraceID {
+		t.Fatalf("Join.TraceID = %s, want %s", loaded.Join.TraceID, original.Join.TraceID)
+	}
+	if len(loaded.Alerts) != 1 || loaded.Alerts[0].Metric != "tokens" {
+		t.Fatalf("Alerts = %+v, want token warning", loaded.Alerts)
+	}
 	if !floatEqual(loaded.ByRole[RolePlanner], original.ByRole[RolePlanner]) {
 		t.Fatalf("ByRole[planner] mismatch")
 	}
+}
+
+func TestDeriveUsageSource(t *testing.T) {
+	t.Run("mixed", func(t *testing.T) {
+		got := DeriveUsageSource([]PhaseCostBreakdown{
+			{UsageSource: UsageSourceReported},
+			{UsageSource: UsageSourceEstimated},
+		})
+		if got != UsageSourceMixed {
+			t.Fatalf("DeriveUsageSource() = %s, want %s", got, UsageSourceMixed)
+		}
+	})
+
+	t.Run("unavailable reason", func(t *testing.T) {
+		got := FirstUsageUnavailableReason([]PhaseCostBreakdown{
+			{UsageSource: UsageSourceReported},
+			{UsageSource: UsageSourceUnavailable, UsageUnavailableReason: "missing usage"},
+		})
+		if got != "missing usage" {
+			t.Fatalf("FirstUsageUnavailableReason() = %q, want %q", got, "missing usage")
+		}
+	})
 }
 
 func TestLoadReportNotFound(t *testing.T) {

--- a/cli/internal/observability/vessel.go
+++ b/cli/internal/observability/vessel.go
@@ -78,6 +78,35 @@ func PhaseResultAttributes(data PhaseResultData) []SpanAttribute {
 	}
 }
 
+// CostReportData holds additive vessel-level cost artifact attributes.
+type CostReportData struct {
+	SummaryPath          string  `json:"summary_path"`
+	CostReportPath       string  `json:"cost_report_path"`
+	EvidenceManifestPath string  `json:"evidence_manifest_path"`
+	UsageSource          string  `json:"usage_source"`
+	TotalTokens          int     `json:"total_tokens"`
+	TotalCostUSD         float64 `json:"total_cost_usd"`
+	BudgetExceeded       bool    `json:"budget_exceeded"`
+	AlertCount           int     `json:"alert_count"`
+}
+
+// CostReportAttributes returns vessel-level attributes that align traces with persisted artifacts.
+func CostReportAttributes(data CostReportData) []SpanAttribute {
+	attrs := []SpanAttribute{
+		{Key: "xylem.artifact.summary_path", Value: data.SummaryPath},
+		{Key: "xylem.artifact.cost_report_path", Value: data.CostReportPath},
+		{Key: "xylem.cost.usage_source", Value: data.UsageSource},
+		{Key: "xylem.cost.total_tokens", Value: fmt.Sprintf("%d", data.TotalTokens)},
+		{Key: "xylem.cost.total_cost_usd", Value: fmt.Sprintf("%.6f", data.TotalCostUSD)},
+		{Key: "xylem.cost.budget_exceeded", Value: fmt.Sprintf("%t", data.BudgetExceeded)},
+		{Key: "xylem.cost.alert_count", Value: fmt.Sprintf("%d", data.AlertCount)},
+	}
+	if data.EvidenceManifestPath != "" {
+		attrs = append(attrs, SpanAttribute{Key: "xylem.artifact.evidence_manifest_path", Value: data.EvidenceManifestPath})
+	}
+	return attrs
+}
+
 // GateSpanData holds gate information for attribute extraction.
 type GateSpanData struct {
 	Type         string `json:"type"`

--- a/cli/internal/observability/vessel_test.go
+++ b/cli/internal/observability/vessel_test.go
@@ -181,3 +181,30 @@ func TestDrainSpanAttributes_ConcurrencyFormatted(t *testing.T) {
 		t.Fatalf("xylem.drain.concurrency = %q, want %q", got["xylem.drain.concurrency"], "17")
 	}
 }
+
+func TestCostReportAttributes(t *testing.T) {
+	attrs := CostReportAttributes(CostReportData{
+		SummaryPath:          "phases/issue-55/summary.json",
+		CostReportPath:       "phases/issue-55/cost-report.json",
+		EvidenceManifestPath: "phases/issue-55/evidence-manifest.json",
+		UsageSource:          "reported",
+		TotalTokens:          420,
+		TotalCostUSD:         0.0123,
+		BudgetExceeded:       false,
+		AlertCount:           1,
+	})
+	got := attrMap(attrs)
+
+	if got["xylem.artifact.summary_path"] != "phases/issue-55/summary.json" {
+		t.Fatalf("summary path = %q", got["xylem.artifact.summary_path"])
+	}
+	if got["xylem.artifact.cost_report_path"] != "phases/issue-55/cost-report.json" {
+		t.Fatalf("cost report path = %q", got["xylem.artifact.cost_report_path"])
+	}
+	if got["xylem.artifact.evidence_manifest_path"] != "phases/issue-55/evidence-manifest.json" {
+		t.Fatalf("evidence manifest path = %q", got["xylem.artifact.evidence_manifest_path"])
+	}
+	if got["xylem.cost.usage_source"] != "reported" {
+		t.Fatalf("usage source = %q", got["xylem.cost.usage_source"])
+	}
+}

--- a/cli/internal/reporter/reporter.go
+++ b/cli/internal/reporter/reporter.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 )
 
@@ -47,9 +49,13 @@ func (r *Reporter) PhaseComplete(ctx context.Context, issueNum int, phaseName st
 }
 
 // VesselFailed posts a failure comment on the GitHub issue.
-func (r *Reporter) VesselFailed(ctx context.Context, issueNum int, phaseName string, errMsg string, gateOutput string) error {
+func (r *Reporter) VesselFailed(ctx context.Context, issueNum int, phaseName string, errMsg string, gateOutput string, reports ...*cost.CostReport) error {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "**xylem — failed at phase `%s`**\n\n**Error:** %s", phaseName, errMsg)
+	if costSection := formatCostSection(firstCostReport(reports)); costSection != "" {
+		sb.WriteString("\n\n")
+		sb.WriteString(costSection)
+	}
 
 	if gateOutput != "" {
 		fmt.Fprintf(&sb, "\n\n<details>\n<summary>Gate output (click to expand)</summary>\n\n%s\n\n</details>", gateOutput)
@@ -62,7 +68,7 @@ func (r *Reporter) VesselFailed(ctx context.Context, issueNum int, phaseName str
 }
 
 // VesselCompleted posts a summary comment when all phases complete.
-func (r *Reporter) VesselCompleted(ctx context.Context, issueNum int, phases []PhaseResult, manifest *evidence.Manifest) error {
+func (r *Reporter) VesselCompleted(ctx context.Context, issueNum int, phases []PhaseResult, manifest *evidence.Manifest, reports ...*cost.CostReport) error {
 	var sb strings.Builder
 	if workflowCompletedViaNoOp(phases) {
 		sb.WriteString("**xylem — workflow completed early via no-op**\n\n")
@@ -80,6 +86,10 @@ func (r *Reporter) VesselCompleted(ctx context.Context, issueNum int, phases []P
 	}
 
 	fmt.Fprintf(&sb, "\nTotal: %s", total)
+	if costSection := formatCostSection(firstCostReport(reports)); costSection != "" {
+		sb.WriteString("\n\n")
+		sb.WriteString(costSection)
+	}
 	if evidenceSection := formatEvidenceSection(manifest); evidenceSection != "" {
 		sb.WriteString("\n\n")
 		sb.WriteString(evidenceSection)
@@ -98,6 +108,63 @@ func workflowCompletedViaNoOp(phases []PhaseResult) bool {
 		}
 	}
 	return false
+}
+
+func firstCostReport(reports []*cost.CostReport) *cost.CostReport {
+	for _, report := range reports {
+		if report != nil {
+			return report
+		}
+	}
+	return nil
+}
+
+func formatCostSection(report *cost.CostReport) string {
+	if report == nil {
+		return ""
+	}
+
+	lines := []string{"### Cost"}
+	totalLine := fmt.Sprintf("- Total: $%.4f", report.TotalCostUSD)
+	if report.TotalTokens > 0 {
+		totalLine += fmt.Sprintf(" (%d tokens)", report.TotalTokens)
+	}
+	if report.UsageSource != "" {
+		totalLine += fmt.Sprintf(" — %s", report.UsageSource)
+	}
+	lines = append(lines, totalLine)
+
+	if report.UsageUnavailableReason != "" {
+		lines = append(lines, "- Usage note: "+report.UsageUnavailableReason)
+	}
+	if report.BudgetExceeded {
+		lines = append(lines, "- Budget status: exceeded")
+	}
+	for _, alert := range report.Alerts {
+		if alert.Type != "warning" {
+			continue
+		}
+		metric := alert.Metric
+		if metric == "" {
+			metric = "budget"
+		}
+		lines = append(lines, fmt.Sprintf("- Warning: %s at %.4f / %.4f", metric, alert.Current, alert.Limit))
+	}
+
+	if len(report.ByModel) > 0 {
+		models := make([]string, 0, len(report.ByModel))
+		for model := range report.ByModel {
+			models = append(models, model)
+		}
+		sort.Strings(models)
+		parts := make([]string, 0, len(models))
+		for _, model := range models {
+			parts = append(parts, fmt.Sprintf("%s ($%.4f)", model, report.ByModel[model]))
+		}
+		lines = append(lines, "- Models: "+strings.Join(parts, ", "))
+	}
+
+	return strings.Join(lines, "\n")
 }
 
 // LabelTimeout posts a timeout comment on the GitHub issue.

--- a/cli/internal/reporter/reporter_test.go
+++ b/cli/internal/reporter/reporter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -590,6 +591,28 @@ func TestVesselCompletedTotalDuration(t *testing.T) {
 	if !strings.Contains(mock.lastBody, "Total: 2m0s") {
 		t.Errorf("expected total 2m0s, got: %s", mock.lastBody)
 	}
+}
+
+func TestVesselCompletedIncludesCostSectionWhenProvided(t *testing.T) {
+	mock := &mockRunner{}
+	r := &Reporter{Runner: mock, Repo: "owner/repo"}
+
+	report := &cost.CostReport{
+		TotalTokens:            420,
+		TotalCostUSD:           0.0123,
+		UsageSource:            cost.UsageSourceEstimated,
+		UsageUnavailableReason: "provider output did not include structured usage metadata",
+		Alerts:                 []cost.BudgetAlert{{Type: "warning", Metric: "tokens", Current: 420, Limit: 500}},
+		ByModel:                map[string]float64{"claude-sonnet-4": 0.0123},
+	}
+
+	err := r.VesselCompleted(context.Background(), 5, []PhaseResult{{Name: "implement", Duration: time.Second, Status: "completed"}}, nil, report)
+	require.NoError(t, err)
+	assert.Contains(t, mock.lastBody, "### Cost")
+	assert.Contains(t, mock.lastBody, "Total: $0.0123 (420 tokens) — estimated")
+	assert.Contains(t, mock.lastBody, "Usage note: provider output did not include structured usage metadata")
+	assert.Contains(t, mock.lastBody, "Warning: tokens at 420.0000 / 500.0000")
+	assert.Contains(t, mock.lastBody, "Models: claude-sonnet-4 ($0.0123)")
 }
 
 func TestVesselFailedGhArgs(t *testing.T) {

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -53,12 +53,13 @@ type DrainResult struct {
 
 // Runner launches Claude sessions for queued vessels with concurrency control.
 type Runner struct {
-	Config   *config.Config
-	Queue    *queue.Queue
-	Worktree WorktreeManager
-	Runner   CommandRunner
-	Sources  map[string]source.Source
-	Reporter *reporter.Reporter // may be nil for non-github vessels
+	Config         *config.Config
+	Queue          *queue.Queue
+	Worktree       WorktreeManager
+	Runner         CommandRunner
+	UsageExtractor UsageExtractor
+	Sources        map[string]source.Source
+	Reporter       *reporter.Reporter // may be nil for non-github vessels
 	// Shared harness scaffolding for phase policy enforcement, audit logging,
 	// protected-surface verification, and tracing.
 	Intermediary *intermediary.Intermediary // nil = no policy enforcement
@@ -69,6 +70,13 @@ type Runner struct {
 // New creates a Runner.
 func New(cfg *config.Config, q *queue.Queue, wt WorktreeManager, r CommandRunner) *Runner {
 	return &Runner{Config: cfg, Queue: q, Worktree: wt, Runner: r}
+}
+
+func (r *Runner) usageExtractor() UsageExtractor {
+	if r != nil && r.UsageExtractor != nil {
+		return r.UsageExtractor
+	}
+	return defaultUsageExtractor{}
 }
 
 // Drain dequeues pending vessels and launches sessions up to Config.Concurrency concurrently.
@@ -257,7 +265,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 		if outcome != "failed" {
 			return
 		}
-		r.persistRunArtifacts(vessel, string(queue.StateFailed), vrs, claims, r.runtimeNow())
+		r.persistRunArtifacts(ctx, vessel, string(queue.StateFailed), vrs, claims, r.runtimeNow())
 	}()
 
 	// Worktree: reuse if set (resuming from waiting), otherwise create.
@@ -548,7 +556,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			if runErr != nil {
 				finishCurrentPhaseSpan(runErr)
 				log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
-				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()))
+				vrs.addPhase(vrs.phaseSummaryWithUsage(r.Config, srcCfg, sk, p, harnessContent, usageDetails{}, phaseDuration, "failed", nil, runErr.Error()))
 				vessel.FailedPhase = p.Name
 				r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, runErr))
 				if err := src.OnFail(ctx, vessel); err != nil {
@@ -557,7 +565,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				issueNum := r.parseIssueNum(vessel)
 				if issueNum > 0 && r.Reporter != nil {
 					r.logReporterError("post vessel-failed comment", vessel.ID,
-						r.Reporter.VesselFailed(ctx, issueNum, p.Name, runErr.Error(), ""))
+						r.Reporter.VesselFailed(ctx, issueNum, p.Name, runErr.Error(), "", r.previewCostReport(vrs, string(queue.StateFailed), r.runtimeNow())))
 				}
 				return "failed"
 			}
@@ -566,7 +574,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if err := r.verifyProtectedSurfaces(vessel, p, worktreePath, beforeSnapshot); err != nil {
 					finishCurrentPhaseSpan(err)
 					log.Printf("%sphase %q violated protected surfaces: %v", vesselLabel(vessel), p.Name, err)
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error()))
+					vrs.addPhase(vrs.phaseSummaryWithUsage(r.Config, srcCfg, sk, p, harnessContent, usageDetails{}, phaseDuration, "failed", nil, err.Error()))
 					vessel.FailedPhase = p.Name
 					r.failVessel(vessel.ID, err.Error())
 					if err := src.OnFail(ctx, vessel); err != nil {
@@ -575,18 +583,26 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					issueNum := r.parseIssueNum(vessel)
 					if issueNum > 0 && r.Reporter != nil {
 						r.logReporterError("post vessel-failed comment", vessel.ID,
-							r.Reporter.VesselFailed(ctx, issueNum, p.Name, err.Error(), ""))
+							r.Reporter.VesselFailed(ctx, issueNum, p.Name, err.Error(), "", r.previewCostReport(vrs, string(queue.StateFailed), r.runtimeNow())))
 					}
 					return "failed"
 				}
 			}
 
 			recordedAt := r.runtimeNow()
-			inputTokensEst, outputTokensEst, costUSDEst := vrs.recordPhaseTokens(p, model, promptForCost, string(output), recordedAt)
+			providerUsage := executionUsage{
+				Source:            cost.UsageSourceUnavailable,
+				UnavailableReason: "command phase does not consume model tokens",
+			}
+			if p.Type != "command" {
+				providerUsage = r.usageExtractor().ExtractUsage(provider, model, output)
+			}
+			usage := vrs.recordPhaseUsage(p, model, promptForCost, string(output), recordedAt, providerUsage)
+			r.logBudgetAlerts(vessel.ID, vrs.consumeBudgetAlerts())
 			if vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() {
 				errMsg := fmt.Sprintf("budget exceeded after phase %q: estimated cost $%.4f, estimated tokens %d",
 					p.Name, vrs.costTracker.TotalCost(), vrs.costTracker.TotalTokens())
-				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg))
+				vrs.addPhase(vrs.phaseSummaryWithUsage(r.Config, srcCfg, sk, p, harnessContent, usage, phaseDuration, "failed", nil, errMsg))
 				vessel.FailedPhase = p.Name
 				r.failVessel(vessel.ID, errMsg)
 				if err := src.OnFail(ctx, vessel); err != nil {
@@ -595,7 +611,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				issueNum := r.parseIssueNum(vessel)
 				if issueNum > 0 && r.Reporter != nil {
 					r.logReporterError("post vessel-failed comment", vessel.ID,
-						r.Reporter.VesselFailed(ctx, issueNum, p.Name, errMsg, ""))
+						r.Reporter.VesselFailed(ctx, issueNum, p.Name, errMsg, "", r.previewCostReport(vrs, string(queue.StateFailed), recordedAt)))
 				}
 				finishCurrentPhaseSpan(fmt.Errorf("%s", errMsg))
 				return "failed"
@@ -631,7 +647,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			}
 
 			if phaseStatus == "no-op" {
-				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, ""))
+				vrs.addPhase(vrs.phaseSummaryWithUsage(r.Config, srcCfg, sk, p, harnessContent, usage, phaseDuration, phaseStatus, nil, ""))
 				log.Printf("%sphase %q triggered no-op; completing workflow early", vesselLabel(vessel), p.Name)
 				finishCurrentPhaseSpan(nil)
 				return r.completeVessel(ctx, vessel, worktreePath, phaseResults, vrs, claims)
@@ -639,7 +655,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 			// Handle gate
 			if p.Gate == nil {
-				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, ""))
+				vrs.addPhase(vrs.phaseSummaryWithUsage(r.Config, srcCfg, sk, p, harnessContent, usage, phaseDuration, phaseStatus, nil, ""))
 				finishCurrentPhaseSpan(nil)
 				break // no gate, proceed to next phase
 			}
@@ -654,7 +670,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					RetryAttempt: retryAttempt,
 				}, gateErr)
 				if gateErr != nil {
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error()))
+					vrs.addPhase(vrs.phaseSummaryWithUsage(r.Config, srcCfg, sk, p, harnessContent, usage, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error()))
 					finishCurrentPhaseSpan(nil)
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate error: %v", p.Name, gateErr))
 					if err := src.OnFail(ctx, vessel); err != nil {
@@ -664,7 +680,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				}
 				if passed {
 					log.Printf("%sgate passed for phase %q", vesselLabel(vessel), p.Name)
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, gatePassedPointer(true), ""))
+					vrs.addPhase(vrs.phaseSummaryWithUsage(r.Config, srcCfg, sk, p, harnessContent, usage, phaseDuration, phaseStatus, gatePassedPointer(true), ""))
 					gateRecordedAt := r.runtimeNow()
 					claims = append(claims, buildGateClaim(p, true, phaseArtifactRelativePath(vessel.ID, p.Name), gateRecordedAt))
 					finishCurrentPhaseSpan(nil)
@@ -681,7 +697,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 				if vessel.GateRetries <= 0 {
 					log.Printf("%sgate failed for phase %q, retries exhausted", vesselLabel(vessel), p.Name)
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted"))
+					vrs.addPhase(vrs.phaseSummaryWithUsage(r.Config, srcCfg, sk, p, harnessContent, usage, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted"))
 					finishCurrentPhaseSpan(nil)
 					vessel.FailedPhase = p.Name
 					vessel.GateOutput = gateOut
@@ -691,7 +707,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					}
 					if issueNum > 0 && r.Reporter != nil {
 						r.logReporterError("post vessel-failed comment", vessel.ID,
-							r.Reporter.VesselFailed(ctx, issueNum, p.Name, "gate failed, retries exhausted", gateOut))
+							r.Reporter.VesselFailed(ctx, issueNum, p.Name, "gate failed, retries exhausted", gateOut, r.previewCostReport(vrs, string(queue.StateFailed), r.runtimeNow())))
 					}
 					return "failed"
 				}
@@ -706,7 +722,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				gateResult = fmt.Sprintf("The following gate check failed after the previous phase. Fix the issues and try again:\n\n%s", gateOut)
 
 				if err := r.runtimeSleep(ctx, retryDelay); err != nil {
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error()))
+					vrs.addPhase(vrs.phaseSummaryWithUsage(r.Config, srcCfg, sk, p, harnessContent, usage, phaseDuration, "failed", gatePassedPointer(false), err.Error()))
 					finishCurrentPhaseSpan(err)
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate retry interrupted: %v", p.Name, err))
 					if failErr := src.OnFail(ctx, vessel); failErr != nil {
@@ -809,15 +825,34 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 			return "failed"
 		}
 	}
+	phasesDir := filepath.Join(r.Config.StateDir, "phases", vessel.ID)
+	if err := os.MkdirAll(phasesDir, 0o755); err != nil {
+		r.failVessel(vessel.ID, fmt.Sprintf("create phases dir: %v", err))
+		if failErr := src.OnFail(ctx, vessel); failErr != nil {
+			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, failErr)
+		}
+		return "failed"
+	}
+	outputPath := filepath.Join(phasesDir, "prompt-only.output")
+	if err := os.WriteFile(outputPath, output, 0o644); err != nil {
+		log.Printf("warn: write output file %s: %v", outputPath, err)
+	}
 	recordedAt := r.runtimeNow()
 	if vrs != nil {
-		vrs.recordPromptOnlyUsage(model, prompt, string(output), recordedAt)
+		providerUsage := r.usageExtractor().ExtractUsage(provider, model, output)
+		vrs.recordPromptOnlyUsageWithUsage(provider, model, prompt, string(output), recordedAt, providerUsage)
+		r.logBudgetAlerts(vessel.ID, vrs.consumeBudgetAlerts())
 		if vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() {
 			errMsg := fmt.Sprintf("budget exceeded: estimated cost $%.4f, estimated tokens %d",
 				vrs.costTracker.TotalCost(), vrs.costTracker.TotalTokens())
 			r.failVessel(vessel.ID, errMsg)
 			if err := src.OnFail(ctx, vessel); err != nil {
 				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+			}
+			issueNum := r.parseIssueNum(vessel)
+			if issueNum > 0 && r.Reporter != nil {
+				r.logReporterError("post vessel-failed comment", vessel.ID,
+					r.Reporter.VesselFailed(ctx, issueNum, "prompt-only", errMsg, "", r.previewCostReport(vrs, string(queue.StateFailed), recordedAt)))
 			}
 			return "failed"
 		}
@@ -872,12 +907,29 @@ func (r *Runner) failVessel(id string, errMsg string) {
 	}
 }
 
+func (r *Runner) previewCostReport(vrs *vesselRunState, state string, now time.Time) *cost.CostReport {
+	if vrs == nil {
+		return nil
+	}
+	return vrs.buildCostReport(state, now, cost.ArtifactJoin{})
+}
+
+func (r *Runner) logBudgetAlerts(vesselID string, alerts []cost.BudgetAlert) {
+	for _, alert := range alerts {
+		metric := alert.Metric
+		if metric == "" {
+			metric = "budget"
+		}
+		log.Printf("%sbudget %s %s: current=%.4f limit=%.4f", vesselLabel(queue.Vessel{ID: vesselID}), metric, alert.Type, alert.Current, alert.Limit)
+	}
+}
+
 func (r *Runner) completeVessel(ctx context.Context, vessel queue.Vessel, worktreePath string, phaseResults []reporter.PhaseResult, vrs *vesselRunState, claims []evidence.Claim) string {
 	if updateErr := r.Queue.Update(vessel.ID, queue.StateCompleted, ""); updateErr != nil {
 		log.Printf("warn: failed to update vessel %s state: %v", vessel.ID, updateErr)
 	}
 
-	manifest := r.persistRunArtifacts(vessel, string(queue.StateCompleted), vrs, claims, r.runtimeNow())
+	manifest, report := r.persistRunArtifacts(ctx, vessel, string(queue.StateCompleted), vrs, claims, r.runtimeNow())
 
 	// Clean up worktree (best-effort)
 	r.removeWorktree(worktreePath, vessel.ID)
@@ -886,17 +938,19 @@ func (r *Runner) completeVessel(ctx context.Context, vessel queue.Vessel, worktr
 	issueNum := r.parseIssueNum(vessel)
 	if issueNum > 0 && r.Reporter != nil {
 		r.logReporterError("post vessel-completed comment", vessel.ID,
-			r.Reporter.VesselCompleted(ctx, issueNum, phaseResults, manifest))
+			r.Reporter.VesselCompleted(ctx, issueNum, phaseResults, manifest, report))
 	}
 
 	return "completed"
 }
 
-func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *vesselRunState, claims []evidence.Claim, now time.Time) *evidence.Manifest {
+func (r *Runner) persistRunArtifacts(ctx context.Context, vessel queue.Vessel, state string, vrs *vesselRunState, claims []evidence.Claim, now time.Time) (*evidence.Manifest, *cost.CostReport) {
 	if vrs == nil {
 		vrs = newVesselRunState(r.Config, vessel, now)
 	}
 
+	summaryPath := filepath.ToSlash(filepath.Join("phases", vessel.ID, summaryFileName))
+	reportPath := filepath.ToSlash(filepath.Join("phases", vessel.ID, cost.ReportFileName))
 	summary := vrs.buildSummary(state, now)
 	var manifest *evidence.Manifest
 	if len(claims) > 0 {
@@ -913,11 +967,42 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 		}
 	}
 
+	spanCtx := oteltrace.SpanContextFromContext(ctx)
+	join := cost.ArtifactJoin{
+		SummaryPath:          summaryPath,
+		EvidenceManifestPath: summary.EvidenceManifestPath,
+	}
+	if spanCtx.IsValid() {
+		join.TraceID = spanCtx.TraceID().String()
+		join.SpanID = spanCtx.SpanID().String()
+	}
+	report := vrs.buildCostReport(state, now, cost.ArtifactJoin{
+		TraceID:              join.TraceID,
+		SpanID:               join.SpanID,
+		SummaryPath:          join.SummaryPath,
+		EvidenceManifestPath: join.EvidenceManifestPath,
+	})
 	if err := SaveVesselSummary(r.Config.StateDir, summary); err != nil {
 		log.Printf("warn: save vessel summary: %v", err)
 	}
+	if err := cost.SaveReport(filepath.Join(r.Config.StateDir, filepath.FromSlash(reportPath)), report); err != nil {
+		log.Printf("warn: save cost report: %v", err)
+	}
+	span := oteltrace.SpanFromContext(ctx)
+	if span != nil {
+		observability.AttachSpanAttributes(span, observability.CostReportAttributes(observability.CostReportData{
+			SummaryPath:          summaryPath,
+			CostReportPath:       reportPath,
+			EvidenceManifestPath: summary.EvidenceManifestPath,
+			UsageSource:          string(report.UsageSource),
+			TotalTokens:          report.TotalTokens,
+			TotalCostUSD:         report.TotalCostUSD,
+			BudgetExceeded:       report.BudgetExceeded,
+			AlertCount:           len(report.Alerts),
+		}))
+	}
 
-	return manifest
+	return manifest, report
 }
 
 // runVesselOrchestrated executes a workflow with explicit phase dependencies
@@ -1074,7 +1159,7 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 			issueNum := r.parseIssueNum(vessel)
 			if issueNum > 0 && r.Reporter != nil {
 				r.logReporterError("post vessel-failed comment", vessel.ID,
-					r.Reporter.VesselFailed(ctx, issueNum, "", errMsg, ""))
+					r.Reporter.VesselFailed(ctx, issueNum, "", errMsg, "", r.previewCostReport(vrs, string(queue.StateFailed), r.runtimeNow())))
 			}
 			return "failed"
 		}
@@ -1307,12 +1392,12 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			issueNum := r.parseIssueNum(vessel)
 			if issueNum > 0 && r.Reporter != nil {
 				r.logReporterError("post vessel-failed comment", vessel.ID,
-					r.Reporter.VesselFailed(ctx, issueNum, p.Name, runErr.Error(), ""))
+					r.Reporter.VesselFailed(ctx, issueNum, p.Name, runErr.Error(), "", r.previewCostReport(vrs, string(queue.StateFailed), r.runtimeNow())))
 			}
 			return singlePhaseResult{
 				status:       "failed",
 				duration:     phaseDuration,
-				phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()),
+				phaseSummary: vrs.phaseSummaryWithUsage(r.Config, srcCfg, wf, p, harnessContent, usageDetails{}, phaseDuration, "failed", nil, runErr.Error()),
 			}
 		}
 
@@ -1328,18 +1413,26 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				issueNum := r.parseIssueNum(vessel)
 				if issueNum > 0 && r.Reporter != nil {
 					r.logReporterError("post vessel-failed comment", vessel.ID,
-						r.Reporter.VesselFailed(ctx, issueNum, p.Name, err.Error(), ""))
+						r.Reporter.VesselFailed(ctx, issueNum, p.Name, err.Error(), "", r.previewCostReport(vrs, string(queue.StateFailed), r.runtimeNow())))
 				}
 				return singlePhaseResult{
 					status:       "failed",
 					duration:     phaseDuration,
-					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error()),
+					phaseSummary: vrs.phaseSummaryWithUsage(r.Config, srcCfg, wf, p, harnessContent, usageDetails{}, phaseDuration, "failed", nil, err.Error()),
 				}
 			}
 		}
 
 		recordedAt := r.runtimeNow()
-		inputTokensEst, outputTokensEst, costUSDEst := vrs.recordPhaseTokens(p, model, promptForCost, string(output), recordedAt)
+		providerUsage := executionUsage{
+			Source:            cost.UsageSourceUnavailable,
+			UnavailableReason: "command phase does not consume model tokens",
+		}
+		if p.Type != "command" {
+			providerUsage = r.usageExtractor().ExtractUsage(provider, model, output)
+		}
+		usage := vrs.recordPhaseUsage(p, model, promptForCost, string(output), recordedAt, providerUsage)
+		r.logBudgetAlerts(vessel.ID, vrs.consumeBudgetAlerts())
 		if enforceBudget && vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() {
 			errMsg := fmt.Sprintf("budget exceeded after phase %q: estimated cost $%.4f, estimated tokens %d",
 				p.Name, vrs.costTracker.TotalCost(), vrs.costTracker.TotalTokens())
@@ -1351,13 +1444,13 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			issueNum := r.parseIssueNum(vessel)
 			if issueNum > 0 && r.Reporter != nil {
 				r.logReporterError("post vessel-failed comment", vessel.ID,
-					r.Reporter.VesselFailed(ctx, issueNum, p.Name, errMsg, ""))
+					r.Reporter.VesselFailed(ctx, issueNum, p.Name, errMsg, "", r.previewCostReport(vrs, string(queue.StateFailed), recordedAt)))
 			}
 			finishCurrentPhaseSpan(fmt.Errorf("%s", errMsg))
 			return singlePhaseResult{
 				status:       "failed",
 				duration:     phaseDuration,
-				phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg),
+				phaseSummary: vrs.phaseSummaryWithUsage(r.Config, srcCfg, wf, p, harnessContent, usage, phaseDuration, "failed", nil, errMsg),
 			}
 		}
 
@@ -1373,7 +1466,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				output:        string(output),
 				status:        "no-op",
 				duration:      phaseDuration,
-				phaseSummary:  vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "no-op", nil, ""),
+				phaseSummary:  vrs.phaseSummaryWithUsage(r.Config, srcCfg, wf, p, harnessContent, usage, phaseDuration, "no-op", nil, ""),
 				evidenceClaim: nil,
 			}
 		}
@@ -1390,7 +1483,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				output:        string(output),
 				status:        "completed",
 				duration:      phaseDuration,
-				phaseSummary:  vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, ""),
+				phaseSummary:  vrs.phaseSummaryWithUsage(r.Config, srcCfg, wf, p, harnessContent, usage, phaseDuration, "completed", nil, ""),
 				evidenceClaim: nil,
 			}
 		}
@@ -1414,7 +1507,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					status:       "failed",
 					duration:     phaseDuration,
 					gateOut:      gateOut,
-					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error()),
+					phaseSummary: vrs.phaseSummaryWithUsage(r.Config, srcCfg, wf, p, harnessContent, usage, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error()),
 				}
 			}
 			if passed {
@@ -1426,7 +1519,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					output:        string(output),
 					status:        "completed",
 					duration:      phaseDuration,
-					phaseSummary:  vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", gatePassedPointer(true), ""),
+					phaseSummary:  vrs.phaseSummaryWithUsage(r.Config, srcCfg, wf, p, harnessContent, usage, phaseDuration, "completed", gatePassedPointer(true), ""),
 					evidenceClaim: &claim,
 				}
 			}
@@ -1448,14 +1541,14 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				}
 				if issueNum > 0 && r.Reporter != nil {
 					r.logReporterError("post vessel-failed comment", vessel.ID,
-						r.Reporter.VesselFailed(ctx, issueNum, p.Name, "gate failed, retries exhausted", gateOut))
+						r.Reporter.VesselFailed(ctx, issueNum, p.Name, "gate failed, retries exhausted", gateOut, r.previewCostReport(vrs, string(queue.StateFailed), r.runtimeNow())))
 				}
 				finishCurrentPhaseSpan(nil)
 				return singlePhaseResult{
 					status:       "failed",
 					duration:     phaseDuration,
 					gateOut:      gateOut,
-					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted"),
+					phaseSummary: vrs.phaseSummaryWithUsage(r.Config, srcCfg, wf, p, harnessContent, usage, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted"),
 				}
 			}
 			gateRetries--
@@ -1471,7 +1564,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					status:       "failed",
 					duration:     phaseDuration,
 					gateOut:      gateOut,
-					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error()),
+					phaseSummary: vrs.phaseSummaryWithUsage(r.Config, srcCfg, wf, p, harnessContent, usage, phaseDuration, "failed", gatePassedPointer(false), err.Error()),
 				}
 			}
 			finishCurrentPhaseSpan(nil)
@@ -1506,7 +1599,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			output:        string(output),
 			status:        "completed",
 			duration:      phaseDuration,
-			phaseSummary:  vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, ""),
+			phaseSummary:  vrs.phaseSummaryWithUsage(r.Config, srcCfg, wf, p, harnessContent, usage, phaseDuration, "completed", nil, ""),
 			evidenceClaim: nil,
 		}
 	}

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
@@ -1604,6 +1605,13 @@ func TestSmoke_S27_CommandTypePhasesDoNotGenerateCostRecords(t *testing.T) {
 	assert.Zero(t, commandPhase.CostUSDEst)
 	assert.Equal(t, promptPhase.InputTokensEst+promptPhase.OutputTokensEst, summary.TotalTokensEst)
 	assert.Equal(t, promptPhase.CostUSDEst, summary.TotalCostUSDEst)
+	assert.Equal(t, cost.UsageSourceEstimated, summary.UsageSource)
+	assert.Contains(t, summary.UsageUnavailableReason, "structured usage metadata")
+
+	report, err := cost.LoadReport(filepath.Join(cfg.StateDir, "phases", "issue-1", cost.ReportFileName))
+	require.NoError(t, err)
+	assert.Equal(t, cost.UsageSourceEstimated, report.UsageSource)
+	assert.Contains(t, report.UsageUnavailableReason, "structured usage metadata")
 }
 
 func TestSmoke_S28_BudgetEnforcementFailsVesselWhenBudgetIsExceeded(t *testing.T) {
@@ -5413,6 +5421,108 @@ func TestSmoke_WS6S11_ErrorRecordedBeforeEnd(t *testing.T) {
 	if phaseSpan.EndTime().IsZero() {
 		t.Fatal("phase span end time not set")
 	}
+}
+
+func TestPromptOnlyPersistsReportedUsageCostReport(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	setPricedModel(cfg)
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	vessel := makePromptVessel(1, "reported usage prompt")
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"reported usage prompt": []byte(`{"usage":{"input_tokens":120,"output_tokens":30,"cost_usd":0.0042}}`),
+		},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Completed)
+
+	report, err := cost.LoadReport(filepath.Join(cfg.StateDir, "phases", vessel.ID, cost.ReportFileName))
+	require.NoError(t, err)
+	require.Equal(t, cost.UsageSourceReported, report.UsageSource)
+	require.Equal(t, 150, report.TotalTokens)
+	require.InDelta(t, 0.0042, report.TotalCostUSD, 1e-9)
+	require.InDelta(t, 0.0042, report.ByRole[cost.RoleGenerator], 1e-9)
+	require.InDelta(t, 0.0042, report.ByPurpose[cost.PurposeReasoning], 1e-9)
+	require.InDelta(t, 0.0042, report.ByModel["claude-sonnet-4"], 1e-9)
+	require.Len(t, report.Phases, 1)
+	require.Equal(t, "prompt-only", report.Phases[0].Name)
+	require.Equal(t, cost.UsageSourceReported, report.Phases[0].UsageSource)
+}
+
+func TestPromptOnlyWarningPersistsWithoutFailing(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	setPricedModel(cfg)
+	setBudget(cfg, 0, 100)
+
+	prompt := strings.Repeat("p", 200) // 50 estimated tokens
+	output := []byte(strings.Repeat("o", 120))
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	vessel := makePromptVessel(2, prompt)
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			prompt: output,
+		},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Completed)
+
+	report, err := cost.LoadReport(filepath.Join(cfg.StateDir, "phases", vessel.ID, cost.ReportFileName))
+	require.NoError(t, err)
+	require.False(t, report.BudgetExceeded)
+	require.Equal(t, cost.UsageSourceEstimated, report.UsageSource)
+	require.NotEmpty(t, report.Alerts)
+	require.Equal(t, "warning", report.Alerts[0].Type)
+	require.Equal(t, "tokens", report.Alerts[0].Metric)
+
+	summary := loadSummary(t, cfg.StateDir, vessel.ID)
+	require.False(t, summary.BudgetExceeded)
+}
+
+func TestCostReportIncludesTraceJoinFields(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	vessel := makePromptVessel(3, "trace prompt")
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	tracer, _ := newTestTracer(t)
+	r := New(cfg, q, &mockWorktree{path: dir}, &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"trace prompt": []byte("done"),
+		},
+	})
+	r.Tracer = tracer
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Completed)
+
+	report, err := cost.LoadReport(filepath.Join(cfg.StateDir, "phases", vessel.ID, cost.ReportFileName))
+	require.NoError(t, err)
+	require.NotEmpty(t, report.Join.TraceID)
+	require.NotEmpty(t, report.Join.SpanID)
+	require.Equal(t, filepath.ToSlash(filepath.Join("phases", vessel.ID, summaryFileName)), report.Join.SummaryPath)
 }
 
 func TestIsRateLimitError(t *testing.T) {

--- a/cli/internal/runner/summary.go
+++ b/cli/internal/runner/summary.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	summaryFileName   = "summary.json"
-	summaryDisclaimer = "Token counts and costs are estimates (len/4 heuristic + static pricing). Not provider-reported values."
+	summaryDisclaimer = "Best-available cost telemetry. Use usage_source fields to distinguish provider-reported, estimated fallback, and unavailable values. Legacy *_est fields remain estimate-only for compatibility."
 )
 
 var safeSummaryPathComponent = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
@@ -35,14 +35,22 @@ type VesselSummary struct {
 
 	Phases []PhaseSummary `json:"phases"`
 
+	TotalInputTokens       int              `json:"total_input_tokens,omitempty"`
+	TotalOutputTokens      int              `json:"total_output_tokens,omitempty"`
+	TotalTokens            int              `json:"total_tokens,omitempty"`
+	TotalCostUSD           float64          `json:"total_cost_usd,omitempty"`
+	UsageSource            cost.UsageSource `json:"usage_source,omitempty"`
+	UsageUnavailableReason string           `json:"usage_unavailable_reason,omitempty"`
+
 	TotalInputTokensEst  int     `json:"total_input_tokens_est"`
 	TotalOutputTokensEst int     `json:"total_output_tokens_est"`
 	TotalTokensEst       int     `json:"total_tokens_est"`
 	TotalCostUSDEst      float64 `json:"total_cost_usd_est"`
 
-	BudgetMaxCostUSD *float64 `json:"budget_max_cost_usd,omitempty"`
-	BudgetMaxTokens  *int     `json:"budget_max_tokens,omitempty"`
-	BudgetExceeded   bool     `json:"budget_exceeded"`
+	BudgetMaxCostUSD *float64           `json:"budget_max_cost_usd,omitempty"`
+	BudgetMaxTokens  *int               `json:"budget_max_tokens,omitempty"`
+	BudgetExceeded   bool               `json:"budget_exceeded"`
+	BudgetAlerts     []cost.BudgetAlert `json:"budget_alerts,omitempty"`
 
 	EvidenceManifestPath string `json:"evidence_manifest_path,omitempty"`
 
@@ -51,18 +59,25 @@ type VesselSummary struct {
 
 // PhaseSummary records the outcome of a single phase.
 type PhaseSummary struct {
-	Name            string  `json:"name"`
-	Type            string  `json:"type"`
-	Provider        string  `json:"provider,omitempty"`
-	Model           string  `json:"model,omitempty"`
-	DurationMS      int64   `json:"duration_ms"`
-	Status          string  `json:"status"`
-	InputTokensEst  int     `json:"input_tokens_est"`
-	OutputTokensEst int     `json:"output_tokens_est"`
-	CostUSDEst      float64 `json:"cost_usd_est"`
-	GateType        string  `json:"gate_type,omitempty"`
-	GatePassed      *bool   `json:"gate_passed,omitempty"`
-	Error           string  `json:"error,omitempty"`
+	Name                   string           `json:"name"`
+	Type                   string           `json:"type"`
+	Provider               string           `json:"provider,omitempty"`
+	Model                  string           `json:"model,omitempty"`
+	DurationMS             int64            `json:"duration_ms"`
+	Status                 string           `json:"status"`
+	ArtifactPath           string           `json:"artifact_path,omitempty"`
+	InputTokens            int              `json:"input_tokens,omitempty"`
+	OutputTokens           int              `json:"output_tokens,omitempty"`
+	TotalTokens            int              `json:"total_tokens,omitempty"`
+	CostUSD                float64          `json:"cost_usd,omitempty"`
+	UsageSource            cost.UsageSource `json:"usage_source,omitempty"`
+	UsageUnavailableReason string           `json:"usage_unavailable_reason,omitempty"`
+	InputTokensEst         int              `json:"input_tokens_est"`
+	OutputTokensEst        int              `json:"output_tokens_est"`
+	CostUSDEst             float64          `json:"cost_usd_est"`
+	GateType               string           `json:"gate_type,omitempty"`
+	GatePassed             *bool            `json:"gate_passed,omitempty"`
+	Error                  string           `json:"error,omitempty"`
 }
 
 type vesselRunState struct {
@@ -78,19 +93,28 @@ type vesselRunState struct {
 	budgetMaxCostUSD *float64
 	budgetMaxTokens  *int
 
-	extraInputTokensEst  int
-	extraOutputTokensEst int
-	extraCostUSDEst      float64
+	extraInputTokens            int
+	extraOutputTokens           int
+	extraCostUSD                float64
+	extraInputTokensEst         int
+	extraOutputTokensEst        int
+	extraCostUSDEst             float64
+	extraUsageSource            cost.UsageSource
+	extraUsageUnavailableReason string
+	extraProvider               string
+	extraModel                  string
+	alertCursor                 int
 }
 
 func newVesselRunState(cfg *config.Config, vessel queue.Vessel, startedAt time.Time) *vesselRunState {
 	s := &vesselRunState{
-		startedAt: startedAt.UTC(),
-		phases:    make([]PhaseSummary, 0),
-		vesselID:  vessel.ID,
-		source:    vessel.Source,
-		workflow:  vessel.Workflow,
-		ref:       vessel.Ref,
+		startedAt:   startedAt.UTC(),
+		phases:      make([]PhaseSummary, 0),
+		costTracker: cost.NewTracker(nil),
+		vesselID:    vessel.ID,
+		source:      vessel.Source,
+		workflow:    vessel.Workflow,
+		ref:         vessel.Ref,
 	}
 
 	if cfg == nil {
@@ -114,6 +138,17 @@ func newVesselRunState(cfg *config.Config, vessel queue.Vessel, startedAt time.T
 
 func (s *vesselRunState) addPhase(ps PhaseSummary) {
 	s.phases = append(s.phases, ps)
+}
+
+func aggregateUsageBreakdowns(phases []cost.PhaseCostBreakdown) []cost.PhaseCostBreakdown {
+	filtered := make([]cost.PhaseCostBreakdown, 0, len(phases))
+	for _, phase := range phases {
+		if phase.Type == "command" {
+			continue
+		}
+		filtered = append(filtered, phase)
+	}
+	return filtered
 }
 
 func (s *vesselRunState) buildSummary(state string, endedAt time.Time) *VesselSummary {
@@ -142,27 +177,106 @@ func (s *vesselRunState) buildSummary(state string, endedAt time.Time) *VesselSu
 	}
 
 	for _, p := range s.phases {
+		summary.TotalInputTokens += p.InputTokens
+		summary.TotalOutputTokens += p.OutputTokens
+		summary.TotalCostUSD += p.CostUSD
 		summary.TotalInputTokensEst += p.InputTokensEst
 		summary.TotalOutputTokensEst += p.OutputTokensEst
 		summary.TotalCostUSDEst += p.CostUSDEst
 	}
 
+	summary.TotalInputTokens += s.extraInputTokens
+	summary.TotalOutputTokens += s.extraOutputTokens
+	summary.TotalCostUSD += s.extraCostUSD
 	summary.TotalInputTokensEst += s.extraInputTokensEst
 	summary.TotalOutputTokensEst += s.extraOutputTokensEst
 	summary.TotalCostUSDEst += s.extraCostUSDEst
+	summary.TotalTokens = summary.TotalInputTokens + summary.TotalOutputTokens
 	summary.TotalTokensEst = summary.TotalInputTokensEst + summary.TotalOutputTokensEst
+
+	usageSources := make([]cost.PhaseCostBreakdown, 0, len(s.phases)+1)
+	for _, p := range s.phases {
+		usageSources = append(usageSources, cost.PhaseCostBreakdown{
+			Type:                   p.Type,
+			UsageSource:            p.UsageSource,
+			UsageUnavailableReason: p.UsageUnavailableReason,
+		})
+	}
+	if s.extraUsageSource != "" {
+		usageSources = append(usageSources, cost.PhaseCostBreakdown{
+			Type:                   "prompt",
+			UsageSource:            s.extraUsageSource,
+			UsageUnavailableReason: s.extraUsageUnavailableReason,
+		})
+	}
+	usageSources = aggregateUsageBreakdowns(usageSources)
+	summary.UsageSource = cost.DeriveUsageSource(usageSources)
+	summary.UsageUnavailableReason = cost.FirstUsageUnavailableReason(usageSources)
 
 	if s.costTracker != nil {
 		summary.BudgetExceeded = s.costTracker.BudgetExceeded()
+		summary.BudgetAlerts = s.costTracker.Alerts()
 	}
 
 	return summary
 }
 
-func (s *vesselRunState) recordLLMUsage(model, inputText, outputText string, recordedAt time.Time) (int, int, float64) {
+type usageDetails struct {
+	inputTokens            int
+	outputTokens           int
+	totalTokens            int
+	costUSD                float64
+	inputTokensEst         int
+	outputTokensEst        int
+	totalTokensEst         int
+	costUSDEst             float64
+	usageSource            cost.UsageSource
+	usageUnavailableReason string
+}
+
+func (s *vesselRunState) recordLLMUsage(model, inputText, outputText string, recordedAt time.Time, providerUsage executionUsage) usageDetails {
 	inputTokens := cost.EstimateTokens(inputText)
 	outputTokens := cost.EstimateTokens(outputText)
 	costUSDEst := cost.EstimateCost(inputTokens, outputTokens, cost.LookupPricing(model))
+
+	details := usageDetails{
+		inputTokensEst:         inputTokens,
+		outputTokensEst:        outputTokens,
+		totalTokensEst:         inputTokens + outputTokens,
+		costUSDEst:             costUSDEst,
+		usageUnavailableReason: providerUsage.UnavailableReason,
+	}
+
+	recordInputTokens := inputTokens
+	recordOutputTokens := outputTokens
+	recordCostUSD := costUSDEst
+
+	switch providerUsage.Source {
+	case cost.UsageSourceReported:
+		details.inputTokens = providerUsage.InputTokens
+		details.outputTokens = providerUsage.OutputTokens
+		details.totalTokens = providerUsage.InputTokens + providerUsage.OutputTokens
+		details.costUSD = costUSDEst
+		if providerUsage.CostUSD != nil {
+			details.costUSD = *providerUsage.CostUSD
+		}
+		details.usageSource = cost.UsageSourceReported
+		recordInputTokens = details.inputTokens
+		recordOutputTokens = details.outputTokens
+		recordCostUSD = details.costUSD
+	case cost.UsageSourceUnavailable:
+		details.inputTokens = inputTokens
+		details.outputTokens = outputTokens
+		details.totalTokens = inputTokens + outputTokens
+		details.costUSD = costUSDEst
+		details.usageSource = cost.UsageSourceEstimated
+	default:
+		details.inputTokens = inputTokens
+		details.outputTokens = outputTokens
+		details.totalTokens = inputTokens + outputTokens
+		details.costUSD = costUSDEst
+		details.usageSource = cost.UsageSourceEstimated
+	}
 
 	if s.costTracker != nil {
 		_ = s.costTracker.Record(cost.UsageRecord{
@@ -170,43 +284,81 @@ func (s *vesselRunState) recordLLMUsage(model, inputText, outputText string, rec
 			AgentRole:    cost.RoleGenerator,
 			Purpose:      cost.PurposeReasoning,
 			Model:        model,
-			InputTokens:  inputTokens,
-			OutputTokens: outputTokens,
-			CostUSD:      costUSDEst,
+			InputTokens:  recordInputTokens,
+			OutputTokens: recordOutputTokens,
+			CostUSD:      recordCostUSD,
 			Timestamp:    recordedAt.UTC(),
 		})
 	}
 
-	return inputTokens, outputTokens, costUSDEst
+	return details
+}
+
+func (s *vesselRunState) recordPromptOnlyUsageWithUsage(provider, model, prompt, output string, recordedAt time.Time, providerUsage executionUsage) usageDetails {
+	details := s.recordLLMUsage(model, prompt, output, recordedAt, providerUsage)
+	s.extraInputTokens += details.inputTokens
+	s.extraOutputTokens += details.outputTokens
+	s.extraCostUSD += details.costUSD
+	s.extraInputTokensEst += details.inputTokensEst
+	s.extraOutputTokensEst += details.outputTokensEst
+	s.extraCostUSDEst += details.costUSDEst
+	s.extraUsageSource = details.usageSource
+	s.extraUsageUnavailableReason = details.usageUnavailableReason
+	s.extraProvider = provider
+	s.extraModel = model
+	return details
 }
 
 func (s *vesselRunState) recordPromptOnlyUsage(model, prompt, output string, recordedAt time.Time) (int, int, float64) {
-	inputTokens, outputTokens, costUSDEst := s.recordLLMUsage(model, prompt, output, recordedAt)
-	s.extraInputTokensEst += inputTokens
-	s.extraOutputTokensEst += outputTokens
-	s.extraCostUSDEst += costUSDEst
-	return inputTokens, outputTokens, costUSDEst
+	details := s.recordPromptOnlyUsageWithUsage("", model, prompt, output, recordedAt, executionUsage{
+		Source:            cost.UsageSourceUnavailable,
+		UnavailableReason: "provider output did not include structured usage metadata",
+	})
+	return details.inputTokensEst, details.outputTokensEst, details.costUSDEst
 }
 
 // recordPhaseTokens records LLM usage for a prompt-type phase and returns the
 // estimated token counts and cost. Command phases do not consume model tokens.
+func (s *vesselRunState) recordPhaseUsage(
+	p workflow.Phase, model, renderedPrompt, output string, recordedAt time.Time, providerUsage executionUsage,
+) usageDetails {
+	if p.Type == "command" {
+		return usageDetails{
+			usageSource:            cost.UsageSourceUnavailable,
+			usageUnavailableReason: "command phase does not consume model tokens",
+		}
+	}
+
+	return s.recordLLMUsage(model, renderedPrompt, output, recordedAt, providerUsage)
+}
+
 func (s *vesselRunState) recordPhaseTokens(
 	p workflow.Phase, model, renderedPrompt, output string, recordedAt time.Time,
 ) (inputTokensEst, outputTokensEst int, costUSDEst float64) {
-	if p.Type == "command" {
-		return 0, 0, 0.0
-	}
-
-	return s.recordLLMUsage(model, renderedPrompt, output, recordedAt)
+	details := s.recordPhaseUsage(p, model, renderedPrompt, output, recordedAt, executionUsage{
+		Source:            cost.UsageSourceUnavailable,
+		UnavailableReason: "provider output did not include structured usage metadata",
+	})
+	return details.inputTokensEst, details.outputTokensEst, details.costUSDEst
 }
 
-func (s *vesselRunState) phaseSummary(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p workflow.Phase, harnessContent string, inputTokensEst, outputTokensEst int, costUSDEst float64, duration time.Duration, status string, gatePassed *bool, errMsg string) PhaseSummary {
+func (s *vesselRunState) phaseSummaryWithUsage(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p workflow.Phase, harnessContent string, usage usageDetails, duration time.Duration, status string, gatePassed *bool, errMsg string) PhaseSummary {
 	summary := PhaseSummary{
-		Name:       p.Name,
-		Type:       phaseTypeLabel(p),
-		DurationMS: duration.Milliseconds(),
-		Status:     status,
-		Error:      errMsg,
+		Name:                   p.Name,
+		Type:                   phaseTypeLabel(p),
+		DurationMS:             duration.Milliseconds(),
+		Status:                 status,
+		Error:                  errMsg,
+		ArtifactPath:           phaseArtifactRelativePath(s.vesselID, p.Name),
+		InputTokens:            usage.inputTokens,
+		OutputTokens:           usage.outputTokens,
+		TotalTokens:            usage.totalTokens,
+		CostUSD:                usage.costUSD,
+		UsageSource:            usage.usageSource,
+		UsageUnavailableReason: usage.usageUnavailableReason,
+		InputTokensEst:         usage.inputTokensEst,
+		OutputTokensEst:        usage.outputTokensEst,
+		CostUSDEst:             usage.costUSDEst,
 	}
 
 	if p.Gate != nil {
@@ -222,11 +374,117 @@ func (s *vesselRunState) phaseSummary(cfg *config.Config, srcCfg *config.SourceC
 	model := resolveModel(cfg, srcCfg, wf, &p, provider)
 	summary.Provider = provider
 	summary.Model = model
-	summary.InputTokensEst = inputTokensEst
-	summary.OutputTokensEst = outputTokensEst
-	summary.CostUSDEst = costUSDEst
 
 	return summary
+}
+
+func (s *vesselRunState) phaseSummary(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p workflow.Phase, harnessContent string, inputTokensEst, outputTokensEst int, costUSDEst float64, duration time.Duration, status string, gatePassed *bool, errMsg string) PhaseSummary {
+	return s.phaseSummaryWithUsage(cfg, srcCfg, wf, p, harnessContent, usageDetails{
+		inputTokensEst:  inputTokensEst,
+		outputTokensEst: outputTokensEst,
+		totalTokensEst:  inputTokensEst + outputTokensEst,
+		costUSDEst:      costUSDEst,
+		usageSource:     cost.UsageSourceEstimated,
+	}, duration, status, gatePassed, errMsg)
+}
+
+func (s *vesselRunState) consumeBudgetAlerts() []cost.BudgetAlert {
+	if s == nil || s.costTracker == nil {
+		return nil
+	}
+	alerts := s.costTracker.Alerts()
+	if s.alertCursor >= len(alerts) {
+		return nil
+	}
+	out := append([]cost.BudgetAlert(nil), alerts[s.alertCursor:]...)
+	s.alertCursor = len(alerts)
+	return out
+}
+
+func (s *vesselRunState) buildCostReport(state string, endedAt time.Time, join cost.ArtifactJoin) *cost.CostReport {
+	if endedAt.IsZero() {
+		endedAt = time.Now().UTC()
+	} else {
+		endedAt = endedAt.UTC()
+	}
+
+	phases := make([]cost.PhaseCostBreakdown, 0, len(s.phases)+1)
+	for _, phase := range s.phases {
+		phases = append(phases, cost.PhaseCostBreakdown{
+			Name:                   phase.Name,
+			Type:                   phase.Type,
+			Provider:               phase.Provider,
+			Model:                  phase.Model,
+			Status:                 phase.Status,
+			DurationMS:             phase.DurationMS,
+			ArtifactPath:           phase.ArtifactPath,
+			InputTokens:            phase.InputTokens,
+			OutputTokens:           phase.OutputTokens,
+			TotalTokens:            phase.TotalTokens,
+			CostUSD:                phase.CostUSD,
+			UsageSource:            phase.UsageSource,
+			UsageUnavailableReason: phase.UsageUnavailableReason,
+		})
+	}
+	if s.extraUsageSource != "" {
+		phases = append(phases, cost.PhaseCostBreakdown{
+			Name:                   "prompt-only",
+			Type:                   "prompt",
+			Provider:               s.extraProvider,
+			Model:                  s.extraModel,
+			Status:                 state,
+			InputTokens:            s.extraInputTokens,
+			OutputTokens:           s.extraOutputTokens,
+			TotalTokens:            s.extraInputTokens + s.extraOutputTokens,
+			CostUSD:                s.extraCostUSD,
+			UsageSource:            s.extraUsageSource,
+			UsageUnavailableReason: s.extraUsageUnavailableReason,
+			ArtifactPath:           phaseArtifactRelativePath(s.vesselID, "prompt-only"),
+		})
+	}
+
+	aggregatePhases := aggregateUsageBreakdowns(phases)
+
+	report := &cost.CostReport{
+		MissionID:              s.vesselID,
+		VesselID:               s.vesselID,
+		Source:                 s.source,
+		Workflow:               s.workflow,
+		Ref:                    s.ref,
+		State:                  state,
+		ByRole:                 map[cost.AgentRole]float64{},
+		ByPurpose:              map[cost.Purpose]float64{},
+		ByModel:                map[string]float64{},
+		GeneratedAt:            endedAt,
+		Phases:                 phases,
+		UsageSource:            cost.DeriveUsageSource(aggregatePhases),
+		UsageUnavailableReason: cost.FirstUsageUnavailableReason(aggregatePhases),
+		BudgetMaxCostUSD:       s.budgetMaxCostUSD,
+		BudgetMaxTokens:        s.budgetMaxTokens,
+		Join:                   join,
+	}
+
+	for _, phase := range phases {
+		report.TotalInputTokens += phase.InputTokens
+		report.TotalOutputTokens += phase.OutputTokens
+		report.TotalTokens += phase.TotalTokens
+		report.TotalCostUSD += phase.CostUSD
+		if phase.Model != "" {
+			report.ByModel[phase.Model] += phase.CostUSD
+		}
+		if phase.UsageSource != "" {
+			report.RecordCount++
+		}
+	}
+	if s.costTracker != nil {
+		report.Alerts = s.costTracker.Alerts()
+		report.BudgetExceeded = s.costTracker.BudgetExceeded()
+		report.ByRole = s.costTracker.CostByRole()
+		report.ByPurpose = s.costTracker.CostByPurpose()
+		report.ByModel = s.costTracker.CostByModel()
+	}
+
+	return report
 }
 
 func phaseTypeLabel(p workflow.Phase) string {

--- a/cli/internal/runner/summary_test.go
+++ b/cli/internal/runner/summary_test.go
@@ -861,7 +861,7 @@ func TestSmoke_WS6S6_EvidenceCollectionFailureIsNonFatal(t *testing.T) {
 	}}
 	vrs := newVesselRunState(cfg, vessel, now)
 
-	r.persistRunArtifacts(vessel, string(queue.StateCompleted), vrs, claims, now)
+	r.persistRunArtifacts(context.Background(), vessel, string(queue.StateCompleted), vrs, claims, now)
 
 	if !strings.Contains(buf.String(), "warn: save evidence manifest:") {
 		t.Fatalf("expected warning log for evidence manifest save failure, got %q", buf.String())
@@ -892,7 +892,7 @@ func TestSmoke_WS6S7_SummaryWriteFailureIsNonFatal(t *testing.T) {
 	now := time.Date(2026, time.April, 2, 10, 0, 0, 0, time.UTC)
 	vrs := newVesselRunState(cfg, vessel, now)
 
-	r.persistRunArtifacts(vessel, string(queue.StateCompleted), vrs, nil, now)
+	r.persistRunArtifacts(context.Background(), vessel, string(queue.StateCompleted), vrs, nil, now)
 
 	if !strings.Contains(buf.String(), "warn: save vessel summary:") {
 		t.Fatalf("expected warning log for summary write failure, got %q", buf.String())

--- a/cli/internal/runner/usage.go
+++ b/cli/internal/runner/usage.go
@@ -1,0 +1,145 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
+)
+
+type executionUsage struct {
+	Source            cost.UsageSource
+	InputTokens       int
+	OutputTokens      int
+	CostUSD           *float64
+	UnavailableReason string
+}
+
+// UsageExtractor extracts provider-reported usage from phase output.
+type UsageExtractor interface {
+	ExtractUsage(provider, model string, output []byte) executionUsage
+}
+
+type defaultUsageExtractor struct{}
+
+func (defaultUsageExtractor) ExtractUsage(provider, model string, output []byte) executionUsage {
+	if usage, ok := parseStructuredUsage(output); ok {
+		return usage
+	}
+
+	name := provider
+	if name == "" {
+		name = "provider"
+	}
+	reason := fmt.Sprintf("%s output did not include structured usage metadata", name)
+	if len(bytes.TrimSpace(output)) == 0 {
+		reason = fmt.Sprintf("%s output was empty; no structured usage metadata was available", name)
+	}
+	return executionUsage{
+		Source:            cost.UsageSourceUnavailable,
+		UnavailableReason: reason,
+	}
+}
+
+func parseStructuredUsage(output []byte) (executionUsage, bool) {
+	candidates := [][]byte{bytes.TrimSpace(output)}
+	for _, line := range bytes.Split(output, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) > 0 {
+			candidates = append(candidates, line)
+		}
+	}
+
+	for i := len(candidates) - 1; i >= 0; i-- {
+		usage, ok := parseUsageCandidate(candidates[i])
+		if ok {
+			return usage, true
+		}
+	}
+	return executionUsage{}, false
+}
+
+func parseUsageCandidate(candidate []byte) (executionUsage, bool) {
+	if len(candidate) == 0 {
+		return executionUsage{}, false
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(candidate, &raw); err != nil {
+		return executionUsage{}, false
+	}
+
+	if nested, ok := raw["usage"].(map[string]any); ok {
+		raw = nested
+	}
+
+	inputTokens, okIn := usageInt(raw, "input_tokens", "prompt_tokens", "inputTokens", "promptTokens")
+	outputTokens, okOut := usageInt(raw, "output_tokens", "completion_tokens", "outputTokens", "completionTokens")
+	if !okIn || !okOut {
+		return executionUsage{}, false
+	}
+
+	var costUSD *float64
+	if value, ok := usageFloat(raw, "cost_usd", "costUSD"); ok {
+		costUSD = &value
+	}
+
+	return executionUsage{
+		Source:       cost.UsageSourceReported,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		CostUSD:      costUSD,
+	}, true
+}
+
+func usageInt(raw map[string]any, keys ...string) (int, bool) {
+	for _, key := range keys {
+		value, ok := raw[key]
+		if !ok {
+			continue
+		}
+		switch v := value.(type) {
+		case float64:
+			return int(v), true
+		case int:
+			return v, true
+		case json.Number:
+			n, err := v.Int64()
+			if err == nil {
+				return int(n), true
+			}
+		case string:
+			var n int
+			if _, err := fmt.Sscanf(strings.TrimSpace(v), "%d", &n); err == nil {
+				return n, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func usageFloat(raw map[string]any, keys ...string) (float64, bool) {
+	for _, key := range keys {
+		value, ok := raw[key]
+		if !ok {
+			continue
+		}
+		switch v := value.(type) {
+		case float64:
+			return v, true
+		case json.Number:
+			n, err := v.Float64()
+			if err == nil {
+				return n, true
+			}
+		case string:
+			var n float64
+			if _, err := fmt.Sscanf(strings.TrimSpace(v), "%f", &n); err == nil {
+				return n, true
+			}
+		}
+	}
+	return 0, false
+}


### PR DESCRIPTION
## Summary
- persist per-vessel cost-report artifacts with reported, estimated, and unavailable usage states plus trace/evidence join fields
- wire runner usage extraction, budget warnings, status output, and reporter comments through the CLI execution path
- add coverage for persisted cost reports, warning surfaces, observability attributes, and prompt-only reported usage

Closes https://github.com/nicholls-inc/xylem/issues/55