### PR TITLE
feat: periodic auto-upgrade in daemon loop

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -60,6 +60,11 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	// Auto-upgrade: pull latest main, rebuild, exec() if binary changed.
 	// Runs after PID lock (prevents concurrent upgrades) and before any vessel
 	// processing. If exec() fires, the new process re-acquires the lock.
+	//
+	// Captures the executable path and repo dir once so the same closure can
+	// also be used for periodic upgrades inside the daemon loop.
+	var upgrade upgradeFunc
+	upgradeInterval := time.Duration(0)
 	if cfg.Daemon.AutoUpgrade {
 		execPath, execErr := os.Executable()
 		if execErr != nil {
@@ -67,6 +72,9 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		} else {
 			repoDir := filepath.Dir(filepath.Dir(execPath))
 			selfUpgrade(repoDir, execPath)
+
+			upgrade = func() { selfUpgrade(repoDir, execPath) }
+			upgradeInterval = parseUpgradeInterval(cfg.Daemon)
 		}
 	}
 
@@ -97,7 +105,22 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		}
 	}
 
-	return daemonLoop(ctx, q, scan, drain, check, scanInterval, drainInterval)
+	return daemonLoop(ctx, q, scan, drain, check, upgrade, scanInterval, drainInterval, upgradeInterval)
+}
+
+// parseUpgradeInterval returns the effective periodic upgrade interval. If
+// the config provides an explicit value, it is parsed; otherwise the default
+// is returned.
+func parseUpgradeInterval(dc config.DaemonConfig) time.Duration {
+	if dc.UpgradeInterval == "" {
+		return defaultUpgradeInterval
+	}
+	d, err := time.ParseDuration(dc.UpgradeInterval)
+	if err != nil || d <= 0 {
+		log.Printf("daemon: invalid upgrade_interval %q, using default %s", dc.UpgradeInterval, defaultUpgradeInterval)
+		return defaultUpgradeInterval
+	}
+	return d
 }
 
 func parseDaemonIntervals(dc config.DaemonConfig) (scan, drain time.Duration) {
@@ -125,20 +148,41 @@ type drainFunc func(ctx context.Context) (runner.DrainResult, error)
 // hung vessel timeouts). May be nil if no checks are needed.
 type checkFunc func(ctx context.Context)
 
+// upgradeFunc runs a self-upgrade attempt. If it succeeds with a binary
+// change, it calls exec() and never returns. If it returns, either the
+// binary was unchanged or the upgrade failed; the daemon continues normally.
+// May be nil to disable periodic upgrades.
+type upgradeFunc func()
+
+// defaultUpgradeInterval is how often the daemon checks for a new binary.
+// Five minutes balances fast activation of newly-merged fixes against
+// excessive git fetches and rebuilds.
+const defaultUpgradeInterval = 5 * time.Minute
+
 // daemonLoop is the core loop extracted for testability. It accepts an
 // externally-controlled context so tests can cancel it without signals,
 // and injectable scan/drain/check functions so tests can use stubs.
-func daemonLoop(ctx context.Context, q *queue.Queue, scan scanFunc, drain drainFunc, check checkFunc, scanInterval, drainInterval time.Duration) error {
+//
+// If upgrade is non-nil, it is called periodically (every upgradeInterval)
+// while no drain goroutine is in-flight, so that newly-merged binary fixes
+// activate without manual restart. Pass nil/zero to disable.
+func daemonLoop(ctx context.Context, q *queue.Queue, scan scanFunc, drain drainFunc, check checkFunc, upgrade upgradeFunc, scanInterval, drainInterval, upgradeInterval time.Duration) error {
 	tickInterval := scanInterval
 	if drainInterval < tickInterval {
 		tickInterval = drainInterval
 	}
 
-	var lastScan, lastDrain time.Time
+	var lastScan, lastDrain, lastUpgrade time.Time
 	var draining int32 // 0=idle, 1=running
 	var drainWg sync.WaitGroup
 
-	log.Printf("daemon started: scan_interval=%s drain_interval=%s", scanInterval, drainInterval)
+	// Initialise lastUpgrade to now so the first upgrade check happens after
+	// upgradeInterval — not immediately, since cmdDaemon already ran the
+	// startup upgrade.
+	lastUpgrade = daemonNow()
+
+	log.Printf("daemon started: scan_interval=%s drain_interval=%s upgrade_interval=%s",
+		scanInterval, drainInterval, upgradeInterval)
 
 	for {
 		select {
@@ -171,6 +215,20 @@ func daemonLoop(ctx context.Context, q *queue.Queue, scan scanFunc, drain drainF
 		// Run vessel health checks (waiting label gates, hung vessel timeouts)
 		if check != nil {
 			check(ctx)
+		}
+
+		// Periodic self-upgrade: check for a newer binary on main and
+		// exec() into it if the hash changed. Only runs when no drain is
+		// in-flight, to avoid killing a running vessel mid-execution.
+		// selfUpgrade handles the exec() internally; if it returns, either
+		// nothing changed or the attempt failed and we keep running.
+		if upgrade != nil && upgradeInterval > 0 && now.Sub(lastUpgrade) >= upgradeInterval {
+			if atomic.LoadInt32(&draining) == 0 {
+				lastUpgrade = now
+				upgrade()
+			} else {
+				log.Printf("daemon: periodic upgrade deferred — drain in-flight")
+			}
 		}
 
 		if now.Sub(lastDrain) >= drainInterval {

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -186,7 +186,7 @@ func TestDaemonShutdown(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, noopScan, noopDrain, nil, time.Hour, time.Hour)
+	err := daemonLoop(ctx, q, noopScan, noopDrain, nil, nil, time.Hour, time.Hour, 0)
 	if err != nil {
 		t.Fatalf("expected nil error on shutdown, got: %v", err)
 	}
@@ -203,6 +203,65 @@ func TestSmoke_S31_TracerWiredInDaemonRunDrain(t *testing.T) {
 	}
 	if result != (runner.DrainResult{}) {
 		t.Fatalf("DrainResult = %+v, want zero value", result)
+	}
+}
+
+func TestDaemonLoopPeriodicUpgradeFiresAfterInterval(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	var upgradeCalls atomic.Int32
+	upgrade := func() { upgradeCalls.Add(1) }
+
+	// Tick fast (1ms), upgrade every 10ms. Within 100ms we expect at least 3
+	// upgrade calls, proving the periodic check fires.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := daemonLoop(ctx, q, noopScan, noopDrain, nil, upgrade, time.Millisecond, time.Hour, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("daemonLoop() error = %v", err)
+	}
+
+	if got := upgradeCalls.Load(); got < 3 {
+		t.Errorf("upgrade called %d times, want at least 3", got)
+	}
+}
+
+func TestDaemonLoopPeriodicUpgradeNilDisables(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	// Passing nil upgrade should not panic even with a non-zero interval.
+	err := daemonLoop(ctx, q, noopScan, noopDrain, nil, nil, time.Hour, time.Hour, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("daemonLoop() error = %v", err)
+	}
+}
+
+func TestParseUpgradeInterval(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  time.Duration
+	}{
+		{"empty uses default", "", defaultUpgradeInterval},
+		{"valid 10m", "10m", 10 * time.Minute},
+		{"valid 30s", "30s", 30 * time.Second},
+		{"invalid falls back to default", "not-a-duration", defaultUpgradeInterval},
+		{"zero falls back to default", "0s", defaultUpgradeInterval},
+		{"negative falls back to default", "-5m", defaultUpgradeInterval},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseUpgradeInterval(config.DaemonConfig{UpgradeInterval: tt.input})
+			if got != tt.want {
+				t.Errorf("parseUpgradeInterval(%q) = %s, want %s", tt.input, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -262,7 +321,7 @@ func TestDaemonNonBlockingDrain(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	err := daemonLoop(ctx, q, noopScan, slowDrain, nil, time.Hour, time.Millisecond)
+	err := daemonLoop(ctx, q, noopScan, slowDrain, nil, nil, time.Hour, time.Millisecond, 0)
 	elapsed := time.Since(start)
 
 	if err != nil {

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -111,6 +111,10 @@ type DaemonConfig struct {
 	ScanInterval  string `yaml:"scan_interval,omitempty"`
 	DrainInterval string `yaml:"drain_interval,omitempty"`
 	AutoUpgrade   bool   `yaml:"auto_upgrade,omitempty"`
+	// UpgradeInterval controls how often the daemon re-runs the
+	// auto_upgrade check while the loop is running. Only meaningful when
+	// AutoUpgrade is true. Defaults to 5m. Accepts any Go duration string.
+	UpgradeInterval string `yaml:"upgrade_interval,omitempty"`
 	// AutoMerge enables automatic copilot review cycle + merge of
 	// xylem-authored PRs. Only merges when the PR is approved, CI-green,
 	// and mergeable. Branches matching feat/issue-*, fix/issue-*, or


### PR DESCRIPTION
## Summary
Auto_upgrade previously only ran at daemon startup. This meant the daemon kept running a stale binary until a human restarted it — exactly what just happened with PRs #139/#140, which sat unused for 30+ minutes because the running daemon started before they merged.

## Change
Add a periodic upgrade check inside \`daemonLoop\`:
- Runs every \`daemon.upgrade_interval\` (default: **5 minutes**), configurable in \`.xylem.yml\`.
- Skipped while a drain goroutine is in-flight, so vessels are never killed mid-execution.
- Shares the same \`selfUpgrade\` closure used at startup (no behavior split).
- First check fires after \`upgradeInterval\` elapses, not immediately (startup already ran once).

When a newer binary is detected, \`selfUpgrade\` exec()s with the same PID and re-acquires the lock. No downtime, no manual restart.

## Impact
After this lands and the daemon restarts **once**, xylem becomes truly self-updating: future merges activate within ~5 minutes automatically.

## Test plan
- [x] \`TestDaemonLoopPeriodicUpgradeFiresAfterInterval\` — proves the closure is called ≥3 times in 100ms with 10ms interval
- [x] \`TestDaemonLoopPeriodicUpgradeNilDisables\` — nil upgrade doesn't panic
- [x] \`TestParseUpgradeInterval\` — 6 cases covering empty/valid/invalid/zero/negative
- [x] Full \`go test ./...\` passes (all existing tests + 8 new test cases)
- [x] \`goimports\`, \`golangci-lint\`, \`go build\` all clean

## Config (optional)
\`\`\`yaml
daemon:
  auto_upgrade: true
  upgrade_interval: 5m  # default, can omit
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)