### PR TITLE
feat: tighten runner policy intent verification and protected surface coverage

### DIFF
--- a/.claude/rules/protected-surfaces.md
+++ b/.claude/rules/protected-surfaces.md
@@ -1,1 +1,5 @@
-Do not modify, delete, or move any files under .xylem/ or the .xylem.yml config file. These are protected workflow and prompt definitions managed by the xylem control plane.
+Do not modify, delete, or move the configured protected control surfaces managed by the xylem control plane:
+- .xylem/HARNESS.md
+- .xylem.yml
+- .xylem/workflows/*.yaml
+- .xylem/prompts/*/*.md

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/surface"
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"pgregory.net/rapid"
@@ -56,10 +57,10 @@ func TestProp_BudgetEnforcementNeverLeaksAcrossVessels(t *testing.T) {
 	})
 }
 
-func TestProp_PromptOnlyCostAlwaysNonNegative(t *testing.T) {
+func TestProp_PromptOnlyUsageAccumulatesEstimatedTotals(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		prompt := rapid.StringMatching(`[a-zA-Z0-9 ]{1,120}`).Draw(t, "prompt")
-		output := rapid.StringMatching(`[a-zA-Z0-9 ]{1,240}`).Draw(t, "output")
+		prompt := rapid.StringMatching(`[a-zA-Z0-9 ]{0,120}`).Draw(t, "prompt")
+		output := rapid.StringMatching(`[a-zA-Z0-9 ]{0,240}`).Draw(t, "output")
 
 		cfg := &config.Config{}
 		setPricedModel(cfg)
@@ -69,11 +70,35 @@ func TestProp_PromptOnlyCostAlwaysNonNegative(t *testing.T) {
 			Source: "manual",
 			Prompt: prompt,
 		}, time.Now().UTC())
-		vrs.recordPromptOnlyUsage("claude-sonnet-4", prompt, output, time.Now().UTC())
+		inputTokens, outputTokens, costUSDEst := vrs.recordPromptOnlyUsage("claude-sonnet-4", prompt, output, time.Now().UTC())
 
 		summary := vrs.buildSummary("completed", time.Now().UTC())
-		if summary.TotalCostUSDEst < 0 {
-			t.Fatalf("summary.TotalCostUSDEst = %f, want >= 0", summary.TotalCostUSDEst)
+		wantInputTokens := cost.EstimateTokens(prompt)
+		if inputTokens != wantInputTokens {
+			t.Fatalf("inputTokens = %d, want %d", inputTokens, wantInputTokens)
+		}
+		wantOutputTokens := cost.EstimateTokens(output)
+		if outputTokens != wantOutputTokens {
+			t.Fatalf("outputTokens = %d, want %d", outputTokens, wantOutputTokens)
+		}
+		wantCostUSDEst := cost.EstimateCost(wantInputTokens, wantOutputTokens, cost.LookupPricing("claude-sonnet-4"))
+		if costUSDEst != wantCostUSDEst {
+			t.Fatalf("costUSDEst = %f, want %f", costUSDEst, wantCostUSDEst)
+		}
+		if summary.TotalInputTokensEst != inputTokens {
+			t.Fatalf("summary.TotalInputTokensEst = %d, want %d", summary.TotalInputTokensEst, inputTokens)
+		}
+		if summary.TotalOutputTokensEst != outputTokens {
+			t.Fatalf("summary.TotalOutputTokensEst = %d, want %d", summary.TotalOutputTokensEst, outputTokens)
+		}
+		if summary.TotalTokensEst != inputTokens+outputTokens {
+			t.Fatalf("summary.TotalTokensEst = %d, want %d", summary.TotalTokensEst, inputTokens+outputTokens)
+		}
+		if summary.TotalCostUSDEst != costUSDEst {
+			t.Fatalf("summary.TotalCostUSDEst = %f, want %f", summary.TotalCostUSDEst, costUSDEst)
+		}
+		if len(summary.Phases) != 0 {
+			t.Fatalf("len(summary.Phases) = %d, want 0", len(summary.Phases))
 		}
 	})
 }
@@ -135,6 +160,111 @@ func TestProp_FormatViolationsIncludesEveryViolation(t *testing.T) {
 		want := strings.Join(wantParts, "; ")
 		if formatted != want {
 			t.Fatalf("formatViolations() = %q, want %q", formatted, want)
+		}
+	})
+}
+
+func TestProp_PhasePolicyIntentsStayUniqueAndClassifyHighRiskActions(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		dir, err := os.MkdirTemp("", "runner-policy-prop-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(dir)
+
+		cfg := makeTestConfig(dir, 1)
+		fallbackRepo := rapid.StringMatching(`[a-z0-9][a-z0-9-]{0,11}/[a-z0-9][a-z0-9-]{0,11}`).Draw(t, "fallbackRepo")
+		r := New(cfg, nil, nil, nil)
+		r.Sources = map[string]source.Source{
+			"github-issue": &source.GitHub{Repo: fallbackRepo},
+		}
+
+		isCommand := rapid.Bool().Draw(t, "isCommand")
+		commitRepeats := rapid.IntRange(0, 3).Draw(t, "commitRepeats")
+		pushRepeats := rapid.IntRange(0, 3).Draw(t, "pushRepeats")
+		prRepeats := rapid.IntRange(0, 3).Draw(t, "prRepeats")
+		explicitRepo := rapid.Bool().Draw(t, "explicitRepo")
+		pushBranch := rapid.StringMatching(`[a-z0-9][a-z0-9-]{0,15}`).Draw(t, "pushBranch")
+		prRepo := rapid.StringMatching(`[a-z0-9][a-z0-9-]{0,11}/[a-z0-9][a-z0-9-]{0,11}`).Draw(t, "prRepo")
+
+		var parts []string
+		for range commitRepeats {
+			parts = append(parts, "commit all changes")
+		}
+		for range pushRepeats {
+			parts = append(parts, "git push origin "+pushBranch)
+		}
+		for range prRepeats {
+			prCommand := "gh pr create"
+			if explicitRepo {
+				prCommand += " --repo " + prRepo
+			}
+			parts = append(parts, prCommand)
+		}
+		classificationText := strings.Join(parts, " && ")
+
+		p := workflow.Phase{Name: "apply"}
+		renderedPrompt := classificationText
+		renderedCommand := ""
+		wantBaseAction := "phase_execute"
+		if isCommand {
+			p.Type = "command"
+			renderedCommand = classificationText
+			renderedPrompt = ""
+			wantBaseAction = "external_command"
+		}
+
+		vessel := queue.Vessel{
+			ID:       "issue-1",
+			Source:   "github-issue",
+			Workflow: "fix-bug",
+		}
+
+		intents := r.phasePolicyIntents(vessel, p, renderedCommand, renderedPrompt)
+		counts := make(map[string]int)
+		resources := make(map[string]string)
+		for _, intent := range intents {
+			key := intent.Action + "\x00" + intent.Resource
+			counts[key]++
+			if counts[key] > 1 {
+				t.Fatalf("duplicate intent generated for %q/%q: %+v", intent.Action, intent.Resource, intents)
+			}
+			resources[intent.Action] = intent.Resource
+		}
+
+		if counts[wantBaseAction+"\x00"+p.Name] != 1 {
+			t.Fatalf("base intent count = %d, want 1 (intents=%+v)", counts[wantBaseAction+"\x00"+p.Name], intents)
+		}
+
+		if commitRepeats == 0 {
+			if _, ok := resources["git_commit"]; ok {
+				t.Fatalf("unexpected git_commit intent in %+v", intents)
+			}
+		} else if resources["git_commit"] != "*" {
+			t.Fatalf("git_commit resource = %q, want *", resources["git_commit"])
+		}
+
+		if pushRepeats == 0 {
+			if _, ok := resources["git_push"]; ok {
+				t.Fatalf("unexpected git_push intent in %+v", intents)
+			}
+		} else if resources["git_push"] != pushBranch {
+			t.Fatalf("git_push resource = %q, want %q", resources["git_push"], pushBranch)
+		}
+
+		if prRepeats == 0 {
+			if _, ok := resources["pr_create"]; ok {
+				t.Fatalf("unexpected pr_create intent in %+v", intents)
+			}
+			return
+		}
+
+		wantPRRepo := fallbackRepo
+		if explicitRepo {
+			wantPRRepo = prRepo
+		}
+		if resources["pr_create"] != wantPRRepo {
+			t.Fatalf("pr_create resource = %q, want %q", resources["pr_create"], wantPRRepo)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Follow-up for [issue #86](https://github.com/nicholls-inc/xylem/issues/86) that tightens verification around runner policy enforcement and protected surface handling.
- Extends property coverage so high-risk intents (`git_commit`, `git_push`, `pr_create`) stay uniquely classified across command and prompt phases.
- Strengthens prompt-only usage accounting assertions and clarifies the exact `.xylem` control surfaces protected by the harness rule.

## Smoke scenarios covered
- S18: Runner policy denies a phase — vessel fails with "denied by policy"
- S19: Runner policy require_approval — vessel fails with approval message
- S21: Surface post-verification detects mutation — vessel fails
- S23: Audit log records surface violations
- S26: formatViolations produces human-readable output

## Changes summary
- **Files modified:** `.claude/rules/protected-surfaces.md`, `cli/internal/runner/runner_prop_test.go`
- **Files added:** none
- Enumerated the protected control surfaces managed by the xylem control plane: `.xylem/HARNESS.md`, `.xylem.yml`, workflow YAML, and prompt markdown.
- Replaced the prompt-only property test with `TestProp_PromptOnlyUsageAccumulatesEstimatedTotals` and added `TestProp_PhasePolicyIntentsStayUniqueAndClassifyHighRiskActions`.
- **Key types and functions:** `Runner`, `queue.Vessel`, `workflow.Phase`, `source.GitHub`, `surface.Violation`, `recordPromptOnlyUsage`, `buildSummary`, `phasePolicyIntents`, `formatViolations`.

## Test plan
- `cd cli && go test ./internal/runner`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #86