### PR TITLE
fix: run periodic auto-upgrade at drain-end, not mid-tick

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -165,9 +165,12 @@ const defaultUpgradeInterval = 5 * time.Minute
 // externally-controlled context so tests can cancel it without signals,
 // and injectable scan/drain/check functions so tests can use stubs.
 //
-// If upgrade is non-nil, it is called periodically (every upgradeInterval)
-// while no drain goroutine is in-flight, so that newly-merged binary fixes
-// activate without manual restart. Pass nil/zero to disable.
+// If upgrade is non-nil, it is called at the END of each drain cycle — when
+// every vessel processed in that cycle has reached a terminal state and no
+// subprocesses are alive — provided at least upgradeInterval has elapsed
+// since the last attempt. This gives the daemon a guaranteed-idle window to
+// exec() into a newer binary without killing in-flight vessel work. Pass
+// nil/zero upgrade/upgradeInterval to disable.
 func daemonLoop(ctx context.Context, q *queue.Queue, scan scanFunc, drain drainFunc, check checkFunc, upgrade upgradeFunc, scanInterval, drainInterval, upgradeInterval time.Duration) error {
 	tickInterval := scanInterval
 	if drainInterval < tickInterval {
@@ -219,20 +222,6 @@ func daemonLoop(ctx context.Context, q *queue.Queue, scan scanFunc, drain drainF
 			check(ctx)
 		}
 
-		// Periodic self-upgrade: check for a newer binary on main and
-		// exec() into it if the hash changed. Only runs when no drain is
-		// in-flight, to avoid killing a running vessel mid-execution.
-		// selfUpgrade handles the exec() internally; if it returns, either
-		// nothing changed or the attempt failed and we keep running.
-		if upgrade != nil && upgradeInterval > 0 && now.Sub(lastUpgrade) >= upgradeInterval {
-			if atomic.LoadInt32(&draining) == 0 {
-				lastUpgrade = now
-				upgrade()
-			} else {
-				log.Printf("daemon: periodic upgrade deferred — drain in-flight")
-			}
-		}
-
 		if now.Sub(lastDrain) >= drainInterval {
 			if atomic.CompareAndSwapInt32(&draining, 0, 1) {
 				lastDrain = now
@@ -243,10 +232,26 @@ func daemonLoop(ctx context.Context, q *queue.Queue, scan scanFunc, drain drainF
 					drainResult, err := drain(ctx)
 					if err != nil {
 						log.Printf("daemon: drain error: %v", err)
-						return
+					} else {
+						log.Printf("daemon: drain complete — completed=%d failed=%d skipped=%d",
+							drainResult.Completed, drainResult.Failed, drainResult.Skipped)
 					}
-					log.Printf("daemon: drain complete — completed=%d failed=%d skipped=%d",
-						drainResult.Completed, drainResult.Failed, drainResult.Skipped)
+
+					// Drain-end self-upgrade: every vessel processed in this
+					// cycle has reached a terminal state (completed, failed,
+					// or timed_out) — there are no subprocesses alive right
+					// now, so exec() is safe. Runs regardless of drain
+					// success/failure, since vessels are in persistent state
+					// either way. lastUpgrade is only written from within
+					// this goroutine (and the CAS guard ensures one drain
+					// runs at a time), so no synchronisation is required.
+					if upgrade != nil && upgradeInterval > 0 {
+						drainEnd := daemonNow()
+						if drainEnd.Sub(lastUpgrade) >= upgradeInterval {
+							lastUpgrade = drainEnd
+							upgrade()
+						}
+					}
 				}()
 			}
 		}

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -239,25 +239,50 @@ func TestSmoke_S32_TracerShutdownDeferredInDaemonPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, exporter.shutdownCalled)
 }
-func TestDaemonLoopPeriodicUpgradeFiresAfterInterval(t *testing.T) {
+func TestDaemonLoopPeriodicUpgradeFiresAtDrainEnd(t *testing.T) {
 	dir := t.TempDir()
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
 
 	var upgradeCalls atomic.Int32
 	upgrade := func() { upgradeCalls.Add(1) }
 
-	// Tick fast (1ms), upgrade every 10ms. Within 100ms we expect at least 3
-	// upgrade calls, proving the periodic check fires.
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	// drainInterval=2ms so drains fire rapidly; upgradeInterval=1ms so every
+	// drain end should trigger an upgrade. Over 200ms we expect at least 5
+	// upgrade calls, proving the drain-end check fires on every cycle.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, noopScan, noopDrain, nil, upgrade, time.Millisecond, time.Hour, 10*time.Millisecond)
+	err := daemonLoop(ctx, q, noopScan, noopDrain, nil, upgrade, time.Hour, 2*time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
 
-	if got := upgradeCalls.Load(); got < 3 {
-		t.Errorf("upgrade called %d times, want at least 3", got)
+	if got := upgradeCalls.Load(); got < 5 {
+		t.Errorf("upgrade called %d times, want at least 5", got)
+	}
+}
+
+func TestDaemonLoopPeriodicUpgradeRespectsInterval(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	var upgradeCalls atomic.Int32
+	upgrade := func() { upgradeCalls.Add(1) }
+
+	// drainInterval=2ms → drains fire rapidly (~50 drains in 100ms), but
+	// upgradeInterval=10s → upgrade fires at most ONCE in that window.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := daemonLoop(ctx, q, noopScan, noopDrain, nil, upgrade, time.Hour, 2*time.Millisecond, 10*time.Second)
+	if err != nil {
+		t.Fatalf("daemonLoop() error = %v", err)
+	}
+
+	// With lastUpgrade initialised to daemonNow() at startup and a 10s
+	// interval, no upgrade should fire within 100ms.
+	if got := upgradeCalls.Load(); got != 0 {
+		t.Errorf("upgrade called %d times, want 0 (interval not elapsed)", got)
 	}
 }
 
@@ -269,9 +294,55 @@ func TestDaemonLoopPeriodicUpgradeNilDisables(t *testing.T) {
 	defer cancel()
 
 	// Passing nil upgrade should not panic even with a non-zero interval.
-	err := daemonLoop(ctx, q, noopScan, noopDrain, nil, nil, time.Hour, time.Hour, 10*time.Millisecond)
+	err := daemonLoop(ctx, q, noopScan, noopDrain, nil, nil, time.Hour, 2*time.Millisecond, 10*time.Millisecond)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
+	}
+}
+
+// TestDaemonLoopUpgradeWaitsForDrainCompletion verifies the upgrade callback
+// only fires AFTER the drain function returns — i.e., in a guaranteed idle
+// window where no vessel subprocesses are alive.
+func TestDaemonLoopUpgradeWaitsForDrainCompletion(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	var (
+		drainActive atomic.Int32
+		drainSeen   atomic.Int32
+		upgradeSaw  atomic.Int32
+	)
+	slowDrain := func(_ context.Context) (runner.DrainResult, error) {
+		drainActive.Store(1)
+		drainSeen.Add(1)
+		defer drainActive.Store(0)
+		// Hold drain long enough for the tick loop to observe it.
+		time.Sleep(20 * time.Millisecond)
+		return runner.DrainResult{}, nil
+	}
+	upgrade := func() {
+		// If the drain goroutine were still running when upgrade fires,
+		// drainActive would be 1. Option A guarantees it's 0 (drain has
+		// returned, but the defer clearing `draining` hasn't run yet).
+		if drainActive.Load() != 0 {
+			t.Errorf("upgrade fired while drain active")
+		}
+		upgradeSaw.Add(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	err := daemonLoop(ctx, q, noopScan, slowDrain, nil, upgrade, time.Hour, time.Millisecond, time.Millisecond)
+	if err != nil {
+		t.Fatalf("daemonLoop() error = %v", err)
+	}
+
+	if drainSeen.Load() < 2 {
+		t.Errorf("expected at least 2 drain invocations, got %d", drainSeen.Load())
+	}
+	if upgradeSaw.Load() < 2 {
+		t.Errorf("expected at least 2 upgrade invocations, got %d", upgradeSaw.Load())
 	}
 }
 


### PR DESCRIPTION
## Summary
Moves the periodic auto-upgrade check out of the main tick loop and into the drain goroutine's tail (after \`drain()\` returns, before \`draining\` is cleared). This guarantees a fully-idle window — all vessels processed in that cycle have reached terminal state, no subprocesses alive — so \`syscall.Exec()\` is safe.

## Why
The old implementation gated the upgrade on \`draining == 0\` in the main tick loop. In practice drains are almost always in-flight, so every tick logged \`periodic upgrade deferred — drain in-flight\` and the upgrade never ran. Confirmed on the live daemon: PRs #139, #140, #141, #145, #148 all merged but the daemon needed manual restarts to activate them.

## Change
```go
go func() {
    defer drainWg.Done()
    defer atomic.StoreInt32(&draining, 0)
    drainResult, err := drain(ctx)
    // ... logging ...
    
    // Drain-end upgrade: guaranteed idle, no subprocesses alive
    if upgrade != nil && upgradeInterval > 0 {
        drainEnd := daemonNow()
        if drainEnd.Sub(lastUpgrade) >= upgradeInterval {
            lastUpgrade = drainEnd
            upgrade()
        }
    }
}()
```

## Cadence
Effective latency = \`upgradeInterval + next drain duration\`. With \`upgradeInterval: 5m\` and typical drain cycles of < 1 minute for non-harness work, new code activates within ~6 minutes of merge.

## Why not alternatives
- **Kill drains mid-flight on a separate timer**: wastes compute-heavy vessel work. Orphan recovery would retry from scratch.
- **Attach new process to running subprocesses across exec()**: Go's \`exec.Cmd\` holds child pipes; they close on exec and the subprocess hits EPIPE. Would require reinventing a process supervisor.
- **Block drain via mutex during upgrade**: unnecessary — the drain boundary is already idle.

## Test plan
- [x] \`TestDaemonLoopPeriodicUpgradeFiresAtDrainEnd\` — upgrade fires on every drain with \`upgradeInterval < drainInterval\`
- [x] \`TestDaemonLoopPeriodicUpgradeRespectsInterval\` — zero upgrades when \`drainInterval << upgradeInterval\`
- [x] \`TestDaemonLoopUpgradeWaitsForDrainCompletion\` — explicitly asserts \`drainActive == 0\` at the moment \`upgrade()\` is called (slow drain with 20ms delay, drainInterval=1ms)
- [x] \`TestDaemonLoopPeriodicUpgradeNilDisables\` — updated for new drainInterval default
- [x] Full \`go test ./...\` passes (all previous tests + 4 upgrade tests)
- [x] \`goimports\`, \`golangci-lint\`, \`go build\` all clean

## Closes
Known limitation noted in previous loop iterations: "The daemon's periodic auto-upgrade check defers while \`draining == 0\`, but drains are almost always in-flight."

🤖 Generated with [Claude Code](https://claude.com/claude-code)