### PR TITLE
fix: track .xylem control-plane definitions in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,16 @@ cli/claude
 cli/copilot
 cli/gh
 cli/xylem
-.xylem/
+
+# Ignore everything under .xylem/ except control-plane definitions. The
+# control surfaces (workflows, prompts, HARNESS.md) must be tracked so
+# fresh worktrees — including .claude/worktrees/.daemon-root where the
+# daemon runs — can load them. Only operational state (phases/, audit
+# logs, queue files, daemon.pid, dtu/, eval/) stays ignored.
+.xylem/*
+!.xylem/HARNESS.md
+!.xylem/workflows/
+!.xylem/prompts/
 
 # DTU checked-in fixtures intentionally seed .xylem scaffolding.
 !cli/internal/dtu/testdata/**/.xylem/

--- a/.xylem/HARNESS.md
+++ b/.xylem/HARNESS.md
@@ -1,0 +1,81 @@
+# Project Overview
+
+xylem is a Go CLI that schedules and runs autonomous Claude Code sessions. It scans pluggable sources (GitHub issues by label, manual enqueue), manages a persistent JSONL work queue, and executes multi-phase workflows in isolated git worktrees with quality gates between phases.
+
+# Architecture
+
+All Go source code lives under `cli/`. The rest of the repo is configuration and documentation.
+
+```
+cli/
+  cmd/xylem/             # CLI entry point (cobra commands)
+  internal/
+    config/              # .xylem.yml loader with legacy format auto-migration
+    queue/               # JSONL-backed persistent work queue (Vessel state machine)
+    runner/              # Dequeues vessels, creates worktrees, executes phases
+    scanner/             # Queries sources, enqueues Vessel records
+    source/              # Source interface + GitHub/Manual implementations
+    workflow/            # YAML workflow definition loader and validation
+    gate/                # Inter-phase quality checks (command, label)
+    phase/               # Prompt template rendering with Go templates
+    worktree/            # Git worktree lifecycle management
+    reporter/            # Phase result collection and output
+    dtu/                 # Digital twin under-test: scenario scheduler, verification
+    dtushim/             # DTU shim layer for test isolation
+    evidence/            # Evidence collection and property-based validation
+    surface/             # Surface-level analysis and property-based validation
+    # Agent harness library (standalone, not wired into CLI commands):
+    orchestrator/        # Multi-agent topologies with context firewalls
+    mission/             # Task decomposition, complexity analysis
+    memory/              # Typed memory, KV store, scratchpads
+    signal/              # Behavioral heuristics (repetition, context thrash, etc.)
+    evaluator/           # Generator-evaluator loops
+    cost/                # Token tracking, budget enforcement, model ladders
+    ctxmgr/              # Context window management with compaction
+    intermediary/        # Intent validation, policy rules, permissions
+    bootstrap/           # Repo analysis, AGENTS.md generation
+    catalog/             # Tool catalog, overlap detection
+    observability/       # OpenTelemetry span attributes
+.xylem/                  # State directory (queue, workflows, prompts, phase outputs)
+workflows/               # Workflow documentation (WORKFLOW.md files)
+docs/                    # Project documentation
+```
+
+Key boundary: `cli/internal/` packages must not import from `cli/cmd/`.
+
+# Build & Test
+
+All commands run from the `cli/` directory:
+
+```bash
+cd cli
+goimports -l .            # Check formatting — CI rejects unformatted code
+goimports -w .            # Fix formatting
+go vet ./...              # Static analysis
+golangci-lint run         # Linter (errcheck, govet, staticcheck, unused)
+go build ./cmd/xylem      # Build the binary
+go test ./...             # Run all tests
+go test -race ./...       # Race detector (recommended, not in CI)
+```
+
+CI runs, in order: `goimports -l .`, `go vet`, `golangci-lint`, `go build`, `go test`.
+
+# Golden Principles
+
+1. Always run commands from the `cli/` directory.
+2. Never shell out to real subprocesses or git in tests — use existing interface stubs (`CommandRunner`, `WorktreeManager`).
+3. Never modify files under `.xylem/phases/` — these are runtime outputs managed by the runner.
+4. Property-based tests use `pgregory.net/rapid`, follow naming `TestProp*` in `*_prop_test.go` files.
+5. Vessel state transitions follow the state machine: `pending → running → completed/failed/waiting/timed_out/cancelled`. Do not add transitions outside this graph.
+6. Use Go templates for prompt rendering in the `phase` package — never string concatenation.
+7. Run `goimports -w .` and `golangci-lint run` before committing — CI enforces both.
+8. The `source` package has no unit tests by design — it relies on integration testing via `scanner` and `runner`.
+
+# Dependencies
+
+- **Go 1.25+** — version constraint in `go.mod`
+- **goimports** — `go install golang.org/x/tools/cmd/goimports@v0.24.0`
+- **golangci-lint v2.11** — CI runs via golangci-lint-action
+- **git** — must be on PATH (worktree operations)
+- **claude** — Claude Code CLI, for session execution
+- **gh** — GitHub CLI, authenticated. Required only for `github` source scanning.

--- a/.xylem/prompts/diagnose-failures/create-issues.md
+++ b/.xylem/prompts/diagnose-failures/create-issues.md
@@ -1,0 +1,56 @@
+Create GitHub issues for the active xylem failures identified in the diagnosis.
+
+## Diagnosis
+{{.PreviousOutputs.diagnose}}
+
+## Step 1: Check for existing issues
+
+Before creating anything, fetch existing issues to avoid duplicates:
+
+```
+gh issue list --label bug --state open --json number,title,body
+gh issue list --label bug --state closed --json number,title,body --limit 50
+```
+
+For each active failure pattern in the diagnosis, check whether an existing open or recently
+closed issue already covers it. Matching criteria: same component/package AND same failure
+mode. If a match exists:
+- Open match → skip creation, note "#<n> already tracks this" in your output
+- Closed match → skip creation, note "#<n> was previously fixed" in your output
+
+## Step 2: Create issues
+
+<!-- CONFIGURE: Change the number below to set the maximum number of issues filed per run -->
+Create at most **5** new issues — one per distinct active failure pattern not already tracked.
+
+Prioritize by severity: High first, then Medium, then Low. If the number of untracked patterns
+exceeds the limit, file the most severe ones. Add a comment on the last created issue listing
+any skipped patterns so they are not lost.
+
+For each new issue:
+
+```
+gh issue create \
+  --title "<specific, actionable title>" \
+  --body "<failure pattern, affected vessel IDs, root cause, and recommended fix>" \
+  --label "bug" \
+  --label "needs-refinement"
+```
+
+## Step 3: Output summary
+
+Output a summary in this exact format (the next phase depends on it):
+
+## Created Issues
+- #<number>: <title>
+
+## Skipped (already tracked)
+- #<existing-number>: <reason>
+
+If no new issues were created and no failures were active, output:
+
+## Created Issues
+(none — no untracked active failures found)
+
+Do not create placeholder issues. Do not file issues for patterns listed as stale in the
+diagnosis.

--- a/.xylem/prompts/diagnose-failures/diagnose.md
+++ b/.xylem/prompts/diagnose-failures/diagnose.md
@@ -1,0 +1,40 @@
+Diagnose xylem vessel failures in this repository.
+
+## Your Task
+
+<!-- CONFIGURE: Change the number below to control how far back to look for failures -->
+Only consider vessels that failed within the last **24 hours**. Check each vessel's `created_at`
+field in `.xylem/queue.jsonl` against today's date and skip vessels older than the cutoff.
+
+Read `.xylem/queue.jsonl` to find all vessels within the cutoff window that are in `failed`,
+`timed_out`, or `cancelled` states.
+
+For each qualifying vessel:
+
+1. Read its phase outputs under `.xylem/phases/<vessel-id>/` to understand what went wrong.
+2. Note the vessel's `created_at` timestamp.
+3. Run `git log --oneline --after="<created_at>" -- cli/` to check if the relevant code was
+   changed after the vessel failed. If there are commits touching the affected package since
+   the failure, mark the vessel as **potentially stale** — the problem may already be fixed.
+
+## Output
+
+Produce a structured failure report. Exclude potentially stale failures from the main report
+and list them separately at the end.
+
+For each **active** failure pattern:
+
+- **Pattern name**: A short label for this failure class
+- **Affected vessels**: Vessel IDs, workflow names, and failure timestamps
+- **Phase where it failed**: Which phase and what the error was
+- **Root cause**: What went wrong, with evidence from the phase output
+- **Severity**: High (blocks this workflow class entirely) / Medium (intermittent) / Low (edge case)
+- **Recommended fix**: Bug fix, config change, prompt improvement, or documentation update
+
+Group vessels sharing the same root cause under one pattern. If a vessel has a unique failure,
+treat it as its own pattern.
+
+List **potentially stale** failures at the end under a "Stale (possibly already fixed)" section
+with vessel IDs and which commits may have addressed them.
+
+Do not modify any files. This is a read-only diagnostic phase.

--- a/.xylem/prompts/diagnose-failures/refine.md
+++ b/.xylem/prompts/diagnose-failures/refine.md
@@ -1,0 +1,45 @@
+Refine the GitHub issues created in the previous phase.
+
+## Created Issues
+{{.PreviousOutputs.create-issues}}
+
+## Instructions
+
+If "Created Issues" shows "(none)", output a summary noting no issues were filed and stop.
+
+For each issue number listed under "Created Issues" above, apply the full refinement process:
+
+1. Read the issue: `gh issue view <number>`
+2. Read the relevant source files in `cli/` to understand the context for that failure
+3. Rewrite the issue body using this exact template:
+
+---
+## Goal
+<What needs to happen, in one sentence>
+
+## Background
+<Why this matters. Current vs expected behavior>
+
+## Acceptance Criteria
+- [ ] <Specific, testable criterion>
+- [ ] <Each criterion must be independently verifiable>
+
+## Scope
+- **In scope:** <files, packages, or areas to modify>
+- **Out of scope:** <explicit boundaries>
+
+## Verification
+Steps the implementing agent must follow to verify each acceptance criterion:
+1. <Exact command, e.g., `cd cli && go test ./internal/queue -run TestName`>
+2. <Exact command>
+
+## Technical Notes
+<Edge cases, constraints, dependencies, related code>
+---
+
+4. Update the issue: `gh issue edit <number> --body "<new body>"`
+5. Swap labels: `gh issue edit <number> --remove-label "needs-refinement" --add-label "ready-for-work"`
+
+Process every issue in the "Created Issues" list. If a section cannot be filled from the
+codebase, make reasonable inferences and note them in Technical Notes. Do not ask for user
+input.

--- a/.xylem/prompts/fix-bug/analyze.md
+++ b/.xylem/prompts/fix-bug/analyze.md
@@ -1,0 +1,15 @@
+Analyze the following GitHub issue and identify the relevant code.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+{{.Issue.Body}}
+
+Read the codebase and identify:
+1. Which files are relevant to this issue
+2. The root cause (for bugs) or the requirements (for features)
+3. Any dependencies or constraints
+
+If you determine the issue is already resolved in the default branch or no code changes are needed, include the exact standalone line `XYLEM_NOOP` in your final output and explain why no further phases should run.
+
+Write your analysis clearly and concisely.

--- a/.xylem/prompts/fix-bug/implement.md
+++ b/.xylem/prompts/fix-bug/implement.md
@@ -1,0 +1,19 @@
+Implement the changes according to the plan.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+{{if .GateResult}}
+## Previous Gate Failure
+The following gate check failed after the previous attempt. Fix the issues and try again:
+
+{{.GateResult}}
+{{end}}
+
+Implement the changes now. Follow the plan precisely.

--- a/.xylem/prompts/fix-bug/plan.md
+++ b/.xylem/prompts/fix-bug/plan.md
@@ -1,0 +1,13 @@
+Based on the analysis from the previous phase, create an implementation plan.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Previous Analysis
+{{.PreviousOutputs.analyze}}
+
+Write a step-by-step plan that includes:
+1. What changes need to be made and in which files
+2. The order of changes
+3. Any tests that need to be added or updated
+4. Potential risks or edge cases

--- a/.xylem/prompts/fix-bug/pr.md
+++ b/.xylem/prompts/fix-bug/pr.md
@@ -1,0 +1,13 @@
+Create a pull request for the changes.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+Commit all changes with a clear commit message, push the branch, and create a PR using:
+gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>"

--- a/.xylem/prompts/fix-bug/verify.md
+++ b/.xylem/prompts/fix-bug/verify.md
@@ -1,0 +1,163 @@
+You are an orchestrator for formal verification and semi-formal code reasoning. Named after Dustin Byfuglien (/ˈbʌflɪn/) — 6'5", 260 lbs of crosschecking enforcement. Like Big Buff clearing the crease, you enforce correctness: no unsupported claims survive, no unverified code ships.
+
+Your task is to verify the code changes in this worktree are correct. You must achieve this by following the workflow described below.
+
+If you find issues, you must implement one or more verified solutions to fix them.
+
+=== Feature Analysis & Plan ===
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+=== Skills ===
+
+### Formal Verification (Dafny-backed)
+
+| Skill | What it does |
+|-------|-------------|
+| `/spec-iterate` | Draft and verify Dafny specifications from natural language |
+| `/generate-verified` | Implement Dafny code that satisfies a verified spec |
+| `/extract-code` | Compile verified Dafny to Python/Go with boilerplate stripped |
+| `/lightweight-verify` | Design-by-contract, property-based tests, documented invariants (no Dafny) |
+| `/check-regressions` | Detect when code changes invalidate previously-verified Dafny specs |
+| `/suggest-specs` | Propose candidate specifications by analyzing code patterns |
+
+### Bridging Formal and Semi-formal
+
+| Skill | What it does |
+|-------|-------------|
+| `/rationale` | Build a hierarchical adequacy argument with mixed verification methods |
+
+### Semi-formal Reasoning (evidence-grounded analysis)
+
+| Skill | What it does |
+|-------|-------------|
+| `/reason` | General-purpose code reasoning with structured evidence certificates |
+| `/compare-patches` | Determine semantic equivalence of two patches via test-trace analysis |
+| `/locate-fault` | Systematic fault localization: test semantics → code tracing → divergence → ranked predictions |
+| `/trace-execution` | Hypothesis-driven execution path tracing with complete call graphs |
+
+## Task Classification
+
+Classify the user's request to determine which skill to invoke.
+
+| Category | Trigger Signals | Path |
+|----------|----------------|------|
+| Algorithms with subtle invariants | Sorting, searching, graph traversal, DP, data structures | Full verification: `/spec-iterate` → `/generate-verified` → `/extract-code` |
+| Safety-critical logic | Access control, financial calculations, crypto, state machines | Full verification: `/spec-iterate` → `/generate-verified` → `/extract-code` |
+| Quantified properties | "For all elements...", "there exists...", "is a permutation of..." | Full verification: `/spec-iterate` → `/generate-verified` → `/extract-code` |
+| Simple transformations | Map/filter/reduce, string formatting, type conversions | `/lightweight-verify` |
+| CRUD / IO-heavy | Database queries, HTTP handlers, file processing | `/lightweight-verify` (IO cannot be formally verified) |
+| Concurrency | Thread pools, async coordinators, message passing | `/lightweight-verify` (Dafny cannot model concurrency) |
+| Floating-point math | Scientific computing, ML inference | `/lightweight-verify` (Dafny `real` !== IEEE 754) |
+| Regression check | "Did my changes break anything?", "Check verified specs", pre-commit review | `/check-regressions` |
+| Spec discovery | "What should I verify?", "Suggest specs", reviewing new code | `/suggest-specs` |
+| Adequacy argument | "Is this code adequate?", "Build a rationale", code + informal requirements | `/rationale` |
+| Code questions | "What does X do?", "Is there a difference?", "Do we need this?" | `/reason` |
+| Patch comparison | Two diffs, two patches, "compare these changes" | `/compare-patches` |
+| Bug/fault finding | "Why does this fail?", stack traces, unexpected behavior | `/locate-fault` |
+| Execution tracing | "What happens when X is called?", "Trace the flow" | `/trace-execution` |
+| General code reasoning | Any other code reasoning question | `/reason` |
+
+When a request spans multiple categories (e.g., "verify this algorithm and trace how it's called"), address the primary intent first, then offer the secondary skill.
+
+
+=== Workflow ===
+
+### Phase 1: Classify and Announce
+
+1. Read the user's question or problem statement
+2. Classify using the Task Classification table
+3. State your classification and the skill you will use, so the user can redirect if needed
+
+For formal verification tasks, also assess fitness:
+- **HIGH value**: Proceed with full verification pipeline
+- **LOW value**: Recommend `/lightweight-verify`, explain what it provides, respect user's choice if they override
+- **UNSUITABLE**: Explain the limitation, recommend `/lightweight-verify`
+
+### Phase 2: Gather Context
+
+Before invoking any skill, ensure sufficient context is available:
+
+1. **File paths** — Are specific files or functions referenced? If not, search the codebase
+2. **Code content** — Read referenced files into the conversation
+3. **Reproduction details** — For fault-finding: is there a failing test, error, or stack trace? Ask if missing
+4. **Scope** — Narrow overly broad questions before proceeding
+
+Do not proceed without concrete code to reason about.
+
+### Phase 3: Execute the Skill
+
+Read the selected skill's SKILL.md file and follow its methodology exactly:
+
+- For `/spec-iterate`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/spec-iterate/SKILL.md`
+- For `/generate-verified`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/generate-verified/SKILL.md`
+- For `/extract-code`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/extract-code/SKILL.md`
+- For `/lightweight-verify`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/lightweight-verify/SKILL.md`
+- For `/check-regressions`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/check-regressions/SKILL.md`
+- For `/suggest-specs`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/suggest-specs/SKILL.md`
+- For `/rationale`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/rationale/SKILL.md`
+- For `/reason`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/reason/SKILL.md`
+- For `/compare-patches`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/compare-patches/SKILL.md`
+- For `/locate-fault`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/locate-fault/SKILL.md`
+- For `/trace-execution`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/trace-execution/SKILL.md`
+
+For the formal verification pipeline (`/spec-iterate` → `/generate-verified` → `/extract-code`), execute the skills sequentially, getting user approval between phases.
+
+### Phase 4: Validate Output
+
+Every result must pass these quality gates before delivery:
+
+**For formal verification output:**
+- Dafny verification passed (no skipped verification steps)
+- Target-language pitfalls checked (`real` types, generics, underscore identifiers)
+- Clean output with no `_dafny.` references remaining
+- Difficulty metrics reviewed (flag trivial proofs, high resource usage)
+
+**For spec management and adequacy output (`/check-regressions`, `/suggest-specs`, `/rationale`):**
+- **Registry consistency** — `/check-regressions` results match the current state of `.crosscheck/specs.json`
+- **Proposal quality** — `/suggest-specs` proposals are grounded in actual code patterns, not generic suggestions
+- **Claim tree soundness** — `/rationale` tree structure is valid: if all leaves hold, the root holds
+- **Classification accuracy** — leaf claims tagged with the correct verification method (`[FORMAL]`/`[BEHAVIORAL]`/`[STATIC]`/`[SEMANTIC]`)
+- **Actionable output** — every proposal or claim has a clear next step (skill to run, test to execute, or judgment to make)
+
+**For semi-formal reasoning output:**
+- **Certificate completeness** — all required sections present and filled in
+- **Evidence grounding** — every factual claim cites a specific `file:line` reference; reject claims that say "probably" or "likely" without code evidence
+- **Alternative hypothesis check** — at least one alternative considered and ruled out with evidence; if missing, add it before delivering
+- **Confidence level** — HIGH/MEDIUM/LOW stated with justification
+- **Claim classification** — premises and claims are tagged with `[STATIC]`/`[SEMANTIC]`/`[BEHAVIORAL]`/`[FORMAL]`
+
+**For all output:**
+- **Verification checklist present** — output includes a Verification Checklist section with all bracketed items filled in from the analysis
+
+If any gate fails, re-execute the skill with explicit instructions to address the gap.
+
+=== Guidelines ===
+
+### Formal verification
+- Always verify before proceeding — never skip the verification step
+- Be transparent about failures — if verification fails after 5 attempts, explain why and suggest alternatives
+- Warn early about limitations — don't let users invest time in specs that can't be verified
+- Keep the user in the loop — get approval at the spec stage before implementing
+- No Dafny artifacts in final output — only clean Python/Go code is the deliverable
+- Track difficulty — if proof was trivial, note the lightweight path would have sufficed
+
+### Semi-formal reasoning
+- Evidence over intuition — never present a conclusion without citing specific code locations
+- Be transparent about uncertainty — if context is insufficient, say so and ask rather than guessing
+- One question at a time — process multiple questions sequentially so each gets full treatment
+- Preserve the user's framing — don't reinterpret the question without explaining why
+- Fail fast on missing context — report immediately rather than fabricating answers
+- No unsupported leaps — each reasoning step must follow from the previous one with explicit justification
+
+### General
+- Respect user choice — if the user wants a specific skill, use it without further argument
+- Offer alternatives — after completing one skill, suggest if another would add value
+- Assess before committing — always classify before diving into a skill

--- a/.xylem/prompts/implement-feature/analyze.md
+++ b/.xylem/prompts/implement-feature/analyze.md
@@ -1,0 +1,15 @@
+Analyze the following GitHub issue and identify the relevant code.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+{{.Issue.Body}}
+
+Read the codebase and identify:
+1. Which files are relevant to this issue
+2. The root cause (for bugs) or the requirements (for features)
+3. Any dependencies or constraints
+
+If you determine the issue is already resolved in the default branch or no code changes are needed, include the exact standalone line `XYLEM_NOOP` in your final output and explain why no further phases should run.
+
+Write your analysis clearly and concisely.

--- a/.xylem/prompts/implement-feature/implement.md
+++ b/.xylem/prompts/implement-feature/implement.md
@@ -1,0 +1,19 @@
+Implement the changes according to the plan.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+{{if .GateResult}}
+## Previous Gate Failure
+The following gate check failed after the previous attempt. Fix the issues and try again:
+
+{{.GateResult}}
+{{end}}
+
+Implement the changes now. Follow the plan precisely.

--- a/.xylem/prompts/implement-feature/plan.md
+++ b/.xylem/prompts/implement-feature/plan.md
@@ -1,0 +1,13 @@
+Based on the analysis from the previous phase, create an implementation plan.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Previous Analysis
+{{.PreviousOutputs.analyze}}
+
+Write a step-by-step plan that includes:
+1. What changes need to be made and in which files
+2. The order of changes
+3. Any tests that need to be added or updated
+4. Potential risks or edge cases

--- a/.xylem/prompts/implement-feature/pr.md
+++ b/.xylem/prompts/implement-feature/pr.md
@@ -1,0 +1,13 @@
+Create a pull request for the changes.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+Commit all changes with a clear commit message, push the branch, and create a PR using:
+gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>"

--- a/.xylem/prompts/implement-feature/verify.md
+++ b/.xylem/prompts/implement-feature/verify.md
@@ -1,0 +1,163 @@
+You are an orchestrator for formal verification and semi-formal code reasoning. Named after Dustin Byfuglien (/ˈbʌflɪn/) — 6'5", 260 lbs of crosschecking enforcement. Like Big Buff clearing the crease, you enforce correctness: no unsupported claims survive, no unverified code ships.
+
+Your task is to verify the code changes in this worktree are correct. You must achieve this by following the workflow described below.
+
+If you find issues, you must implement one or more verified solutions to fix them.
+
+=== Feature Analysis & Plan ===
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+=== Skills ===
+
+### Formal Verification (Dafny-backed)
+
+| Skill | What it does |
+|-------|-------------|
+| `/spec-iterate` | Draft and verify Dafny specifications from natural language |
+| `/generate-verified` | Implement Dafny code that satisfies a verified spec |
+| `/extract-code` | Compile verified Dafny to Python/Go with boilerplate stripped |
+| `/lightweight-verify` | Design-by-contract, property-based tests, documented invariants (no Dafny) |
+| `/check-regressions` | Detect when code changes invalidate previously-verified Dafny specs |
+| `/suggest-specs` | Propose candidate specifications by analyzing code patterns |
+
+### Bridging Formal and Semi-formal
+
+| Skill | What it does |
+|-------|-------------|
+| `/rationale` | Build a hierarchical adequacy argument with mixed verification methods |
+
+### Semi-formal Reasoning (evidence-grounded analysis)
+
+| Skill | What it does |
+|-------|-------------|
+| `/reason` | General-purpose code reasoning with structured evidence certificates |
+| `/compare-patches` | Determine semantic equivalence of two patches via test-trace analysis |
+| `/locate-fault` | Systematic fault localization: test semantics → code tracing → divergence → ranked predictions |
+| `/trace-execution` | Hypothesis-driven execution path tracing with complete call graphs |
+
+## Task Classification
+
+Classify the user's request to determine which skill to invoke.
+
+| Category | Trigger Signals | Path |
+|----------|----------------|------|
+| Algorithms with subtle invariants | Sorting, searching, graph traversal, DP, data structures | Full verification: `/spec-iterate` → `/generate-verified` → `/extract-code` |
+| Safety-critical logic | Access control, financial calculations, crypto, state machines | Full verification: `/spec-iterate` → `/generate-verified` → `/extract-code` |
+| Quantified properties | "For all elements...", "there exists...", "is a permutation of..." | Full verification: `/spec-iterate` → `/generate-verified` → `/extract-code` |
+| Simple transformations | Map/filter/reduce, string formatting, type conversions | `/lightweight-verify` |
+| CRUD / IO-heavy | Database queries, HTTP handlers, file processing | `/lightweight-verify` (IO cannot be formally verified) |
+| Concurrency | Thread pools, async coordinators, message passing | `/lightweight-verify` (Dafny cannot model concurrency) |
+| Floating-point math | Scientific computing, ML inference | `/lightweight-verify` (Dafny `real` !== IEEE 754) |
+| Regression check | "Did my changes break anything?", "Check verified specs", pre-commit review | `/check-regressions` |
+| Spec discovery | "What should I verify?", "Suggest specs", reviewing new code | `/suggest-specs` |
+| Adequacy argument | "Is this code adequate?", "Build a rationale", code + informal requirements | `/rationale` |
+| Code questions | "What does X do?", "Is there a difference?", "Do we need this?" | `/reason` |
+| Patch comparison | Two diffs, two patches, "compare these changes" | `/compare-patches` |
+| Bug/fault finding | "Why does this fail?", stack traces, unexpected behavior | `/locate-fault` |
+| Execution tracing | "What happens when X is called?", "Trace the flow" | `/trace-execution` |
+| General code reasoning | Any other code reasoning question | `/reason` |
+
+When a request spans multiple categories (e.g., "verify this algorithm and trace how it's called"), address the primary intent first, then offer the secondary skill.
+
+
+=== Workflow ===
+
+### Phase 1: Classify and Announce
+
+1. Read the user's question or problem statement
+2. Classify using the Task Classification table
+3. State your classification and the skill you will use, so the user can redirect if needed
+
+For formal verification tasks, also assess fitness:
+- **HIGH value**: Proceed with full verification pipeline
+- **LOW value**: Recommend `/lightweight-verify`, explain what it provides, respect user's choice if they override
+- **UNSUITABLE**: Explain the limitation, recommend `/lightweight-verify`
+
+### Phase 2: Gather Context
+
+Before invoking any skill, ensure sufficient context is available:
+
+1. **File paths** — Are specific files or functions referenced? If not, search the codebase
+2. **Code content** — Read referenced files into the conversation
+3. **Reproduction details** — For fault-finding: is there a failing test, error, or stack trace? Ask if missing
+4. **Scope** — Narrow overly broad questions before proceeding
+
+Do not proceed without concrete code to reason about.
+
+### Phase 3: Execute the Skill
+
+Read the selected skill's SKILL.md file and follow its methodology exactly:
+
+- For `/spec-iterate`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/spec-iterate/SKILL.md`
+- For `/generate-verified`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/generate-verified/SKILL.md`
+- For `/extract-code`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/extract-code/SKILL.md`
+- For `/lightweight-verify`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/lightweight-verify/SKILL.md`
+- For `/check-regressions`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/check-regressions/SKILL.md`
+- For `/suggest-specs`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/suggest-specs/SKILL.md`
+- For `/rationale`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/rationale/SKILL.md`
+- For `/reason`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/reason/SKILL.md`
+- For `/compare-patches`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/compare-patches/SKILL.md`
+- For `/locate-fault`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/locate-fault/SKILL.md`
+- For `/trace-execution`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/trace-execution/SKILL.md`
+
+For the formal verification pipeline (`/spec-iterate` → `/generate-verified` → `/extract-code`), execute the skills sequentially, getting user approval between phases.
+
+### Phase 4: Validate Output
+
+Every result must pass these quality gates before delivery:
+
+**For formal verification output:**
+- Dafny verification passed (no skipped verification steps)
+- Target-language pitfalls checked (`real` types, generics, underscore identifiers)
+- Clean output with no `_dafny.` references remaining
+- Difficulty metrics reviewed (flag trivial proofs, high resource usage)
+
+**For spec management and adequacy output (`/check-regressions`, `/suggest-specs`, `/rationale`):**
+- **Registry consistency** — `/check-regressions` results match the current state of `.crosscheck/specs.json`
+- **Proposal quality** — `/suggest-specs` proposals are grounded in actual code patterns, not generic suggestions
+- **Claim tree soundness** — `/rationale` tree structure is valid: if all leaves hold, the root holds
+- **Classification accuracy** — leaf claims tagged with the correct verification method (`[FORMAL]`/`[BEHAVIORAL]`/`[STATIC]`/`[SEMANTIC]`)
+- **Actionable output** — every proposal or claim has a clear next step (skill to run, test to execute, or judgment to make)
+
+**For semi-formal reasoning output:**
+- **Certificate completeness** — all required sections present and filled in
+- **Evidence grounding** — every factual claim cites a specific `file:line` reference; reject claims that say "probably" or "likely" without code evidence
+- **Alternative hypothesis check** — at least one alternative considered and ruled out with evidence; if missing, add it before delivering
+- **Confidence level** — HIGH/MEDIUM/LOW stated with justification
+- **Claim classification** — premises and claims are tagged with `[STATIC]`/`[SEMANTIC]`/`[BEHAVIORAL]`/`[FORMAL]`
+
+**For all output:**
+- **Verification checklist present** — output includes a Verification Checklist section with all bracketed items filled in from the analysis
+
+If any gate fails, re-execute the skill with explicit instructions to address the gap.
+
+=== Guidelines ===
+
+### Formal verification
+- Always verify before proceeding — never skip the verification step
+- Be transparent about failures — if verification fails after 5 attempts, explain why and suggest alternatives
+- Warn early about limitations — don't let users invest time in specs that can't be verified
+- Keep the user in the loop — get approval at the spec stage before implementing
+- No Dafny artifacts in final output — only clean Python/Go code is the deliverable
+- Track difficulty — if proof was trivial, note the lightweight path would have sufficed
+
+### Semi-formal reasoning
+- Evidence over intuition — never present a conclusion without citing specific code locations
+- Be transparent about uncertainty — if context is insufficient, say so and ask rather than guessing
+- One question at a time — process multiple questions sequentially so each gets full treatment
+- Preserve the user's framing — don't reinterpret the question without explaining why
+- Fail fast on missing context — report immediately rather than fabricating answers
+- No unsupported leaps — each reasoning step must follow from the previous one with explicit justification
+
+### General
+- Respect user choice — if the user wants a specific skill, use it without further argument
+- Offer alternatives — after completing one skill, suggest if another would add value
+- Assess before committing — always classify before diving into a skill

--- a/.xylem/prompts/refine-issue/analyze.md
+++ b/.xylem/prompts/refine-issue/analyze.md
@@ -1,0 +1,21 @@
+Assess the following GitHub issue to gather context for refinement.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+Labels: {{.Issue.Labels}}
+
+{{.Issue.Body}}
+
+## Your Task
+
+Read the codebase to understand what this issue requires, then produce:
+
+1. **Summary** — What this issue is asking for in one sentence
+2. **Relevant code** — Files and packages involved, with brief notes on what each does
+3. **Requirements** — What specific changes are needed
+4. **Acceptance criteria** — Testable criteria that define "done"
+5. **Verification steps** — For each criterion, the specific command or check to verify it (e.g., `cd cli && go test ./internal/queue -run TestDequeue`, "confirm function X exists and handles Y")
+6. **Scope boundaries** — What is in scope and what is explicitly out of scope
+7. **Edge cases and constraints** — Anything an implementer needs to watch out for
+
+Do not modify any files. This is a read-only analysis phase.

--- a/.xylem/prompts/refine-issue/refine.md
+++ b/.xylem/prompts/refine-issue/refine.md
@@ -1,0 +1,45 @@
+Refine the GitHub issue based on the analysis from the previous phase.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+Issue Number: {{.Issue.Number}}
+Labels: {{.Issue.Labels}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Issue Template
+
+Rewrite the issue description using this exact format:
+
+## Goal
+<What needs to happen, in one sentence>
+
+## Background
+<Why this matters. Current vs expected behavior for bugs, or motivation for features>
+
+## Acceptance Criteria
+- [ ] <Specific, testable criterion>
+- [ ] <Each criterion must be independently verifiable>
+
+## Scope
+- **In scope:** <files, packages, or areas to modify>
+- **Out of scope:** <explicit boundaries>
+
+## Verification
+Steps the implementing agent must follow to verify each acceptance criterion:
+1. <Exact command or check, e.g., `cd cli && go test ./internal/queue -run TestName`>
+2. <Exact command or check>
+
+## Technical Notes
+<Edge cases, constraints, dependencies, related code>
+
+---
+
+## Instructions
+
+1. Rewrite the issue description using the template above, filling in all sections from the analysis
+2. Update the issue: `gh issue edit {{.Issue.Number}} --body "<new body>"`
+3. Swap labels: `gh issue edit {{.Issue.Number}} --remove-label "needs-refinement" --add-label "ready-for-work"`
+
+Do not ask for user input. If information is missing, make reasonable inferences from the codebase and note assumptions in Technical Notes.

--- a/.xylem/prompts/review-pr/analyze.md
+++ b/.xylem/prompts/review-pr/analyze.md
@@ -1,0 +1,33 @@
+Analyze a pull request for review.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+PR Number: {{.Issue.Number}}
+
+{{.Issue.Body}}
+
+## Instructions
+
+1. Verify this is a pull request: `gh pr view {{.Issue.Number}} --json number`. If it fails, output "NOT_A_PR" and stop.
+
+2. Checkout the PR branch: `gh pr checkout {{.Issue.Number}}`
+
+3. Read the full diff: `gh pr diff {{.Issue.Number}}`
+
+4. Read every changed file in full to understand the context around the changes.
+
+5. Check for an existing xylem review anchor comment. Search all PR comments for one containing the HTML marker `<!-- xylem-review -->`. Record its comment ID if found.
+
+6. Fetch all existing unresolved inline review comments on the PR. For each, record the path, line, and body.
+
+## Output
+
+- **Summary**: What this PR does (1-2 sentences)
+- **Changed files**: List with modification type (added/modified/deleted)
+- **Test files changed**: List of *_test.go files in the diff
+- **Intent**: What problem/feature this addresses
+- **Scope assessment**: Is the change well-scoped?
+- **Anchor comment ID**: Existing anchor comment ID, or "none"
+- **Existing inline comments**: List of (path, line, body) for unresolved comments
+
+Do not modify any files. Read-only phase.

--- a/.xylem/prompts/review-pr/review.md
+++ b/.xylem/prompts/review-pr/review.md
@@ -1,0 +1,81 @@
+Post review comments on this pull request.
+
+PR Number: {{.Issue.Number}}
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Verification Findings
+{{.PreviousOutputs.verify}}
+
+## Test Critic Findings
+{{.PreviousOutputs.test-critic}}
+
+## Comment Quality Filter
+
+**Include** comments about:
+- Correctness issues (bugs, logic errors, missed edge cases)
+- Missing error handling for real failure modes
+- Test quality issues from the test-critic findings
+- Security concerns
+- Design issues with clear impact on correctness or maintainability
+
+**Exclude** comments about:
+- Naming, formatting, or style preferences (nit picks)
+- Issues a linter would catch (unused imports, formatting, vet warnings)
+- Minor documentation suggestions
+- Opinions without a concrete "what goes wrong" scenario
+
+Every comment must explain what breaks or degrades if the issue isn't addressed.
+
+## Duplicate Avoidance
+
+The analysis identified existing review state:
+- Check the "Anchor comment ID" and "Existing inline comments" from the analysis
+- Do NOT add an inline comment that covers the same issue as an existing unresolved comment on the same file and line range
+- If an anchor comment already exists, UPDATE it — do not create a second one
+
+## Step 1: Build the Anchor Comment
+
+Format:
+
+```
+<!-- xylem-review -->
+## Review Summary
+
+**Verdict:** APPROVE / REQUEST_CHANGES / COMMENT
+
+### Verification
+[Key findings from verify phase, or "No issues found"]
+
+### Test Quality
+[Key findings from test-critic phase, or "Tests look solid" / "No test files changed"]
+
+### Inline Comments
+[N inline comment(s) posted on specific lines]
+```
+
+## Step 2: Post or Update the Anchor Comment
+
+Determine the repo: `gh repo view --json nameWithOwner --jq '.nameWithOwner'`
+
+- If an anchor comment ID exists in the analysis: update it with `gh api repos/{owner}/{repo}/issues/comments/{id} --method PATCH -f body='...'`
+- If no anchor comment exists: create with `gh pr comment {{.Issue.Number}} --body '...'`
+
+## Step 3: Post Inline Comments
+
+Collect all findings from verify and test-critic that apply to specific lines. Remove any that duplicate existing unresolved comments.
+
+If there are inline comments to post, submit them as a single PR review:
+```
+gh api repos/{owner}/{repo}/pulls/{{.Issue.Number}}/reviews \
+  --method POST \
+  -f event="COMMENT" \
+  -f 'comments=[{"path":"file.go","line":N,"side":"RIGHT","body":"..."}]'
+```
+
+If there are no inline comments to post, skip this step.
+
+Do not modify any code files. Only post review comments.

--- a/.xylem/prompts/review-pr/test-critic.md
+++ b/.xylem/prompts/review-pr/test-critic.md
@@ -1,0 +1,52 @@
+Analyze tests in this pull request for test theatre — tests that look productive but verify nothing meaningful.
+
+PR Number: {{.Issue.Number}}
+Issue: {{.Issue.Title}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Instructions
+
+Identify all `*_test.go` files from the "Test files changed" list in the analysis. If none, output "NO_TEST_FILES" and stop.
+
+For each test file, read it in full and analyze every `Test*` function for these anti-patterns:
+
+### Anti-Patterns
+
+1. **Tautological Tests** (CRITICAL) — Assertions always true regardless of implementation. Signals: comparing a value to itself, asserting a mock returns what you configured it to return, asserting a variable has the value just assigned.
+
+2. **Mock Soup** (HIGH) — So much is stubbed that only mock wiring is tested. Signals: more stub setup than assertions, all dependencies faked AND assertions only check call args.
+
+3. **No Meaningful Assertions** (CRITICAL) — Code executes but outcomes aren't verified. Signals: zero `assert.*`/`require.*`/`t.Error`/`t.Fatal` calls, only checking `err == nil` without checking the actual result.
+
+4. **Overly Loose Assertions** (MEDIUM) — Assertions too broad to catch bugs. Signals: `assert.Contains` when exact match is possible, `len(result) > 0` instead of checking contents, checking one struct field when multiple matter.
+
+5. **Testing the Framework** (MEDIUM) — Verifying Go/library behavior, not application logic. Signals: testing `json.Marshal` produces JSON, testing standard library functions.
+
+6. **Carbon Copy Tests** (LOW) — Near-duplicate tests without different code paths. Signals: table-driven tests where every row exercises the same branch. Note: table-driven tests exercising different branches are GOOD.
+
+7. **Assertion-Free Side Effect Tests** (HIGH) — Relying on "no panic = pass." Signals: function called with no assertions, `// should not panic` comments.
+
+## Output
+
+```
+## Test Critic Report
+
+### Summary
+- X test file(s) analyzed
+- Y finding(s) across Z test function(s)
+- Severity breakdown: N critical, N high, N medium, N low
+
+### Findings
+
+#### [file_path:line] `TestFunctionName`
+**Verdict:** [Anti-pattern] (SEVERITY)
+**Problem:** [One sentence]
+**Recommendation:** [Specific fix]
+
+### Final Verdict
+[Are these tests adding real value?]
+```
+
+If tests look solid, confirm and explain why. Do not modify any files.

--- a/.xylem/prompts/review-pr/verify.md
+++ b/.xylem/prompts/review-pr/verify.md
@@ -1,0 +1,101 @@
+You are an orchestrator for formal verification and semi-formal code reasoning. Named after Dustin Byfuglien — the crosschecking enforcer. No unsupported claims survive, no unverified code ships.
+
+Your task is to verify the code changes in this pull request are correct. Report all findings — do NOT implement fixes. This is a read-only review.
+
+=== PR Context ===
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+=== Skills ===
+
+### Formal Verification (Dafny-backed)
+
+| Skill | What it does |
+|-------|-------------|
+| `/spec-iterate` | Draft and verify Dafny specifications from natural language |
+| `/generate-verified` | Implement Dafny code that satisfies a verified spec |
+| `/extract-code` | Compile verified Dafny to Python/Go with boilerplate stripped |
+| `/lightweight-verify` | Design-by-contract, property-based tests, documented invariants (no Dafny) |
+| `/check-regressions` | Detect when code changes invalidate previously-verified Dafny specs |
+| `/suggest-specs` | Propose candidate specifications by analyzing code patterns |
+
+### Bridging Formal and Semi-formal
+
+| Skill | What it does |
+|-------|-------------|
+| `/rationale` | Build a hierarchical adequacy argument with mixed verification methods |
+
+### Semi-formal Reasoning (evidence-grounded analysis)
+
+| Skill | What it does |
+|-------|-------------|
+| `/reason` | General-purpose code reasoning with structured evidence certificates |
+| `/compare-patches` | Determine semantic equivalence of two patches via test-trace analysis |
+| `/locate-fault` | Systematic fault localization: test semantics → code tracing → divergence → ranked predictions |
+| `/trace-execution` | Hypothesis-driven execution path tracing with complete call graphs |
+
+## Task Classification
+
+Classify the PR changes to determine which skill(s) to invoke.
+
+| Category | Trigger Signals | Path |
+|----------|----------------|------|
+| Algorithms with subtle invariants | Sorting, searching, graph traversal, DP, data structures | `/spec-iterate` → `/generate-verified` (report spec violations) |
+| Safety-critical logic | Access control, financial calculations, crypto, state machines | `/spec-iterate` → report violations |
+| Simple transformations | Map/filter/reduce, string formatting, type conversions | `/lightweight-verify` |
+| CRUD / IO-heavy | Database queries, HTTP handlers, file processing | `/lightweight-verify` |
+| Concurrency | Thread pools, async coordinators, message passing | `/lightweight-verify` |
+| Regression check | Changes to existing code paths | `/check-regressions` |
+| General code changes | Any other changes | `/reason` |
+
+=== Workflow ===
+
+### Phase 1: Classify
+1. Read the changed files from the analysis
+2. Classify using the table above
+3. State your classification
+
+### Phase 2: Gather Context
+1. Read all referenced files in full
+2. Understand the code paths affected by the changes
+3. Identify invariants, preconditions, and postconditions
+
+### Phase 3: Execute Skill(s)
+Read the selected skill's SKILL.md file and follow its methodology:
+- For `/spec-iterate`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/spec-iterate/SKILL.md`
+- For `/generate-verified`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/generate-verified/SKILL.md`
+- For `/lightweight-verify`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/lightweight-verify/SKILL.md`
+- For `/check-regressions`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/check-regressions/SKILL.md`
+- For `/suggest-specs`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/suggest-specs/SKILL.md`
+- For `/rationale`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/rationale/SKILL.md`
+- For `/reason`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/reason/SKILL.md`
+- For `/locate-fault`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/locate-fault/SKILL.md`
+- For `/trace-execution`: read `~/.claude/plugins/marketplaces/nicholls/crosscheck/skills/trace-execution/SKILL.md`
+
+### Phase 4: Validate Output
+Every result must pass quality gates:
+
+**For formal verification:** Dafny verification passed, target-language pitfalls checked.
+
+**For semi-formal reasoning:**
+- Certificate completeness — all required sections present
+- Evidence grounding — every claim cites `file:line`
+- Alternative hypothesis check — at least one alternative considered
+- Confidence level stated with justification
+
+=== Output ===
+
+Produce a structured verification report. For each finding:
+- **File and line**: `file:line`
+- **Severity**: CRITICAL / HIGH / MEDIUM
+- **Category**: Correctness / Edge case / Invariant violation / Logic error / Regression
+- **Description**: What's wrong and why
+- **Evidence**: Code references supporting the claim
+
+If no issues found, state that with a confidence assessment.
+
+Do not modify any files. Do not implement fixes. Report findings only.

--- a/.xylem/prompts/triage/analyze.md
+++ b/.xylem/prompts/triage/analyze.md
@@ -1,0 +1,27 @@
+Assess the following GitHub issue to determine its type and whether it needs splitting.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+Labels: {{.Issue.Labels}}
+
+{{.Issue.Body}}
+
+## Your Task
+
+Read the codebase to understand the scope of this issue, then produce:
+
+1. **Summary** — What this issue is asking for in one sentence
+2. **Type** — Classify as exactly one of: `bug`, `enhancement`, or `refactor`
+   - `bug` — Something is broken or behaving incorrectly
+   - `enhancement` — New functionality or capability
+   - `refactor` — Restructuring existing code without changing behavior
+3. **Relevant code** — List the files and packages involved
+4. **Scope assessment** — How many distinct concerns? How many files would change?
+5. **Split decision** — Answer YES if any of:
+   - More than 3 distinct, independently-deliverable concerns
+   - Changes span multiple unrelated packages with no shared dependency
+   - It mixes refactoring with new functionality
+   - A reasonable implementation would touch more than 15 files
+6. **If splitting** — List each sub-issue with a one-line title, its type, and the files/packages it covers
+
+Do not modify any files. This is a read-only analysis phase.

--- a/.xylem/prompts/triage/triage.md
+++ b/.xylem/prompts/triage/triage.md
@@ -1,0 +1,29 @@
+Triage the GitHub issue based on the analysis from the previous phase.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+Issue Number: {{.Issue.Number}}
+Labels: {{.Issue.Labels}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Instructions
+
+**If the analysis says DO NOT split:**
+
+1. Add the type label and "needs-refinement":
+   `gh issue edit {{.Issue.Number}} --add-label "<type>,needs-refinement"`
+2. Remove "needs-triage":
+   `gh issue edit {{.Issue.Number}} --remove-label "needs-triage"`
+
+**If the analysis says SPLIT:**
+
+1. For each sub-issue identified in the analysis, create it with:
+   `gh issue create --title "<title>" --label "<type>,needs-triage" --body "<relevant section of the original issue body>"`
+   Keep the body minimal — the refinement workflow will flesh it out.
+2. Update the original issue body to reference the created sub-issues with a "Split into:" prefix
+3. Close the original:
+   `gh issue close {{.Issue.Number}} --reason "not planned" --comment "Split into focused sub-issues."`
+
+Do not ask for user input. If the type is ambiguous, pick the best fit and note the reasoning in a comment.

--- a/.xylem/workflows/diagnose-failures.yaml
+++ b/.xylem/workflows/diagnose-failures.yaml
@@ -1,0 +1,12 @@
+name: diagnose-failures
+description: "Diagnose xylem vessel failures and file refined GitHub issues"
+phases:
+  - name: diagnose
+    prompt_file: .xylem/prompts/diagnose-failures/diagnose.md
+    max_turns: 20
+  - name: create-issues
+    prompt_file: .xylem/prompts/diagnose-failures/create-issues.md
+    max_turns: 20
+  - name: refine
+    prompt_file: .xylem/prompts/diagnose-failures/refine.md
+    max_turns: 40

--- a/.xylem/workflows/fix-bug.yaml
+++ b/.xylem/workflows/fix-bug.yaml
@@ -1,0 +1,28 @@
+name: fix-bug
+description: "Diagnose and fix a bug from a GitHub issue"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/fix-bug/analyze.md
+    max_turns: 20
+    noop:
+      match: XYLEM_NOOP
+  - name: plan
+    prompt_file: .xylem/prompts/fix-bug/plan.md
+    max_turns: 20
+  - name: implement
+    prompt_file: .xylem/prompts/fix-bug/implement.md
+    max_turns: 60
+    gate:
+      type: command
+      run: "cd cli && go test ./..."
+      retries: 2
+  - name: verify
+    prompt_file: .xylem/prompts/fix-bug/verify.md
+    max_turns: 60
+    gate:
+      type: command
+      run: "cd cli && go test ./..."
+      retries: 1
+  - name: pr
+    prompt_file: .xylem/prompts/fix-bug/pr.md
+    max_turns: 10

--- a/.xylem/workflows/implement-feature.yaml
+++ b/.xylem/workflows/implement-feature.yaml
@@ -1,0 +1,28 @@
+name: implement-feature
+description: "Implement a feature from a GitHub issue"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/implement-feature/analyze.md
+    max_turns: 20
+    noop:
+      match: XYLEM_NOOP
+  - name: plan
+    prompt_file: .xylem/prompts/implement-feature/plan.md
+    max_turns: 20
+  - name: implement
+    prompt_file: .xylem/prompts/implement-feature/implement.md
+    max_turns: 60
+    gate:
+      type: command
+      run: "cd cli && go test ./..."
+      retries: 2
+  - name: verify
+    prompt_file: .xylem/prompts/implement-feature/verify.md
+    max_turns: 60
+    gate:
+      type: command
+      run: "cd cli && go test ./..."
+      retries: 1
+  - name: pr
+    prompt_file: .xylem/prompts/implement-feature/pr.md
+    max_turns: 10

--- a/.xylem/workflows/refine-issue.yaml
+++ b/.xylem/workflows/refine-issue.yaml
@@ -1,0 +1,9 @@
+name: refine-issue
+description: "Rewrite issue descriptions with structured template for AI agent consumption"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/refine-issue/analyze.md
+    max_turns: 20
+  - name: refine
+    prompt_file: .xylem/prompts/refine-issue/refine.md
+    max_turns: 20

--- a/.xylem/workflows/review-pr.yaml
+++ b/.xylem/workflows/review-pr.yaml
@@ -1,0 +1,15 @@
+name: review-pr
+description: "Review pull requests with crosscheck verification, test criticism, and structured comments"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/review-pr/analyze.md
+    max_turns: 20
+  - name: verify
+    prompt_file: .xylem/prompts/review-pr/verify.md
+    max_turns: 60
+  - name: test-critic
+    prompt_file: .xylem/prompts/review-pr/test-critic.md
+    max_turns: 20
+  - name: review
+    prompt_file: .xylem/prompts/review-pr/review.md
+    max_turns: 30

--- a/.xylem/workflows/triage.yaml
+++ b/.xylem/workflows/triage.yaml
@@ -1,0 +1,9 @@
+name: triage
+description: "Classify issues, split if too large, and label for refinement"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/triage/analyze.md
+    max_turns: 20
+  - name: triage
+    prompt_file: .xylem/prompts/triage/triage.md
+    max_turns: 20


### PR DESCRIPTION
## Summary
Six workflow YAMLs and their prompt trees were never committed because \`.gitignore\` had a blanket \`.xylem/\` rule. Fresh worktrees (including the daemon's isolated \`.claude/worktrees/.daemon-root\`) don't have them, so any vessel trying to load \`fix-bug.yaml\`, \`refine-issue.yaml\`, \`implement-feature.yaml\`, etc. fails with:

\`\`\`
read workflow file \".xylem/workflows/refine-issue.yaml\": no such file or directory
\`\`\`

This was silently blocking the entire \"scheduled vessel\" issue cluster (#150–#154) and any fix-bug / refine-issue / implement-feature / triage / review-pr / diagnose-failures work from ever succeeding in daemon-root.

## Change
1. Rewrite \`.gitignore\` from \`.xylem/\` to \`.xylem/*\` + negation entries for \`HARNESS.md\`, \`workflows/\`, \`prompts/\`. Operational state (phases/, audit, queue, daemon.pid, dtu/, eval/) stays ignored.
2. Commit the 6 missing workflow YAMLs and their prompt directories (22 prompt files total).
3. Commit \`.xylem/HARNESS.md\` so fresh worktrees get the harness context.

## Files added (29 total)
- 6 \`workflows/*.yaml\`: diagnose-failures, fix-bug, implement-feature, refine-issue, review-pr, triage
- 22 prompt files across 6 workflow directories
- HARNESS.md

## Why this is safe
- The files already exist and run successfully in the main repo.
- They are NOT being modified, only added to the git index.
- Protected-surface enforcement still applies at runtime (the runner's \`surface.Snapshot\` blocks vessel agents from editing these files).
- Operational state remains untracked.

## Test plan
- [x] Files copied via \`cat\` redirect (preserves content exactly — no modifications)
- [x] \`git status\` confirms 29 new files + .gitignore modification
- [x] \`go build ./cmd/xylem\` passes
- [x] Full \`go test ./...\` passes  
- [x] Pre-commit hooks clean

## Effect
After merge and daemon drain-end auto-upgrade (~5 minutes), the daemon-root worktree fast-forwards and picks up all 12 workflow definitions. Vessels for issues #117, #150-154, and any future bug/feature/triage/refine work will succeed instead of erroring on missing workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)