### PR TITLE
fix: AND semantics for multi-label github-pr tasks

### DIFF
--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -42,63 +42,74 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 	seen := make(map[int]bool)
 
 	for _, task := range g.Tasks {
+		if len(task.Labels) == 0 {
+			continue
+		}
+		// Pass every label for this task in a single `gh pr list` call so
+		// multiple `--label` flags are AND'd together — a task with labels
+		// [needs-conflict-resolution, harness-impl] must only match PRs
+		// carrying BOTH labels, not either one. Querying labels separately
+		// and unioning (the previous behaviour) meant a PR matching only
+		// one label could be routed to the wrong workflow.
+		args := []string{
+			"pr", "list",
+			"--repo", g.Repo,
+			"--state", "open",
+		}
 		for _, label := range task.Labels {
-			args := []string{
-				"pr", "list",
-				"--repo", g.Repo,
-				"--state", "open",
-				"--label", label,
-				"--json", "number,title,body,url,labels,headRefName",
-				"--limit", "20",
-			}
+			args = append(args, "--label", label)
+		}
+		args = append(args,
+			"--json", "number,title,body,url,labels,headRefName",
+			"--limit", "20",
+		)
 
-			out, err := g.CmdRunner.Run(ctx, "gh", args...)
-			if err != nil {
-				return vessels, fmt.Errorf("gh pr list: %w", err)
-			}
+		out, err := g.CmdRunner.Run(ctx, "gh", args...)
+		if err != nil {
+			return vessels, fmt.Errorf("gh pr list: %w", err)
+		}
 
-			var prs []ghPR
-			if err := json.Unmarshal(out, &prs); err != nil {
-				return vessels, fmt.Errorf("parse gh pr list output: %w", err)
-			}
+		var prs []ghPR
+		if err := json.Unmarshal(out, &prs); err != nil {
+			return vessels, fmt.Errorf("parse gh pr list output: %w", err)
+		}
 
-			for _, pr := range prs {
-				if seen[pr.Number] {
-					continue
-				}
-				fingerprint := githubSourceFingerprint(pr.Title, pr.Body, issueLabelNames(pr.Labels))
-				if g.hasExcludedLabel(pr, excludeSet) ||
-					g.Queue.HasRef(pr.URL) ||
-					g.hasMatchingFailedFingerprint(pr.URL, fingerprint) ||
-					g.hasBranch(ctx, pr.Number) {
-					continue
-				}
-				seen[pr.Number] = true
-				meta := map[string]string{
-					"pr_num":                   strconv.Itoa(pr.Number),
-					"pr_title":                 pr.Title,
-					"pr_body":                  pr.Body,
-					"pr_labels":                strings.Join(issueLabelNames(pr.Labels), ","),
-					"source_input_fingerprint": fingerprint,
-				}
-				sl := task.StatusLabels
-				if sl != nil {
-					meta["status_label_queued"] = sl.Queued
-					meta["status_label_running"] = sl.Running
-					meta["status_label_completed"] = sl.Completed
-					meta["status_label_failed"] = sl.Failed
-					meta["status_label_timed_out"] = sl.TimedOut
-				}
-				vessels = append(vessels, queue.Vessel{
-					ID:        fmt.Sprintf("pr-%d", pr.Number),
-					Source:    "github-pr",
-					Ref:       pr.URL,
-					Workflow:  task.Workflow,
-					Meta:      meta,
-					State:     queue.StatePending,
-					CreatedAt: sourceNow(),
-				})
+		for _, pr := range prs {
+			if seen[pr.Number] {
+				continue
 			}
+			fingerprint := githubSourceFingerprint(pr.Title, pr.Body, issueLabelNames(pr.Labels))
+			if g.hasExcludedLabel(pr, excludeSet) ||
+				g.Queue.HasRef(pr.URL) ||
+				g.hasMatchingFailedFingerprint(pr.URL, fingerprint) ||
+				g.hasBranch(ctx, pr.Number) {
+				continue
+			}
+			seen[pr.Number] = true
+			meta := map[string]string{
+				"pr_num":                   strconv.Itoa(pr.Number),
+				"pr_title":                 pr.Title,
+				"pr_body":                  pr.Body,
+				"pr_labels":                strings.Join(issueLabelNames(pr.Labels), ","),
+				"source_input_fingerprint": fingerprint,
+			}
+			sl := task.StatusLabels
+			if sl != nil {
+				meta["status_label_queued"] = sl.Queued
+				meta["status_label_running"] = sl.Running
+				meta["status_label_completed"] = sl.Completed
+				meta["status_label_failed"] = sl.Failed
+				meta["status_label_timed_out"] = sl.TimedOut
+			}
+			vessels = append(vessels, queue.Vessel{
+				ID:        fmt.Sprintf("pr-%d", pr.Number),
+				Source:    "github-pr",
+				Ref:       pr.URL,
+				Workflow:  task.Workflow,
+				Meta:      meta,
+				State:     queue.StatePending,
+				CreatedAt: sourceNow(),
+			})
 		}
 	}
 	return vessels, nil

--- a/cli/internal/source/github_pr_test.go
+++ b/cli/internal/source/github_pr_test.go
@@ -225,6 +225,102 @@ func TestGitHubPRScanDeduplicates(t *testing.T) {
 	}
 }
 
+func TestGitHubPRScanMultiLabelAND(t *testing.T) {
+	// A task with multiple labels must match only PRs carrying ALL of
+	// those labels (AND semantics), so multi-label tasks route to the
+	// correct workflow instead of being stolen by a sibling source that
+	// shares one label in common.
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 143, Title: "needs conflict resolution", Body: "has both labels",
+			URL: "https://github.com/owner/repo/pull/143", HeadRefName: "feat/issue-137",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "needs-conflict-resolution"}, {Name: "harness-impl"}}},
+	}
+	// The single gh call must include BOTH --label flags in order.
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open",
+		"--label", "needs-conflict-resolution", "--label", "harness-impl",
+		"--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo: "owner/repo",
+		Tasks: map[string]GitHubTask{
+			"resolve": {
+				Labels:   []string{"needs-conflict-resolution", "harness-impl"},
+				Workflow: "resolve-conflicts",
+			},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	if vessels[0].Workflow != "resolve-conflicts" {
+		t.Errorf("expected workflow resolve-conflicts, got %q", vessels[0].Workflow)
+	}
+	if vessels[0].ID != "pr-143" {
+		t.Errorf("expected ID pr-143, got %q", vessels[0].ID)
+	}
+
+	// Exactly one gh pr list call — labels ANDed in a single query, not
+	// fanned out as separate per-label queries that union at the client.
+	var prListCalls int
+	for _, call := range r.calls {
+		if len(call) >= 3 && call[0] == "gh" && call[1] == "pr" && call[2] == "list" {
+			prListCalls++
+		}
+	}
+	if prListCalls != 1 {
+		t.Errorf("expected exactly 1 gh pr list call for AND semantics, got %d", prListCalls)
+	}
+}
+
+func TestGitHubPRScanMultiLabelANDMissingOneLabel(t *testing.T) {
+	// A PR that carries only one of a multi-label task's required labels
+	// must NOT be enqueued. Because the labels are ANDed server-side, the
+	// gh call returns empty and no vessel is produced — even though the
+	// PR has one matching label.
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	// gh returns [] for the AND query — PR has harness-impl but not
+	// ready-to-merge, so the server-side filter excludes it.
+	r.set([]byte("[]"), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open",
+		"--label", "ready-to-merge", "--label", "harness-impl",
+		"--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo: "owner/repo",
+		Tasks: map[string]GitHubTask{
+			"merge": {
+				Labels:   []string{"ready-to-merge", "harness-impl"},
+				Workflow: "merge-pr",
+			},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels (AND semantics require both labels), got %d", len(vessels))
+	}
+}
+
 func TestGitHubPRScanGHFailure(t *testing.T) {
 	dir := t.TempDir()
 	q := queue.New(dir + "/queue.jsonl")


### PR DESCRIPTION
## Summary

PR #143 was stuck because the daemon kept enqueueing it with the **wrong** workflow. Root cause: `github_pr.go` queried each of a task's labels *separately* and unioned the results client-side — effectively **OR semantics** — instead of requiring PRs to match **all** of a task's labels.

### Concrete symptom

PR #143 had labels `[harness-impl, needs-conflict-resolution]`. Two sources in `.xylem.yml` match on `harness-impl`:

- `harness-merge`: `[ready-to-merge, harness-impl]` → workflow `merge-pr`
- `conflict-resolution`: `[needs-conflict-resolution, harness-impl]` → workflow `resolve-conflicts`

Under the old OR behaviour, `harness-merge` would see PR #143 via its `harness-impl` query alone and enqueue it as `merge-pr` — the wrong workflow for a conflicting PR. `xylem scan --dry-run` reproduced it:

```
pr-143          github-pr       merge-pr              https://github.com/nicholls-inc/xylem/pull/143
```

After this fix, the same dry-run reports:

```
pr-143          github-pr       resolve-conflicts     https://github.com/nicholls-inc/xylem/pull/143
```

### The fix

Pass every label for a task in a single `gh pr list --label X --label Y ...` call. `gh` ANDs multiple `--label` flags server-side, so a task now only matches PRs carrying *all* of its labels.

I left `cli/internal/source/github.go` (the issues source) alone on purpose — it has the same structural OR bug, but `hasOpenPR` / `hasMergedPR` / `hasBranch` filters mask the effect in practice. Worth a follow-up, but out of scope for unblocking PR #143.

## Test plan

- [x] `cd cli && gofmt -l internal/source/...` clean
- [x] `cd cli && go vet ./...`
- [x] `cd cli && go build ./cmd/xylem`
- [x] `cd cli && go test ./...` — full suite green
- [x] New tests: `TestGitHubPRScanMultiLabelAND` (both labels present → enqueued with correct workflow, exactly one `gh pr list` call) and `TestGitHubPRScanMultiLabelANDMissingOneLabel` (gh returns empty AND query → no vessel)
- [x] Manual dry-run against live `nicholls-inc/xylem` — PR #143 now routes to `resolve-conflicts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)