### PR TITLE
Audit default approval policy for strategic human gates

### DIFF
--- a/cli/cmd/xylem/init.go
+++ b/cli/cmd/xylem/init.go
@@ -131,10 +131,10 @@ max_turns: 50
 timeout: "30m"
 state_dir: ".xylem"
 
-# Default harness policy denies writes to xylem control files and requires
-# approval for git_push and pr_create. Keep the scaffolded PR phase behind an
-# approval step in your workflow, or replace it with a deterministic command
-# phase after review.
+# Default harness policy denies writes to xylem control files and allows
+# git_push/pr_create so autonomous drains can finish. If you want a strategic
+# human gate before publication, add workflow review steps or
+# harness.policy.rules that require approval for those actions.
 
 # llm selects the global default LLM provider: "claude" (default) or "copilot"
 llm: claude
@@ -237,7 +237,9 @@ phases:
   - name: pr
     prompt_file: .xylem/prompts/fix-bug/pr.md
     max_turns: 3
-    # High-risk phase: default harness policy requires approval for git_push and pr_create.
+    # Publication phase: git_push/pr_create are allowed by default so autonomous
+    # drains can finish. Add a review gate or restrictive harness.policy.rules
+    # if you want a human checkpoint here.
 `
 
 const implementFeatureWorkflowContent = `name: implement-feature
@@ -265,7 +267,9 @@ phases:
   - name: pr
     prompt_file: .xylem/prompts/implement-feature/pr.md
     max_turns: 3
-    # High-risk phase: default harness policy requires approval for git_push and pr_create.
+    # Publication phase: git_push/pr_create are allowed by default so autonomous
+    # drains can finish. Add a review gate or restrictive harness.policy.rules
+    # if you want a human checkpoint here.
 `
 
 const analyzePrompt = `Analyze the following GitHub issue and identify the relevant code.
@@ -323,8 +327,10 @@ Implement the changes now. Follow the plan precisely.
 
 const prPrompt = `Create a pull request for the changes.
 
-This phase is high-risk. Under the default harness policy, actions that push a
-branch or create a pull request require approval. Do not work around that
+This phase crosses the highest-blast-radius publication boundary the runner
+currently classifies. By default xylem allows ` + "`git_push`" + ` and ` + "`pr_create`" + `
+so autonomous drains can finish, but repositories may add a workflow gate or
+` + "`harness.policy.rules`" + ` that requires approval. Do not work around any configured
 policy boundary.
 
 Issue: {{.Issue.Title}}
@@ -337,7 +343,7 @@ URL: {{.Issue.URL}}
 {{.PreviousOutputs.plan}}
 
 Commit all changes with a clear commit message. Push the branch and create a PR
-only when the repository policy or workflow has explicitly approved ` + "`git_push`" + ` and ` + "`pr_create`" + `. Use:
+only when the repository policy and workflow allow ` + "`git_push`" + ` and ` + "`pr_create`" + `. Use:
 gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>"
 `
 

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -201,7 +201,8 @@ func TestInitScaffoldConfigLoads(t *testing.T) {
 
 	data, err := os.ReadFile(configPath)
 	require.NoError(t, err)
-	assert.Contains(t, string(data), "approval for git_push and pr_create")
+	assert.Contains(t, string(data), "allows")
+	assert.Contains(t, string(data), "git_push/pr_create")
 }
 
 func TestInitRespectsConfigFlag(t *testing.T) {
@@ -233,7 +234,8 @@ func TestInitRespectsConfigFlag(t *testing.T) {
 
 func TestPromptContentPRMentionsApprovalBoundary(t *testing.T) {
 	content := promptContent("fix-bug", "pr")
-	assert.Contains(t, content, "default harness policy")
+	assert.Contains(t, content, "publication boundary")
+	assert.Contains(t, content, "autonomous drains can finish")
 	assert.Contains(t, content, "`git_push`")
 	assert.Contains(t, content, "`pr_create`")
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -482,12 +482,14 @@ func (c *Config) BuildIntermediaryPolicies() []intermediary.Policy {
 }
 
 // DefaultPolicy returns the default intermediary policy. Protected control
-// surfaces are denied, and all other actions — including git_push and
-// pr_create — are allowed by default so the daemon can operate autonomously.
+// surfaces are denied, and all currently classified execution actions —
+// including git_commit, git_push, and pr_create — are allowed so the daemon can
+// operate autonomously.
 //
-// Operators who want approval gates on destructive actions can override this
-// by configuring `harness.policy.rules` in `.xylem.yml`; those rules take
-// precedence over the default policy.
+// Destructive git operations and deploy-class actions are not yet emitted as
+// separate intents at the runner/intermediary boundary; they currently inherit
+// the enclosing phase action. Operators who want human gates on those surfaces
+// can override the defaults with `harness.policy.rules` or workflow gates.
 func DefaultPolicy() intermediary.Policy {
 	return intermediary.Policy{
 		Name: "default",
@@ -497,9 +499,10 @@ func DefaultPolicy() intermediary.Policy {
 			{Action: "file_write", Resource: ".xylem.yml", Effect: intermediary.Deny},
 			{Action: "file_write", Resource: ".xylem/workflows/*", Effect: intermediary.Deny},
 			{Action: "file_write", Resource: ".xylem/prompts/*/*.md", Effect: intermediary.Deny},
-			// All other actions — including git_push and pr_create — are
-			// allowed. Autonomous operation requires these to succeed without
-			// manual approval. Override via harness.policy for stricter rules.
+			// All other actions — including git_commit, git_push, and pr_create
+			// — are allowed. Autonomous operation requires publication steps to
+			// complete without a built-in approval pause. Override via
+			// harness.policy for stricter rules.
 			{Action: "*", Resource: "*", Effect: intermediary.Allow},
 		},
 	}

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -1356,6 +1356,45 @@ func TestSmoke_S7_DefaultPolicyAllowsGitPush(t *testing.T) {
 	assert.Equal(t, "*", result.MatchedRule.Resource)
 }
 
+func TestDefaultPolicyAllowsClassifiedGitLifecycleActions(t *testing.T) {
+	tests := []struct {
+		name     string
+		action   string
+		resource string
+	}{
+		{
+			name:     "git commit",
+			action:   "git_commit",
+			resource: "*",
+		},
+		{
+			name:     "git push",
+			action:   "git_push",
+			resource: "main",
+		},
+		{
+			name:     "pull request create",
+			action:   "pr_create",
+			resource: "owner/name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := newSmokeIntermediary(t, validConfig()).Evaluate(intermediary.Intent{
+				Action:   tt.action,
+				Resource: tt.resource,
+				AgentID:  "vessel-009",
+			})
+
+			assert.Equal(t, intermediary.Allow, result.Effect)
+			require.NotNil(t, result.MatchedRule)
+			assert.Equal(t, "*", result.MatchedRule.Action)
+			assert.Equal(t, "*", result.MatchedRule.Resource)
+		})
+	}
+}
+
 func TestDefaultPolicyDeniesPromptFileWrite(t *testing.T) {
 	result := newSmokeIntermediary(t, validConfig()).Evaluate(intermediary.Intent{
 		Action:   "file_write",

--- a/cli/internal/dtu/scenario_ws1_test.go
+++ b/cli/internal/dtu/scenario_ws1_test.go
@@ -251,7 +251,7 @@ func TestWS1PolicyDenyBlocksPhase(t *testing.T) {
 // TestWS1PolicyRequireApproval verifies that a require_approval policy blocks
 // the phase and the vessel fails with an approval message.
 //
-// Covers: S7  (default policy requires approval for git_push)
+// Covers: S7  (default policy allows classified publication actions)
 //
 //	S19 (runner policy require_approval — vessel fails with approval message)
 func TestWS1PolicyRequireApproval(t *testing.T) {
@@ -819,23 +819,11 @@ func TestWS1ConfigValidationSurfaceGlobInvalid(t *testing.T) {
 //
 // Covers: S6  (deny file_write to .xylem/HARNESS.md)
 //
-//	S7  (require_approval for git_push)
+//	S7  (allow classified publication actions)
 //	S8  (allow general phase_execute)
 func TestWS1IntermediaryPolicyEffects(t *testing.T) {
-	// Construct the default policy described in the spec (§2.3).
-	defaultPolicy := intermediary.Policy{
-		Name: "default",
-		Rules: []intermediary.Rule{
-			{Action: "file_write", Resource: ".xylem/HARNESS.md", Effect: intermediary.Deny},
-			{Action: "file_write", Resource: ".xylem.yml", Effect: intermediary.Deny},
-			{Action: "file_write", Resource: ".xylem/workflows/*", Effect: intermediary.Deny},
-			{Action: "git_push", Resource: "*", Effect: intermediary.RequireApproval},
-			{Action: "*", Resource: "*", Effect: intermediary.Allow},
-		},
-	}
-
 	auditLog := intermediary.NewAuditLog(filepath.Join(t.TempDir(), "audit.jsonl"))
-	interm := intermediary.NewIntermediary([]intermediary.Policy{defaultPolicy}, auditLog, nil)
+	interm := intermediary.NewIntermediary([]intermediary.Policy{config.DefaultPolicy()}, auditLog, nil)
 
 	// S6: deny file_write to .xylem/HARNESS.md
 	result := interm.Evaluate(intermediary.Intent{
@@ -845,12 +833,26 @@ func TestWS1IntermediaryPolicyEffects(t *testing.T) {
 		t.Fatalf("S6: effect = %q, want %q", result.Effect, intermediary.Deny)
 	}
 
-	// S7: require_approval for git_push
+	// S7: allow classified publication actions
 	result = interm.Evaluate(intermediary.Intent{
-		Action: "git_push", Resource: "main", AgentID: "vessel-002",
+		Action: "git_commit", Resource: "*", AgentID: "vessel-002",
 	})
-	if result.Effect != intermediary.RequireApproval {
-		t.Fatalf("S7: effect = %q, want %q", result.Effect, intermediary.RequireApproval)
+	if result.Effect != intermediary.Allow {
+		t.Fatalf("S7 git_commit: effect = %q, want %q", result.Effect, intermediary.Allow)
+	}
+
+	result = interm.Evaluate(intermediary.Intent{
+		Action: "git_push", Resource: "main", AgentID: "vessel-003",
+	})
+	if result.Effect != intermediary.Allow {
+		t.Fatalf("S7 git_push: effect = %q, want %q", result.Effect, intermediary.Allow)
+	}
+
+	result = interm.Evaluate(intermediary.Intent{
+		Action: "pr_create", Resource: "owner/repo", AgentID: "vessel-004",
+	})
+	if result.Effect != intermediary.Allow {
+		t.Fatalf("S7 pr_create: effect = %q, want %q", result.Effect, intermediary.Allow)
 	}
 
 	// S8: allow phase_execute

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -809,6 +809,27 @@ func TestPhasePolicyIntents_IgnoresHighRiskPhrasesFromRenderedPromptContext(t *t
 	assert.Equal(t, "analyze", intents[0].Resource)
 }
 
+func TestPhasePolicyIntents_DoesNotClassifyDestructiveGitOrDeploySeparately(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	r := New(cfg, nil, nil, nil)
+	vessel := queue.Vessel{
+		ID:       "issue-1",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Meta:     map[string]string{"config_source": "github"},
+	}
+	phaseDef := workflow.Phase{Name: "publish", Type: "command"}
+
+	intents := r.phasePolicyIntents(vessel, phaseDef, "git reset --hard HEAD~1 && git push --force origin main && ./deploy.sh production", "")
+	require.Len(t, intents, 2)
+
+	assert.Equal(t, "external_command", intents[0].Action)
+	assert.Equal(t, "publish", intents[0].Resource)
+	assert.Equal(t, "git_push", intents[1].Action)
+	assert.Equal(t, "main", intents[1].Resource)
+}
+
 func TestSmoke_S1_PolicyDenialShortCircuitsBeforeSurfaceSnapshot(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,7 +279,16 @@ The `daemon` section controls polling intervals when running `xylem daemon`.
 
 The `harness` section configures agent safety guardrails: protected file surfaces, policy rules, and audit logging.
 
-When `harness.policy.rules` is empty, xylem installs a default policy that denies writes to the protected control surfaces, requires approval for `git_push` and `pr_create`, and allows other actions. The runner classifies those high-risk actions from rendered command phases and from prompt phases that explicitly instruct an agent to push or open a pull request. The same `harness.protected_surfaces.paths` list also drives the worktree's read-only hardening and the runner's post-phase surface verification.
+When `harness.policy.rules` is empty, xylem installs a default policy that denies writes to protected control surfaces and otherwise allows the actions the runner currently classifies, so autonomous drains can finish without a built-in approval pause. Today that boundary is narrow: every phase is classified as `phase_execute` or `external_command`, and the runner may additionally emit `git_commit`, `git_push`, and `pr_create` when it detects those publication steps in rendered prompts or commands. The same `harness.protected_surfaces.paths` list also drives the worktree's read-only hardening and the runner's post-phase surface verification.
+
+| Action class | Current runner classification | Default effect | Notes |
+|--------------|-------------------------------|----------------|-------|
+| Protected-surface writes | `file_write` on matched path | `deny` | Prevents agents from mutating xylem control files. |
+| Git commit | `git_commit` | `allow` | Commit creation is classified separately but kept autonomous by default. |
+| Git push | `git_push` | `allow` | Publication is allowed by default so daemon runs can complete end-to-end. |
+| Pull request creation | `pr_create` | `allow` | PR creation stays autonomous unless the operator adds a stricter rule or workflow gate. |
+| Destructive git operations (`reset --hard`, branch deletion, force-push) | No separate action today; `git push --force` still collapses to `git_push`, other cases remain `phase_execute`/`external_command` | No separate default effect | If you need review here today, gate the phase or add stricter rules around the enclosing action class. |
+| Deploy or production-impacting actions | No separate action today; they remain `phase_execute`/`external_command` | No separate default effect | Add an explicit workflow gate or policy rule for the deploy phase until xylem grows deploy-specific classification. |
 
 | Field | Type | Default | Required | Description |
 |-------|------|---------|----------|-------------|
@@ -300,6 +309,8 @@ When `harness.policy.rules` is empty, xylem installs a default policy that denie
 | `action` | string | Yes | The action to match (e.g., `file_write`, `git_push`, `pr_create`, `*`). |
 | `resource` | string | Yes | The resource to match (e.g., `.xylem.yml`, `*`). Supports glob patterns. |
 | `effect` | string | Yes | The effect when matched. Valid values: `allow`, `deny`, `require_approval`. |
+
+The example below opts into human review before publication:
 
 ```yaml
 harness:

--- a/docs/design/harness-smoke-scenarios/ws1-config-surface-policy.md
+++ b/docs/design/harness-smoke-scenarios/ws1-config-surface-policy.md
@@ -113,17 +113,17 @@ harness:
 
 ---
 
-### S7: Default policy requires approval for git_push
+### S7: Default policy allows classified publication actions
 
 **Spec ref:** Section 2.3 (`DefaultPolicy`)
 
 **Preconditions:** A `Config` with no policy rules configured (default policy active).
 
-**Action:** Construct an `Intermediary` from `cfg.BuildIntermediaryPolicies()`, call `Evaluate` with intent `{Action: "git_push", Resource: "main", AgentID: "vessel-002"}`.
+**Action:** Construct an `Intermediary` from `cfg.BuildIntermediaryPolicies()`, then call `Evaluate` with intents for `{Action: "git_commit", Resource: "*", AgentID: "vessel-002"}`, `{Action: "git_push", Resource: "main", AgentID: "vessel-003"}`, and `{Action: "pr_create", Resource: "owner/name", AgentID: "vessel-004"}`.
 
-**Expected outcome:** `PolicyResult.Effect` equals `intermediary.RequireApproval`.
+**Expected outcome:** Each `PolicyResult.Effect` equals `intermediary.Allow`, with the wildcard allow rule recorded as the match.
 
-**Verification:** Assert `result.Effect == intermediary.RequireApproval`.
+**Verification:** Assert each result equals `intermediary.Allow`.
 
 ---
 

--- a/docs/design/xylem-harness-impl-spec.md
+++ b/docs/design/xylem-harness-impl-spec.md
@@ -194,9 +194,7 @@ func DefaultPolicy() intermediary.Policy {
             {Action: "file_write", Resource: ".xylem/HARNESS.md", Effect: intermediary.Deny},
             {Action: "file_write", Resource: ".xylem.yml", Effect: intermediary.Deny},
             {Action: "file_write", Resource: ".xylem/workflows/*", Effect: intermediary.Deny},
-            {Action: "file_write", Resource: ".xylem/prompts/*", Effect: intermediary.Deny},
-            {Action: "git_push", Resource: "*", Effect: intermediary.RequireApproval},
-            {Action: "pr_create", Resource: "*", Effect: intermediary.RequireApproval},
+            {Action: "file_write", Resource: ".xylem/prompts/*/*.md", Effect: intermediary.Deny},
             {Action: "*", Resource: "*", Effect: intermediary.Allow},
         },
     }
@@ -287,12 +285,6 @@ harness:
       - action: "file_write"
         resource: ".xylem/*"
         effect: "deny"
-      - action: "git_push"
-        resource: "*"
-        effect: "require_approval"
-      - action: "pr_create"
-        resource: "*"
-        effect: "require_approval"
       - action: "*"
         resource: "*"
         effect: "allow"
@@ -341,17 +333,23 @@ observability:
   enabled: false
 ```
 
-### 2.6 Action vocabulary
+### 2.6 Action vocabulary and audited defaults
 
-| Action | When emitted | Resource value |
-|--------|-------------|----------------|
-| `file_write` | Protected surface mutation detected | Relative file path |
-| `git_push` | Push phase in workflow | Branch name or `*` |
-| `git_commit` | Commit phase in workflow | `*` |
-| `pr_create` | PR creation phase | `owner/repo` |
-| `pr_comment` | Issue/PR comment | `owner/repo#N` |
-| `external_command` | Command-type phase execution | Phase name |
-| `phase_execute` | Prompt-type phase execution | Phase name |
+| Action | When emitted | Resource value | Default effect | Notes |
+|--------|-------------|----------------|----------------|-------|
+| `file_write` | Protected surface mutation detected | Relative file path | `deny` on protected paths | Protects xylem control files. |
+| `git_push` | Push phase in workflow | Branch name or `*` | `allow` | Includes force-push today because the classifier does not distinguish it. |
+| `git_commit` | Commit phase in workflow | `*` | `allow` | Classified separately for audit visibility, not paused by default. |
+| `pr_create` | PR creation phase | `owner/repo` | `allow` | Kept autonomous unless the operator adds a stricter rule. |
+| `pr_comment` | Issue/PR comment | `owner/repo#N` | `allow` | Follows the wildcard allow rule today. |
+| `external_command` | Command-type phase execution | Phase name | `allow` | Deploy and destructive non-push git actions currently fall back here. |
+| `phase_execute` | Prompt-type phase execution | Phase name | `allow` | Deploy and destructive non-push git actions currently fall back here. |
+
+Destructive git operations other than push (for example `git reset --hard` or
+branch deletion) and deploy or production-impacting actions do not yet emit
+separate intents. If operators need a human gate at those boundaries today,
+they must gate the whole phase or add stricter rules around `phase_execute` /
+`external_command` for the affected workflow.
 
 ---
 
@@ -2052,7 +2050,7 @@ Add to existing `config_test.go`:
 - `TestValidate_BadGlob` — invalid glob fails
 - `TestValidate_BadEffect` — unknown effect fails
 - `TestDefaultPolicy_DeniesProtectedSurface` — file_write to `.xylem/HARNESS.md` returns Deny
-- `TestDefaultPolicy_RequiresApprovalForPush` — git_push returns RequireApproval
+- `TestDefaultPolicy_AllowsClassifiedGitLifecycleActions` — git_commit/git_push/pr_create return Allow
 - `TestDefaultPolicy_AllowsGeneral` — phase_execute returns Allow
 - `TestLoadWithObservability` — full observability config
 - `TestLoadWithObservabilityDefaults` — absent config = enabled, rate 1.0

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -478,11 +478,11 @@ phases:
 1. **analyze** -- Reads the issue and the codebase to identify relevant files, the root cause, and constraints. If the output contains `XYLEM_NOOP`, the workflow completes early.
 2. **plan** -- Takes the analysis output and produces a step-by-step implementation plan: which files to change, in what order, what tests to update, and what risks exist.
 3. **implement** -- Executes the plan. After implementation, a command gate runs `make test`. If tests fail, the phase retries up to 2 times with the test output fed back via `{{.GateResult}}`.
-4. **pr** -- Commits changes, pushes the branch, and creates a pull request linking to the issue. Under the default harness policy, `git_push` and `pr_create` are mediated high-risk actions and will stop here until your workflow or policy explicitly approves them.
+4. **pr** -- Commits changes, pushes the branch, and creates a pull request linking to the issue. Under the default harness policy, `git_push` and `pr_create` are classified publication actions but still allowed so autonomous runs can finish. Add a workflow review gate or stricter `harness.policy.rules` if you want a human checkpoint before publication.
 
 **When to use:** Assign this workflow to tasks triggered by `bug`-labeled GitHub issues. It works best for well-described bugs with clear reproduction steps.
 
-**Customization:** After running `xylem init`, edit the `run` field in the implement phase's gate to match your project's test command. The scaffolded default is `make test`, but you might need `go test ./...`, `npm test`, `pytest`, or something else. If you keep the scaffolded `pr` prompt phase, add an approval step before it or a policy rule that explicitly allows `git_push` and `pr_create` after review.
+**Customization:** After running `xylem init`, edit the `run` field in the implement phase's gate to match your project's test command. The scaffolded default is `make test`, but you might need `go test ./...`, `npm test`, `pytest`, or something else. If you want human review before publication, add a gate before the scaffolded `pr` phase or policy rules that require approval for `git_push` and `pr_create`.
 
 ### implement-feature
 
@@ -521,11 +521,11 @@ phases:
 1. **analyze** -- Reads the issue and the codebase to identify requirements, affected modules, and existing patterns to follow.
 2. **plan** -- Produces an implementation plan with file changes, ordering, test strategy, and risk assessment. A label gate then waits for `plan-approved` before implementation continues.
 3. **implement** -- Executes the approved plan. Gated on `make test` with 2 retries in the scaffolded workflow.
-4. **pr** -- Commits, pushes, and creates a pull request. Under the default harness policy, `git_push` and `pr_create` are mediated high-risk actions and will stop here until your workflow or policy explicitly approves them.
+4. **pr** -- Commits, pushes, and creates a pull request. Under the default harness policy, `git_push` and `pr_create` are classified publication actions but still allowed so autonomous runs can finish. Add a workflow review gate or stricter `harness.policy.rules` if you want a human checkpoint before publication.
 
 **When to use:** Assign this workflow to tasks triggered by `enhancement`-labeled issues that have been refined and marked as ready for autonomous implementation.
 
-**Customization:** After running `xylem init`, update the label gate and test command to match your process. For example, you might use a different approval label than `plan-approved`, or replace `make test` with `go test ./...`, `npm test`, or `pytest`. If you keep the scaffolded `pr` prompt phase, add an approval step before it or a policy rule that explicitly allows `git_push` and `pr_create` after review.
+**Customization:** After running `xylem init`, update the label gate and test command to match your process. For example, you might use a different approval label than `plan-approved`, or replace `make test` with `go test ./...`, `npm test`, or `pytest`. If you want human review before publication, add a gate before the scaffolded `pr` phase or policy rules that require approval for `git_push` and `pr_create`.
 
 ### implement-harness (repo-specific)
 


### PR DESCRIPTION
## Summary
- align the default harness policy, tests, and DTU coverage around the current autonomous publication boundary
- update init scaffolding and workflow/config docs to explain that protected surfaces stay denied while classified git publication actions are allowed by default
- document how operators can add strategic human gates with workflow review steps or explicit harness.policy.rules

Closes https://github.com/nicholls-inc/xylem/issues/161
