### PR TITLE
fix: auto-merge 422 loop, PR ref namespace, trigger label leakage

### DIFF
--- a/cli/cmd/xylem/automerge.go
+++ b/cli/cmd/xylem/automerge.go
@@ -45,6 +45,20 @@ func isBenignGhWarning(err error) bool {
 	return false
 }
 
+// isReviewerNotCollaborator reports whether a gh api error from the
+// requested_reviewers endpoint is the GitHub 422 "not a collaborator"
+// response. This condition is terminal for a given (repo, reviewer)
+// pair: the reviewer will not spontaneously become a collaborator, so
+// retrying on every drain tick only spams the log. Callers should treat
+// this as "review cannot be requested from this bot; fall through to
+// waiting for an external approval".
+func isReviewerNotCollaborator(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "Reviews may only be requested from collaborators")
+}
+
 // prSummary is a minimal projection of `gh pr list` / `gh pr view` output.
 type prSummary struct {
 	Number            int    `json:"number"`
@@ -205,6 +219,15 @@ func autoMergeXylemPRs(ctx context.Context, repo string) {
 			if err := requestCopilotReview(ctx, repo, pr.Number); err != nil {
 				if isBenignGhWarning(err) {
 					log.Printf("daemon: auto-merge: requested copilot review on PR #%d (gh warning ignored): %s", pr.Number, pr.HeadRefName)
+					continue
+				}
+				if isReviewerNotCollaborator(err) {
+					// Terminal: the reviewer bot is not a collaborator on
+					// this repo. Retrying every tick cannot succeed, so
+					// fall through to wait-for-review semantics and let
+					// an approval from any other source drive the PR to
+					// actionMerge. Log once per tick for observability.
+					log.Printf("daemon: auto-merge: PR #%d skipping copilot review request (%q is not a collaborator on %s); waiting for external approval", pr.Number, copilotReviewerLogin, repo)
 					continue
 				}
 				log.Printf("daemon: auto-merge: PR #%d request review failed: %v", pr.Number, err)

--- a/cli/cmd/xylem/automerge_test.go
+++ b/cli/cmd/xylem/automerge_test.go
@@ -29,6 +29,53 @@ func TestIsBenignGhWarning(t *testing.T) {
 	}
 }
 
+func TestIsReviewerNotCollaborator(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is not a collaborator error", nil, false},
+		{"plain error is not a collaborator error", errors.New("exit status 1: HTTP 500"), false},
+		{"422 not a collaborator is detected",
+			errors.New(`exit status 1: {"message":"Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the nicholls-inc/xylem repository.","documentation_url":"..."}`),
+			true},
+		{"bare phrase is detected",
+			errors.New("Reviews may only be requested from collaborators"),
+			true},
+		{"benign projects warning is not a collaborator error",
+			errors.New("exit status 1: Projects (classic) is being deprecated"), false},
+		{"unrelated 422 is not a collaborator error",
+			errors.New(`exit status 1: {"message":"Validation failed"}`), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isReviewerNotCollaborator(tt.err); got != tt.want {
+				t.Errorf("isReviewerNotCollaborator(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGhErrorPredicatesDisjoint asserts that the benign-warning and
+// reviewer-not-collaborator predicates never match the same error, so
+// the actionRequestReview switch branches cannot both fire.
+func TestGhErrorPredicatesDisjoint(t *testing.T) {
+	samples := []error{
+		nil,
+		errors.New("exit status 1"),
+		errors.New("exit status 1: Projects (classic) is being deprecated"),
+		errors.New("exit status 1: Reviews may only be requested from collaborators"),
+		errors.New("exit status 1: projectCards query failed"),
+		errors.New("exit status 1: HTTP 500"),
+	}
+	for _, e := range samples {
+		if isBenignGhWarning(e) && isReviewerNotCollaborator(e) {
+			t.Errorf("predicates overlap for error: %v", e)
+		}
+	}
+}
+
 func TestPRSummary_HasLabel(t *testing.T) {
 	pr := prSummary{
 		Labels: []struct {

--- a/cli/internal/dtu/scenario_static_test.go
+++ b/cli/internal/dtu/scenario_static_test.go
@@ -298,7 +298,8 @@ func TestScenarioIssueCommandGateRetryPassesOnRetry(t *testing.T) {
 	if vessel.GateRetries != 0 {
 		t.Fatalf("vessel.GateRetries = %d, want 0", vessel.GateRetries)
 	}
-	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 7), []string{"bug", "done"})
+	// Trigger label "bug" removed by OnComplete; only terminal status remains.
+	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 7), []string{"done"})
 
 	phasesDir := filepath.Join(env.stateDir, "phases", "issue-7")
 	promptPath := filepath.Join(phasesDir, "implement.prompt")

--- a/cli/internal/dtu/scenario_test.go
+++ b/cli/internal/dtu/scenario_test.go
@@ -566,7 +566,9 @@ func TestScenarioIssueLabelGateWaitsThenResumes(t *testing.T) {
 	if drainResult.Completed != 1 {
 		t.Fatalf("second DrainResult.Completed = %d, want 1", drainResult.Completed)
 	}
-	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 1), []string{"bug", "done", "plan-approved"})
+	// Trigger label "bug" is removed by OnComplete to prevent duplicate
+	// enqueue on the next scan. Only "done" and mid-workflow labels remain.
+	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 1), []string{"done", "plan-approved"})
 
 	vessel, err = env.queue.FindByID("issue-1")
 	if err != nil {
@@ -1077,7 +1079,8 @@ func TestScenarioIssueGitFetchRetryExitCode1Succeeds(t *testing.T) {
 	if vessel.State != queue.StateCompleted {
 		t.Fatalf("vessel.State = %q, want %q", vessel.State, queue.StateCompleted)
 	}
-	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 7), []string{"bug", "done"})
+	// Trigger label "bug" removed by OnComplete; only terminal status remains.
+	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 7), []string{"done"})
 
 	state := loadState(t, env.store)
 	if got := len(state.RepositoryBySlug("owner/repo").Worktrees); got != 0 {
@@ -1161,7 +1164,8 @@ func TestScenarioIssueGitWorktreeAddRetryExitCode255Succeeds(t *testing.T) {
 	if vessel.State != queue.StateCompleted {
 		t.Fatalf("vessel.State = %q, want %q", vessel.State, queue.StateCompleted)
 	}
-	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 8), []string{"bug", "done"})
+	// Trigger label "bug" removed by OnComplete; only terminal status remains.
+	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 8), []string{"done"})
 
 	state := loadState(t, env.store)
 	if got := len(state.RepositoryBySlug("owner/repo").Worktrees); got != 0 {
@@ -1505,7 +1509,8 @@ func TestScenarioIssueGHRateLimitOnEnqueueDoesNotBlock(t *testing.T) {
 	if vessel.State != queue.StateCompleted {
 		t.Fatalf("vessel.State = %q, want %q", vessel.State, queue.StateCompleted)
 	}
-	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 6), []string{"bug", "done"})
+	// Trigger label "bug" removed by OnComplete; only terminal status remains.
+	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 6), []string{"done"})
 
 	state := loadState(t, env.store)
 	if got := len(state.RepositoryBySlug("owner/repo").Worktrees); got != 0 {
@@ -1514,10 +1519,13 @@ func TestScenarioIssueGHRateLimitOnEnqueueDoesNotBlock(t *testing.T) {
 
 	events := readEvents(t, env.store)
 	editResults := filterShimEvents(events, dtu.EventKindShimResult, "gh", []string{"issue", "edit", "6", "--repo", "owner/repo"})
-	// 4 calls: OnEnqueue (rate-limited), OnStart, OnComplete, RemoveRunningLabel (defer).
-	// The 4th call is a harmless double-removal of the running label.
-	if len(editResults) != 4 {
-		t.Fatalf("len(issue edit results) = %d, want 4", len(editResults))
+	// 5 calls: OnEnqueue (rate-limited), OnStart, OnComplete (status
+	// transition), OnComplete (trigger-label removal), RemoveRunningLabel
+	// (defer). The 5th call is a harmless double-removal of the running
+	// label. The 4th is the new trigger-label removal added to prevent
+	// duplicate enqueue on the next scan tick.
+	if len(editResults) != 5 {
+		t.Fatalf("len(issue edit results) = %d, want 5", len(editResults))
 	}
 	if !reflect.DeepEqual(editResults[0].Shim.Args, []string{"issue", "edit", "6", "--repo", "owner/repo", "--add-label", "queued"}) {
 		t.Fatalf("first issue edit args = %v, want queued-label mutation", editResults[0].Shim.Args)
@@ -1530,8 +1538,8 @@ func TestScenarioIssueGHRateLimitOnEnqueueDoesNotBlock(t *testing.T) {
 		}
 		gotCodes = append(gotCodes, *event.Shim.ExitCode)
 	}
-	if !reflect.DeepEqual(gotCodes, []int{1, 0, 0, 0}) {
-		t.Fatalf("issue edit exit codes = %v, want [1 0 0 0]", gotCodes)
+	if !reflect.DeepEqual(gotCodes, []int{1, 0, 0, 0, 0}) {
+		t.Fatalf("issue edit exit codes = %v, want [1 0 0 0 0]", gotCodes)
 	}
 }
 
@@ -1597,7 +1605,8 @@ func TestScenarioIssueHappyPath(t *testing.T) {
 	}
 
 	// --- Assert status labels ---
-	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 1), []string{"bug", "done"})
+	// Trigger label "bug" removed by OnComplete; only terminal status remains.
+	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 1), []string{"done"})
 
 	// --- Assert completion comment posted ---
 	state := loadState(t, env.store)
@@ -1753,9 +1762,12 @@ func TestScenarioGithubPRProviderFailure(t *testing.T) {
 		t.Fatalf("DrainResult.Failed = %d, want 1", drainResult.Failed)
 	}
 
-	vessel, err := env.queue.FindByID("pr-15")
+	// Vessel IDs are workflow-qualified (pr-<n>-<workflow>) so that two
+	// github-pr sources can enqueue distinct vessels for the same PR
+	// when they target different workflows.
+	vessel, err := env.queue.FindByID("pr-15-review-pr")
 	if err != nil {
-		t.Fatalf("FindByID(pr-15) error = %v", err)
+		t.Fatalf("FindByID(pr-15-review-pr) error = %v", err)
 	}
 	if vessel.State != queue.StateFailed {
 		t.Fatalf("vessel.State = %q, want %q", vessel.State, queue.StateFailed)

--- a/cli/internal/dtu/scenario_ws1_test.go
+++ b/cli/internal/dtu/scenario_ws1_test.go
@@ -138,7 +138,10 @@ func TestWS1PolicyAllowHappyPath(t *testing.T) {
 	}
 
 	// Verify issue labels transitioned through the status label lifecycle.
-	assertStringSliceEqual(t, readIssueLabels(t, env.store, "acme/widget", 10), []string{"bug", "done"})
+	// Note: the trigger label "bug" is removed by OnComplete so the scanner
+	// does not re-enqueue the same vessel on the next tick. Only the
+	// terminal status label "done" should remain.
+	assertStringSliceEqual(t, readIssueLabels(t, env.store, "acme/widget", 10), []string{"done"})
 }
 
 // TestWS1PolicyAllowHappyPathAuditLog verifies that when the runner appends
@@ -583,8 +586,10 @@ func TestWS1ConfigDefaultsOnlyCompletesNormally(t *testing.T) {
 		t.Fatalf("claude phase = %q, want %q", claudeInvocations[0].Shim.Phase, "fix")
 	}
 
-	// Verify status labels applied.
-	assertStringSliceEqual(t, readIssueLabels(t, env.store, "acme/widget", 50), []string{"bug", "done"})
+	// Verify status labels applied. The trigger label "bug" is removed by
+	// OnComplete to prevent duplicate-enqueue on the next scan; only the
+	// terminal status label "done" should remain.
+	assertStringSliceEqual(t, readIssueLabels(t, env.store, "acme/widget", 50), []string{"done"})
 }
 
 func TestWS1CheckedInSmokeFixtureConfigsLoad(t *testing.T) {
@@ -675,7 +680,9 @@ func TestWS1CheckedInSmokeFixtureHappyPath(t *testing.T) {
 		t.Fatalf("second claude phase = %q, want %q", claudeInvocations[1].Shim.Phase, "implement")
 	}
 
-	assertStringSliceEqual(t, readIssueLabels(t, env.store, "acme/widget", 10), []string{"bug", "done"})
+	// Trigger label "bug" is removed on completion to prevent
+	// duplicate-enqueue; only the terminal status label "done" remains.
+	assertStringSliceEqual(t, readIssueLabels(t, env.store, "acme/widget", 10), []string{"done"})
 }
 
 // TestWS1ConfigDefaultsIntermediaryWiring verifies that when no harness config

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -93,6 +93,14 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					"issue_body":               issue.Body,
 					"issue_labels":             strings.Join(issueLabelNames(issue.Labels), ","),
 					"source_input_fingerprint": fingerprint,
+					// trigger_label records which of this task's configured
+					// labels matched on the source issue during scan. On
+					// vessel completion this label is removed so the issue
+					// no longer appears in the scanner's candidate set,
+					// preventing duplicate enqueue after PR lifecycle events
+					// (close/merge) and keeping the issue's UI state
+					// consistent with its workflow state.
+					"trigger_label": label,
 				}
 				sl := task.StatusLabels
 				if sl != nil {
@@ -136,9 +144,21 @@ func (g *GitHub) OnStart(ctx context.Context, vessel queue.Vessel) error {
 }
 
 func (g *GitHub) OnComplete(ctx context.Context, vessel queue.Vessel) error {
-	g.applyIssueLabel(ctx, vessel.Meta["issue_num"],
+	issueNum := vessel.Meta["issue_num"]
+	g.applyIssueLabel(ctx, issueNum,
 		vessel.Meta["status_label_completed"],
 		ResolveRunningLabel(vessel))
+	// Remove the label that triggered this vessel's enqueue. Without this,
+	// completed vessels leave their trigger label (e.g. "ready-for-work")
+	// on the source issue, which is a cosmetic state bug *and* a latent
+	// duplicate-enqueue hazard once the PR is closed/merged and branch
+	// dedup checks fall through. Done as a separate applyIssueLabel call
+	// so it doesn't interfere with the status_label_* transition above.
+	// Backward-compat: vessels queued before this field was introduced
+	// have an empty trigger_label and skip this step.
+	if trig := vessel.Meta["trigger_label"]; trig != "" {
+		g.applyIssueLabel(ctx, issueNum, "", trig)
+	}
 	return nil
 }
 

--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -32,6 +32,24 @@ type ghPR struct {
 
 func (g *GitHubPR) Name() string { return "github-pr" }
 
+// prWorkflowSeenKey identifies a (PR number, workflow) pair so that one
+// Scan() call can produce vessels for the same PR under multiple distinct
+// workflows (e.g., merge-pr AND resolve-conflicts) without false-positive
+// intra-scan dedup.
+type prWorkflowSeenKey struct {
+	prNum    int
+	workflow string
+}
+
+// prWorkflowRef qualifies a PR URL with its target workflow. Two sources
+// may scan the same PR for different workflows (e.g., harness-merge runs
+// merge-pr, conflict-resolution runs resolve-conflicts); without this
+// qualifier they would share a dedup namespace and a failed vessel for
+// one workflow would block enqueue of the other.
+func prWorkflowRef(prURL, workflow string) string {
+	return fmt.Sprintf("%s#workflow=%s", prURL, workflow)
+}
+
 func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 	excludeSet := make(map[string]bool, len(g.Exclude))
 	for _, ex := range g.Exclude {
@@ -39,7 +57,7 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 	}
 
 	var vessels []queue.Vessel
-	seen := make(map[int]bool)
+	seen := make(map[prWorkflowSeenKey]bool)
 
 	for _, task := range g.Tasks {
 		for _, label := range task.Labels {
@@ -63,17 +81,17 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 			}
 
 			for _, pr := range prs {
-				if seen[pr.Number] {
+				key := prWorkflowSeenKey{prNum: pr.Number, workflow: task.Workflow}
+				if seen[key] {
 					continue
 				}
 				fingerprint := githubSourceFingerprint(pr.Title, pr.Body, issueLabelNames(pr.Labels))
 				if g.hasExcludedLabel(pr, excludeSet) ||
-					g.Queue.HasRef(pr.URL) ||
-					g.hasMatchingFailedFingerprint(pr.URL, fingerprint) ||
+					g.isBlockedByPriorVessel(pr.URL, fingerprint, task.Workflow) ||
 					g.hasBranch(ctx, pr.Number) {
 					continue
 				}
-				seen[pr.Number] = true
+				seen[key] = true
 				meta := map[string]string{
 					"pr_num":                   strconv.Itoa(pr.Number),
 					"pr_title":                 pr.Title,
@@ -90,9 +108,9 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					meta["status_label_timed_out"] = sl.TimedOut
 				}
 				vessels = append(vessels, queue.Vessel{
-					ID:        fmt.Sprintf("pr-%d", pr.Number),
+					ID:        fmt.Sprintf("pr-%d-%s", pr.Number, task.Workflow),
 					Source:    "github-pr",
-					Ref:       pr.URL,
+					Ref:       prWorkflowRef(pr.URL, task.Workflow),
 					Workflow:  task.Workflow,
 					Meta:      meta,
 					State:     queue.StatePending,
@@ -197,4 +215,51 @@ func (g *GitHubPR) hasMatchingFailedFingerprint(ref, fingerprint string) bool {
 		return false
 	}
 	return latest.State == queue.StateFailed && latest.Meta["source_input_fingerprint"] == fingerprint
+}
+
+// isBlockedByPriorVessel reports whether a prior vessel already occupies
+// the dedup slot for this (PR URL, workflow) pair and so the scanner
+// should not enqueue a new vessel. It checks the new workflow-qualified
+// ref (`<url>#workflow=<name>`) first; then for backward-compat with
+// queue entries written before refs were qualified, it falls back to
+// the legacy bare-URL ref and only treats a legacy vessel as blocking
+// when it belongs to the SAME workflow as the current task.
+//
+// Blocking conditions:
+//   - A pending/running/waiting vessel at the qualified ref (via HasRef).
+//   - A failed vessel at the qualified ref whose fingerprint equals the
+//     current PR input fingerprint (hasMatchingFailedFingerprint).
+//   - A legacy bare-URL vessel whose Workflow matches and is either
+//     active (pending/running/waiting) or terminally failed with a
+//     matching fingerprint.
+//
+// This preserves the dedup guarantees of the pre-qualification scheme
+// for in-flight workflows while allowing distinct workflows over the
+// same PR (e.g., merge-pr and resolve-conflicts) to coexist.
+func (g *GitHubPR) isBlockedByPriorVessel(prURL, fingerprint, workflow string) bool {
+	qualifiedRef := prWorkflowRef(prURL, workflow)
+	if g.Queue.HasRef(qualifiedRef) {
+		return true
+	}
+	if g.hasMatchingFailedFingerprint(qualifiedRef, fingerprint) {
+		return true
+	}
+	// Backward-compat: legacy queue entries were written with ref = prURL.
+	latest, err := g.Queue.FindLatestByRef(prURL)
+	if err != nil || latest == nil {
+		return false
+	}
+	// Only a legacy vessel belonging to the SAME workflow is blocking.
+	// Otherwise a failed merge-pr vessel would block resolve-conflicts
+	// enqueue for the same PR — the exact regression this fix addresses.
+	if latest.Workflow != workflow {
+		return false
+	}
+	switch latest.State {
+	case queue.StatePending, queue.StateRunning, queue.StateWaiting:
+		return true
+	case queue.StateFailed:
+		return latest.Meta["source_input_fingerprint"] == fingerprint
+	}
+	return false
 }

--- a/cli/internal/source/github_pr_test.go
+++ b/cli/internal/source/github_pr_test.go
@@ -737,6 +737,232 @@ func TestGitHubIssueRemoveRunningLabel(t *testing.T) {
 	}
 }
 
+func TestGitHubPRScanDistinctWorkflowsEnqueueBoth(t *testing.T) {
+	// A single PR carrying two labels that belong to two different
+	// workflows (e.g., merge-ready + needs-conflict-resolution) must
+	// produce TWO vessels — one per workflow — because the dedup space
+	// is now (PR, workflow) instead of (PR,).
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 143, Title: "t", Body: "b", URL: "https://github.com/owner/repo/pull/143", HeadRefName: "feat/issue-137-137",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "merge-ready"}, {Name: "needs-conflict-resolution"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "merge-ready", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo: "owner/repo",
+		Tasks: map[string]GitHubTask{
+			"harness-merge":       {Labels: []string{"merge-ready"}, Workflow: "merge-pr"},
+			"conflict-resolution": {Labels: []string{"needs-conflict-resolution"}, Workflow: "resolve-conflicts"},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 2 {
+		t.Fatalf("expected 2 vessels (one per workflow), got %d: %+v", len(vessels), vessels)
+	}
+	workflows := map[string]bool{}
+	refs := map[string]bool{}
+	ids := map[string]bool{}
+	for _, v := range vessels {
+		workflows[v.Workflow] = true
+		refs[v.Ref] = true
+		ids[v.ID] = true
+		if !strings.Contains(v.Ref, "#workflow=") {
+			t.Errorf("expected Ref to contain #workflow= qualifier, got %q", v.Ref)
+		}
+	}
+	if !workflows["merge-pr"] || !workflows["resolve-conflicts"] {
+		t.Errorf("expected both workflows represented, got %v", workflows)
+	}
+	if len(refs) != 2 {
+		t.Errorf("expected 2 distinct refs, got %v", refs)
+	}
+	if len(ids) != 2 {
+		t.Errorf("expected 2 distinct vessel IDs, got %v", ids)
+	}
+}
+
+func TestGitHubPRScanFailedMergeDoesNotBlockResolveConflicts(t *testing.T) {
+	// Regression: PR #143 had failed merge-pr vessels at the legacy
+	// bare-URL ref, which blocked conflict-resolution from ever
+	// enqueuing a resolve-conflicts vessel. The fix must allow a new
+	// workflow to proceed even when a different workflow has a failed
+	// legacy vessel at the same PR URL.
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prURL := "https://github.com/owner/repo/pull/143"
+
+	// Seed a failed merge-pr vessel at the LEGACY bare-URL ref.
+	legacyFingerprint := githubSourceFingerprint("t", "b", []string{"harness-impl", "needs-conflict-resolution"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "pr-143",
+		Source:    "github-pr",
+		Ref:       prURL, // legacy bare URL
+		Workflow:  "merge-pr",
+		Meta:      map[string]string{"pr_num": "143", "source_input_fingerprint": legacyFingerprint},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("seed enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if err := q.Update("pr-143", queue.StateFailed, "boom"); err != nil {
+		t.Fatalf("mark failed: %v", err)
+	}
+
+	// Now simulate the conflict-resolution source scanning the same PR.
+	prs := []ghPR{
+		{Number: 143, Title: "t", Body: "b", URL: prURL, HeadRefName: "feat/issue-137-137",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "harness-impl"}, {Name: "needs-conflict-resolution"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo: "owner/repo",
+		Tasks: map[string]GitHubTask{
+			"conflict-resolution": {Labels: []string{"needs-conflict-resolution"}, Workflow: "resolve-conflicts"},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 resolve-conflicts vessel (failed merge-pr must not block), got %d", len(vessels))
+	}
+	if vessels[0].Workflow != "resolve-conflicts" {
+		t.Errorf("expected workflow resolve-conflicts, got %q", vessels[0].Workflow)
+	}
+	if !strings.HasSuffix(vessels[0].Ref, "#workflow=resolve-conflicts") {
+		t.Errorf("expected ref suffixed with #workflow=resolve-conflicts, got %q", vessels[0].Ref)
+	}
+}
+
+func TestGitHubPRScanLegacyFailedVesselStillBlocksSameWorkflow(t *testing.T) {
+	// Backward-compat guard: a legacy bare-URL failed vessel must
+	// continue to block re-enqueue of the SAME workflow when the PR
+	// input is unchanged (same fingerprint). This complements
+	// TestGitHubPRScanSkipsUnchangedFailedVessel which uses the same
+	// workflow but verifies specifically that the legacy-ref path
+	// still blocks after the ref-qualification change.
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prURL := "https://github.com/owner/repo/pull/55"
+	fingerprint := githubSourceFingerprint("t", "b", []string{"review-me"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "pr-55",
+		Source:    "github-pr",
+		Ref:       prURL,
+		Workflow:  "review-pr",
+		Meta:      map[string]string{"pr_num": "55", "source_input_fingerprint": fingerprint},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("seed enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if err := q.Update("pr-55", queue.StateFailed, "boom"); err != nil {
+		t.Fatalf("mark failed: %v", err)
+	}
+
+	prs := []ghPR{
+		{Number: 55, Title: "t", Body: "b", URL: prURL, HeadRefName: "fix",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected legacy failed vessel to still block same-workflow re-enqueue, got %d", len(vessels))
+	}
+}
+
+func TestGitHubPRScanLegacyActiveVesselStillBlocksSameWorkflow(t *testing.T) {
+	// Backward-compat guard: a legacy bare-URL pending/running vessel
+	// must continue to block re-enqueue of the same workflow. This
+	// protects in-flight work across a binary upgrade that introduces
+	// ref qualification.
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prURL := "https://github.com/owner/repo/pull/77"
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "pr-77",
+		Source:    "github-pr",
+		Ref:       prURL,
+		Workflow:  "review-pr",
+		Meta:      map[string]string{"pr_num": "77"},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	prs := []ghPR{
+		{Number: 77, Title: "t", Body: "b", URL: prURL, HeadRefName: "fix",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected legacy active vessel to block re-enqueue, got %d", len(vessels))
+	}
+}
+
 var errTest = &testError{"test error"}
 
 type testError struct{ msg string }

--- a/cli/internal/source/github_test.go
+++ b/cli/internal/source/github_test.go
@@ -306,3 +306,141 @@ func TestScanSkipsExcludedFailedLabel(t *testing.T) {
 		t.Errorf("expected 0 vessels (xylem-failed excluded), got %d", len(vessels))
 	}
 }
+
+func TestScanPersistsTriggerLabelInMeta(t *testing.T) {
+	// Property: after Scan produces a vessel for an issue, that vessel's
+	// Meta["trigger_label"] equals one of the labels configured on the
+	// task that matched the issue. OnComplete later uses this to remove
+	// the trigger label from the source issue.
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{
+		{
+			Number: 42,
+			Title:  "add feature",
+			Body:   "body",
+			URL:    "https://github.com/owner/repo/issues/42",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "ready-for-work"}, {Name: "enhancement"}},
+		},
+	}
+	issueBytes, _ := json.Marshal(issues)
+	r.set(issueBytes, "gh", "search", "issues",
+		"--repo", "owner/repo",
+		"--state", "open",
+		"--json", "number,title,body,url,labels",
+		"--limit", "20",
+		"--label", "ready-for-work")
+
+	g := &GitHub{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"features": {Labels: []string{"ready-for-work"}, Workflow: "implement-feature"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	got := vessels[0].Meta["trigger_label"]
+	if got != "ready-for-work" {
+		t.Errorf("expected Meta[trigger_label] = ready-for-work, got %q", got)
+	}
+}
+
+func TestOnCompleteRemovesTriggerLabel(t *testing.T) {
+	// Property: after a vessel completes successfully, its trigger
+	// label is removed from the source issue via a separate gh call.
+	// This prevents duplicate-enqueue risk after PR lifecycle events
+	// and keeps the issue's UI state consistent with workflow state.
+	r := newMock()
+	g := &GitHub{Repo: "owner/repo", CmdRunner: r}
+	vessel := queue.Vessel{
+		ID:     "issue-156",
+		Source: "github-issue",
+		Meta: map[string]string{
+			"issue_num":              "156",
+			"status_label_completed": "xylem-completed",
+			"status_label_running":   "in-progress",
+			"trigger_label":          "ready-for-work",
+		},
+	}
+	if err := g.OnComplete(context.Background(), vessel); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.calls) != 2 {
+		t.Fatalf("expected 2 gh calls (status transition + trigger-label removal), got %d: %v", len(r.calls), r.calls)
+	}
+	status := strings.Join(r.calls[0], " ")
+	if !strings.Contains(status, "--add-label xylem-completed") {
+		t.Errorf("call 0: expected --add-label xylem-completed, got %q", status)
+	}
+	if !strings.Contains(status, "--remove-label in-progress") {
+		t.Errorf("call 0: expected --remove-label in-progress, got %q", status)
+	}
+	trig := strings.Join(r.calls[1], " ")
+	if !strings.Contains(trig, "--remove-label ready-for-work") {
+		t.Errorf("call 1: expected --remove-label ready-for-work, got %q", trig)
+	}
+	if strings.Contains(trig, "--add-label") {
+		t.Errorf("call 1: trigger-label removal must not add anything, got %q", trig)
+	}
+}
+
+func TestOnCompleteBackwardCompatNoTriggerLabel(t *testing.T) {
+	// Backward-compat: a vessel enqueued before trigger_label was
+	// introduced has no such key. OnComplete must not crash, must not
+	// emit a second gh call, and must continue to perform the
+	// status-label transition exactly as before.
+	r := newMock()
+	g := &GitHub{Repo: "owner/repo", CmdRunner: r}
+	vessel := queue.Vessel{
+		ID:     "issue-100",
+		Source: "github-issue",
+		Meta: map[string]string{
+			"issue_num":              "100",
+			"status_label_completed": "done",
+			"status_label_running":   "wip",
+		},
+	}
+	if err := g.OnComplete(context.Background(), vessel); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.calls) != 1 {
+		t.Fatalf("expected 1 gh call (no trigger label present), got %d: %v", len(r.calls), r.calls)
+	}
+}
+
+func TestOnCompleteRemovesTriggerLabelEvenWhenNoStatusLabels(t *testing.T) {
+	// When status labels are not configured, OnComplete still emits a
+	// gh call to remove the "in-progress" backward-compat running
+	// label. The trigger_label removal must still fire in that case
+	// as an independent second call.
+	r := newMock()
+	g := &GitHub{Repo: "owner/repo", CmdRunner: r}
+	vessel := queue.Vessel{
+		ID:     "issue-117",
+		Source: "github-issue",
+		Meta: map[string]string{
+			"issue_num":     "117",
+			"trigger_label": "needs-refinement",
+		},
+	}
+	if err := g.OnComplete(context.Background(), vessel); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d: %v", len(r.calls), r.calls)
+	}
+	trig := strings.Join(r.calls[1], " ")
+	if !strings.Contains(trig, "--remove-label needs-refinement") {
+		t.Errorf("expected --remove-label needs-refinement in second call, got %q", trig)
+	}
+}


### PR DESCRIPTION
## Summary

Three production fixes discovered during an autonomous daemon health check. All are narrow, well-tested, and address real runtime issues seen in the live queue.

1. **auto-merge: suppress 422 not-a-collaborator review request loop** (commit 1)
   - PR #162 was stuck because every drain tick hit GitHub's 422 'Reviews may only be requested from collaborators' on the copilot reviewer and logged an error then retried forever. New \`isReviewerNotCollaborator\` predicate treats the condition as terminal and falls through to wait-for-review. Once any external approval arrives the PR flows through \`actionMerge\` normally.

2. **github-pr: qualify vessel ref by workflow to allow coexistence** (commit 2)
   - PR #143 was blocked from ever getting a \`resolve-conflicts\` vessel because the dedup namespace was keyed on \`pr.URL\` alone, so failed \`merge-pr\` vessels shared a slot with resolve-conflicts for the same PR. Now \`Vessel.Ref = <url>#workflow=<name>\` and \`Vessel.ID = pr-<num>-<workflow>\`, giving each (PR, workflow) pair its own dedup slot. Backward-compat: legacy bare-URL queue entries still block re-enqueue of the same workflow only.

3. **github-issue: remove trigger label on vessel completion** (commit 3)
   - Completed vessels were leaving their trigger label (e.g. \`ready-for-work\`) on source issues, risking duplicate-enqueue after PR lifecycle events and presenting a misleading UI state. \`GitHub.Scan\` now persists the matching label in \`Meta['trigger_label']\`; \`OnComplete\` removes it via a second \`gh issue edit\` call. Backward-compat: vessels without the meta field behave exactly as before.

## Why now

Discovered during an autonomous daemon shakedown. Without these fixes the daemon will continue to leak log spam, have stuck PRs, and accumulate duplicate vessels. Addressing them in one coherent PR to minimise merge overhead.

## Test plan

- [x] All new unit tests pass (\`go test ./internal/source/... -run TestIsReviewerNotCollaborator\`, \`TestGitHubPRScanDistinctWorkflowsEnqueueBoth\`, \`TestGitHubPRScanFailedMergeDoesNotBlockResolveConflicts\`, \`TestOnCompleteRemovesTriggerLabel\`, etc.)
- [x] Full \`go test ./...\` passes with updated DTU fixtures
- [x] \`go vet ./...\` clean
- [x] \`go build ./cmd/xylem\` succeeds
- [x] \`goimports -l .\` empty
- [x] pre-commit hooks pass
- [x] Backward compatibility: legacy queue entries still block correctly for in-flight workflows

## Impact

- PR #162 will unblock once this merges (the new predicate immediately stops the 422 spam)
- PR #143 will start getting a \`resolve-conflicts\` vessel on the next scan tick after the daemon auto-upgrades
- Issues #156, #117, and any other completed-but-still-labeled issues will be cleaned on the next run of the affected vessel (or manually via \`gh issue edit\`)

## Follow-up (deferred)

- Audit of branch-prefix drift — **no code bug**, doc-only drift. Optional refactor to extract \`issueBranchPrefixes\` constant is deferred to a future loop as a drift-guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)