### PR TITLE
fix: exec: propagate extraEnv + skip empty expansions (auth cascade)

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -99,7 +99,13 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		return runDrain(ctx, cfg, q, wt, drainInterval)
 	}
 	check := func(ctx context.Context) {
-		cmdRunner := &realCmdRunner{}
+		// Use newCmdRunner(cfg) here (not a bare &realCmdRunner{}) so the
+		// periodic label-poll and hang-detection paths receive the same
+		// configured env (claude.env / copilot.env) as the scan/drain
+		// paths. A bare runner silently strips any configured env which
+		// caused gh/copilot auth failures on hosts that rely on the
+		// config-declared tokens during label polling.
+		cmdRunner := newCmdRunner(cfg)
 		r := runner.New(cfg, q, wt, cmdRunner)
 		r.Sources = buildSourceMap(cfg, q, cmdRunner)
 		r.CheckWaitingVessels(ctx)

--- a/cli/cmd/xylem/exec.go
+++ b/cli/cmd/xylem/exec.go
@@ -77,26 +77,70 @@ type realCmdRunner struct {
 
 // newCmdRunner creates a realCmdRunner with extra env vars merged from
 // claude.env and copilot.env config sections.
+//
+// When an env value contains an unset shell variable reference (e.g.
+// "${COPILOT_GITHUB_TOKEN}" when COPILOT_GITHUB_TOKEN is not exported),
+// os.ExpandEnv returns an empty string. Propagating an empty value into
+// the subprocess environment is actively harmful because it *unsets*
+// (shadows) any matching variable the subprocess might otherwise inherit
+// from the daemon's own environment. For example, if the daemon has
+// GITHUB_TOKEN set directly but .xylem.yml declares
+//
+//	copilot.env.GITHUB_TOKEN: "${COPILOT_GITHUB_TOKEN}"
+//
+// then a naive expansion would emit "GITHUB_TOKEN=" and the gh/copilot
+// subprocess would see no token at all — producing the "No
+// authentication information found" cascade observed on 2026-04-09.
+//
+// Skip any empty-value expansions so the subprocess falls back to the
+// daemon's own env. Operators who intentionally want to unset a var can
+// remove it from .xylem.yml rather than relying on implicit blanking.
 func newCmdRunner(cfg *config.Config) *realCmdRunner {
 	if cfg == nil {
 		return &realCmdRunner{}
 	}
 	var env []string
+	addEnv := func(k, v string) {
+		expanded := os.ExpandEnv(v)
+		if expanded == "" {
+			return
+		}
+		env = append(env, k+"="+expanded)
+	}
 	for k, v := range cfg.Claude.Env {
-		env = append(env, k+"="+os.ExpandEnv(v))
+		addEnv(k, v)
 	}
 	for k, v := range cfg.Copilot.Env {
-		env = append(env, k+"="+os.ExpandEnv(v))
+		addEnv(k, v)
 	}
 	return &realCmdRunner{extraEnv: env}
 }
 
+// cmdEnv returns the environment to use for a subprocess: the daemon's
+// own env with extraEnv appended (extraEnv values take precedence
+// because Go's exec package uses the last occurrence of a given key).
+//
+// Always returning a non-nil slice means cmd.Env is set explicitly,
+// which makes the subprocess environment deterministic regardless of
+// whether extraEnv is empty.
+func (r *realCmdRunner) cmdEnv() []string {
+	base := os.Environ()
+	if len(r.extraEnv) == 0 {
+		return base
+	}
+	return append(base, r.extraEnv...)
+}
+
 func (r *realCmdRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = r.cmdEnv()
+	return cmd.CombinedOutput()
 }
 
 func (r *realCmdRunner) RunOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = r.cmdEnv()
+	return cmd.CombinedOutput()
 }
 
 func (r *realCmdRunner) RunProcess(ctx context.Context, dir string, name string, args ...string) error {
@@ -104,6 +148,7 @@ func (r *realCmdRunner) RunProcess(ctx context.Context, dir string, name string,
 	cmd.Dir = dir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Env = r.cmdEnv()
 	return cmd.Run()
 }
 
@@ -112,7 +157,10 @@ func (r *realCmdRunner) RunProcessWithEnv(ctx context.Context, dir string, extra
 	cmd.Dir = dir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = append(os.Environ(), extraEnv...)
+	// Merge the caller-supplied extraEnv on top of the runner's own
+	// configured env so caller overrides win.
+	base := r.cmdEnv()
+	cmd.Env = append(base, extraEnv...)
 	return cmd.Run()
 }
 
@@ -120,9 +168,7 @@ func (r *realCmdRunner) RunPhase(ctx context.Context, dir string, stdin io.Reade
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
 	cmd.Stdin = stdin
-	if len(r.extraEnv) > 0 {
-		cmd.Env = append(os.Environ(), r.extraEnv...)
-	}
+	cmd.Env = r.cmdEnv()
 
 	var stdout bytes.Buffer
 	stderr := newLimitedWriter(maxStderrBytes)

--- a/cli/cmd/xylem/exec_test.go
+++ b/cli/cmd/xylem/exec_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+)
+
+// TestNewCmdRunner_SkipsEmptyExpansion documents the fix for the
+// 2026-04-09 auth cascade: when .xylem.yml declares
+//
+//	copilot.env.GITHUB_TOKEN: "${COPILOT_GITHUB_TOKEN}"
+//
+// but COPILOT_GITHUB_TOKEN is not set in the daemon's environment,
+// os.ExpandEnv yields an empty string. Propagating "GITHUB_TOKEN="
+// would unset any GITHUB_TOKEN the subprocess might otherwise inherit.
+// The runner must skip empty expansions entirely.
+func TestNewCmdRunner_SkipsEmptyExpansion(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "") // explicitly unset
+	cfg := &config.Config{
+		Claude: config.ClaudeConfig{
+			Env: map[string]string{
+				"ANTHROPIC_API_KEY": "${ANTHROPIC_API_KEY_XYLEM_TEST_UNSET}",
+			},
+		},
+		Copilot: config.CopilotConfig{
+			Env: map[string]string{
+				"COPILOT_GITHUB_TOKEN": "${COPILOT_GITHUB_TOKEN}",
+			},
+		},
+	}
+
+	runner := newCmdRunner(cfg)
+	if len(runner.extraEnv) != 0 {
+		t.Fatalf("expected empty extraEnv when all expansions are empty, got %v", runner.extraEnv)
+	}
+}
+
+// TestNewCmdRunner_PropagatesExpandedEnv verifies that non-empty
+// expansions are merged into extraEnv.
+func TestNewCmdRunner_PropagatesExpandedEnv(t *testing.T) {
+	t.Setenv("XYLEM_TEST_TOKEN", "abc123")
+	cfg := &config.Config{
+		Copilot: config.CopilotConfig{
+			Env: map[string]string{
+				"COPILOT_GITHUB_TOKEN": "${XYLEM_TEST_TOKEN}",
+			},
+		},
+	}
+
+	runner := newCmdRunner(cfg)
+	if len(runner.extraEnv) != 1 {
+		t.Fatalf("expected one extraEnv entry, got %v", runner.extraEnv)
+	}
+	want := "COPILOT_GITHUB_TOKEN=abc123"
+	if runner.extraEnv[0] != want {
+		t.Fatalf("expected %q, got %q", want, runner.extraEnv[0])
+	}
+}
+
+// TestNewCmdRunner_MixedEnv verifies the addEnv helper handles
+// non-empty Claude env alongside empty Copilot env correctly (one
+// expansion resolves, the other should be dropped).
+func TestNewCmdRunner_MixedEnv(t *testing.T) {
+	t.Setenv("XYLEM_TEST_ANTHROPIC", "sk-test")
+	t.Setenv("XYLEM_TEST_COPILOT_UNSET", "")
+	cfg := &config.Config{
+		Claude: config.ClaudeConfig{
+			Env: map[string]string{
+				"ANTHROPIC_API_KEY": "${XYLEM_TEST_ANTHROPIC}",
+			},
+		},
+		Copilot: config.CopilotConfig{
+			Env: map[string]string{
+				"COPILOT_GITHUB_TOKEN": "${XYLEM_TEST_COPILOT_UNSET}",
+			},
+		},
+	}
+
+	runner := newCmdRunner(cfg)
+	if len(runner.extraEnv) != 1 {
+		t.Fatalf("expected exactly one extraEnv entry (Claude only), got %v", runner.extraEnv)
+	}
+	if runner.extraEnv[0] != "ANTHROPIC_API_KEY=sk-test" {
+		t.Fatalf("expected ANTHROPIC_API_KEY=sk-test, got %q", runner.extraEnv[0])
+	}
+}
+
+// TestRealCmdRunner_RunOutputInheritsEnv verifies that the non-phase
+// Run* methods now propagate extraEnv into the subprocess. Before the
+// fix, `gh`/`copilot` calls from the scanner and source commands
+// silently lost the token because Run/RunOutput/RunProcess did not set
+// cmd.Env. The test executes `sh -c 'echo "$XYLEM_TEST_PROBE"'` (or a
+// platform equivalent) and asserts the probe value reaches the child.
+func TestRealCmdRunner_RunOutputInheritsEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh unavailable on windows")
+	}
+	t.Setenv("XYLEM_TEST_PROBE_SRC", "proof-of-propagation")
+	cfg := &config.Config{
+		Copilot: config.CopilotConfig{
+			Env: map[string]string{
+				"XYLEM_TEST_PROBE": "${XYLEM_TEST_PROBE_SRC}",
+			},
+		},
+	}
+	runner := newCmdRunner(cfg)
+	out, err := runner.RunOutput(context.Background(), "sh", "-c", "printf %s \"$XYLEM_TEST_PROBE\"")
+	if err != nil {
+		t.Fatalf("RunOutput failed: %v (output: %q)", err, string(out))
+	}
+	got := strings.TrimSpace(string(out))
+	if got != "proof-of-propagation" {
+		t.Fatalf("expected RunOutput subprocess to see XYLEM_TEST_PROBE=proof-of-propagation, got %q", got)
+	}
+}
+
+// TestRealCmdRunner_RunPhaseInheritsBaseEnv verifies that RunPhase
+// still passes base os.Environ() through even when extraEnv is empty
+// (previous code gated cmd.Env on len(extraEnv) > 0, which relied on
+// Go's default-inherit behavior). After the refactor cmd.Env is always
+// set explicitly for determinism — the probe from os.Environ() must
+// still reach the subprocess.
+func TestRealCmdRunner_RunPhaseInheritsBaseEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh unavailable on windows")
+	}
+	t.Setenv("XYLEM_TEST_BASE_PROBE", "inherited")
+	runner := newCmdRunner(&config.Config{})
+	out, err := runner.RunPhase(context.Background(), ".", nil, "sh", "-c", "printf %s \"$XYLEM_TEST_BASE_PROBE\"")
+	if err != nil {
+		t.Fatalf("RunPhase failed: %v (output: %q)", err, string(out))
+	}
+	got := strings.TrimSpace(string(out))
+	if got != "inherited" {
+		t.Fatalf("expected RunPhase subprocess to see XYLEM_TEST_BASE_PROBE=inherited, got %q", got)
+	}
+}
+
+// TestCmdEnv_AppendsExtraAfterBase verifies the ordering contract:
+// extraEnv entries come AFTER base os.Environ() so they take precedence
+// (exec uses the last occurrence of a duplicate key).
+func TestCmdEnv_AppendsExtraAfterBase(t *testing.T) {
+	t.Setenv("XYLEM_TEST_OVERRIDE", "from-base")
+	cfg := &config.Config{
+		Copilot: config.CopilotConfig{
+			Env: map[string]string{
+				"XYLEM_TEST_OVERRIDE": "from-config",
+			},
+		},
+	}
+	runner := newCmdRunner(cfg)
+	env := runner.cmdEnv()
+
+	// Find all occurrences of the key
+	var values []string
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "XYLEM_TEST_OVERRIDE=") {
+			values = append(values, strings.TrimPrefix(entry, "XYLEM_TEST_OVERRIDE="))
+		}
+	}
+	if len(values) < 1 {
+		t.Fatalf("expected XYLEM_TEST_OVERRIDE to appear in cmdEnv, got none")
+	}
+	if values[len(values)-1] != "from-config" {
+		t.Fatalf("expected config value to come last (wins via exec precedence), got values=%v", values)
+	}
+}
+
+// TestCmdEnv_StableOrdering sanity-checks that cmdEnv returns a
+// deterministic slice so future debugging isn't confused by nondeterminism.
+func TestCmdEnv_StableOrdering(t *testing.T) {
+	cfg := &config.Config{
+		Copilot: config.CopilotConfig{
+			Env: map[string]string{
+				"ZZZ_KEY": "zz",
+				"AAA_KEY": "aa",
+			},
+		},
+	}
+	runner := newCmdRunner(cfg)
+
+	// Go map iteration order is non-deterministic, so extraEnv order
+	// itself is unstable — that's acceptable because exec() doesn't
+	// care. We only verify that cmdEnv() returns a superset of
+	// os.Environ() and the configured keys all appear.
+	env := runner.cmdEnv()
+	want := map[string]bool{"AAA_KEY=aa": false, "ZZZ_KEY=zz": false}
+	for _, entry := range env {
+		if _, ok := want[entry]; ok {
+			want[entry] = true
+		}
+	}
+	var missing []string
+	for k, seen := range want {
+		if !seen {
+			missing = append(missing, k)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Fatalf("cmdEnv missing configured entries: %v", missing)
+	}
+
+	// Sanity: base env should be included
+	baseCount := len(os.Environ())
+	if len(env) < baseCount {
+		t.Fatalf("cmdEnv should include os.Environ() (base=%d) + extraEnv, got len=%d", baseCount, len(env))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the 2026-04-09 auth cascade where every copilot/gh subprocess call was failing with \`No authentication information found\` after daemon restart, leaving the queue idle with 26 failed vessels.

- **Empty-expansion shadowing**: \`newCmdRunner\` was emitting \`GITHUB_TOKEN=\"\"\` into \`extraEnv\` whenever \`${COPILOT_GITHUB_TOKEN}\` expanded to an empty string, which (via last-wins in \`exec.Cmd.Env\`) shadowed any token the daemon had inherited from its own shell. Fixed by skipping empty expansions.
- **extraEnv dropped by non-phase methods**: only \`RunPhase\` propagated \`extraEnv\`; \`Run\`, \`RunOutput\`, and \`RunProcess\` silently dropped it. Every \`gh\`/\`git\`/\`copilot\` call made through the scanner's \`CommandRunner\` interface missed configured env. Fixed via a new \`cmdEnv()\` helper wired into all five methods.
- **daemon.go check closure gap**: \`cmdDaemon\`'s periodic \`check\` closure constructed a bare \`&realCmdRunner{}\` instead of \`newCmdRunner(cfg)\`, meaning label polling and hung-vessel checks also skipped the configured env. This was a latent gap flagged by the crosscheck verifier — fixing in the same PR avoids an identical failure mode.

## Verification

Reasoning certificate from \`crosscheck:byfuglien\` semi-formal verifier: **VERIFIED** (all five methods propagate extraEnv, ordering contract correct, no caller can observe the old nil-env behavior through the interface).

Regression tests (\`cli/cmd/xylem/exec_test.go\`):
- \`TestNewCmdRunner_SkipsEmptyExpansion\` — the direct test for the shadowing bug.
- \`TestNewCmdRunner_PropagatesExpandedEnv\` — non-empty expansion is merged.
- \`TestNewCmdRunner_MixedEnv\` — mixed empty/non-empty entries are handled per-key.
- \`TestRealCmdRunner_RunOutputInheritsEnv\` — end-to-end subprocess env propagation via \`sh -c 'printf %s \"\$VAR\"'\`.
- \`TestRealCmdRunner_RunPhaseInheritsBaseEnv\` — base env still reaches subprocess when extraEnv is empty.
- \`TestCmdEnv_AppendsExtraAfterBase\` — ordering contract: extraEnv wins on duplicate keys.
- \`TestCmdEnv_StableOrdering\` — sanity check of superset semantics.

Full test suite passes (\`go test ./...\`), \`go vet ./...\` clean, \`goimports -l .\` empty, \`golangci-lint run\` 0 issues.

## Not addressed (follow-up)

The protected-surface deletion cascade affecting PR #143 (\`resolve-conflicts\` workflow) is root-caused but not patched here. Root cause: \`gh pr checkout\` inside a worktree that was created at \`origin/main\` drops \`.xylem/\` files if the PR branch predates #157. Will be filed as a separate issue + PR.

## Test plan

- [x] \`go build ./cmd/xylem\`
- [x] \`go test ./...\`
- [x] \`go vet ./...\`
- [x] \`goimports -l .\` (empty)
- [x] \`golangci-lint run\` (0 issues)
- [x] New regression tests directly exercise the failure mode (empty-expansion shadowing + non-phase runner env propagation)
- [ ] Post-merge: daemon auto-upgrades to the new binary, next scan tick runs without auth errors, queued vessels (#89, #91, #150, #151, #158, #159, #160) transition to \`running\`.

Diagnosis derived from \`/xylem-status\` against \`.daemon-root\` at 2026-04-09T04:06Z.

Co-authored with Claude Opus 4.6 (autonomous hourly loop, /loop 1h /xylem-status).