### PR TITLE
fix: runner: canonicalize + self-heal protected surfaces (#170)

### DIFF
--- a/.xylem/prompts/resolve-conflicts/analyze.md
+++ b/.xylem/prompts/resolve-conflicts/analyze.md
@@ -10,6 +10,8 @@ Check out the PR branch and attempt a merge from main:
 1. Run `gh pr checkout {{.Issue.Number}}`
 2. Run `git fetch origin main && git merge origin/main --no-commit`
 
+Do not modify, stage, or delete anything under `.xylem/`. The xylem control plane is out of scope for conflict resolution.
+
 If the merge completes with no conflicts, include the exact standalone line `XYLEM_NOOP` in your final output and explain that no conflict resolution is needed.
 
 If there are conflicts:

--- a/.xylem/prompts/resolve-conflicts/resolve.md
+++ b/.xylem/prompts/resolve-conflicts/resolve.md
@@ -19,6 +19,8 @@ Resolve each conflict using these strategies:
 - **Overlapping**: both sides modified the same code. Combine the intent of both changes.
 - **Structural**: one side refactored while the other made localized edits. Apply the localized edits to the new structure.
 
+Do not modify, stage, or delete anything under `.xylem/`. The xylem control plane is out of scope for conflict resolution.
+
 For every conflicting file:
 
 1. Remove all conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -528,7 +528,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					}
 					return "failed"
 				}
-				beforeSnapshot, checkProtectedSurfaces, err = r.takeProtectedSurfaceSnapshot(worktreePath)
+				beforeSnapshot, checkProtectedSurfaces, err = r.takeProtectedSurfaceSnapshot(ctx, worktreePath)
 				if err != nil {
 					snapErr := fmt.Errorf("protected surface snapshot failed: %w", err)
 					finishCurrentPhaseSpan(snapErr)
@@ -590,7 +590,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					}
 					return "failed"
 				}
-				beforeSnapshot, checkProtectedSurfaces, err = r.takeProtectedSurfaceSnapshot(worktreePath)
+				beforeSnapshot, checkProtectedSurfaces, err = r.takeProtectedSurfaceSnapshot(ctx, worktreePath)
 				if err != nil {
 					snapErr := fmt.Errorf("protected surface snapshot failed: %w", err)
 					finishCurrentPhaseSpan(snapErr)
@@ -859,7 +859,7 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 	cmd, args := buildPromptOnlyCmdArgs(r.Config, prompt)
 	provider := resolveProvider(r.Config, nil, nil, nil)
 	model := resolveModel(r.Config, nil, nil, nil, provider)
-	beforeSnapshot, checkProtectedSurfaces, err := r.takeProtectedSurfaceSnapshot(worktreePath)
+	beforeSnapshot, checkProtectedSurfaces, err := r.takeProtectedSurfaceSnapshot(ctx, worktreePath)
 	if err != nil {
 		snapErr := fmt.Errorf("protected surface snapshot failed: %w", err)
 		r.failVessel(vessel.ID, snapErr.Error())
@@ -1328,7 +1328,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				}
 				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
 			}
-			beforeSnapshot, checkProtectedSurfaces, err = r.takeProtectedSurfaceSnapshot(worktreePath)
+			beforeSnapshot, checkProtectedSurfaces, err = r.takeProtectedSurfaceSnapshot(ctx, worktreePath)
 			if err != nil {
 				snapErr := fmt.Errorf("protected surface snapshot failed: %w", err)
 				finishCurrentPhaseSpan(snapErr)
@@ -1389,7 +1389,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				}
 				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
 			}
-			beforeSnapshot, checkProtectedSurfaces, err = r.takeProtectedSurfaceSnapshot(worktreePath)
+			beforeSnapshot, checkProtectedSurfaces, err = r.takeProtectedSurfaceSnapshot(ctx, worktreePath)
 			if err != nil {
 				snapErr := fmt.Errorf("protected surface snapshot failed: %w", err)
 				finishCurrentPhaseSpan(snapErr)
@@ -1955,10 +1955,17 @@ func extractRepoFlag(rendered, fallback string) string {
 	return "*"
 }
 
-func (r *Runner) takeProtectedSurfaceSnapshot(worktreePath string) (surface.Snapshot, bool, error) {
+func (r *Runner) takeProtectedSurfaceSnapshot(ctx context.Context, worktreePath string) (surface.Snapshot, bool, error) {
 	patterns := r.Config.EffectiveProtectedSurfaces()
 	if len(patterns) == 0 {
 		return surface.Snapshot{}, false, nil
+	}
+
+	sourceRoot, err := r.protectedSurfaceSourceRoot(ctx, worktreePath)
+	if err == nil {
+		if _, restoreErr := restoreMissingProtectedSurfacesFromRoot(worktreePath, sourceRoot, patterns); restoreErr != nil {
+			return surface.Snapshot{}, false, fmt.Errorf("restore missing protected surfaces: %w", restoreErr)
+		}
 	}
 
 	snapshot, err := surface.TakeSnapshot(worktreePath, patterns)
@@ -2005,7 +2012,149 @@ func (r *Runner) verifyProtectedSurfaces(vessel queue.Vessel, p workflow.Phase, 
 	if err := r.recordProtectedSurfaceViolations(vessel, p, errMsg, violations); err != nil {
 		return fmt.Errorf("%s (record audit evidence: %w)", errMsg, err)
 	}
+	if err := r.restoreDeletedProtectedSurfaces(context.Background(), worktreePath, violations); err != nil {
+		log.Printf("%sphase %q protected surface self-heal failed: %v", vesselLabel(vessel), p.Name, err)
+	}
 	return fmt.Errorf("%s", errMsg)
+}
+
+func (r *Runner) protectedSurfaceSourceRoot(ctx context.Context, worktreePath string) (string, error) {
+	out, err := r.Runner.RunOutput(ctx, "git", "-C", worktreePath, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if err != nil {
+		return worktreePath, nil
+	}
+
+	commonDir := strings.TrimSpace(string(out))
+	if commonDir == "" {
+		return worktreePath, nil
+	}
+	if filepath.Base(commonDir) == ".git" {
+		return filepath.Dir(commonDir), nil
+	}
+	return worktreePath, nil
+}
+
+func restoreMissingProtectedSurfacesFromRoot(worktreePath, sourceRoot string, patterns []string) (int, error) {
+	if len(patterns) == 0 {
+		return 0, nil
+	}
+
+	sourceSnapshot, err := surface.TakeSnapshot(sourceRoot, patterns)
+	if err != nil {
+		return 0, fmt.Errorf("take source protected surface snapshot: %w", err)
+	}
+	worktreeSnapshot, err := surface.TakeSnapshot(worktreePath, patterns)
+	if err != nil {
+		return 0, fmt.Errorf("take worktree protected surface snapshot: %w", err)
+	}
+
+	restored := 0
+	for _, violation := range surface.Compare(sourceSnapshot, worktreeSnapshot) {
+		if violation.After != "deleted" {
+			continue
+		}
+		if err := copyProtectedSurfaceFile(sourceRoot, worktreePath, violation.Path); err != nil {
+			return restored, fmt.Errorf("restore %s from source root: %w", violation.Path, err)
+		}
+		restored++
+	}
+
+	return restored, nil
+}
+
+func copyProtectedSurfaceFile(sourceRoot, worktreePath, relPath string) error {
+	srcPath := filepath.Join(sourceRoot, filepath.FromSlash(relPath))
+	dstPath := filepath.Join(worktreePath, filepath.FromSlash(relPath))
+
+	info, err := os.Stat(srcPath)
+	if err != nil {
+		return fmt.Errorf("stat source file: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir parent dir: %w", err)
+	}
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return fmt.Errorf("read source file: %w", err)
+	}
+	if err := os.WriteFile(dstPath, data, info.Mode()); err != nil {
+		return fmt.Errorf("write restored file: %w", err)
+	}
+	if err := os.Chmod(dstPath, 0o444); err != nil {
+		return fmt.Errorf("mark restored file read-only: %w", err)
+	}
+	return nil
+}
+
+func (r *Runner) restoreDeletedProtectedSurfaces(ctx context.Context, worktreePath string, violations []surface.Violation) error {
+	var errs []error
+	defaultBranch := ""
+
+	for _, violation := range violations {
+		if violation.After != "deleted" {
+			continue
+		}
+		if err := r.restoreProtectedSurfacePath(ctx, worktreePath, violation.Path, &defaultBranch); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", violation.Path, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (r *Runner) restoreProtectedSurfacePath(ctx context.Context, worktreePath, relPath string, defaultBranch *string) error {
+	if _, err := r.Runner.RunOutput(ctx, "git", "-C", worktreePath, "checkout", "--", relPath); err == nil {
+		return markProtectedSurfaceReadOnly(worktreePath, relPath)
+	}
+
+	if defaultBranch != nil && *defaultBranch == "" {
+		branch, err := r.detectDefaultBranchAtPath(ctx, worktreePath)
+		if err != nil {
+			return fmt.Errorf("detect default branch: %w", err)
+		}
+		*defaultBranch = branch
+	}
+
+	if defaultBranch == nil || *defaultBranch == "" {
+		return fmt.Errorf("default branch unavailable for restore")
+	}
+
+	if _, err := r.Runner.RunOutput(ctx, "git", "-C", worktreePath, "checkout", "origin/"+*defaultBranch, "--", relPath); err != nil {
+		return fmt.Errorf("checkout origin/%s -- %s: %w", *defaultBranch, relPath, err)
+	}
+	return markProtectedSurfaceReadOnly(worktreePath, relPath)
+}
+
+func markProtectedSurfaceReadOnly(worktreePath, relPath string) error {
+	if err := os.Chmod(filepath.Join(worktreePath, filepath.FromSlash(relPath)), 0o444); err != nil {
+		return fmt.Errorf("chmod restored file: %w", err)
+	}
+	return nil
+}
+
+func (r *Runner) detectDefaultBranchAtPath(ctx context.Context, worktreePath string) (string, error) {
+	out, err := r.Runner.RunOutput(ctx, "git", "-C", worktreePath, "symbolic-ref", "refs/remotes/origin/HEAD")
+	if err == nil {
+		ref := strings.TrimSpace(string(out))
+		if branch := strings.TrimPrefix(ref, "refs/remotes/origin/"); branch != ref && branch != "" {
+			return branch, nil
+		}
+	}
+
+	out, err = r.Runner.RunOutput(ctx, "git", "-C", worktreePath, "remote", "show", "origin")
+	if err != nil {
+		return "", fmt.Errorf("git remote show origin: %w", err)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "HEAD branch:") {
+			branch := strings.TrimSpace(strings.TrimPrefix(line, "HEAD branch:"))
+			if branch != "" {
+				return branch, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("could not detect default branch from origin")
 }
 
 func (r *Runner) recordProtectedSurfaceViolations(vessel queue.Vessel, p workflow.Phase, errMsg string, violations []surface.Violation) error {

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -160,6 +161,79 @@ func TestProp_FormatViolationsIncludesEveryViolation(t *testing.T) {
 		want := strings.Join(wantParts, "; ")
 		if formatted != want {
 			t.Fatalf("formatViolations() = %q, want %q", formatted, want)
+		}
+	})
+}
+
+func TestProp_RestoreMissingProtectedSurfacesFromRootRepairsMissingFiles(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		sourceRoot, err := os.MkdirTemp("", "runner-surface-source-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp(sourceRoot) error = %v", err)
+		}
+		defer os.RemoveAll(sourceRoot)
+
+		worktreePath, err := os.MkdirTemp("", "runner-surface-worktree-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp(worktreePath) error = %v", err)
+		}
+		defer os.RemoveAll(worktreePath)
+
+		files := map[string]string{
+			".xylem.yml":                        rapid.StringMatching(`[a-zA-Z0-9 _:\n-]{1,48}`).Draw(t, "config"),
+			".xylem/HARNESS.md":                 rapid.StringMatching(`[a-zA-Z0-9 _:\n-]{1,48}`).Draw(t, "harness"),
+			".xylem/workflows/fix-bug.yaml":     rapid.StringMatching(`[a-zA-Z0-9 _:\n-]{1,48}`).Draw(t, "workflow"),
+			".xylem/prompts/fix-bug/analyze.md": rapid.StringMatching(`[a-zA-Z0-9 _:\n-]{1,48}`).Draw(t, "prompt"),
+		}
+		patterns := []string{
+			".xylem.yml",
+			".xylem/HARNESS.md",
+			".xylem/workflows/*.yaml",
+			".xylem/prompts/*/*.md",
+		}
+
+		expectedRestored := 0
+		for path, content := range files {
+			srcPath := filepath.Join(sourceRoot, filepath.FromSlash(path))
+			if err := os.MkdirAll(filepath.Dir(srcPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll(%s) error = %v", srcPath, err)
+			}
+			if err := os.WriteFile(srcPath, []byte(content), 0o644); err != nil {
+				t.Fatalf("WriteFile(%s) error = %v", srcPath, err)
+			}
+
+			if rapid.Bool().Draw(t, "missing-"+path) {
+				expectedRestored++
+				continue
+			}
+
+			dstPath := filepath.Join(worktreePath, filepath.FromSlash(path))
+			if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll(%s) error = %v", dstPath, err)
+			}
+			if err := os.WriteFile(dstPath, []byte(content), 0o644); err != nil {
+				t.Fatalf("WriteFile(%s) error = %v", dstPath, err)
+			}
+		}
+
+		restored, err := restoreMissingProtectedSurfacesFromRoot(worktreePath, sourceRoot, patterns)
+		if err != nil {
+			t.Fatalf("restoreMissingProtectedSurfacesFromRoot() error = %v", err)
+		}
+		if restored != expectedRestored {
+			t.Fatalf("restored = %d, want %d", restored, expectedRestored)
+		}
+
+		sourceSnapshot, err := surface.TakeSnapshot(sourceRoot, patterns)
+		if err != nil {
+			t.Fatalf("TakeSnapshot(sourceRoot) error = %v", err)
+		}
+		worktreeSnapshot, err := surface.TakeSnapshot(worktreePath, patterns)
+		if err != nil {
+			t.Fatalf("TakeSnapshot(worktreePath) error = %v", err)
+		}
+		if diff := surface.Compare(sourceSnapshot, worktreeSnapshot); len(diff) != 0 {
+			t.Fatalf("restored snapshot diff = %+v, want none", diff)
 		}
 	})
 }

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -4850,7 +4850,7 @@ func TestVerifyProtectedSurfacesSkipsWhenWorktreeMissing(t *testing.T) {
 	r := New(cfg, queue.New(filepath.Join(stateDir, "queue.jsonl")), &mockWorktree{path: worktreeDir}, &mockCmdRunner{})
 	r.AuditLog = auditLog
 
-	before, ok, err := r.takeProtectedSurfaceSnapshot(worktreeDir)
+	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), worktreeDir)
 	if err != nil {
 		t.Fatalf("takeProtectedSurfaceSnapshot() error = %v", err)
 	}
@@ -4920,7 +4920,7 @@ func TestVerifyProtectedSurfacesDetectsLegitimateDeletionWhenWorktreeExists(t *t
 	r := New(cfg, queue.New(filepath.Join(stateDir, "queue.jsonl")), &mockWorktree{path: worktreeDir}, &mockCmdRunner{})
 	r.AuditLog = auditLog
 
-	before, ok, err := r.takeProtectedSurfaceSnapshot(worktreeDir)
+	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), worktreeDir)
 	if err != nil {
 		t.Fatalf("takeProtectedSurfaceSnapshot() error = %v", err)
 	}
@@ -4972,6 +4972,136 @@ func TestVerifyProtectedSurfacesDetectsLegitimateDeletionWhenWorktreeExists(t *t
 	}
 	if !found {
 		t.Fatalf("no file_write audit entry recorded; entries = %+v", entries)
+	}
+}
+
+func TestTakeProtectedSurfaceSnapshotRestoresMissingProtectedFilesFromSourceRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeDir := filepath.Join(repoRoot, ".claude", "worktrees", "review", "pr-1")
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.git) = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".xylem", "workflows"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(workflows) = %v", err)
+	}
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(worktree) = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, ".xylem.yml"), []byte("repo: owner/repo\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(.xylem.yml) = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, ".xylem", "workflows", "fix-bug.yaml"), []byte("name: fix-bug\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(workflow) = %v", err)
+	}
+
+	cfg := makeTestConfig(repoRoot, 1)
+	cfg.StateDir = filepath.Join(repoRoot, ".xylem-state")
+	cmdRunner := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name != "git" {
+				return nil, nil, false
+			}
+			if len(args) == 5 &&
+				args[0] == "-C" &&
+				args[1] == worktreeDir &&
+				args[2] == "rev-parse" &&
+				args[3] == "--path-format=absolute" &&
+				args[4] == "--git-common-dir" {
+				return []byte(filepath.Join(repoRoot, ".git")), nil, true
+			}
+			return nil, nil, false
+		},
+	}
+
+	r := New(cfg, queue.New(filepath.Join(repoRoot, "queue.jsonl")), &mockWorktree{path: worktreeDir}, cmdRunner)
+	snapshot, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), worktreeDir)
+	if err != nil {
+		t.Fatalf("takeProtectedSurfaceSnapshot() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("takeProtectedSurfaceSnapshot() checkProtectedSurfaces = false, want true")
+	}
+
+	restoredConfig := filepath.Join(worktreeDir, ".xylem.yml")
+	if _, err := os.Stat(restoredConfig); err != nil {
+		t.Fatalf("restored .xylem.yml missing: %v", err)
+	}
+	restoredWorkflow := filepath.Join(worktreeDir, ".xylem", "workflows", "fix-bug.yaml")
+	if _, err := os.Stat(restoredWorkflow); err != nil {
+		t.Fatalf("restored workflow missing: %v", err)
+	}
+	if len(snapshot.Files) != 2 {
+		t.Fatalf("len(snapshot.Files) = %d, want 2", len(snapshot.Files))
+	}
+}
+
+func TestVerifyProtectedSurfacesSelfHealsDeletedFileFromDefaultBranch(t *testing.T) {
+	worktreeDir := t.TempDir()
+	protectedFile := filepath.Join(worktreeDir, ".xylem.yml")
+	if err := os.WriteFile(protectedFile, []byte("repo: owner/repo\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(.xylem.yml) = %v", err)
+	}
+
+	before, err := surface.TakeSnapshot(worktreeDir, []string{".xylem.yml"})
+	if err != nil {
+		t.Fatalf("TakeSnapshot(before) = %v", err)
+	}
+	if err := os.Remove(protectedFile); err != nil {
+		t.Fatalf("Remove(.xylem.yml) = %v", err)
+	}
+
+	cfg := makeTestConfig(t.TempDir(), 1)
+	cfg.StateDir = t.TempDir()
+	cmdRunner := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name != "git" {
+				return nil, nil, false
+			}
+			command := strings.Join(append([]string{name}, args...), " ")
+			switch command {
+			case "git -C " + worktreeDir + " checkout -- .xylem.yml":
+				return nil, errors.New("path missing from HEAD"), true
+			case "git -C " + worktreeDir + " symbolic-ref refs/remotes/origin/HEAD":
+				return []byte("refs/remotes/origin/main\n"), nil, true
+			case "git -C " + worktreeDir + " checkout origin/main -- .xylem.yml":
+				if err := os.WriteFile(protectedFile, []byte("repo: owner/repo\n"), 0o644); err != nil {
+					return nil, err, true
+				}
+				return []byte{}, nil, true
+			default:
+				return nil, nil, false
+			}
+		},
+	}
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	r := New(cfg, queue.New(filepath.Join(cfg.StateDir, "queue.jsonl")), &mockWorktree{path: worktreeDir}, cmdRunner)
+	r.AuditLog = auditLog
+
+	err = r.verifyProtectedSurfaces(
+		queue.Vessel{ID: "issue-self-heal", Source: "github-issue", Workflow: "fix-bug"},
+		workflow.Phase{Name: "analyze"},
+		worktreeDir,
+		before,
+	)
+	if err == nil {
+		t.Fatal("verifyProtectedSurfaces() returned nil, want violation error")
+	}
+	if !strings.Contains(err.Error(), "violated protected surfaces") {
+		t.Fatalf("verifyProtectedSurfaces() error = %q, want violation", err)
+	}
+	data, readErr := os.ReadFile(protectedFile)
+	if readErr != nil {
+		t.Fatalf("ReadFile(restored .xylem.yml) = %v", readErr)
+	}
+	if string(data) != "repo: owner/repo\n" {
+		t.Fatalf("restored .xylem.yml = %q, want canonical contents", string(data))
+	}
+	info, statErr := os.Stat(protectedFile)
+	if statErr != nil {
+		t.Fatalf("Stat(restored .xylem.yml) = %v", statErr)
+	}
+	if info.Mode().Perm() != 0o444 {
+		t.Fatalf("restored .xylem.yml perms = %#o, want 0444", info.Mode().Perm())
 	}
 }
 


### PR DESCRIPTION
## Summary

Resolves #170. Fixes the resolve-conflicts cascade where the analyze phase's \`gh pr checkout\` removes tracked \`.xylem/\` files from the worktree when the PR branch predates #157, causing every retry to fail the post-phase verifier with 14 deletion violations — observed in \`pr-143-resolve-conflicts-retry-1\` on 2026-04-09 03:52Z.

### Four-part fix

1. **Pre-phase canonicalize** — \`takeProtectedSurfaceSnapshot\` now resolves the canonical source root via \`git rev-parse --git-common-dir\` (which returns the shared \`.git\` for linked worktrees, so the source root becomes the main repo checkout), then copies any protected files missing from the vessel worktree before snapshotting. Fails closed.

2. **Post-phase self-heal** — \`verifyProtectedSurfaces\` now attempts \`git checkout -- <path>\` followed by \`git checkout origin/<default-branch> -- <path>\` fallback for each deletion violation, then re-marks the file \`0o444\`. Vessel still fails; worktree is left self-consistent.

3. **Prompt hardening** — \`resolve-conflicts/{analyze,resolve}.md\` now state explicitly that \`.xylem/\` is out of scope for conflict resolution.

4. **Tests** — property test for \`restoreMissingProtectedSurfacesFromRoot\` round-trip, unit tests for snapshot-with-restore and self-heal via \`origin/main\` fallback.

### Provenance

Implementation was **drafted autonomously by xylem vessel issue-170** running an \`implement-harness\` workflow at 2026-04-09 04:27-04:42 UTC. That vessel failed in its implement phase because the \`chmod +w\` + prompt edit triggered the runtime verifier (which is the correct behavior — protected files can only be modified via merged PRs, not vessel execution). This PR ports the vessel's uncommitted work to a clean worktree at \`origin/main\` and ships it via the normal PR workflow.

### Verification

- **crosscheck:byfuglien** semi-formal reasoning certificate: **VERIFIED**, HIGH confidence
  - Source-root resolution correct for daemon-root-as-worktree deployment (verified via live \`git rev-parse\`)
  - Idempotent on clean worktrees (zero perm drift)
  - Fail-closed error handling
  - \`context.Background()\` in self-heal is intentional (cleanup must survive vessel cancellation)
- Full test suite green: \`go test ./...\`
- \`go vet ./...\` clean
- \`goimports -l .\` empty
- \`golangci-lint run\` 0 issues

### Non-blocking follow-ups (will file as separate issues if user requests)

- Add unit tests for \`restoreProtectedSurfacePath\` HEAD-success path and \`detectDefaultBranchAtPath\` fallback
- Handle bare-repo / renamed-\`.git\` case in \`protectedSurfaceSourceRoot\`

## Test plan

- [x] \`go build ./cmd/xylem\`
- [x] \`go test ./...\` (all packages green)
- [x] \`go vet ./...\`
- [x] \`goimports -l .\` (empty)
- [x] \`golangci-lint run\` (0 issues)
- [x] New regression tests directly exercise the deletion → self-heal flow
- [ ] Post-merge: next resolve-conflicts vessel on a PR cut before #157 (e.g., PR #143) should self-heal instead of cascading

Filed autonomously by the hourly /xylem-status rescue loop on 2026-04-09 (loop 4). Related: #169 (env propagation fix, already merged), #171 (drain concurrency issue, currently being worked on by xylem's own vessel).