### PR TITLE
Keep daemon drain ticks responsive while vessels remain in flight

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -91,25 +91,17 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	scan := func(ctx context.Context) (scanner.ScanResult, error) {
 		return runScan(ctx, cfg, q)
 	}
+	cmdRunner := newCmdRunner(cfg)
+	drainRunner, cleanupDrainRunner := buildDrainRunner(cfg, q, wt, cmdRunner)
+	defer cleanupDrainRunner()
+	drainRunner.Reporter = buildReporter(cfg, cmdRunner)
+	drainRunner.DrainBudget = drainInterval
 	drain := func(ctx context.Context) (runner.DrainResult, error) {
-		// Pass drainInterval as the drain budget so Drain() returns
-		// roughly once per tick even under sustained saturation. This is
-		// what keeps the drain-end auto-upgrade check reachable — see
-		// the comment on Runner.DrainBudget in cli/internal/runner/runner.go.
-		return runDrain(ctx, cfg, q, wt, drainInterval)
+		return drainRunner.Drain(ctx)
 	}
 	check := func(ctx context.Context) {
-		// Use newCmdRunner(cfg) here (not a bare &realCmdRunner{}) so the
-		// periodic label-poll and hang-detection paths receive the same
-		// configured env (claude.env / copilot.env) as the scan/drain
-		// paths. A bare runner silently strips any configured env which
-		// caused gh/copilot auth failures on hosts that rely on the
-		// config-declared tokens during label polling.
-		cmdRunner := newCmdRunner(cfg)
-		r := runner.New(cfg, q, wt, cmdRunner)
-		r.Sources = buildSourceMap(cfg, q, cmdRunner)
-		r.CheckWaitingVessels(ctx)
-		r.CheckHungVessels(ctx)
+		drainRunner.CheckWaitingVessels(ctx)
+		drainRunner.CheckHungVessels(ctx)
 		// Auto-merge: request copilot review on unreviewed xylem PRs,
 		// and merge PRs that are approved + CI-green + mergeable.
 		if cfg.Daemon.AutoMerge {
@@ -117,7 +109,7 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		}
 	}
 
-	return daemonLoop(ctx, q, scan, drain, check, upgrade, scanInterval, drainInterval, upgradeInterval)
+	return daemonLoop(ctx, q, drainRunner, scan, drain, check, upgrade, scanInterval, drainInterval, upgradeInterval)
 }
 
 // parseUpgradeInterval returns the effective periodic upgrade interval. If
@@ -155,6 +147,10 @@ func parseDaemonIntervals(dc config.DaemonConfig) (scan, drain time.Duration) {
 // scanFunc and drainFunc abstract scan/drain for testability.
 type scanFunc func(ctx context.Context) (scanner.ScanResult, error)
 type drainFunc func(ctx context.Context) (runner.DrainResult, error)
+type inFlightTracker interface {
+	Wait() runner.DrainResult
+	InFlightCount() int
+}
 
 // checkFunc runs periodic vessel health checks (waiting vessel label checks,
 // hung vessel timeouts). May be nil if no checks are needed.
@@ -175,13 +171,10 @@ const defaultUpgradeInterval = 5 * time.Minute
 // externally-controlled context so tests can cancel it without signals,
 // and injectable scan/drain/check functions so tests can use stubs.
 //
-// If upgrade is non-nil, it is called at the END of each drain cycle — when
-// every vessel processed in that cycle has reached a terminal state and no
-// subprocesses are alive — provided at least upgradeInterval has elapsed
-// since the last attempt. This gives the daemon a guaranteed-idle window to
-// exec() into a newer binary without killing in-flight vessel work. Pass
-// nil/zero upgrade/upgradeInterval to disable.
-func daemonLoop(ctx context.Context, q *queue.Queue, scan scanFunc, drain drainFunc, check checkFunc, upgrade upgradeFunc, scanInterval, drainInterval, upgradeInterval time.Duration) error {
+// If upgrade is non-nil, it is called only when the daemon is fully idle:
+// there is no active drain tick and the shared runner reports zero in-flight
+// vessels. Pass nil/zero upgrade/upgradeInterval to disable.
+func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, scan scanFunc, drain drainFunc, check checkFunc, upgrade upgradeFunc, scanInterval, drainInterval, upgradeInterval time.Duration) error {
 	tickInterval := scanInterval
 	if drainInterval < tickInterval {
 		tickInterval = drainInterval
@@ -204,10 +197,16 @@ func daemonLoop(ctx context.Context, q *queue.Queue, scan scanFunc, drain drainF
 		case <-ctx.Done():
 			log.Println("daemon: received shutdown signal, waiting for in-flight drain")
 			waitDone := make(chan struct{})
-			go func() { drainWg.Wait(); close(waitDone) }()
+			go func() {
+				drainWg.Wait()
+				if tracker != nil {
+					tracker.Wait()
+				}
+				close(waitDone)
+			}()
 			select {
 			case <-waitDone:
-				log.Println("daemon: in-flight drain finished")
+				log.Println("daemon: in-flight drain and vessels finished")
 			case <-time.After(drainShutdownTimeout):
 				log.Println("daemon: drain shutdown timeout exceeded, exiting")
 			}
@@ -232,6 +231,14 @@ func daemonLoop(ctx context.Context, q *queue.Queue, scan scanFunc, drain drainF
 			check(ctx)
 		}
 
+		if upgrade != nil && upgradeInterval > 0 &&
+			atomic.LoadInt32(&draining) == 0 &&
+			trackerInFlightCount(tracker) == 0 &&
+			now.Sub(lastUpgrade) >= upgradeInterval {
+			lastUpgrade = now
+			upgrade()
+		}
+
 		if now.Sub(lastDrain) >= drainInterval {
 			if atomic.CompareAndSwapInt32(&draining, 0, 1) {
 				lastDrain = now
@@ -243,24 +250,8 @@ func daemonLoop(ctx context.Context, q *queue.Queue, scan scanFunc, drain drainF
 					if err != nil {
 						log.Printf("daemon: drain error: %v", err)
 					} else {
-						log.Printf("daemon: drain complete — completed=%d failed=%d skipped=%d",
-							drainResult.Completed, drainResult.Failed, drainResult.Skipped)
-					}
-
-					// Drain-end self-upgrade: every vessel processed in this
-					// cycle has reached a terminal state (completed, failed,
-					// or timed_out) — there are no subprocesses alive right
-					// now, so exec() is safe. Runs regardless of drain
-					// success/failure, since vessels are in persistent state
-					// either way. lastUpgrade is only written from within
-					// this goroutine (and the CAS guard ensures one drain
-					// runs at a time), so no synchronisation is required.
-					if upgrade != nil && upgradeInterval > 0 {
-						drainEnd := daemonNow()
-						if drainEnd.Sub(lastUpgrade) >= upgradeInterval {
-							lastUpgrade = drainEnd
-							upgrade()
-						}
+						log.Printf("daemon: drain tick complete — launched=%d in_flight=%d",
+							drainResult.Launched, trackerInFlightCount(tracker))
 					}
 				}()
 			}
@@ -272,10 +263,16 @@ func daemonLoop(ctx context.Context, q *queue.Queue, scan scanFunc, drain drainF
 		case <-ctx.Done():
 			log.Println("daemon: received shutdown signal, waiting for in-flight drain")
 			waitDone := make(chan struct{})
-			go func() { drainWg.Wait(); close(waitDone) }()
+			go func() {
+				drainWg.Wait()
+				if tracker != nil {
+					tracker.Wait()
+				}
+				close(waitDone)
+			}()
 			select {
 			case <-waitDone:
-				log.Println("daemon: in-flight drain finished")
+				log.Println("daemon: in-flight drain and vessels finished")
 			case <-time.After(drainShutdownTimeout):
 				log.Println("daemon: drain shutdown timeout exceeded, exiting")
 			}
@@ -296,11 +293,18 @@ func runDrain(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *workt
 	r, cleanup := buildDrainRunner(cfg, q, wt, cmdRunner)
 	defer cleanup()
 	r.DrainBudget = budget
-	result, err := r.Drain(ctx)
+	result, err := r.DrainAndWait(ctx)
 	if err == nil {
 		maybeAutoGenerateHarnessReview(cfg, result)
 	}
 	return result, err
+}
+
+func trackerInFlightCount(tracker inFlightTracker) int {
+	if tracker == nil {
+		return 0
+	}
+	return tracker.InFlightCount()
 }
 
 func logTickSummary(q *queue.Queue) {

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -183,6 +185,37 @@ func noopDrain(_ context.Context) (runner.DrainResult, error) {
 	return runner.DrainResult{}, nil
 }
 
+type trackerStub struct {
+	wg       sync.WaitGroup
+	inFlight atomic.Int32
+	maxSeen  atomic.Int32
+}
+
+func (t *trackerStub) Wait() runner.DrainResult {
+	t.wg.Wait()
+	return runner.DrainResult{}
+}
+
+func (t *trackerStub) InFlightCount() int {
+	return int(t.inFlight.Load())
+}
+
+func (t *trackerStub) Start(duration time.Duration) {
+	cur := t.inFlight.Add(1)
+	for {
+		old := t.maxSeen.Load()
+		if cur <= old || t.maxSeen.CompareAndSwap(old, cur) {
+			break
+		}
+	}
+	t.wg.Add(1)
+	go func() {
+		defer t.wg.Done()
+		time.Sleep(duration)
+		t.inFlight.Add(-1)
+	}()
+}
+
 func TestDaemonShutdown(t *testing.T) {
 	dir := t.TempDir()
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
@@ -190,7 +223,7 @@ func TestDaemonShutdown(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, noopScan, noopDrain, nil, nil, time.Hour, time.Hour, 0)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, nil, time.Hour, time.Hour, 0)
 	if err != nil {
 		t.Fatalf("expected nil error on shutdown, got: %v", err)
 	}
@@ -252,7 +285,7 @@ func TestDaemonLoopPeriodicUpgradeFiresAtDrainEnd(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, noopScan, noopDrain, nil, upgrade, time.Hour, 2*time.Millisecond, time.Millisecond)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, upgrade, time.Hour, 2*time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -274,7 +307,7 @@ func TestDaemonLoopPeriodicUpgradeRespectsInterval(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, noopScan, noopDrain, nil, upgrade, time.Hour, 2*time.Millisecond, 10*time.Second)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, upgrade, time.Hour, 2*time.Millisecond, 10*time.Second)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -294,7 +327,7 @@ func TestDaemonLoopPeriodicUpgradeNilDisables(t *testing.T) {
 	defer cancel()
 
 	// Passing nil upgrade should not panic even with a non-zero interval.
-	err := daemonLoop(ctx, q, noopScan, noopDrain, nil, nil, time.Hour, 2*time.Millisecond, 10*time.Millisecond)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, nil, time.Hour, 2*time.Millisecond, 10*time.Millisecond)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -333,7 +366,7 @@ func TestDaemonLoopUpgradeWaitsForDrainCompletion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, noopScan, slowDrain, nil, upgrade, time.Hour, time.Millisecond, time.Millisecond)
+	err := daemonLoop(ctx, q, nil, noopScan, slowDrain, nil, upgrade, time.Hour, time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -344,6 +377,64 @@ func TestDaemonLoopUpgradeWaitsForDrainCompletion(t *testing.T) {
 	if upgradeSaw.Load() < 2 {
 		t.Errorf("expected at least 2 upgrade invocations, got %d", upgradeSaw.Load())
 	}
+}
+
+func TestSmoke_S35_DaemonLoopAllowsNewDrainTicksWhileVesselsRemainInFlight(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	tracker := &trackerStub{}
+
+	var drainCalls atomic.Int32
+	drain := func(_ context.Context) (runner.DrainResult, error) {
+		drainCalls.Add(1)
+		tracker.Start(80 * time.Millisecond)
+		return runner.DrainResult{Launched: 1}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Millisecond)
+	defer cancel()
+
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, nil, time.Hour, 10*time.Millisecond, 0)
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, drainCalls.Load(), int32(2))
+	assert.GreaterOrEqual(t, tracker.maxSeen.Load(), int32(2))
+}
+
+func TestSmoke_S36_DaemonLoopUpgradeWaitsForTrackerIdle(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	tracker := &trackerStub{}
+
+	var (
+		launchedAt  atomic.Int64
+		upgradedAt  atomic.Int64
+		drainCalls  atomic.Int32
+		upgradeSeen atomic.Int32
+	)
+	drain := func(_ context.Context) (runner.DrainResult, error) {
+		if drainCalls.Add(1) == 1 {
+			launchedAt.Store(time.Now().UnixNano())
+			tracker.Start(60 * time.Millisecond)
+			return runner.DrainResult{Launched: 1}, nil
+		}
+		return runner.DrainResult{}, nil
+	}
+	upgrade := func() {
+		upgradedAt.Store(time.Now().UnixNano())
+		upgradeSeen.Add(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, time.Hour, 10*time.Millisecond, time.Millisecond)
+	require.NoError(t, err)
+
+	assert.NotZero(t, upgradeSeen.Load())
+	launchTime := time.Unix(0, launchedAt.Load())
+	upgradeTime := time.Unix(0, upgradedAt.Load())
+	assert.GreaterOrEqual(t, upgradeTime.Sub(launchTime), 60*time.Millisecond)
 }
 
 func TestParseUpgradeInterval(t *testing.T) {
@@ -425,7 +516,7 @@ func TestDaemonNonBlockingDrain(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	err := daemonLoop(ctx, q, noopScan, slowDrain, nil, nil, time.Hour, time.Millisecond, 0)
+	err := daemonLoop(ctx, q, nil, noopScan, slowDrain, nil, nil, time.Hour, time.Millisecond, 0)
 	elapsed := time.Since(start)
 
 	if err != nil {
@@ -450,10 +541,26 @@ func TestLogTickSummary(t *testing.T) {
 	now := time.Now().UTC()
 
 	q.Enqueue(queue.Vessel{ID: "v1", Source: "manual", State: queue.StatePending, CreatedAt: now})   //nolint:errcheck
-	q.Enqueue(queue.Vessel{ID: "v2", Source: "manual", State: queue.StateCompleted, CreatedAt: now}) //nolint:errcheck
+	q.Enqueue(queue.Vessel{ID: "v2", Source: "manual", State: queue.StateRunning, CreatedAt: now})   //nolint:errcheck
+	q.Enqueue(queue.Vessel{ID: "v3", Source: "manual", State: queue.StateCompleted, CreatedAt: now}) //nolint:errcheck
+	q.Enqueue(queue.Vessel{ID: "v4", Source: "manual", State: queue.StateFailed, CreatedAt: now})    //nolint:errcheck
 
-	// logTickSummary should not panic on any queue state
+	var logBuf bytes.Buffer
+	oldLogWriter := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(oldLogWriter)
+
 	logTickSummary(q)
+
+	got := logBuf.String()
+	if !strings.Contains(got, "daemon: tick summary") {
+		t.Fatalf("logTickSummary() log = %q, want daemon tick summary prefix", got)
+	}
+	for _, want := range []string{"pending=1", "running=1", "completed=1", "failed=1"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("logTickSummary() log = %q, want substring %q", got, want)
+		}
+	}
 }
 
 // TestWS1S28DaemonPathWiresScaffolding verifies that the daemon drain path

--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -51,7 +51,7 @@ func cmdDrain(cfg *config.Config, q *queue.Queue, wt *worktree.Manager, dryRun b
 	// Check waiting vessels before draining pending ones
 	r.CheckWaitingVessels(ctx)
 
-	result, err := r.Drain(ctx)
+	result, err := r.DrainAndWait(ctx)
 	if err != nil {
 		return &exitError{code: 2, err: fmt.Errorf("drain error: %w", err)}
 	}

--- a/cli/cmd/xylem/drain_test.go
+++ b/cli/cmd/xylem/drain_test.go
@@ -276,7 +276,7 @@ func TestSmoke_S8_TracerInitializationFailureLogsWarningAndContinuesWithoutTraci
 
 	assert.Nil(t, runnerInstance.Tracer)
 
-	result, err := runnerInstance.Drain(context.Background())
+	result, err := runnerInstance.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 	assert.Zero(t, result.Failed)

--- a/cli/internal/dtu/scenario_static_test.go
+++ b/cli/internal/dtu/scenario_static_test.go
@@ -277,7 +277,7 @@ func TestScenarioIssueCommandGateRetryPassesOnRetry(t *testing.T) {
 
 	src := &source.GitHub{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}

--- a/cli/internal/dtu/scenario_test.go
+++ b/cli/internal/dtu/scenario_test.go
@@ -503,7 +503,7 @@ func TestScenarioIssueLabelGateWaitsThenResumes(t *testing.T) {
 	src := &source.GitHub{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
 
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -559,7 +559,7 @@ func TestScenarioIssueLabelGateWaitsThenResumes(t *testing.T) {
 	// state (runVessel defer). It will be re-added when the vessel resumes.
 	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 1), []string{"bug", "plan-approved"})
 
-	drainResult, err = drainer.Drain(context.Background())
+	drainResult, err = drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("second Drain() error = %v", err)
 	}
@@ -668,7 +668,7 @@ func TestScenarioGitHubPROfflineCopilot(t *testing.T) {
 
 	src := &source.GitHubPR{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -745,7 +745,7 @@ func TestScenarioGitHubPREventsChecksFailed(t *testing.T) {
 
 	src := &source.GitHubPREvents{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -806,7 +806,7 @@ func TestScenarioGithubPREventsProviderFailure(t *testing.T) {
 
 	src := &source.GitHubPREvents{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -868,7 +868,7 @@ func TestScenarioGitHubMergeHappyPath(t *testing.T) {
 
 	src := &source.GitHubMerge{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -928,7 +928,7 @@ func TestScenarioIssueProviderFailureMarksFailed(t *testing.T) {
 
 	src := &source.GitHub{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -994,7 +994,7 @@ func TestScenarioIssueGitFetchRetrySucceeds(t *testing.T) {
 
 	src := &source.GitHub{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1064,7 +1064,7 @@ func TestScenarioIssueGitFetchRetryExitCode1Succeeds(t *testing.T) {
 
 	src := &source.GitHub{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1149,7 +1149,7 @@ func TestScenarioIssueGitWorktreeAddRetryExitCode255Succeeds(t *testing.T) {
 
 	src := &source.GitHub{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1237,7 +1237,7 @@ func TestScenarioIssueGitWorktreeAddRetryExitCode128Succeeds(t *testing.T) {
 
 	src := &source.GitHub{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1314,7 +1314,7 @@ func TestScenarioIssueGitWorktreeAddExhaustRetriesExitCode128Fails(t *testing.T)
 
 	src := &source.GitHub{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1494,7 +1494,7 @@ func TestScenarioIssueGHRateLimitOnEnqueueDoesNotBlock(t *testing.T) {
 
 	src := &source.GitHub{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1587,7 +1587,7 @@ func TestScenarioIssueHappyPath(t *testing.T) {
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
 	drainer.Reporter = &reporter.Reporter{Runner: env.cmdRunner, Repo: "owner/repo"}
 
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1685,7 +1685,7 @@ func TestScenarioGithubMergeProviderFailure(t *testing.T) {
 
 	src := &source.GitHubMerge{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1754,7 +1754,7 @@ func TestScenarioGithubPRProviderFailure(t *testing.T) {
 
 	src := &source.GitHubPR{Repo: "owner/repo", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}

--- a/cli/internal/dtu/scenario_timed_test.go
+++ b/cli/internal/dtu/scenario_timed_test.go
@@ -58,7 +58,7 @@ func TestScenarioIssueLabelGateTimesOut(t *testing.T) {
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
 	drainer.Reporter = &reporter.Reporter{Runner: env.cmdRunner, Repo: "owner/repo"}
 
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}

--- a/cli/internal/dtu/scenario_ws1_test.go
+++ b/cli/internal/dtu/scenario_ws1_test.go
@@ -65,7 +65,7 @@ func ws1Drain(t *testing.T, env *dtuScenarioEnv, cfg *config.Config) (scanner.Sc
 
 	src := &source.GitHub{Repo: "acme/widget", CmdRunner: env.cmdRunner}
 	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
-	drainResult, err := drainer.Drain(context.Background())
+	drainResult, err := drainer.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -74,6 +74,7 @@ func ws1Drain(t *testing.T, env *dtuScenarioEnv, cfg *config.Config) (scanner.Sc
 
 // DrainResult is imported from runner; alias here for the helper signature.
 type DrainResult = struct {
+	Launched  int
 	Completed int
 	Failed    int
 	Skipped   int

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
@@ -47,6 +48,7 @@ type WorktreeManager interface {
 
 // DrainResult summarises a drain run.
 type DrainResult struct {
+	Launched  int
 	Completed int
 	Failed    int
 	Skipped   int
@@ -68,26 +70,46 @@ type Runner struct {
 	Tracer       *observability.Tracer      // nil = no tracing
 	// DrainBudget bounds the wall time that Drain() spends dequeueing new
 	// vessels. When the deadline elapses, Drain() stops dequeueing and
-	// waits for the already-started goroutines to finish via wg.Wait(),
-	// then returns a partial DrainResult. Any pending vessels are picked
-	// up by the next drain tick. Zero means unbounded (legacy behavior).
+	// returns immediately while already-started goroutines continue in the
+	// background. Call Wait or DrainAndWait if the caller needs terminal
+	// outcomes for the in-flight vessels. Any pending vessels are picked up
+	// by the next drain tick. Zero means unbounded (legacy behavior).
 	//
 	// Set this to drainInterval in the daemon so that Drain() returns
 	// roughly once per tick even under sustained pool saturation. Without
-	// this bound, the daemon's drain-end auto-upgrade check at
-	// cli/cmd/xylem/daemon.go:248-254 can never fire because Drain()
-	// never returns — the upgrade goroutine is wired post-drain and the
-	// CAS guard prevents a fresh tick from starting.
+	// this bound, a saturated tick holds the daemon's draining CAS guard
+	// for the full vessel runtime, which prevents later ticks from using
+	// newly available capacity and blocks idle-only work such as upgrades.
 	DrainBudget time.Duration
+
+	sem      chan struct{}
+	wg       sync.WaitGroup
+	traceWg  sync.WaitGroup
+	inFlight atomic.Int32
+
+	resultMu sync.Mutex
+	result   DrainResult
 }
 
 // New creates a Runner.
 func New(cfg *config.Config, q *queue.Queue, wt WorktreeManager, r CommandRunner) *Runner {
-	return &Runner{Config: cfg, Queue: q, Worktree: wt, Runner: r}
+	concurrency := 1
+	if cfg != nil && cfg.Concurrency > 0 {
+		concurrency = cfg.Concurrency
+	}
+	return &Runner{
+		Config:   cfg,
+		Queue:    q,
+		Worktree: wt,
+		Runner:   r,
+		sem:      make(chan struct{}, concurrency),
+	}
 }
 
 // Drain dequeues pending vessels and launches sessions up to Config.Concurrency concurrently.
 // On context cancellation, no new vessels are launched; running vessels complete normally.
+// Drain returns once the current dequeue tick ends. Use DrainAndWait or Wait for
+// synchronous callers that need terminal outcomes.
 func (r *Runner) Drain(ctx context.Context) (DrainResult, error) {
 	var drainSpan observability.SpanContext
 	if r.Tracer != nil {
@@ -96,7 +118,6 @@ func (r *Runner) Drain(ctx context.Context) (DrainResult, error) {
 			Timeout:     r.Config.Timeout,
 		}))
 		ctx = drainSpan.Context()
-		defer drainSpan.End()
 	}
 
 	timeout, err := time.ParseDuration(r.Config.Timeout)
@@ -107,46 +128,61 @@ func (r *Runner) Drain(ctx context.Context) (DrainResult, error) {
 		return DrainResult{}, fmt.Errorf("parse timeout: %w", err)
 	}
 
-	sem := make(chan struct{}, r.Config.Concurrency)
-	var wg sync.WaitGroup
-	var mu sync.Mutex
 	var result DrainResult
 	healthCounts := FleetStatusReport{}
 	patternCounts := map[string]int{}
+	var drainStatsMu sync.Mutex
+	var drainLaunchWg sync.WaitGroup
 
 	// Drain budget: if set, Drain() stops dequeueing once the deadline
-	// elapses. Already-started goroutines continue until wg.Wait() below.
-	// This guarantees Drain() returns in bounded time so the daemon's
-	// periodic self-upgrade (wired post-drain) can fire under load.
+	// elapses. Already-started goroutines continue in the background.
 	var drainDeadline time.Time
 	if r.DrainBudget > 0 {
 		drainDeadline = time.Now().Add(r.DrainBudget)
 	}
 
+drainLoop:
 	for {
 		select {
 		case <-ctx.Done():
-			goto wait
+			break drainLoop
 		default:
 		}
 
 		if !drainDeadline.IsZero() && time.Now().After(drainDeadline) {
-			log.Printf("drain: budget %s elapsed, stopping dequeue (waiting for %d in-flight)", r.DrainBudget, len(sem))
-			goto wait
+			log.Printf("drain: budget %s elapsed, stopping dequeue (%d in-flight)", r.DrainBudget, r.InFlightCount())
+			break drainLoop
+		}
+
+		select {
+		case r.sem <- struct{}{}:
+		default:
+			if result.Launched == 0 && r.InFlightCount() > 0 {
+				log.Printf("drain: concurrency saturated, ending tick with %d in-flight", r.InFlightCount())
+			}
+			break drainLoop
 		}
 
 		vessel, err := r.Queue.Dequeue()
 		if err != nil || vessel == nil {
-			break
+			<-r.sem
+			break drainLoop
 		}
 
 		log.Printf("%sdequeued vessel workflow=%s", vesselLabel(*vessel), vessel.Workflow)
 
-		sem <- struct{}{}
-		wg.Add(1)
+		result.Launched++
+		r.recordLaunched()
+		r.inFlight.Add(1)
+		r.wg.Add(1)
+		drainLaunchWg.Add(1)
 		go func(j queue.Vessel) {
-			defer wg.Done()
-			defer func() { <-sem }()
+			defer r.wg.Done()
+			defer drainLaunchWg.Done()
+			defer func() {
+				<-r.sem
+				r.inFlight.Add(-1)
+			}()
 
 			vesselBaseCtx := context.Background()
 			var vesselSpan observability.SpanContext
@@ -188,17 +224,7 @@ func (r *Runner) Drain(ctx context.Context) (DrainResult, error) {
 				}))
 			}
 
-			mu.Lock()
-			switch outcome {
-			case "completed":
-				result.Completed++
-			case "failed":
-				result.Failed++
-			case "waiting":
-				result.Waiting++
-			default:
-				result.Skipped++
-			}
+			drainStatsMu.Lock()
 			switch status.Health {
 			case VesselHealthHealthy:
 				healthCounts.Healthy++
@@ -210,31 +236,119 @@ func (r *Runner) Drain(ctx context.Context) (DrainResult, error) {
 			for _, anomaly := range status.Anomalies {
 				patternCounts[anomaly.Code]++
 			}
-			mu.Unlock()
+			drainStatsMu.Unlock()
+			r.recordOutcome(outcome)
 		}(*vessel)
 	}
 
-wait:
-	wg.Wait()
 	if r.Tracer != nil {
-		patterns := make([]FleetPattern, 0, len(patternCounts))
-		for code, count := range patternCounts {
-			patterns = append(patterns, FleetPattern{Code: code, Count: count})
+		if result.Launched == 0 {
+			drainSpan.End()
+		} else {
+			r.traceWg.Add(1)
+			go func() {
+				defer r.traceWg.Done()
+				drainLaunchWg.Wait()
+				drainStatsMu.Lock()
+				patterns := make([]FleetPattern, 0, len(patternCounts))
+				for code, count := range patternCounts {
+					patterns = append(patterns, FleetPattern{Code: code, Count: count})
+				}
+				drainStatsMu.Unlock()
+				sort.Slice(patterns, func(i, j int) bool {
+					if patterns[i].Count == patterns[j].Count {
+						return patterns[i].Code < patterns[j].Code
+					}
+					return patterns[i].Count > patterns[j].Count
+				})
+				drainSpan.AddAttributes(observability.DrainHealthAttributes(observability.DrainHealthData{
+					Healthy:   healthCounts.Healthy,
+					Degraded:  healthCounts.Degraded,
+					Unhealthy: healthCounts.Unhealthy,
+					Patterns:  FormatFleetPatterns(patterns),
+				}))
+				drainSpan.End()
+			}()
 		}
-		sort.Slice(patterns, func(i, j int) bool {
-			if patterns[i].Count == patterns[j].Count {
-				return patterns[i].Code < patterns[j].Code
-			}
-			return patterns[i].Count > patterns[j].Count
-		})
-		drainSpan.AddAttributes(observability.DrainHealthAttributes(observability.DrainHealthData{
-			Healthy:   healthCounts.Healthy,
-			Degraded:  healthCounts.Degraded,
-			Unhealthy: healthCounts.Unhealthy,
-			Patterns:  FormatFleetPatterns(patterns),
-		}))
+	}
+
+	return result, nil
+}
+
+// DrainAndWait preserves the historical synchronous Drain behaviour for callers
+// that need a terminal outcome summary rather than a per-tick launch count.
+func (r *Runner) DrainAndWait(ctx context.Context) (DrainResult, error) {
+	before := r.SnapshotResults()
+	var launched int
+	for {
+		tickResult, err := r.Drain(ctx)
+		if err != nil {
+			return DrainResult{}, err
+		}
+		launched += tickResult.Launched
+		r.Wait()
+		if r.DrainBudget > 0 || tickResult.Launched == 0 || ctx.Err() != nil {
+			break
+		}
+		pending, pendingErr := r.Queue.ListByState(queue.StatePending)
+		if pendingErr != nil {
+			return DrainResult{}, fmt.Errorf("list pending vessels: %w", pendingErr)
+		}
+		if len(pending) == 0 {
+			break
+		}
+	}
+	after := r.SnapshotResults()
+	result := DrainResult{
+		Launched:  launched,
+		Completed: after.Completed - before.Completed,
+		Failed:    after.Failed - before.Failed,
+		Skipped:   after.Skipped - before.Skipped,
+		Waiting:   after.Waiting - before.Waiting,
 	}
 	return result, nil
+}
+
+// Wait blocks until all in-flight vessels have finished and returns the
+// cumulative outcome counts recorded by this Runner.
+func (r *Runner) Wait() DrainResult {
+	r.wg.Wait()
+	r.traceWg.Wait()
+	return r.SnapshotResults()
+}
+
+// InFlightCount reports the number of launched vessels that have not yet
+// reached a terminal outcome.
+func (r *Runner) InFlightCount() int {
+	return int(r.inFlight.Load())
+}
+
+// SnapshotResults returns the cumulative outcome counts recorded by this Runner.
+func (r *Runner) SnapshotResults() DrainResult {
+	r.resultMu.Lock()
+	defer r.resultMu.Unlock()
+	return r.result
+}
+
+func (r *Runner) recordLaunched() {
+	r.resultMu.Lock()
+	defer r.resultMu.Unlock()
+	r.result.Launched++
+}
+
+func (r *Runner) recordOutcome(outcome string) {
+	r.resultMu.Lock()
+	defer r.resultMu.Unlock()
+	switch outcome {
+	case "completed":
+		r.result.Completed++
+	case "failed":
+		r.result.Failed++
+	case "waiting":
+		r.result.Waiting++
+	default:
+		r.result.Skipped++
+	}
 }
 
 // CheckWaitingVessels checks all waiting vessels for label gate resolution.

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -1,8 +1,10 @@
 package runner
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -265,6 +267,85 @@ func TestProp_PhasePolicyIntentsStayUniqueAndClassifyHighRiskActions(t *testing.
 		}
 		if resources["pr_create"] != wantPRRepo {
 			t.Fatalf("pr_create resource = %q, want %q", resources["pr_create"], wantPRRepo)
+		}
+	})
+}
+
+func TestProp_InFlightAccountingMatchesLaunchedWork(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		concurrency := rapid.IntRange(1, 4).Draw(t, "concurrency")
+		occupied := rapid.IntRange(0, concurrency-1).Draw(t, "occupied")
+		pendingCount := rapid.IntRange(0, 8).Draw(t, "pending")
+
+		dir, err := os.MkdirTemp("", "runner-inflight-prop-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(dir)
+
+		cfg := makeTestConfig(dir, concurrency)
+		cfg.StateDir = filepath.Join(dir, ".xylem")
+		q := queue.New(filepath.Join(dir, "queue.jsonl"))
+		for i := 1; i <= pendingCount; i++ {
+			if _, err := q.Enqueue(makeVessel(i, "fix-bug")); err != nil {
+				t.Fatalf("Enqueue(%d) error = %v", i, err)
+			}
+		}
+		writeSinglePhaseWorkflow(t, dir, "fix-bug")
+
+		oldWd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Getwd() error = %v", err)
+		}
+		if err := os.Chdir(dir); err != nil {
+			t.Fatalf("Chdir(%q) error = %v", dir, err)
+		}
+		defer os.Chdir(oldWd)
+
+		r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{
+			phaseOutputs: map[string][]byte{
+				"Analyze": []byte("analysis complete"),
+			},
+		})
+		r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+		heldDone := make(chan struct{})
+		for range occupied {
+			r.sem <- struct{}{}
+			r.inFlight.Add(1)
+			r.wg.Add(1)
+			go func() {
+				<-heldDone
+				<-r.sem
+				r.inFlight.Add(-1)
+				r.wg.Done()
+			}()
+		}
+
+		result, err := r.Drain(context.Background())
+		if err != nil {
+			t.Fatalf("Drain() error = %v", err)
+		}
+
+		available := concurrency - occupied
+		wantLaunched := pendingCount
+		if wantLaunched > available {
+			wantLaunched = available
+		}
+		if result.Launched != wantLaunched {
+			t.Fatalf("Drain().Launched = %d, want %d (pending=%d, available=%d)", result.Launched, wantLaunched, pendingCount, available)
+		}
+		if got := r.InFlightCount(); got != occupied+result.Launched {
+			t.Fatalf("InFlightCount() = %d, want %d", got, occupied+result.Launched)
+		}
+
+		close(heldDone)
+		waited := r.Wait()
+		if got := r.InFlightCount(); got != 0 {
+			t.Fatalf("InFlightCount() after Wait = %d, want 0", got)
+		}
+		if waited.Completed != result.Launched {
+			t.Fatalf("Wait().Completed = %d, want %d", waited.Completed, result.Launched)
 		}
 	})
 }

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -617,7 +617,7 @@ func TestDrainTracingSurfacesVesselHealthAndPatterns(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -831,7 +831,7 @@ func TestSmoke_S1_PolicyDenialShortCircuitsBeforeSurfaceSnapshot(t *testing.T) {
 		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.Deny}},
 	}}, nil, nil)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 
@@ -862,7 +862,7 @@ func TestSmoke_S2_SurfacePreSnapshotFailureShortCircuitsBeforePhaseExecution(t *
 	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
 	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 
@@ -906,7 +906,7 @@ func TestSmoke_S3_PhaseExecutionFailureShortCircuitsBeforeSurfacePostVerificatio
 		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.Allow}},
 	}}, auditLog, nil)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 
@@ -950,7 +950,7 @@ func TestSmoke_S4_SurfaceViolationShortCircuitsBeforeBudgetCheck(t *testing.T) {
 	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
 	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 
@@ -983,7 +983,7 @@ func TestSmoke_S17_RunnerWithNilIntermediarySkipsPolicyCheck(t *testing.T) {
 	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
 	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -1014,7 +1014,7 @@ func TestSmoke_S18_RunnerPolicyDeniesPhase(t *testing.T) {
 		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.Deny}},
 	}}, nil, nil)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 
@@ -1046,7 +1046,7 @@ func TestSmoke_S19_RunnerPolicyRequireApproval(t *testing.T) {
 		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.RequireApproval}},
 	}}, nil, nil)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 
@@ -1089,7 +1089,7 @@ func TestSmoke_S20_SurfacePreSnapshotIsTakenBeforePhaseExecution(t *testing.T) {
 	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
 	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 	assert.True(t, sawOriginal.Load())
@@ -1125,7 +1125,7 @@ func TestSmoke_S21_SurfacePostVerificationDetectsMutation(t *testing.T) {
 	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
 	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 
@@ -1160,7 +1160,7 @@ func TestSmoke_S22_AuditLogRecordsPolicyDecisions(t *testing.T) {
 		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.Allow}},
 	}}, auditLog, nil)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -1203,7 +1203,7 @@ func TestSmoke_S23_AuditLogRecordsSurfaceViolations(t *testing.T) {
 		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.Allow}},
 	}}, auditLog, nil)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 
@@ -1257,7 +1257,7 @@ func TestDrainSingleVessel(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1323,7 +1323,7 @@ func TestWS6S29NilHarnessFieldsRunsNormally(t *testing.T) {
 		t.Fatalf("r.Tracer = %#v, want nil", r.Tracer)
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1383,7 +1383,7 @@ func TestDrainBudgetStopsDequeueingAfterDeadline(t *testing.T) {
 	r.DrainBudget = 150 * time.Millisecond
 
 	start := time.Now()
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
@@ -1452,7 +1452,7 @@ func TestDrainBudgetZeroDisablesBudget(t *testing.T) {
 	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
 	// DrainBudget deliberately left at zero.
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1496,7 +1496,7 @@ func TestDrainBudgetRespectsContextCancellation(t *testing.T) {
 	}()
 
 	start := time.Now()
-	_, err := r.Drain(ctx)
+	_, err := r.DrainAndWait(ctx)
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
@@ -1506,6 +1506,97 @@ func TestDrainBudgetRespectsContextCancellation(t *testing.T) {
 	if elapsed > 500*time.Millisecond {
 		t.Errorf("Drain() took %s, expected fast cancel-driven return", elapsed)
 	}
+}
+
+func TestSmoke_S33_DrainReturnsBeforeInFlightWorkCompletes(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, err := q.Enqueue(makeVessel(1, "fix-bug"))
+	require.NoError(t, err)
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{name: "fix", promptContent: "Fix issue.", maxTurns: 5},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &countingCmdRunner{delay: 120 * time.Millisecond}
+	r := New(cfg, q, &mockWorktree{}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	start := time.Now()
+	result, err := r.Drain(context.Background())
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Launched)
+	assert.LessOrEqual(t, elapsed, 80*time.Millisecond)
+	assert.Equal(t, 1, r.InFlightCount())
+	vessel, err := q.FindByID("issue-1")
+	require.NoError(t, err)
+	require.NotNil(t, vessel)
+	assert.Equal(t, queue.StateRunning, vessel.State)
+
+	waited := r.Wait()
+	assert.Equal(t, 1, waited.Completed)
+	assert.Equal(t, 0, r.InFlightCount())
+}
+
+func TestSmoke_S34_DrainUsesRemainingCapacityFromPreviousTicks(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 3)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	for i := 1; i <= 3; i++ {
+		_, err := q.Enqueue(makeVessel(i, "fix-bug"))
+		require.NoError(t, err)
+	}
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{name: "fix", promptContent: "Fix issue.", maxTurns: 5},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &countingCmdRunner{delay: 60 * time.Millisecond}
+	r := New(cfg, q, &mockWorktree{}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	r.sem <- struct{}{}
+	r.inFlight.Add(1)
+	r.wg.Add(1)
+	heldDone := make(chan struct{})
+	go func() {
+		<-heldDone
+		<-r.sem
+		r.inFlight.Add(-1)
+		r.wg.Done()
+	}()
+
+	result, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Launched)
+	assert.Equal(t, 3, r.InFlightCount())
+
+	close(heldDone)
+	waited := r.Wait()
+	assert.Equal(t, 2, waited.Completed)
+	vessels, err := q.List()
+	require.NoError(t, err)
+	var pending, completed int
+	for _, vessel := range vessels {
+		switch vessel.State {
+		case queue.StatePending:
+			pending++
+		case queue.StateCompleted:
+			completed++
+		}
+	}
+	assert.Equal(t, 1, pending)
+	assert.Equal(t, 2, completed)
 }
 
 func TestDrainMultiPhaseWorkflow(t *testing.T) {
@@ -1538,7 +1629,7 @@ func TestDrainMultiPhaseWorkflow(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1594,7 +1685,7 @@ func TestDrainPhaseNoOpCompletesWorkflowEarly(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1663,7 +1754,7 @@ func TestDrainPhaseFailsStopsSubsequent(t *testing.T) {
 	wt := &mockWorktree{}
 	r := New(cfg, q, wt, cmdRunner)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1693,7 +1784,7 @@ func TestDrainPromptOnlyVessel(t *testing.T) {
 	wt := &mockWorktree{}
 	r := New(cfg, q, wt, cmdRunner)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1744,7 +1835,7 @@ func TestDrainPromptOnlyWithRef(t *testing.T) {
 	wt := &mockWorktree{}
 	r := New(cfg, q, wt, cmdRunner)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1792,7 +1883,7 @@ func TestSmoke_WS3_S25_PerVesselTrackerIsCreatedFreshForEachVessel(t *testing.T)
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 2, result.Completed)
 
@@ -1843,7 +1934,7 @@ func TestSmoke_WS3_S26_CostRecordedAfterEachPromptTypePhase(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -1893,7 +1984,7 @@ func TestSmoke_S27_CommandTypePhasesDoNotGenerateCostRecords(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -1944,7 +2035,7 @@ func TestSmoke_S28_BudgetEnforcementFailsVesselWhenBudgetIsExceeded(t *testing.T
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 
@@ -1992,7 +2083,7 @@ func TestSmoke_S29_NilBudgetMeansNoEnforcement(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -2041,7 +2132,7 @@ func TestSmoke_WS6_S5_BudgetExceededShortCircuitsBeforeGate(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 	assert.Equal(t, 0, countRunOutputCalls(cmdRunner, "sh"))
@@ -2069,7 +2160,7 @@ func TestSmoke_WS6_S12_PromptOnlyVesselGetsVesselSpan(t *testing.T) {
 
 	r := New(cfg, q, &mockWorktree{path: dir}, &mockCmdRunner{})
 	r.Tracer = tracer
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -2136,7 +2227,7 @@ func TestSmoke_WS6_S14_PromptOnlyVesselGetsSurfaceVerification(t *testing.T) {
 	}
 	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 	assert.True(t, sawOriginalContents)
@@ -2164,7 +2255,7 @@ func TestSmoke_WS6_S15_PromptOnlyVesselNoPolicy(t *testing.T) {
 		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.Deny}},
 	}}, auditLog, nil)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -2190,7 +2281,7 @@ func TestSmoke_WS6_S16_PromptOnlyVesselNoEvidence(t *testing.T) {
 	_, _ = q.Enqueue(makePromptVessel(1, "prompt-only no evidence"))
 
 	r := New(cfg, q, &mockWorktree{path: dir}, &mockCmdRunner{})
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -2207,7 +2298,7 @@ func TestSmoke_WS6_S17_PromptOnlyVesselSummaryArtifact(t *testing.T) {
 	_, _ = q.Enqueue(makePromptVessel(1, "prompt-only summary"))
 
 	r := New(cfg, q, &mockWorktree{path: dir}, &mockCmdRunner{})
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -2226,7 +2317,7 @@ func TestSmoke_WS6_S18_PromptOnlyVesselSummaryEmptyPhases(t *testing.T) {
 	_, _ = q.Enqueue(makePromptVessel(1, "prompt-only empty phases"))
 
 	r := New(cfg, q, &mockWorktree{path: dir}, &mockCmdRunner{})
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -2269,7 +2360,7 @@ func TestDrainCommandGatePasses(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2312,7 +2403,7 @@ func TestDrainCommandGateFailsNoRetries(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2369,7 +2460,7 @@ func TestDrainGateRetriesNotBleedBetweenPhases(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2413,7 +2504,7 @@ func TestDrainCommandGateFailsWithRetries(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2466,7 +2557,7 @@ func TestDrainLabelGateTransitionsToWaiting(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2520,7 +2611,7 @@ func TestCheckWaitingVesselsResumesAndDrainCompletes(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	first, err := r.Drain(context.Background())
+	first, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("first Drain() error = %v", err)
 	}
@@ -2564,7 +2655,7 @@ func TestCheckWaitingVesselsResumesAndDrainCompletes(t *testing.T) {
 		t.Fatalf("WorktreePath after resume = %q, want %q", resumed.WorktreePath, waiting.WorktreePath)
 	}
 
-	second, err := r.Drain(context.Background())
+	second, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("second Drain() error = %v", err)
 	}
@@ -2609,7 +2700,7 @@ func TestDrainVesselFails(t *testing.T) {
 	wt := &mockWorktree{}
 	r := New(cfg, q, wt, cmdRunner)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2633,7 +2724,7 @@ func TestDrainWorktreeCreateFails(t *testing.T) {
 	wt := &mockWorktree{createErr: errors.New("git fetch failed")}
 	r := New(cfg, q, wt, cmdRunner)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2671,13 +2762,16 @@ func TestDrainConcurrencyLimit(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	_, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	max := atomic.LoadInt32(&counter.maxSeen)
-	if max > 2 {
-		t.Errorf("concurrency exceeded limit: max concurrent = %d, limit = 2", max)
+	if result.Completed != 4 {
+		t.Fatalf("DrainAndWait().Completed = %d, want 4", result.Completed)
+	}
+	if max != 2 {
+		t.Fatalf("max concurrent = %d, want exactly 2 to prove the limit is enforced without collapsing throughput", max)
 	}
 }
 
@@ -2713,7 +2807,7 @@ func TestDrainContextCancel(t *testing.T) {
 		cancel()
 	}()
 
-	result, err := r.Drain(ctx)
+	result, err := r.DrainAndWait(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2737,7 +2831,7 @@ func TestDrainTimeout(t *testing.T) {
 	wt := &mockWorktree{}
 	r := New(cfg, q, wt, cmdRunner)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2773,7 +2867,7 @@ func TestDrainEmptyQueue(t *testing.T) {
 	wt := &mockWorktree{}
 	r := New(cfg, q, wt, cmdRunner)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2815,7 +2909,7 @@ func TestDrainHarnessAppended(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	_, err := r.Drain(context.Background())
+	_, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2866,7 +2960,7 @@ func TestDrainPreviousOutputsAvailable(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	_, err := r.Drain(context.Background())
+	_, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2918,7 +3012,7 @@ func TestBranchPrefixSelection(t *testing.T) {
 				"github-issue": makeGitHubSource(),
 			}
 
-			_, err := r.Drain(context.Background())
+			_, err := r.DrainAndWait(context.Background())
 			if err != nil {
 				t.Fatalf("drain: %v", err)
 			}
@@ -3224,7 +3318,7 @@ func TestDrainTimeoutV2Phase(t *testing.T) {
 	wt := &mockWorktree{}
 	r := New(cfg, q, wt, cmdRunner)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -3846,7 +3940,7 @@ func TestDrainCommandPhase(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -3916,7 +4010,7 @@ func TestDrainCommandPhaseFailure(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -3961,7 +4055,7 @@ func TestDrainCommandPhaseWithGate(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -4014,7 +4108,7 @@ func TestDrainCommandPhaseWithNoOp(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -4076,7 +4170,7 @@ func TestDrainPREventsVessel(t *testing.T) {
 		"github-pr-events": &source.GitHubPREvents{Repo: "owner/repo"},
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -4146,7 +4240,7 @@ func TestDrainOrchestratedDiamondWorkflow(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -4200,7 +4294,7 @@ func TestDrainOrchestratedContextFirewall(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -4248,7 +4342,7 @@ func TestDrainOrchestratedPhaseFailure(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -4288,7 +4382,7 @@ func TestDrainOrchestratedNoOp(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -4328,7 +4422,7 @@ func TestDrainOrchestratedWithGate(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -4407,7 +4501,7 @@ func TestDrainOrchestratedParallelFailureNoRace(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -4478,7 +4572,7 @@ func TestDrainPolicyBlocksPhaseBeforeExecution(t *testing.T) {
 				Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: tt.policy}},
 			}}, auditLog, nil)
 
-			result, err := r.Drain(context.Background())
+			result, err := r.DrainAndWait(context.Background())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -4558,7 +4652,7 @@ func TestDrainCommandPhaseHighRiskActionRequiresApproval(t *testing.T) {
 	r.AuditLog = auditLog
 	r.Intermediary = intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), auditLog, nil)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 	assert.Equal(t, 0, countRunOutputCalls(cmdRunner, "sh"))
@@ -4608,7 +4702,7 @@ func TestDrainPromptPhaseHighRiskActionRequiresApproval(t *testing.T) {
 	r.AuditLog = auditLog
 	r.Intermediary = intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), auditLog, nil)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 	assert.Len(t, cmdRunner.phaseCalls, 0)
@@ -4659,7 +4753,7 @@ func TestDrainOrchestratedPolicyBlocksSinglePhaseWave(t *testing.T) {
 		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.Deny}},
 	}}, auditLog, nil)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -4744,7 +4838,7 @@ func TestDrainOrchestratedProtectedSurfaceViolationFails(t *testing.T) {
 		Rules: []intermediary.Rule{{Action: "*", Resource: "*", Effect: intermediary.Allow}},
 	}}, auditLog, nil)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -5005,7 +5099,7 @@ func TestSmoke_WS6_S19_OrchestratedVesselRunStateNoRace(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -5115,7 +5209,7 @@ func TestSmoke_WS6_S22_WaveResultsMergedAfterWgWait(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 	require.Len(t, cmdRunner.phaseCalls, 2)
@@ -5167,7 +5261,7 @@ func TestSmoke_WS6_S23_CostTrackerConcurrentAccessSafe(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -5220,7 +5314,7 @@ func TestSmoke_WS6_S24_VesselSpanContextPropagatedToGoroutines(t *testing.T) {
 	}
 	r.Tracer = tracer
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -5271,7 +5365,7 @@ func TestSmoke_WS6_S25_ConcurrentPhasesAllowOverspend(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -5407,7 +5501,7 @@ func TestDrainCommandPhaseTemplateValidation(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -5559,7 +5653,7 @@ func TestSmoke_S9_NilTracerSkipsAllSpanCreationWithoutPanicking(t *testing.T) {
 		{name: "analyze", promptContent: "Analyze", maxTurns: 5},
 	}, cmdRunner, nil)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -5584,7 +5678,7 @@ func TestSmoke_S10_DrainRunSpanWrapsEntireDrainCall(t *testing.T) {
 		{name: "analyze", promptContent: "Analyze", maxTurns: 5},
 	}, cmdRunner, tracer)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -5612,7 +5706,7 @@ func TestSmoke_S11_VesselSpanIsChildOfDrainRunSpan(t *testing.T) {
 		{name: "analyze", promptContent: "Analyze", maxTurns: 5},
 	}, cmdRunner, tracer)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -5639,7 +5733,7 @@ func TestSmoke_S12_PhaseSpanIsChildOfVesselSpan(t *testing.T) {
 		{name: "analyze", promptContent: "Analyze", maxTurns: 5},
 	}, cmdRunner, tracer)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -5666,7 +5760,7 @@ func TestSmoke_S13_GateSpanIsChildOfPhaseSpan(t *testing.T) {
 		},
 	}, cmdRunner, tracer)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -5692,7 +5786,7 @@ func TestSmoke_S14_PhaseSpanGetsResultAttributesAddedAfterExecution(t *testing.T
 		{name: "analyze", promptContent: "Analyze", maxTurns: 5},
 	}, cmdRunner, tracer)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
@@ -5717,7 +5811,7 @@ func TestSmoke_S15_PhaseSpanRecordsErrorOnPhaseFailure(t *testing.T) {
 		{name: "analyze", promptContent: "Analyze", maxTurns: 5},
 	}, cmdRunner, tracer)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 
@@ -5735,7 +5829,7 @@ func TestSmoke_S16_PhaseSpanAlwaysEndsEvenWhenPhaseFails(t *testing.T) {
 		{name: "analyze", promptContent: "Analyze", maxTurns: 5},
 	}, cmdRunner, tracer)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 
@@ -5756,7 +5850,7 @@ func TestSmoke_S10_PhaseSpanIsAlwaysEndedEvenOnFailureDuringOrchestratedExecutio
 		{name: "implement", promptContent: "Implement {{.PreviousOutputs.analyze}}", maxTurns: 5, dependsOn: []string{"analyze"}},
 	}, cmdRunner, tracer)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 	assert.Len(t, cmdRunner.phaseCalls, 1)
@@ -5777,7 +5871,7 @@ func TestSmoke_S11_ErrorIsRecordedOnSpanBeforeEndDuringOrchestratedExecution(t *
 		{name: "implement", promptContent: "Implement {{.PreviousOutputs.analyze}}", maxTurns: 5, dependsOn: []string{"analyze"}},
 	}, cmdRunner, tracer)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Failed)
 
@@ -5864,7 +5958,7 @@ func TestDrainRateLimitRetrySucceeds(t *testing.T) {
 	r := New(cfg, q, &mockWorktree{}, cmdRunner)
 	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -5904,7 +5998,7 @@ func TestDrainRateLimitRetryExhausted(t *testing.T) {
 	r := New(cfg, q, &mockWorktree{}, cmdRunner)
 	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -5949,7 +6043,7 @@ func TestDrainNonRateLimitErrorNotRetried(t *testing.T) {
 	r := New(cfg, q, &mockWorktree{}, cmdRunner)
 	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -5982,7 +6076,7 @@ func TestDrainPromptOnlyRateLimitRetry(t *testing.T) {
 	}
 	r := New(cfg, q, &mockWorktree{}, cmdRunner)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}

--- a/cli/internal/runner/runner_tracing_prop_test.go
+++ b/cli/internal/runner/runner_tracing_prop_test.go
@@ -104,7 +104,7 @@ func TestProp_SpanHierarchyMaintainedAcrossVessels(t *testing.T) {
 			"github-issue": makeGitHubSource(),
 		}
 
-		result, err := r.Drain(context.Background())
+		result, err := r.DrainAndWait(context.Background())
 		if err != nil {
 			t.Fatalf("Drain() error = %v", err)
 		}
@@ -199,7 +199,7 @@ func TestProp_NilTracerNeverPanicsUnderConcurrency(t *testing.T) {
 			"github-issue": makeGitHubSource(),
 		}
 
-		result, err := r.Drain(context.Background())
+		result, err := r.DrainAndWait(context.Background())
 		if err != nil {
 			t.Fatalf("Drain() error = %v", err)
 		}

--- a/cli/internal/runner/summary_test.go
+++ b/cli/internal/runner/summary_test.go
@@ -308,7 +308,7 @@ func TestSmoke_S14_SaveVesselSummaryFailureIsNonFatalCallerContinues(t *testing.
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, result.Failed)
@@ -545,7 +545,7 @@ func TestSmoke_S19_FailurePathBuildsSummaryWithStateFailedAndCallsSaveVesselSumm
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, result.Failed)
@@ -977,7 +977,7 @@ func TestDrainPromptOnlyWritesSummaryArtifact(t *testing.T) {
 	}
 	r := New(cfg, q, &mockWorktree{}, cmdRunner)
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1049,7 +1049,7 @@ func TestDrainWritesFailureSummaryAndEvidenceManifest(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1135,7 +1135,7 @@ func TestSmoke_WS6S8_ClaimsFromPriorPhasesPreservedWhenLaterPhaseFails(t *testin
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1193,7 +1193,7 @@ func TestSmoke_WS6S9_ClaimsFromFailedPhaseAreDiscarded(t *testing.T) {
 		"github-issue": makeGitHubSource(),
 	}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1259,7 +1259,7 @@ func TestDrainOrchestratedWritesSummaryManifestAndReporterEvidence(t *testing.T)
 	}
 	r.Reporter = &reporter.Reporter{Runner: cmdRunner, Repo: "owner/repo"}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}
@@ -1331,7 +1331,7 @@ func TestDrainWorkflowWithoutGateOmitsEvidenceFromCompletionComment(t *testing.T
 	}
 	r.Reporter = &reporter.Reporter{Runner: cmdRunner, Repo: "owner/repo"}
 
-	result, err := r.Drain(context.Background())
+	result, err := r.DrainAndWait(context.Background())
 	if err != nil {
 		t.Fatalf("Drain() error = %v", err)
 	}


### PR DESCRIPTION
## Summary
- Implements [issue #171](https://github.com/nicholls-inc/xylem/issues/171) by separating per-tick dequeue/launch work from terminal waiting so long-running vessels do not collapse daemon drain throughput to an effective concurrency of 1.
- Reuses a single `runner.Runner` across daemon ticks, tracks shared in-flight work, and only runs idle-only upgrade/shutdown paths once the tracker is fully idle.

## Smoke scenarios covered
- `S33` — `DrainReturnsBeforeInFlightWorkCompletes`
- `S34` — `DrainUsesRemainingCapacityFromPreviousTicks`
- `S35` — `DaemonLoopAllowsNewDrainTicksWhileVesselsRemainInFlight`
- `S36` — `DaemonLoopUpgradeWaitsForTrackerIdle`

## Changes summary
- Modified `cli/internal/runner/runner.go` to add `DrainResult.Launched`, keep concurrency controls on the runner instance, and introduce `DrainAndWait()`, `Wait()`, `InFlightCount()`, `SnapshotResults()`, `recordLaunched()`, and shared in-flight accounting.
- Modified `cli/cmd/xylem/daemon.go` and `cli/cmd/xylem/drain.go` so daemon mode reuses one drain runner across ticks, logs per-tick launch/in-flight state, and keeps synchronous drain callers on `DrainAndWait()`.
- Modified `cli/cmd/xylem/daemon_test.go`, `cli/internal/runner/runner_test.go`, `cli/internal/runner/runner_prop_test.go`, `cli/internal/runner/runner_tracing_prop_test.go`, `cli/internal/runner/summary_test.go`, `cli/cmd/xylem/drain_test.go`, and DTU scenario tests in `cli/internal/dtu/` to cover the new tick/in-flight semantics and update synchronous callers to the waiting API.
- Key types and functions touched: `runner.Runner`, `runner.DrainResult`, `Runner.Drain`, `Runner.DrainAndWait`, `Runner.Wait`, `Runner.InFlightCount`, `daemonLoop`, and `runDrain`.

## Test plan
- `cd cli && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #171