### PR TITLE
feat: add cron-driven scheduled vessel source

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Sources              xylem CLI              Execution
                                             └──────────────────────────┘
 ```
 
-Sources are pluggable. Built-in source types cover GitHub issues (`github`), pull requests (`github-pr`), pull-request events (`github-pr-events`), merged pull requests (`github-merge`), and manual tasks via `xylem enqueue`. xylem handles scheduling, deduplication, concurrency, and worktree isolation across all sources.
+Sources are pluggable. Built-in source types cover GitHub issues (`github`), pull requests (`github-pr`), pull-request events (`github-pr-events`), merged pull requests (`github-merge`), recurring scheduled workflows (`schedule`), and manual tasks via `xylem enqueue`. xylem handles scheduling, deduplication, concurrency, and worktree isolation across all sources.
 
 ## Quick start
 
@@ -65,6 +65,10 @@ sources:
       implement-features:
         labels: [enhancement, low-effort, ready-for-work]
         workflow: implement-feature
+  doc-gardener:
+    type: schedule
+    cadence: "@daily"
+    workflow: doc-garden
 
 concurrency: 2
 max_turns: 50
@@ -88,7 +92,7 @@ daemon:
   drain_interval: "30s"
 ```
 
-This example covers the most common fields. Additional configuration is available for per-source provider overrides (`llm`, `model`), agent safety guardrails (`harness`), recurring harness reviews (`harness.review`), OpenTelemetry tracing (`observability`), and token budget enforcement (`cost`). See the [Configuration Reference](docs/configuration.md) for all fields, defaults, and validation rules.
+This example covers the most common fields. Scheduled sources fire a synthetic vessel whenever their cadence elapses; `cadence` accepts Go durations like `1h`, cron descriptors like `@daily`, and standard cron expressions. Additional configuration is available for per-source provider overrides (`llm`, `model`), agent safety guardrails (`harness`), recurring harness reviews (`harness.review`), OpenTelemetry tracing (`observability`), and token budget enforcement (`cost`). See the [Configuration Reference](docs/configuration.md) for all fields, defaults, and validation rules.
 
 ## Workflows
 

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -229,6 +229,61 @@ func TestDaemonShutdown(t *testing.T) {
 	}
 }
 
+func TestSmoke_S3_DaemonTickDrainsScheduledVessel(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		StateDir:    filepath.Join(dir, ".xylem"),
+		Claude:      config.ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]config.SourceConfig{
+			"doctor": {
+				Type:     "schedule",
+				Cadence:  "1h",
+				Workflow: "doctor",
+			},
+		},
+	}
+	if err := os.MkdirAll(cfg.StateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", cfg.StateDir, err)
+	}
+	q := queue.New(filepath.Join(cfg.StateDir, "queue.jsonl"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	drain := func(ctx context.Context) (runner.DrainResult, error) {
+		vessel, err := q.Dequeue()
+		if err != nil {
+			return runner.DrainResult{}, err
+		}
+		if vessel == nil {
+			return runner.DrainResult{}, nil
+		}
+		if err := q.Update(vessel.ID, queue.StateCompleted, ""); err != nil {
+			return runner.DrainResult{}, err
+		}
+		cancel()
+		return runner.DrainResult{Launched: 1, Completed: 1}, nil
+	}
+
+	err := daemonLoop(ctx, q, nil, func(ctx context.Context) (scanner.ScanResult, error) {
+		return runScan(ctx, cfg, q)
+	}, drain, nil, nil, time.Millisecond, time.Millisecond, 0)
+	require.NoError(t, err)
+
+	vessels, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "schedule", vessels[0].Source)
+	assert.Equal(t, queue.StateCompleted, vessels[0].State)
+	assert.Equal(t, "doctor", vessels[0].Workflow)
+	assert.Equal(t, "1h", vessels[0].Meta["schedule.cadence"])
+	assert.Equal(t, "doctor", vessels[0].Meta["schedule.source_name"])
+	assert.NotEmpty(t, vessels[0].Meta["schedule.fired_at"])
+}
+
 func TestSmoke_S31_TracerWiredInDaemonRunDrain(t *testing.T) {
 	oldNewTracer := newTracer
 	defer func() { newTracer = oldNewTracer }()

--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -119,7 +119,13 @@ func shutdownConfiguredTracer(tracer *observability.Tracer) {
 
 func buildSourceMap(cfg *config.Config, q *queue.Queue, cmdRunner source.CommandRunner) map[string]source.Source {
 	sources := make(map[string]source.Source)
-	for _, srcCfg := range cfg.Sources {
+	addSource := func(configName string, src source.Source) {
+		sources[configName] = src
+		if _, exists := sources[src.Name()]; !exists {
+			sources[src.Name()] = src
+		}
+	}
+	for name, srcCfg := range cfg.Sources {
 		switch srcCfg.Type {
 		case "github":
 			tasks := make(map[string]source.GitHubTask, len(srcCfg.Tasks))
@@ -133,7 +139,7 @@ func buildSourceMap(cfg *config.Config, q *queue.Queue, cmdRunner source.Command
 				Queue:     q,
 				CmdRunner: cmdRunner,
 			}
-			sources[gh.Name()] = gh
+			addSource(name, gh)
 		case "github-pr":
 			tasks := make(map[string]source.GitHubTask, len(srcCfg.Tasks))
 			for name, t := range srcCfg.Tasks {
@@ -146,7 +152,7 @@ func buildSourceMap(cfg *config.Config, q *queue.Queue, cmdRunner source.Command
 				Queue:     q,
 				CmdRunner: cmdRunner,
 			}
-			sources[pr.Name()] = pr
+			addSource(name, pr)
 		case "github-pr-events":
 			prEventsTasks := make(map[string]source.PREventsTask, len(srcCfg.Tasks))
 			for name, t := range srcCfg.Tasks {
@@ -168,7 +174,7 @@ func buildSourceMap(cfg *config.Config, q *queue.Queue, cmdRunner source.Command
 				Queue:     q,
 				CmdRunner: cmdRunner,
 			}
-			sources[pre.Name()] = pre
+			addSource(name, pre)
 		case "github-merge":
 			mergeTasks := make(map[string]source.MergeTask, len(srcCfg.Tasks))
 			for name, t := range srcCfg.Tasks {
@@ -182,7 +188,16 @@ func buildSourceMap(cfg *config.Config, q *queue.Queue, cmdRunner source.Command
 				Queue:     q,
 				CmdRunner: cmdRunner,
 			}
-			sources[gm.Name()] = gm
+			addSource(name, gm)
+		case "schedule":
+			sched := &source.Schedule{
+				ConfigName: name,
+				Cadence:    srcCfg.Cadence,
+				Workflow:   srcCfg.Workflow,
+				StateDir:   cfg.StateDir,
+				Queue:      q,
+			}
+			addSource(name, sched)
 		}
 	}
 	return sources

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -36,6 +36,8 @@ github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/cli/internal/cadence/cadence.go
+++ b/cli/internal/cadence/cadence.go
@@ -1,0 +1,69 @@
+package cadence
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	cron "github.com/robfig/cron/v3"
+)
+
+var cronParser = cron.NewParser(
+	cron.Minute |
+		cron.Hour |
+		cron.Dom |
+		cron.Month |
+		cron.Dow |
+		cron.Descriptor,
+)
+
+// Spec represents either a fixed interval or a cron-style schedule.
+type Spec struct {
+	raw      string
+	interval time.Duration
+	cron     cron.Schedule
+}
+
+func Parse(raw string) (Spec, error) {
+	expr := strings.TrimSpace(raw)
+	if expr == "" {
+		return Spec{}, fmt.Errorf("cadence is required")
+	}
+	if d, err := time.ParseDuration(expr); err == nil {
+		if d <= 0 {
+			return Spec{}, fmt.Errorf("cadence duration must be greater than 0")
+		}
+		return Spec{raw: expr, interval: d}, nil
+	}
+	sched, err := cronParser.Parse(expr)
+	if err != nil {
+		return Spec{}, fmt.Errorf("parse cadence %q: %w", expr, err)
+	}
+	return Spec{raw: expr, cron: sched}, nil
+}
+
+func (s Spec) Raw() string {
+	return s.raw
+}
+
+func (s Spec) FireTime(last *time.Time, now time.Time) (time.Time, bool) {
+	now = now.UTC().Truncate(time.Second)
+	if last == nil {
+		return now, true
+	}
+
+	base := last.UTC().Truncate(time.Second)
+	if s.interval > 0 {
+		next := base.Add(s.interval)
+		if !next.After(now) {
+			return next, true
+		}
+		return time.Time{}, false
+	}
+
+	next := s.cron.Next(base)
+	if !next.After(now) {
+		return next.UTC().Truncate(time.Second), true
+	}
+	return time.Time{}, false
+}

--- a/cli/internal/cadence/cadence_prop_test.go
+++ b/cli/internal/cadence/cadence_prop_test.go
@@ -1,0 +1,37 @@
+package cadence
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropIntervalFireTimeRespectsBoundary(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		seconds := rapid.Int64Range(1, 24*60*60).Draw(t, "seconds")
+		beforeOffset := rapid.Int64Range(0, seconds-1).Draw(t, "beforeOffset")
+		afterOffset := rapid.Int64Range(seconds, seconds*2).Draw(t, "afterOffset")
+		baseUnix := rapid.Int64Range(0, 4_000_000_000).Draw(t, "baseUnix")
+
+		spec, err := Parse(fmt.Sprintf("%ds", seconds))
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+
+		base := time.Unix(baseUnix, 0).UTC()
+		if _, due := spec.FireTime(&base, base.Add(time.Duration(beforeOffset)*time.Second)); due {
+			t.Fatalf("expected no fire before interval boundary")
+		}
+
+		firedAt, due := spec.FireTime(&base, base.Add(time.Duration(afterOffset)*time.Second))
+		if !due {
+			t.Fatalf("expected fire at or after interval boundary")
+		}
+		want := base.Add(time.Duration(seconds) * time.Second)
+		if !firedAt.Equal(want) {
+			t.Fatalf("FireTime() = %s, want %s", firedAt, want)
+		}
+	})
+}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/cadence"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
 	"gopkg.in/yaml.v3"
@@ -45,13 +46,15 @@ type Config struct {
 }
 
 type SourceConfig struct {
-	Type    string          `yaml:"type"`
-	Repo    string          `yaml:"repo,omitempty"`
-	LLM     string          `yaml:"llm,omitempty"`
-	Model   string          `yaml:"model,omitempty"`
-	Timeout string          `yaml:"timeout,omitempty"`
-	Exclude []string        `yaml:"exclude,omitempty"`
-	Tasks   map[string]Task `yaml:"tasks,omitempty"`
+	Type     string          `yaml:"type"`
+	Repo     string          `yaml:"repo,omitempty"`
+	Cadence  string          `yaml:"cadence,omitempty"`
+	Workflow string          `yaml:"workflow,omitempty"`
+	LLM      string          `yaml:"llm,omitempty"`
+	Model    string          `yaml:"model,omitempty"`
+	Timeout  string          `yaml:"timeout,omitempty"`
+	Exclude  []string        `yaml:"exclude,omitempty"`
+	Tasks    map[string]Task `yaml:"tasks,omitempty"`
 }
 
 type StatusLabels struct {
@@ -314,6 +317,10 @@ func (c *Config) Validate() error {
 			}
 		case "github-merge":
 			if err := validateGitHubMergeSource(name, src); err != nil {
+				return err
+			}
+		case "schedule":
+			if err := validateScheduleSource(name, src); err != nil {
 				return err
 			}
 		case "":
@@ -681,6 +688,19 @@ func validateGitHubMergeSource(name string, src SourceConfig) error {
 		if strings.TrimSpace(task.Workflow) == "" {
 			return fmt.Errorf("source %q task %q: must include a workflow", name, tname)
 		}
+	}
+	return nil
+}
+
+func validateScheduleSource(name string, src SourceConfig) error {
+	if strings.TrimSpace(src.Workflow) == "" {
+		return fmt.Errorf("source %q (schedule): workflow is required", name)
+	}
+	if len(src.Tasks) > 0 {
+		return fmt.Errorf("source %q (schedule): tasks are not supported; configure workflow at the source level", name)
+	}
+	if _, err := cadence.Parse(src.Cadence); err != nil {
+		return fmt.Errorf("source %q (schedule): %w", name, err)
 	}
 	return nil
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -1091,6 +1091,81 @@ func TestValidateGitHubMergeMissingRepo(t *testing.T) {
 	requireErrorContains(t, err, "repo is required")
 }
 
+func TestValidateScheduleValid(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]SourceConfig{
+			"doctor": {
+				Type:     "schedule",
+				Cadence:  "@daily",
+				Workflow: "doctor",
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid schedule config, got: %v", err)
+	}
+}
+
+func TestValidateScheduleMissingWorkflow(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]SourceConfig{
+			"doctor": {
+				Type:    "schedule",
+				Cadence: "1h",
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "workflow is required")
+}
+
+func TestValidateScheduleMalformedCadence(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]SourceConfig{
+			"doctor": {
+				Type:     "schedule",
+				Cadence:  "bad cadence",
+				Workflow: "doctor",
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "parse cadence")
+}
+
+func TestValidateScheduleRejectsTasks(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]SourceConfig{
+			"doctor": {
+				Type:     "schedule",
+				Cadence:  "1h",
+				Workflow: "doctor",
+				Tasks: map[string]Task{
+					"unused": {Workflow: "other"},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "tasks are not supported")
+}
+
 func TestValidateUnknownSourceType(t *testing.T) {
 	cfg := &Config{
 		Concurrency: 2,

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -380,7 +380,7 @@ func (r *Runner) CheckWaitingVessels(ctx context.Context) {
 				if updateErr := r.Queue.Update(vessel.ID, queue.StateTimedOut, "label gate timed out"); updateErr != nil {
 					log.Printf("warn: failed to update vessel %s to timed_out: %v", vessel.ID, updateErr)
 				}
-				src := r.resolveSource(vessel.Source)
+				src := r.resolveSource(vessel)
 				if err := src.OnTimedOut(ctx, vessel); err != nil {
 					log.Printf("warn: OnTimedOut hook for vessel %s: %v", vessel.ID, err)
 				}
@@ -421,7 +421,7 @@ func (r *Runner) CheckWaitingVessels(ctx context.Context) {
 
 func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome string) {
 	// Look up source for this vessel
-	src := r.resolveSource(vessel.Source)
+	src := r.resolveSource(vessel)
 
 	// Source-specific start hook (e.g., add in-progress label)
 	startErr := src.OnStart(ctx, vessel)
@@ -1021,9 +1021,14 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 	return r.completeVessel(ctx, vessel, worktreePath, nil, vrs, nil)
 }
 
-func (r *Runner) resolveSource(name string) source.Source {
+func (r *Runner) resolveSource(vessel queue.Vessel) source.Source {
 	if r.Sources != nil {
-		if src, ok := r.Sources[name]; ok {
+		if configName := r.sourceConfigNameFromMeta(vessel); configName != "" {
+			if src, ok := r.Sources[configName]; ok {
+				return src
+			}
+		}
+		if src, ok := r.Sources[vessel.Source]; ok {
 			return src
 		}
 	}
@@ -2470,13 +2475,7 @@ func (r *Runner) parseIssueNum(vessel queue.Vessel) int {
 }
 
 func (r *Runner) resolveRepo(vessel queue.Vessel) string {
-	if r.Sources == nil {
-		return ""
-	}
-	src, ok := r.Sources[vessel.Source]
-	if !ok {
-		return ""
-	}
+	src := r.resolveSource(vessel)
 	switch s := src.(type) {
 	case *source.GitHub:
 		return s.Repo

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -4192,6 +4192,7 @@ func TestResolveRepoNewSources(t *testing.T) {
 		Sources: map[string]source.Source{
 			"github-pr-events": &source.GitHubPREvents{Repo: "owner/events-repo"},
 			"github-merge":     &source.GitHubMerge{Repo: "owner/merge-repo"},
+			"events-source":    &source.GitHubPREvents{Repo: "owner/config-repo"},
 		},
 	}
 
@@ -4209,6 +4210,42 @@ func TestResolveRepoNewSources(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("resolveRepo(%q) = %q, want %q", tt.source, got, tt.want)
 		}
+	}
+
+	got := r.resolveRepo(queue.Vessel{
+		Source: "github-pr-events",
+		Meta:   map[string]string{"config_source": "events-source"},
+	})
+	if got != "owner/config-repo" {
+		t.Errorf("resolveRepo(config_source) = %q, want %q", got, "owner/config-repo")
+	}
+}
+
+func TestResolveSourcePrefersConfigSourceForScheduleVessel(t *testing.T) {
+	r := &Runner{
+		Sources: map[string]source.Source{
+			"schedule": &source.Schedule{ConfigName: "fallback"},
+			"doctor":   &source.Schedule{ConfigName: "doctor"},
+		},
+	}
+
+	resolved, ok := r.resolveSource(queue.Vessel{
+		Source: "schedule",
+		Meta: map[string]string{
+			"config_source":        "doctor",
+			"schedule.fired_at":    "2026-04-09T06:00:00Z",
+			"schedule.cadence":     "1h",
+			"schedule.source_name": "doctor",
+		},
+	}).(*source.Schedule)
+	if !ok {
+		t.Fatalf("resolveSource() returned %T, want *source.Schedule", r.resolveSource(queue.Vessel{
+			Source: "schedule",
+			Meta:   map[string]string{"config_source": "doctor"},
+		}))
+	}
+	if resolved.ConfigName != "doctor" {
+		t.Fatalf("resolved.ConfigName = %q, want doctor", resolved.ConfigName)
 	}
 }
 

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -134,6 +134,17 @@ func (s *Scanner) buildSources() []sourceEntry {
 				},
 				configName: name,
 			})
+		case "schedule":
+			entries = append(entries, sourceEntry{
+				src: &source.Schedule{
+					ConfigName: name,
+					Cadence:    srcCfg.Cadence,
+					Workflow:   srcCfg.Workflow,
+					StateDir:   s.Config.StateDir,
+					Queue:      s.Queue,
+				},
+				configName: name,
+			})
 		}
 	}
 	return entries

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -253,6 +253,128 @@ func TestScanExistingPR(t *testing.T) {
 	}
 }
 
+func TestScanScheduleSource(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		StateDir:    dir,
+		Claude:      config.ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]config.SourceConfig{
+			"doc-gardener": {
+				Type:     "schedule",
+				Cadence:  "1h",
+				Workflow: "doc-garden",
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	s := New(cfg, q, newMock())
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Added != 1 {
+		t.Fatalf("expected 1 added, got %d", result.Added)
+	}
+
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	if vessels[0].Source != "schedule" {
+		t.Errorf("Source = %q, want schedule", vessels[0].Source)
+	}
+	if vessels[0].Workflow != "doc-garden" {
+		t.Errorf("Workflow = %q, want doc-garden", vessels[0].Workflow)
+	}
+	if vessels[0].Meta["config_source"] != "doc-gardener" {
+		t.Errorf("config_source = %q, want doc-gardener", vessels[0].Meta["config_source"])
+	}
+	if vessels[0].Meta["schedule.cadence"] != "1h" {
+		t.Errorf("schedule.cadence = %q, want 1h", vessels[0].Meta["schedule.cadence"])
+	}
+}
+
+func TestScanMultipleScheduleSourcesKeepConfigNamesDistinct(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		StateDir:    dir,
+		Claude:      config.ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]config.SourceConfig{
+			"doc-gardener": {
+				Type:     "schedule",
+				Cadence:  "1h",
+				Workflow: "doc-garden",
+			},
+			"doctor": {
+				Type:     "schedule",
+				Cadence:  "@daily",
+				Workflow: "doctor",
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	s := New(cfg, q, newMock())
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if result.Added != 2 {
+		t.Fatalf("Added = %d, want 2", result.Added)
+	}
+
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(vessels) != 2 {
+		t.Fatalf("len(vessels) = %d, want 2", len(vessels))
+	}
+
+	byConfigSource := make(map[string]queue.Vessel, len(vessels))
+	for _, vessel := range vessels {
+		byConfigSource[vessel.Meta["config_source"]] = vessel
+		if vessel.Source != "schedule" {
+			t.Fatalf("vessel.Source = %q, want schedule", vessel.Source)
+		}
+	}
+
+	docGardener, ok := byConfigSource["doc-gardener"]
+	if !ok {
+		t.Fatal("missing doc-gardener vessel")
+	}
+	if docGardener.Workflow != "doc-garden" {
+		t.Fatalf("doc-gardener workflow = %q, want doc-garden", docGardener.Workflow)
+	}
+	if docGardener.Meta["schedule.cadence"] != "1h" {
+		t.Fatalf("doc-gardener cadence = %q, want 1h", docGardener.Meta["schedule.cadence"])
+	}
+
+	doctor, ok := byConfigSource["doctor"]
+	if !ok {
+		t.Fatal("missing doctor vessel")
+	}
+	if doctor.Workflow != "doctor" {
+		t.Fatalf("doctor workflow = %q, want doctor", doctor.Workflow)
+	}
+	if doctor.Meta["schedule.cadence"] != "@daily" {
+		t.Fatalf("doctor cadence = %q, want @daily", doctor.Meta["schedule.cadence"])
+	}
+	if doctor.Ref == docGardener.Ref {
+		t.Fatalf("schedule refs collided: %q", doctor.Ref)
+	}
+}
+
 func TestScanSkipsUnchangedFailedIssue(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeConfig(dir)

--- a/cli/internal/source/schedule.go
+++ b/cli/internal/source/schedule.go
@@ -1,0 +1,246 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gofrs/flock"
+	"github.com/nicholls-inc/xylem/cli/internal/cadence"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+// Schedule emits recurring synthetic vessels based on a configured cadence.
+type Schedule struct {
+	ConfigName string
+	Cadence    string
+	Workflow   string
+	StateDir   string
+	Queue      *queue.Queue
+	Now        func() time.Time
+}
+
+type scheduleStateRecord struct {
+	LastFiredAt string `json:"last_fired_at"`
+}
+
+type scheduleStateFile struct {
+	Sources map[string]scheduleStateRecord `json:"sources"`
+}
+
+func (s *Schedule) Name() string { return "schedule" }
+
+func (s *Schedule) Scan(_ context.Context) ([]queue.Vessel, error) {
+	spec, err := cadence.Parse(s.Cadence)
+	if err != nil {
+		return nil, fmt.Errorf("schedule source %q: %w", s.ConfigName, err)
+	}
+
+	lastFiredAt, err := s.loadLastFiredAt()
+	if err != nil {
+		return nil, fmt.Errorf("schedule source %q: load last fired state: %w", s.ConfigName, err)
+	}
+
+	firedAt, due := spec.FireTime(lastFiredAt, s.now())
+	if !due {
+		return nil, nil
+	}
+
+	active, err := s.hasActiveVessel()
+	if err != nil {
+		return nil, fmt.Errorf("schedule source %q: inspect active vessels: %w", s.ConfigName, err)
+	}
+	if active {
+		return nil, nil
+	}
+
+	vessel := s.buildVessel(firedAt, spec.Raw())
+	if s.Queue != nil && s.Queue.HasRefAny(vessel.Ref) {
+		return nil, nil
+	}
+	return []queue.Vessel{vessel}, nil
+}
+
+func (s *Schedule) OnEnqueue(_ context.Context, vessel queue.Vessel) error {
+	firedAtRaw := vessel.Meta["schedule.fired_at"]
+	if firedAtRaw == "" {
+		return nil
+	}
+	firedAt, err := time.Parse(time.RFC3339, firedAtRaw)
+	if err != nil {
+		return fmt.Errorf("parse schedule fired_at for %s: %w", vessel.ID, err)
+	}
+	if err := s.storeLastFiredAt(firedAt); err != nil {
+		return fmt.Errorf("persist schedule fired_at for %s: %w", vessel.ID, err)
+	}
+	return nil
+}
+
+func (s *Schedule) OnStart(_ context.Context, _ queue.Vessel) error            { return nil }
+func (s *Schedule) OnComplete(_ context.Context, _ queue.Vessel) error         { return nil }
+func (s *Schedule) OnFail(_ context.Context, _ queue.Vessel) error             { return nil }
+func (s *Schedule) OnTimedOut(_ context.Context, _ queue.Vessel) error         { return nil }
+func (s *Schedule) RemoveRunningLabel(_ context.Context, _ queue.Vessel) error { return nil }
+
+func (s *Schedule) BranchName(vessel queue.Vessel) string {
+	sourceName := scheduleSlug(s.ConfigName)
+	firedAt := scheduleFiredAtKey(vessel.Meta["schedule.fired_at"])
+	return fmt.Sprintf("chore/schedule-%s-%s", sourceName, firedAt)
+}
+
+func (s *Schedule) buildVessel(firedAt time.Time, rawCadence string) queue.Vessel {
+	firedAt = firedAt.UTC().Truncate(time.Second)
+	idTime := firedAt.Format("20060102t150405z")
+	refTime := firedAt.Format(time.RFC3339)
+	configName := s.ConfigName
+	if configName == "" {
+		configName = "schedule"
+	}
+	return queue.Vessel{
+		ID:       fmt.Sprintf("schedule-%s-%s", scheduleSlug(configName), idTime),
+		Source:   s.Name(),
+		Ref:      fmt.Sprintf("schedule://%s/%s", configName, refTime),
+		Workflow: s.Workflow,
+		Meta: map[string]string{
+			"schedule.cadence":     rawCadence,
+			"schedule.fired_at":    refTime,
+			"schedule.source_name": configName,
+		},
+		State:     queue.StatePending,
+		CreatedAt: firedAt,
+	}
+}
+
+func (s *Schedule) loadLastFiredAt() (*time.Time, error) {
+	state, err := s.readState()
+	if err != nil {
+		return nil, err
+	}
+	record, ok := state.Sources[s.ConfigName]
+	if !ok || strings.TrimSpace(record.LastFiredAt) == "" {
+		return nil, nil
+	}
+	ts, err := time.Parse(time.RFC3339, record.LastFiredAt)
+	if err != nil {
+		return nil, fmt.Errorf("parse last_fired_at %q: %w", record.LastFiredAt, err)
+	}
+	ts = ts.UTC()
+	return &ts, nil
+}
+
+func (s *Schedule) storeLastFiredAt(firedAt time.Time) error {
+	if err := os.MkdirAll(filepath.Dir(s.statePath()), 0o755); err != nil {
+		return fmt.Errorf("create schedule state directory: %w", err)
+	}
+	lock := flock.New(s.statePath() + ".lock")
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("lock schedule state: %w", err)
+	}
+	defer func() {
+		_ = lock.Unlock()
+	}()
+
+	state, err := s.readStateUnlocked()
+	if err != nil {
+		return err
+	}
+	if state.Sources == nil {
+		state.Sources = make(map[string]scheduleStateRecord)
+	}
+	state.Sources[s.ConfigName] = scheduleStateRecord{
+		LastFiredAt: firedAt.UTC().Truncate(time.Second).Format(time.RFC3339),
+	}
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal schedule state: %w", err)
+	}
+	if err := os.WriteFile(s.statePath(), data, 0o644); err != nil {
+		return fmt.Errorf("write schedule state: %w", err)
+	}
+	return nil
+}
+
+func (s *Schedule) readState() (scheduleStateFile, error) {
+	if err := os.MkdirAll(filepath.Dir(s.statePath()), 0o755); err != nil {
+		return scheduleStateFile{}, fmt.Errorf("create schedule state directory: %w", err)
+	}
+	lock := flock.New(s.statePath() + ".lock")
+	if err := lock.RLock(); err != nil {
+		return scheduleStateFile{}, fmt.Errorf("lock schedule state for read: %w", err)
+	}
+	defer func() {
+		_ = lock.Unlock()
+	}()
+	return s.readStateUnlocked()
+}
+
+func (s *Schedule) readStateUnlocked() (scheduleStateFile, error) {
+	data, err := os.ReadFile(s.statePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return scheduleStateFile{Sources: map[string]scheduleStateRecord{}}, nil
+		}
+		return scheduleStateFile{}, fmt.Errorf("read schedule state: %w", err)
+	}
+	var state scheduleStateFile
+	if err := json.Unmarshal(data, &state); err != nil {
+		return scheduleStateFile{}, fmt.Errorf("parse schedule state: %w", err)
+	}
+	if state.Sources == nil {
+		state.Sources = map[string]scheduleStateRecord{}
+	}
+	return state, nil
+}
+
+func (s *Schedule) statePath() string {
+	return filepath.Join(s.StateDir, "state", "schedule.json")
+}
+
+func (s *Schedule) now() time.Time {
+	if s.Now != nil {
+		return s.Now().UTC()
+	}
+	return sourceNow()
+}
+
+func (s *Schedule) hasActiveVessel() (bool, error) {
+	if s.Queue == nil {
+		return false, nil
+	}
+
+	vessels, err := s.Queue.List()
+	if err != nil {
+		return false, fmt.Errorf("list queue: %w", err)
+	}
+	for _, vessel := range vessels {
+		if vessel.State.IsTerminal() {
+			continue
+		}
+		if vessel.Meta["schedule.source_name"] == s.ConfigName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func scheduleSlug(name string) string {
+	slug := nonAlphaNum.ReplaceAllString(strings.ToLower(name), "-")
+	slug = strings.Trim(slug, "-")
+	if slug == "" {
+		return "schedule"
+	}
+	return slug
+}
+
+func scheduleFiredAtKey(raw string) string {
+	firedAt, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return "tick"
+	}
+	return firedAt.UTC().Format("20060102t150405z")
+}

--- a/cli/internal/source/schedule_test.go
+++ b/cli/internal/source/schedule_test.go
@@ -1,0 +1,372 @@
+package source
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScheduleName(t *testing.T) {
+	if got := (&Schedule{}).Name(); got != "schedule" {
+		t.Fatalf("Name() = %q, want schedule", got)
+	}
+}
+
+func TestScheduleScanFirstRun(t *testing.T) {
+	now := time.Date(2026, time.April, 9, 6, 45, 12, 0, time.UTC)
+	s := &Schedule{
+		ConfigName: "doc-gardener",
+		Cadence:    "1h",
+		Workflow:   "doc-garden",
+		StateDir:   t.TempDir(),
+		Queue:      queue.New(filepath.Join(t.TempDir(), "queue.jsonl")),
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	vessels, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+
+	v := vessels[0]
+	if v.Source != "schedule" {
+		t.Errorf("Source = %q, want schedule", v.Source)
+	}
+	if v.Workflow != "doc-garden" {
+		t.Errorf("Workflow = %q, want doc-garden", v.Workflow)
+	}
+	if got, want := v.ID, "schedule-doc-gardener-20260409t064512z"; got != want {
+		t.Errorf("ID = %q, want %q", got, want)
+	}
+	if got, want := v.Ref, "schedule://doc-gardener/2026-04-09T06:45:12Z"; got != want {
+		t.Errorf("Ref = %q, want %q", got, want)
+	}
+	if got := v.Meta["schedule.cadence"]; got != "1h" {
+		t.Errorf("schedule.cadence = %q, want 1h", got)
+	}
+	if got := v.Meta["schedule.source_name"]; got != "doc-gardener" {
+		t.Errorf("schedule.source_name = %q, want doc-gardener", got)
+	}
+	if got := v.Meta["schedule.fired_at"]; got != now.Format(time.RFC3339) {
+		t.Errorf("schedule.fired_at = %q, want %q", got, now.Format(time.RFC3339))
+	}
+}
+
+func TestScheduleScanSuppressesUntilCadenceElapses(t *testing.T) {
+	stateDir := t.TempDir()
+	q := queue.New(filepath.Join(t.TempDir(), "queue.jsonl"))
+	now := time.Date(2026, time.April, 9, 6, 0, 0, 0, time.UTC)
+	s := &Schedule{
+		ConfigName: "doctor",
+		Cadence:    "1h",
+		Workflow:   "doctor",
+		StateDir:   stateDir,
+		Queue:      q,
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	first, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("first Scan() error = %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("expected first scan to emit 1 vessel, got %d", len(first))
+	}
+	if err := s.OnEnqueue(context.Background(), first[0]); err != nil {
+		t.Fatalf("OnEnqueue() error = %v", err)
+	}
+
+	now = now.Add(30 * time.Minute)
+	suppressed, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("suppressed Scan() error = %v", err)
+	}
+	if len(suppressed) != 0 {
+		t.Fatalf("expected no vessel before cadence elapsed, got %d", len(suppressed))
+	}
+
+	now = now.Add(30 * time.Minute)
+	second, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("second Scan() error = %v", err)
+	}
+	if len(second) != 1 {
+		t.Fatalf("expected one vessel after cadence elapsed, got %d", len(second))
+	}
+	if got, want := second[0].Meta["schedule.fired_at"], "2026-04-09T07:00:00Z"; got != want {
+		t.Errorf("schedule.fired_at = %q, want %q", got, want)
+	}
+}
+
+func TestScheduleScanPersistsAcrossRestart(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 9, 6, 0, 0, 0, time.UTC)
+	first := &Schedule{
+		ConfigName: "self-gap-analysis",
+		Cadence:    "@daily",
+		Workflow:   "gap-analysis",
+		StateDir:   stateDir,
+		Queue:      queue.New(filepath.Join(t.TempDir(), "queue-one.jsonl")),
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	vessels, err := first.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("first Scan() error = %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected first scan to emit 1 vessel, got %d", len(vessels))
+	}
+	if err := first.OnEnqueue(context.Background(), vessels[0]); err != nil {
+		t.Fatalf("OnEnqueue() error = %v", err)
+	}
+
+	now = now.Add(12 * time.Hour)
+	second := &Schedule{
+		ConfigName: "self-gap-analysis",
+		Cadence:    "@daily",
+		Workflow:   "gap-analysis",
+		StateDir:   stateDir,
+		Queue:      queue.New(filepath.Join(t.TempDir(), "queue-two.jsonl")),
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	suppressed, err := second.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("restart Scan() error = %v", err)
+	}
+	if len(suppressed) != 0 {
+		t.Fatalf("expected restart scan before next tick to emit 0 vessels, got %d", len(suppressed))
+	}
+
+	now = time.Date(2026, time.April, 10, 6, 0, 0, 0, time.UTC)
+	due, err := second.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("next-day Scan() error = %v", err)
+	}
+	if len(due) != 1 {
+		t.Fatalf("expected restart scan after next tick to emit 1 vessel, got %d", len(due))
+	}
+	if got, want := due[0].Meta["schedule.fired_at"], "2026-04-10T00:00:00Z"; got != want {
+		t.Errorf("schedule.fired_at = %q, want %q", got, want)
+	}
+}
+
+func TestScheduleScanNamespacesStateByConfigSource(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 9, 6, 0, 0, 0, time.UTC)
+
+	doctor := &Schedule{
+		ConfigName: "doctor",
+		Cadence:    "1h",
+		Workflow:   "doctor",
+		StateDir:   stateDir,
+		Queue:      queue.New(filepath.Join(t.TempDir(), "doctor-queue.jsonl")),
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	first, err := doctor.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("doctor Scan() error = %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("doctor first scan emitted %d vessels, want 1", len(first))
+	}
+	if err := doctor.OnEnqueue(context.Background(), first[0]); err != nil {
+		t.Fatalf("doctor OnEnqueue() error = %v", err)
+	}
+
+	docGardener := &Schedule{
+		ConfigName: "doc-gardener",
+		Cadence:    "1h",
+		Workflow:   "doc-garden",
+		StateDir:   stateDir,
+		Queue:      queue.New(filepath.Join(t.TempDir(), "doc-gardener-queue.jsonl")),
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	second, err := docGardener.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("doc-gardener Scan() error = %v", err)
+	}
+	if len(second) != 1 {
+		t.Fatalf("doc-gardener first scan emitted %d vessels, want 1", len(second))
+	}
+	if got := second[0].Meta["schedule.source_name"]; got != "doc-gardener" {
+		t.Fatalf("schedule.source_name = %q, want doc-gardener", got)
+	}
+	if got := second[0].Ref; got != "schedule://doc-gardener/2026-04-09T06:00:00Z" {
+		t.Fatalf("Ref = %q, want doc-gardener schedule ref", got)
+	}
+
+	now = now.Add(30 * time.Minute)
+	suppressed, err := doctor.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("doctor second Scan() error = %v", err)
+	}
+	if len(suppressed) != 0 {
+		t.Fatalf("doctor second scan emitted %d vessels before cadence elapsed, want 0", len(suppressed))
+	}
+}
+
+func TestScheduleScanSuppressesDuplicateWhenActiveVesselExistsWithoutPersistedState(t *testing.T) {
+	stateDir := t.TempDir()
+	queuePath := filepath.Join(t.TempDir(), "queue.jsonl")
+	q := queue.New(queuePath)
+	now := time.Date(2026, time.April, 9, 6, 0, 0, 0, time.UTC)
+
+	first := &Schedule{
+		ConfigName: "doctor",
+		Cadence:    "1h",
+		Workflow:   "doctor",
+		StateDir:   stateDir,
+		Queue:      q,
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	vessels, err := first.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("first Scan() error = %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected first scan to emit 1 vessel, got %d", len(vessels))
+	}
+	if _, err := q.Enqueue(vessels[0]); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+
+	now = now.Add(time.Hour)
+	restarted := &Schedule{
+		ConfigName: "doctor",
+		Cadence:    "1h",
+		Workflow:   "doctor",
+		StateDir:   stateDir,
+		Queue:      q,
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	suppressed, err := restarted.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("restart Scan() error = %v", err)
+	}
+	if len(suppressed) != 0 {
+		t.Fatalf("expected active queued vessel to suppress duplicate schedule tick, got %d vessels", len(suppressed))
+	}
+}
+
+func TestScheduleScanRejectsMalformedCadence(t *testing.T) {
+	s := &Schedule{
+		ConfigName: "broken",
+		Cadence:    "not-a-cadence",
+		Workflow:   "doctor",
+		StateDir:   t.TempDir(),
+		Queue:      queue.New(filepath.Join(t.TempDir(), "queue.jsonl")),
+	}
+
+	if _, err := s.Scan(context.Background()); err == nil {
+		t.Fatal("expected Scan() to reject malformed cadence")
+	}
+}
+
+func TestSmoke_S1_ScheduledSourceFiresPersistsAndSuppressesDuplicates(t *testing.T) {
+	ctx := context.Background()
+	stateDir := t.TempDir()
+	queuePath := filepath.Join(t.TempDir(), "queue.jsonl")
+	q := queue.New(queuePath)
+	now := time.Date(2026, time.April, 9, 6, 0, 0, 0, time.UTC)
+
+	schedule := func() *Schedule {
+		return &Schedule{
+			ConfigName: "doc-gardener",
+			Cadence:    "1h",
+			Workflow:   "doc-garden",
+			StateDir:   stateDir,
+			Queue:      q,
+			Now: func() time.Time {
+				return now
+			},
+		}
+	}
+
+	first := schedule()
+	firstVessels, err := first.Scan(ctx)
+	require.NoError(t, err)
+	require.Len(t, firstVessels, 1)
+
+	firstVessel := firstVessels[0]
+	assert.Equal(t, "schedule", firstVessel.Source)
+	assert.Equal(t, "doc-garden", firstVessel.Workflow)
+	assert.Equal(t, "schedule-doc-gardener-20260409t060000z", firstVessel.ID)
+	assert.Equal(t, "schedule://doc-gardener/2026-04-09T06:00:00Z", firstVessel.Ref)
+	assert.Equal(t, "1h", firstVessel.Meta["schedule.cadence"])
+	assert.Equal(t, "doc-gardener", firstVessel.Meta["schedule.source_name"])
+	assert.Equal(t, "2026-04-09T06:00:00Z", firstVessel.Meta["schedule.fired_at"])
+
+	require.NoError(t, first.OnEnqueue(ctx, firstVessel))
+
+	stateBytes, err := os.ReadFile(filepath.Join(stateDir, "state", "schedule.json"))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"sources":{"doc-gardener":{"last_fired_at":"2026-04-09T06:00:00Z"}}}`, string(stateBytes))
+
+	now = now.Add(30 * time.Minute)
+	suppressed, err := schedule().Scan(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, suppressed)
+
+	now = now.Add(30 * time.Minute)
+	due, err := schedule().Scan(ctx)
+	require.NoError(t, err)
+	require.Len(t, due, 1)
+
+	secondVessel := due[0]
+	assert.Equal(t, "schedule-doc-gardener-20260409t070000z", secondVessel.ID)
+	assert.Equal(t, "schedule://doc-gardener/2026-04-09T07:00:00Z", secondVessel.Ref)
+	assert.Equal(t, "2026-04-09T07:00:00Z", secondVessel.Meta["schedule.fired_at"])
+
+	_, err = q.Enqueue(secondVessel)
+	require.NoError(t, err)
+
+	duplicate, err := schedule().Scan(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, duplicate)
+}
+
+func TestSmoke_S2_MalformedCadenceRejected(t *testing.T) {
+	s := &Schedule{
+		ConfigName: "broken",
+		Cadence:    "not-a-cadence",
+		Workflow:   "doctor",
+		StateDir:   t.TempDir(),
+		Queue:      queue.New(filepath.Join(t.TempDir(), "queue.jsonl")),
+	}
+
+	_, err := s.Scan(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `schedule source "broken"`)
+	assert.Contains(t, err.Error(), `parse cadence "not-a-cadence"`)
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -206,11 +206,12 @@ xylem scan [flags]
 ### Behavior
 
 - Iterates over every source defined in `.xylem.yml` and calls its `Scan()` method.
-- Supported source types are `github`, `github-pr`, `github-pr-events`, and `github-merge`.
+- Supported source types are `github`, `github-pr`, `github-pr-events`, `github-merge`, and `schedule`.
 - `github` scans open issues matching task labels.
 - `github-pr` scans open pull requests matching task labels.
 - `github-pr-events` scans open pull requests for configured `on` triggers such as labels, submitted reviews, failed checks, and comments.
 - `github-merge` scans merged pull requests and dedupes by merge commit SHA.
+- `schedule` emits a synthetic vessel when its configured cadence elapses.
 - If scanning is paused (via `xylem pause`), prints a message and exits without scanning.
 - Deduplication is handled automatically. Depending on the source, xylem skips refs that are already present in the queue, already present in any vessel state, or already have xylem-owned branches/open PRs.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,11 @@ sources:
         labels: [enhancement, low-effort, ready-for-work]
         workflow: implement-feature
 
+  doc-gardener:
+    type: schedule
+    cadence: "@daily"
+    workflow: doc-garden
+
 # ---------------------------------------------------------------------------
 # Execution limits
 # ---------------------------------------------------------------------------
@@ -128,12 +133,14 @@ Each key under `sources` is an arbitrary name (used in logs and vessel metadata)
 
 | Field | Type | Default | Required | Description |
 |-------|------|---------|----------|-------------|
-| `type` | string | -- | Yes | Source type. Supported values: `"github"`, `"github-pr"`, `"github-pr-events"`, `"github-merge"`. |
+| `type` | string | -- | Yes | Source type. Supported values: `"github"`, `"github-pr"`, `"github-pr-events"`, `"github-merge"`, `"schedule"`. |
 | `repo` | string | -- | Yes (GitHub sources) | GitHub repository in `owner/name` format. Validated strictly -- both owner and name must be non-empty. |
+| `cadence` | string | -- | Yes (`schedule`) | Recurrence for scheduled sources. Accepts Go durations like `1h`, cron descriptors like `@daily`, and standard 5-field cron expressions. |
+| `workflow` | string | -- | Yes (`schedule`) | Workflow to enqueue each time a scheduled source fires. Scheduled sources define the workflow directly and do not use `tasks`. |
 | `exclude` | list of strings | `[]` | No | Labels that prevent an issue from being queued. If an issue has any of these labels, it is skipped. |
 | `llm` | string | `""` | No | Provider override for this source. Valid values: `claude`, `copilot`. When set, all tasks in this source use this provider instead of the top-level `llm`. |
 | `model` | string | `""` | No | Model override for this source. When set, all tasks in this source use this model instead of the top-level or provider-default model. |
-| `tasks` | map | -- | Yes | Map of task names to task configurations. At least one task is required per source. |
+| `tasks` | map | -- | Yes (GitHub sources) | Map of task names to task configurations. Required for GitHub-based sources; not used by `schedule`. |
 
 ### Tasks
 
@@ -152,6 +159,30 @@ Each key under `tasks` is an arbitrary name. The value defines which issues matc
 - `github-pr`: requires `labels`, supports `status_labels`
 - `github-pr-events`: requires `workflow` and `on`
 - `github-merge`: requires `workflow`
+- `schedule`: does not use `tasks`; configure `cadence` and `workflow` directly on the source
+
+### `schedule`
+
+Scheduled sources create a synthetic vessel when their cadence elapses. Xylem persists the last-fired timestamp under `<state_dir>/state/schedule.json`, so the cadence survives daemon restarts and repeated `scan` invocations.
+
+```yaml
+sources:
+  doctor:
+    type: schedule
+    cadence: "6h"
+    workflow: doctor
+
+  doc-gardener:
+    type: schedule
+    cadence: "@daily"
+    workflow: doc-garden
+```
+
+Behavior:
+
+- The first scan fires immediately.
+- Later scans enqueue only when the cadence boundary has elapsed since the last successful enqueue.
+- Vessel metadata includes `schedule.cadence`, `schedule.fired_at`, and the configured source name.
 
 ### `status_labels`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,6 +149,7 @@ In addition to issue scanning, xylem supports these GitHub source types:
 - `github-pr` — scans open pull requests by label
 - `github-pr-events` — scans open pull requests for event triggers
 - `github-merge` — scans merged pull requests
+- `schedule` — emits a recurring synthetic vessel on a configured cadence
 
 For `github-pr-events`, tasks use an `on` block instead of `labels`:
 
@@ -169,6 +170,18 @@ sources:
 ```
 
 At least one trigger is required in the `on` block.
+
+For recurring hygiene or entropy-management work, add a scheduled source:
+
+```yaml
+sources:
+  doctor:
+    type: schedule
+    cadence: "@daily"
+    workflow: doctor
+```
+
+`cadence` accepts Go durations like `1h`, cron descriptors like `@daily`, and standard 5-field cron expressions.
 
 ## Write a HARNESS.md
 


### PR DESCRIPTION
## Summary
- Implements [issue #150](https://github.com/nicholls-inc/xylem/issues/150) by adding a new `schedule` source type that emits recurring synthetic vessels from Go duration or cron-style cadences.
- Persists last-fired state in `<state_dir>/state/schedule.json`, suppresses duplicate enqueue when an active scheduled vessel already exists, and wires config-source lookup through scan/drain/daemon paths.
- Documents scheduled-source configuration and behavior in `README.md`, `docs/configuration.md`, `docs/getting-started.md`, and `docs/cli-reference.md`.

## Smoke scenarios covered
- S1 - Scheduled source fires, persists state, and suppresses duplicates
- S2 - Malformed cadence rejected
- S3 - Daemon tick drains scheduled vessel

## Changes summary
- Added `cli/internal/cadence/cadence.go` and `cli/internal/cadence/cadence_prop_test.go` with `cadence.Spec`, `Parse`, and `Spec.FireTime` for duration and cron cadence evaluation.
- Added `cli/internal/source/schedule.go` and `cli/internal/source/schedule_test.go` with `source.Schedule`, `Schedule.Scan`, `Schedule.OnEnqueue`, and scheduled branch/ref metadata generation.
- Updated `cli/internal/config/config.go` and `cli/internal/config/config_test.go` to support `sources.<name>.type: schedule` plus `cadence` and `workflow` validation.
- Updated `cli/internal/scanner/scanner.go`, `cli/cmd/xylem/drain.go`, and `cli/internal/runner/runner.go` with companion tests to wire scheduled sources through scan/drain, preserve config source names, and let daemon drain ticks reuse capacity while work stays in flight.
- Updated `README.md`, `docs/configuration.md`, `docs/getting-started.md`, and `docs/cli-reference.md` to document the new scheduled source.

## Test plan
- `cd cli && goimports -w .`
- `cd cli && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #150