### PR TITLE
Add scheduled context-weight audit vessel

### DIFF
--- a/cli/cmd/xylem/builtin_audit.go
+++ b/cli/cmd/xylem/builtin_audit.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	reviewpkg "github.com/nicholls-inc/xylem/cli/internal/review"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+)
+
+type auditCommandRunner interface {
+	RunOutput(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+func runBuiltInScheduledVessels(ctx context.Context, cfg *config.Config, q *queue.Queue, cmdRunner auditCommandRunner) (runner.DrainResult, error) {
+	pending, err := q.ListByState(queue.StatePending)
+	if err != nil {
+		return runner.DrainResult{}, fmt.Errorf("list pending vessels: %w", err)
+	}
+
+	var result runner.DrainResult
+	for _, vessel := range pending {
+		if vessel.Source != "scheduled" || vessel.Workflow != reviewpkg.ContextWeightAuditWorkflow {
+			continue
+		}
+		result.Launched++
+
+		if err := q.Update(vessel.ID, queue.StateRunning, ""); err != nil {
+			return result, fmt.Errorf("mark built-in vessel %s running: %w", vessel.ID, err)
+		}
+
+		updated, err := q.FindByID(vessel.ID)
+		if err != nil {
+			return result, fmt.Errorf("load built-in vessel %s after start: %w", vessel.ID, err)
+		}
+
+		state := queue.StateCompleted
+		errMsg := ""
+		repo := resolveScheduledAuditRepo(cfg, *updated)
+		if strings.TrimSpace(repo) == "" {
+			state = queue.StateFailed
+			errMsg = "context-weight audit requires a source repo for GitHub issue publication"
+		} else if _, err := reviewpkg.RunContextWeightAudit(ctx, cfg.StateDir, repo, cmdRunner, reviewpkg.ContextWeightOptions{
+			LookbackRuns: cfg.HarnessReviewLookbackRuns(),
+			MinSamples:   cfg.HarnessReviewMinSamples(),
+			OutputDir:    cfg.HarnessReviewOutputDir(),
+			Now:          time.Now().UTC(),
+		}); err != nil {
+			state = queue.StateFailed
+			errMsg = err.Error()
+		}
+
+		if err := q.Update(vessel.ID, state, errMsg); err != nil {
+			return result, fmt.Errorf("finish built-in vessel %s: %w", vessel.ID, err)
+		}
+		finalVessel, err := q.FindByID(vessel.ID)
+		if err != nil {
+			return result, fmt.Errorf("load built-in vessel %s after completion: %w", vessel.ID, err)
+		}
+		if err := persistBuiltInAuditSummary(cfg, *finalVessel); err != nil {
+			return result, err
+		}
+
+		if state == queue.StateCompleted {
+			result.Completed++
+		} else {
+			result.Failed++
+			log.Printf("warn: built-in vessel %s failed: %s", vessel.ID, errMsg)
+		}
+	}
+	return result, nil
+}
+
+func resolveScheduledAuditRepo(cfg *config.Config, vessel queue.Vessel) string {
+	if cfg == nil {
+		return ""
+	}
+	if vessel.Meta != nil {
+		if name := strings.TrimSpace(vessel.Meta["config_source"]); name != "" {
+			if srcCfg, ok := cfg.Sources[name]; ok {
+				return strings.TrimSpace(srcCfg.Repo)
+			}
+		}
+		if repo := strings.TrimSpace(vessel.Meta["scheduled_repo"]); repo != "" {
+			return repo
+		}
+	}
+	return ""
+}
+
+func persistBuiltInAuditSummary(cfg *config.Config, vessel queue.Vessel) error {
+	if cfg == nil {
+		return nil
+	}
+	startedAt := time.Now().UTC()
+	if vessel.StartedAt != nil {
+		startedAt = vessel.StartedAt.UTC()
+	}
+	endedAt := startedAt
+	if vessel.EndedAt != nil {
+		endedAt = vessel.EndedAt.UTC()
+	}
+	summary := &runner.VesselSummary{
+		VesselID:   vessel.ID,
+		Source:     vessel.Source,
+		Workflow:   vessel.Workflow,
+		Ref:        vessel.Ref,
+		State:      string(vessel.State),
+		StartedAt:  startedAt,
+		EndedAt:    endedAt,
+		DurationMS: endedAt.Sub(startedAt).Milliseconds(),
+		Note:       "Built-in context-weight audit uses persisted summary artifacts and may open de-duplicated GitHub issues.",
+	}
+	if vessel.State == queue.StateFailed {
+		summary.Note = fmt.Sprintf("%s Failure: %s", summary.Note, vessel.Error)
+	}
+	if err := runner.SaveVesselSummary(cfg.StateDir, summary); err != nil {
+		return fmt.Errorf("save built-in audit summary for %s: %w", vessel.ID, err)
+	}
+	return nil
+}
+
+func addDrainResults(dst *runner.DrainResult, src runner.DrainResult) {
+	dst.Launched += src.Launched
+	dst.Completed += src.Completed
+	dst.Failed += src.Failed
+	dst.Skipped += src.Skipped
+	dst.Waiting += src.Waiting
+}

--- a/cli/cmd/xylem/builtin_audit_test.go
+++ b/cli/cmd/xylem/builtin_audit_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	reviewpkg "github.com/nicholls-inc/xylem/cli/internal/review"
+)
+
+type auditTestRunner struct {
+	calls [][]string
+}
+
+func (r *auditTestRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, append([]string{name}, args...))
+	return []byte("[]"), nil
+}
+
+func TestRunBuiltInScheduledVesselsCompletesContextWeightAudit(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		StateDir: dir,
+		Claude: config.ClaudeConfig{
+			Command:      "claude",
+			DefaultModel: "claude-sonnet-4-6",
+		},
+		Sources: map[string]config.SourceConfig{
+			"scheduled-audit": {
+				Type:     "scheduled",
+				Repo:     "owner/repo",
+				Schedule: "24h",
+				Tasks: map[string]config.Task{
+					"context": {Workflow: reviewpkg.ContextWeightAuditWorkflow},
+				},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "scheduled-audit-1",
+		Source:    "scheduled",
+		Ref:       "scheduled://scheduled-audit/context@1",
+		Workflow:  reviewpkg.ContextWeightAuditWorkflow,
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+		Meta: map[string]string{
+			"config_source":         "scheduled-audit",
+			"scheduled_task_name":   "context",
+			"scheduled_bucket":      "1",
+			"scheduled_config_name": "scheduled-audit",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+
+	cmdRunner := &auditTestRunner{}
+	result, err := runBuiltInScheduledVessels(context.Background(), cfg, q, cmdRunner)
+	if err != nil {
+		t.Fatalf("runBuiltInScheduledVessels() error = %v", err)
+	}
+	if result.Completed != 1 {
+		t.Fatalf("Completed = %d, want 1", result.Completed)
+	}
+	if result.Failed != 0 {
+		t.Fatalf("Failed = %d, want 0", result.Failed)
+	}
+
+	vessel, err := q.FindByID("scheduled-audit-1")
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	if vessel.State != queue.StateCompleted {
+		t.Fatalf("vessel.State = %s, want %s", vessel.State, queue.StateCompleted)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "reviews", "context-weight-audit.json")); err != nil {
+		t.Fatalf("context-weight-audit.json missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "phases", "scheduled-audit-1", "summary.json")); err != nil {
+		t.Fatalf("summary.json missing: %v", err)
+	}
+}

--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -293,7 +293,12 @@ func runDrain(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *workt
 	r, cleanup := buildDrainRunner(cfg, q, wt, cmdRunner)
 	defer cleanup()
 	r.DrainBudget = budget
+	builtInResult, err := runBuiltInScheduledVessels(ctx, cfg, q, cmdRunner)
+	if err != nil {
+		return builtInResult, fmt.Errorf("drain built-in audit vessels: %w", err)
+	}
 	result, err := r.DrainAndWait(ctx)
+	addDrainResults(&result, builtInResult)
 	if err == nil {
 		maybeAutoGenerateHarnessReview(cfg, result)
 	}

--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -51,10 +52,16 @@ func cmdDrain(cfg *config.Config, q *queue.Queue, wt *worktree.Manager, dryRun b
 	// Check waiting vessels before draining pending ones
 	r.CheckWaitingVessels(ctx)
 
+	builtInResult, err := runBuiltInScheduledVessels(ctx, cfg, q, cmdRunner)
+	if err != nil {
+		return &exitError{code: 2, err: fmt.Errorf("drain built-in audit vessels: %w", err)}
+	}
+
 	result, err := r.DrainAndWait(ctx)
 	if err != nil {
 		return &exitError{code: 2, err: fmt.Errorf("drain error: %w", err)}
 	}
+	addDrainResults(&result, builtInResult)
 	maybeAutoGenerateHarnessReview(cfg, result)
 	fmt.Printf("Completed %d, failed %d, skipped %d, waiting %d\n", result.Completed, result.Failed, result.Skipped, result.Waiting)
 	if result.Failed > 0 {
@@ -119,7 +126,7 @@ func shutdownConfiguredTracer(tracer *observability.Tracer) {
 
 func buildSourceMap(cfg *config.Config, q *queue.Queue, cmdRunner source.CommandRunner) map[string]source.Source {
 	sources := make(map[string]source.Source)
-	for _, srcCfg := range cfg.Sources {
+	for name, srcCfg := range cfg.Sources {
 		switch srcCfg.Type {
 		case "github":
 			tasks := make(map[string]source.GitHubTask, len(srcCfg.Tasks))
@@ -183,6 +190,26 @@ func buildSourceMap(cfg *config.Config, q *queue.Queue, cmdRunner source.Command
 				CmdRunner: cmdRunner,
 			}
 			sources[gm.Name()] = gm
+		case "scheduled":
+			scheduledTasks := make(map[string]source.ScheduledTask, len(srcCfg.Tasks))
+			for name, t := range srcCfg.Tasks {
+				scheduledTasks[name] = source.ScheduledTask{
+					Workflow: t.Workflow,
+				}
+			}
+			scheduledDur, err := time.ParseDuration(srcCfg.Schedule)
+			if err != nil {
+				log.Printf("warn: skip scheduled source %q: parse schedule %q: %v", name, srcCfg.Schedule, err)
+				continue
+			}
+			scheduled := &source.Scheduled{
+				Repo:       srcCfg.Repo,
+				StateDir:   cfg.StateDir,
+				ConfigName: name,
+				Schedule:   scheduledDur,
+				Tasks:      scheduledTasks,
+			}
+			sources[scheduled.Name()] = scheduled
 		}
 	}
 	return sources
@@ -192,7 +219,7 @@ func buildReporter(cfg *config.Config, cmdRunner reporter.Runner) *reporter.Repo
 	// Find the first GitHub-based source repo for reporting
 	for _, srcCfg := range cfg.Sources {
 		switch srcCfg.Type {
-		case "github", "github-pr", "github-pr-events", "github-merge":
+		case "github", "github-pr", "github-pr-events", "github-merge", "scheduled":
 			if srcCfg.Repo != "" {
 				return &reporter.Reporter{Runner: cmdRunner, Repo: srcCfg.Repo}
 			}

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -98,7 +98,8 @@ func newRootCmd() *cobra.Command {
 
 func hasGitHubSource(cfg *config.Config) bool {
 	for _, src := range cfg.Sources {
-		if src.Type == "github" {
+		switch src.Type {
+		case "github", "github-pr", "github-pr-events", "github-merge", "scheduled":
 			return true
 		}
 	}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -45,13 +45,14 @@ type Config struct {
 }
 
 type SourceConfig struct {
-	Type    string          `yaml:"type"`
-	Repo    string          `yaml:"repo,omitempty"`
-	LLM     string          `yaml:"llm,omitempty"`
-	Model   string          `yaml:"model,omitempty"`
-	Timeout string          `yaml:"timeout,omitempty"`
-	Exclude []string        `yaml:"exclude,omitempty"`
-	Tasks   map[string]Task `yaml:"tasks,omitempty"`
+	Type     string          `yaml:"type"`
+	Repo     string          `yaml:"repo,omitempty"`
+	Schedule string          `yaml:"schedule,omitempty"`
+	LLM      string          `yaml:"llm,omitempty"`
+	Model    string          `yaml:"model,omitempty"`
+	Timeout  string          `yaml:"timeout,omitempty"`
+	Exclude  []string        `yaml:"exclude,omitempty"`
+	Tasks    map[string]Task `yaml:"tasks,omitempty"`
 }
 
 type StatusLabels struct {
@@ -314,6 +315,10 @@ func (c *Config) Validate() error {
 			}
 		case "github-merge":
 			if err := validateGitHubMergeSource(name, src); err != nil {
+				return err
+			}
+		case "scheduled":
+			if err := validateScheduledSource(name, src); err != nil {
 				return err
 			}
 		case "":
@@ -676,6 +681,36 @@ func validateGitHubMergeSource(name string, src SourceConfig) error {
 	}
 	if len(src.Tasks) == 0 {
 		return fmt.Errorf("source %q (github-merge): at least one task is required", name)
+	}
+	for tname, task := range src.Tasks {
+		if strings.TrimSpace(task.Workflow) == "" {
+			return fmt.Errorf("source %q task %q: must include a workflow", name, tname)
+		}
+	}
+	return nil
+}
+
+func validateScheduledSource(name string, src SourceConfig) error {
+	repo := strings.TrimSpace(src.Repo)
+	if repo == "" {
+		return fmt.Errorf("source %q (scheduled): repo is required", name)
+	}
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return fmt.Errorf("source %q (scheduled): repo must be in owner/name format", name)
+	}
+	if strings.TrimSpace(src.Schedule) == "" {
+		return fmt.Errorf("source %q (scheduled): schedule is required", name)
+	}
+	dur, err := time.ParseDuration(src.Schedule)
+	if err != nil {
+		return fmt.Errorf("source %q (scheduled): schedule must be a valid duration: %w", name, err)
+	}
+	if dur <= 0 {
+		return fmt.Errorf("source %q (scheduled): schedule must be greater than 0", name)
+	}
+	if len(src.Tasks) == 0 {
+		return fmt.Errorf("source %q (scheduled): at least one task is required", name)
 	}
 	for tname, task := range src.Tasks {
 		if strings.TrimSpace(task.Workflow) == "" {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -1091,6 +1091,48 @@ func TestValidateGitHubMergeMissingRepo(t *testing.T) {
 	requireErrorContains(t, err, "repo is required")
 }
 
+func TestValidateScheduledSourceValid(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]SourceConfig{
+			"audit": {
+				Type:     "scheduled",
+				Repo:     "owner/name",
+				Schedule: "24h",
+				Tasks: map[string]Task{
+					"context": {Workflow: "context-weight-audit"},
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid config, got: %v", err)
+	}
+}
+
+func TestValidateScheduledSourceMissingSchedule(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]SourceConfig{
+			"audit": {
+				Type: "scheduled",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"context": {Workflow: "context-weight-audit"},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "schedule is required")
+}
+
 func TestValidateUnknownSourceType(t *testing.T) {
 	cfg := &Config{
 		Concurrency: 2,

--- a/cli/internal/review/context_weight.go
+++ b/cli/internal/review/context_weight.go
@@ -1,0 +1,686 @@
+package review
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	ContextWeightAuditWorkflow       = "context-weight-audit"
+	contextWeightReportJSONName      = "context-weight-audit.json"
+	contextWeightReportMarkdownName  = "context-weight-audit.md"
+	contextWeightIssueStateName      = "context-weight-audit-issues.json"
+	contextWeightFindingMarkerPrefix = "<!-- xylem:context-weight-fingerprint="
+	contextWeightOutlierRatio        = 2
+	contextWeightMaxOffendingPhases  = 3
+)
+
+type ContextWeightOptions struct {
+	LookbackRuns int
+	MinSamples   int
+	OutputDir    string
+	Now          time.Time
+}
+
+type ContextWeightResult struct {
+	Report       *ContextWeightReport
+	JSONPath     string
+	MarkdownPath string
+	Markdown     string
+	Published    []PublishedIssue
+}
+
+type ContextWeightReport struct {
+	GeneratedAt       time.Time              `json:"generated_at"`
+	LookbackRuns      int                    `json:"lookback_runs"`
+	MinSamples        int                    `json:"min_samples"`
+	TotalRunsObserved int                    `json:"total_runs_observed"`
+	ReviewedRuns      int                    `json:"reviewed_runs"`
+	Baseline          ContextWeightBaseline  `json:"baseline"`
+	Findings          []ContextWeightFinding `json:"findings,omitempty"`
+	Warnings          []string               `json:"warnings,omitempty"`
+}
+
+type ContextWeightBaseline struct {
+	WorkflowInputTokens  int `json:"workflow_input_tokens"`
+	WorkflowOutputTokens int `json:"workflow_output_tokens"`
+}
+
+type ContextWeightFinding struct {
+	Fingerprint               string               `json:"fingerprint"`
+	Source                    string               `json:"source"`
+	Workflow                  string               `json:"workflow"`
+	Samples                   int                  `json:"samples"`
+	AverageInputTokens        int                  `json:"average_input_tokens"`
+	AverageOutputTokens       int                  `json:"average_output_tokens"`
+	RepeatedHighFootprintRuns int                  `json:"repeated_high_footprint_runs"`
+	LargestPhases             []ContextWeightPhase `json:"largest_phases,omitempty"`
+	Reasons                   []string             `json:"reasons,omitempty"`
+	Remediations              []string             `json:"remediations,omitempty"`
+}
+
+type ContextWeightPhase struct {
+	Name                string `json:"name"`
+	Type                string `json:"type"`
+	Samples             int    `json:"samples"`
+	AverageInputTokens  int    `json:"average_input_tokens"`
+	AverageOutputTokens int    `json:"average_output_tokens"`
+}
+
+type PublishedIssue struct {
+	Fingerprint string `json:"fingerprint"`
+	IssueNumber int    `json:"issue_number"`
+	Title       string `json:"title"`
+	Created     bool   `json:"created"`
+}
+
+type contextWeightWorkflowAccumulator struct {
+	source      string
+	workflow    string
+	samples     int
+	totalInput  int
+	totalOutput int
+	runs        []contextWeightRun
+	phases      map[string]*contextWeightPhaseAccumulator
+}
+
+type contextWeightRun struct {
+	input  int
+	output int
+}
+
+type contextWeightPhaseAccumulator struct {
+	name        string
+	phaseType   string
+	samples     int
+	totalInput  int
+	totalOutput int
+}
+
+type contextWeightIssueState struct {
+	Findings map[string]contextWeightIssueRecord `json:"findings,omitempty"`
+}
+
+type contextWeightIssueRecord struct {
+	IssueNumber     int       `json:"issue_number"`
+	Title           string    `json:"title"`
+	FirstReportedAt time.Time `json:"first_reported_at"`
+	LastObservedAt  time.Time `json:"last_observed_at"`
+}
+
+type contextWeightIssue struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	Body   string `json:"body"`
+}
+
+type issueRunner interface {
+	RunOutput(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+func GenerateContextWeightAudit(stateDir string, opts ContextWeightOptions) (*ContextWeightResult, error) {
+	if opts.LookbackRuns <= 0 {
+		opts.LookbackRuns = defaultLookbackRuns
+	}
+	if opts.MinSamples <= 0 {
+		opts.MinSamples = defaultMinSamples
+	}
+	if strings.TrimSpace(opts.OutputDir) == "" {
+		opts.OutputDir = defaultOutputDir
+	}
+	if opts.Now.IsZero() {
+		opts.Now = time.Now().UTC()
+	} else {
+		opts.Now = opts.Now.UTC()
+	}
+
+	runs, totalRuns, warnings, err := loadRuns(stateDir, opts.LookbackRuns)
+	if err != nil {
+		return nil, fmt.Errorf("generate context-weight audit: %w", err)
+	}
+
+	findings, baseline := buildContextWeightFindings(runs, opts.MinSamples)
+	report := &ContextWeightReport{
+		GeneratedAt:       opts.Now,
+		LookbackRuns:      opts.LookbackRuns,
+		MinSamples:        opts.MinSamples,
+		TotalRunsObserved: totalRuns,
+		ReviewedRuns:      len(runs),
+		Baseline:          baseline,
+		Findings:          findings,
+		Warnings:          append([]string(nil), warnings...),
+	}
+
+	outputDir := filepath.Join(stateDir, opts.OutputDir)
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return nil, fmt.Errorf("generate context-weight audit: create output dir: %w", err)
+	}
+
+	jsonPath := filepath.Join(outputDir, contextWeightReportJSONName)
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("generate context-weight audit: marshal report: %w", err)
+	}
+	if err := os.WriteFile(jsonPath, data, 0o644); err != nil {
+		return nil, fmt.Errorf("generate context-weight audit: write json report: %w", err)
+	}
+
+	markdown := renderContextWeightMarkdown(report)
+	markdownPath := filepath.Join(outputDir, contextWeightReportMarkdownName)
+	if err := os.WriteFile(markdownPath, []byte(markdown), 0o644); err != nil {
+		return nil, fmt.Errorf("generate context-weight audit: write markdown report: %w", err)
+	}
+
+	return &ContextWeightResult{
+		Report:       report,
+		JSONPath:     jsonPath,
+		MarkdownPath: markdownPath,
+		Markdown:     markdown,
+	}, nil
+}
+
+func RunContextWeightAudit(ctx context.Context, stateDir, repo string, runner issueRunner, opts ContextWeightOptions) (*ContextWeightResult, error) {
+	result, err := GenerateContextWeightAudit(stateDir, opts)
+	if err != nil {
+		return nil, err
+	}
+	published, err := PublishContextWeightIssues(ctx, stateDir, repo, runner, result.Report, opts.OutputDir, opts.Now)
+	if err != nil {
+		return nil, err
+	}
+	result.Published = published
+	return result, nil
+}
+
+func PublishContextWeightIssues(ctx context.Context, stateDir, repo string, runner issueRunner, report *ContextWeightReport, outputDir string, now time.Time) ([]PublishedIssue, error) {
+	if report == nil {
+		return nil, nil
+	}
+	if strings.TrimSpace(outputDir) == "" {
+		outputDir = defaultOutputDir
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+
+	statePath := filepath.Join(stateDir, outputDir, contextWeightIssueStateName)
+	state, err := loadContextWeightIssueState(statePath)
+	if err != nil {
+		return nil, err
+	}
+
+	openByFingerprint := map[string]contextWeightIssue{}
+	if runner != nil && strings.TrimSpace(repo) != "" && len(report.Findings) > 0 {
+		openByFingerprint, err = loadOpenContextWeightIssues(ctx, runner, repo)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	published := make([]PublishedIssue, 0, len(report.Findings))
+	for _, finding := range report.Findings {
+		title := contextWeightIssueTitle(finding)
+		record, ok := state.Findings[finding.Fingerprint]
+		switch {
+		case ok:
+			record.Title = title
+			record.LastObservedAt = now
+			state.Findings[finding.Fingerprint] = record
+			published = append(published, PublishedIssue{
+				Fingerprint: finding.Fingerprint,
+				IssueNumber: record.IssueNumber,
+				Title:       record.Title,
+				Created:     false,
+			})
+			continue
+		case openByFingerprint[finding.Fingerprint].Number > 0:
+			issue := openByFingerprint[finding.Fingerprint]
+			state.Findings[finding.Fingerprint] = contextWeightIssueRecord{
+				IssueNumber:     issue.Number,
+				Title:           issue.Title,
+				FirstReportedAt: now,
+				LastObservedAt:  now,
+			}
+			published = append(published, PublishedIssue{
+				Fingerprint: finding.Fingerprint,
+				IssueNumber: issue.Number,
+				Title:       issue.Title,
+				Created:     false,
+			})
+			continue
+		}
+
+		if runner == nil || strings.TrimSpace(repo) == "" {
+			continue
+		}
+
+		body := renderContextWeightIssueBody(finding, report.Baseline)
+		out, err := runner.RunOutput(ctx, "gh", "issue", "create", "--repo", repo, "--title", title, "--body", body)
+		if err != nil {
+			return nil, fmt.Errorf("publish context-weight issue for %s: %w", finding.Workflow, err)
+		}
+		issueNumber, err := parseIssueNumberFromCreateOutput(string(out))
+		if err != nil {
+			return nil, fmt.Errorf("publish context-weight issue for %s: %w", finding.Workflow, err)
+		}
+		state.Findings[finding.Fingerprint] = contextWeightIssueRecord{
+			IssueNumber:     issueNumber,
+			Title:           title,
+			FirstReportedAt: now,
+			LastObservedAt:  now,
+		}
+		published = append(published, PublishedIssue{
+			Fingerprint: finding.Fingerprint,
+			IssueNumber: issueNumber,
+			Title:       title,
+			Created:     true,
+		})
+	}
+
+	if err := saveContextWeightIssueState(statePath, state); err != nil {
+		return nil, err
+	}
+	return published, nil
+}
+
+func buildContextWeightFindings(runs []loadedRun, minSamples int) ([]ContextWeightFinding, ContextWeightBaseline) {
+	workflows := make(map[string]*contextWeightWorkflowAccumulator)
+	for _, run := range runs {
+		if run.Summary.TotalInputTokensEst == 0 && run.Summary.TotalOutputTokensEst == 0 {
+			continue
+		}
+		key := run.Summary.Source + "\x00" + run.Summary.Workflow
+		group := workflows[key]
+		if group == nil {
+			group = &contextWeightWorkflowAccumulator{
+				source:   run.Summary.Source,
+				workflow: run.Summary.Workflow,
+				phases:   make(map[string]*contextWeightPhaseAccumulator),
+			}
+			workflows[key] = group
+		}
+		group.samples++
+		group.totalInput += run.Summary.TotalInputTokensEst
+		group.totalOutput += run.Summary.TotalOutputTokensEst
+		group.runs = append(group.runs, contextWeightRun{
+			input:  run.Summary.TotalInputTokensEst,
+			output: run.Summary.TotalOutputTokensEst,
+		})
+		for _, phase := range run.Summary.Phases {
+			if phase.Type != "prompt" {
+				continue
+			}
+			phaseKey := phase.Name + "\x00" + phase.Type
+			phaseGroup := group.phases[phaseKey]
+			if phaseGroup == nil {
+				phaseGroup = &contextWeightPhaseAccumulator{
+					name:      phase.Name,
+					phaseType: phase.Type,
+				}
+				group.phases[phaseKey] = phaseGroup
+			}
+			phaseGroup.samples++
+			phaseGroup.totalInput += phase.InputTokensEst
+			phaseGroup.totalOutput += phase.OutputTokensEst
+		}
+	}
+
+	inputAverages := make([]int, 0, len(workflows))
+	outputAverages := make([]int, 0, len(workflows))
+	for _, group := range workflows {
+		if group.samples < minSamples {
+			continue
+		}
+		inputAverages = append(inputAverages, group.totalInput/group.samples)
+		outputAverages = append(outputAverages, group.totalOutput/group.samples)
+	}
+	baseline := ContextWeightBaseline{
+		WorkflowInputTokens:  medianInt(inputAverages),
+		WorkflowOutputTokens: medianInt(outputAverages),
+	}
+
+	findings := make([]ContextWeightFinding, 0)
+	for _, group := range workflows {
+		if group.samples < minSamples {
+			continue
+		}
+		avgInput := group.totalInput / group.samples
+		avgOutput := group.totalOutput / group.samples
+		reasons := make([]string, 0, 3)
+		if baseline.WorkflowInputTokens > 0 && avgInput >= baseline.WorkflowInputTokens*contextWeightOutlierRatio {
+			reasons = append(reasons, fmt.Sprintf(
+				"average input tokens %d are %.1fx the repo baseline %d",
+				avgInput,
+				float64(avgInput)/float64(baseline.WorkflowInputTokens),
+				baseline.WorkflowInputTokens,
+			))
+		}
+		if baseline.WorkflowOutputTokens > 0 && avgOutput >= baseline.WorkflowOutputTokens*contextWeightOutlierRatio {
+			reasons = append(reasons, fmt.Sprintf(
+				"average output tokens %d are %.1fx the repo baseline %d",
+				avgOutput,
+				float64(avgOutput)/float64(baseline.WorkflowOutputTokens),
+				baseline.WorkflowOutputTokens,
+			))
+		}
+		highRuns := countHighFootprintRuns(group.runs, baseline)
+		if highRuns >= minSamples {
+			reasons = append(reasons, fmt.Sprintf(
+				"%d of %d recent runs stayed above the %dx repo baseline",
+				highRuns,
+				group.samples,
+				contextWeightOutlierRatio,
+			))
+		}
+		if len(reasons) == 0 {
+			continue
+		}
+
+		largestPhases := topContextWeightPhases(group.phases)
+		finding := ContextWeightFinding{
+			Source:                    group.source,
+			Workflow:                  group.workflow,
+			Samples:                   group.samples,
+			AverageInputTokens:        avgInput,
+			AverageOutputTokens:       avgOutput,
+			RepeatedHighFootprintRuns: highRuns,
+			LargestPhases:             largestPhases,
+			Reasons:                   reasons,
+			Remediations:              contextWeightRemediations(group.workflow, largestPhases),
+		}
+		finding.Fingerprint = contextWeightFindingFingerprint(finding)
+		findings = append(findings, finding)
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].AverageInputTokens != findings[j].AverageInputTokens {
+			return findings[i].AverageInputTokens > findings[j].AverageInputTokens
+		}
+		if findings[i].AverageOutputTokens != findings[j].AverageOutputTokens {
+			return findings[i].AverageOutputTokens > findings[j].AverageOutputTokens
+		}
+		return findings[i].Workflow < findings[j].Workflow
+	})
+	return findings, baseline
+}
+
+func countHighFootprintRuns(runs []contextWeightRun, baseline ContextWeightBaseline) int {
+	count := 0
+	for _, run := range runs {
+		highInput := baseline.WorkflowInputTokens > 0 && run.input >= baseline.WorkflowInputTokens*contextWeightOutlierRatio
+		highOutput := baseline.WorkflowOutputTokens > 0 && run.output >= baseline.WorkflowOutputTokens*contextWeightOutlierRatio
+		if highInput || highOutput {
+			count++
+		}
+	}
+	return count
+}
+
+func topContextWeightPhases(phases map[string]*contextWeightPhaseAccumulator) []ContextWeightPhase {
+	if len(phases) == 0 {
+		return nil
+	}
+	out := make([]ContextWeightPhase, 0, len(phases))
+	for _, phase := range phases {
+		if phase.samples == 0 {
+			continue
+		}
+		out = append(out, ContextWeightPhase{
+			Name:                phase.name,
+			Type:                phase.phaseType,
+			Samples:             phase.samples,
+			AverageInputTokens:  phase.totalInput / phase.samples,
+			AverageOutputTokens: phase.totalOutput / phase.samples,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].AverageInputTokens != out[j].AverageInputTokens {
+			return out[i].AverageInputTokens > out[j].AverageInputTokens
+		}
+		if out[i].AverageOutputTokens != out[j].AverageOutputTokens {
+			return out[i].AverageOutputTokens > out[j].AverageOutputTokens
+		}
+		return out[i].Name < out[j].Name
+	})
+	if len(out) > contextWeightMaxOffendingPhases {
+		out = out[:contextWeightMaxOffendingPhases]
+	}
+	return out
+}
+
+func contextWeightRemediations(workflow string, phases []ContextWeightPhase) []string {
+	remediations := []string{
+		"Trim large prompt templates or static context in the heaviest phases before adding more workflow logic.",
+		"Split the workflow with an explicit context reset or handoff if the same run keeps carrying too much prior output forward.",
+		fmt.Sprintf("Keep the workflow aligned with #60 by prioritizing ctxmgr-backed compaction or handoff for `%s` instead of assuming runner integration already exists.", workflow),
+	}
+	if len(phases) == 0 {
+		return remediations
+	}
+	names := make([]string, 0, len(phases))
+	for _, phase := range phases {
+		names = append(names, phase.Name)
+	}
+	remediations[0] = fmt.Sprintf("Trim large prompt templates or static context in the heaviest phases (%s) before adding more workflow logic.", strings.Join(names, ", "))
+	return remediations
+}
+
+func contextWeightFindingFingerprint(finding ContextWeightFinding) string {
+	signals := make([]string, 0, 3)
+	for _, reason := range finding.Reasons {
+		switch {
+		case strings.Contains(reason, "input tokens"):
+			signals = append(signals, "input")
+		case strings.Contains(reason, "output tokens"):
+			signals = append(signals, "output")
+		case strings.Contains(reason, "recent runs"):
+			signals = append(signals, "persistent")
+		}
+	}
+	phaseNames := make([]string, 0, len(finding.LargestPhases))
+	for _, phase := range finding.LargestPhases {
+		phaseNames = append(phaseNames, phase.Name)
+	}
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		finding.Source,
+		finding.Workflow,
+		strings.Join(signals, ","),
+		strings.Join(phaseNames, ","),
+	}, "\n")))
+	return fmt.Sprintf("%x", sum[:8])
+}
+
+func renderContextWeightMarkdown(report *ContextWeightReport) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Context-weight audit\n\n")
+	fmt.Fprintf(&b, "- Generated: %s\n", report.GeneratedAt.Format(time.RFC3339))
+	fmt.Fprintf(&b, "- Reviewed runs: %d of %d available\n", report.ReviewedRuns, report.TotalRunsObserved)
+	fmt.Fprintf(&b, "- Baseline: median workflow input=%d tokens, median workflow output=%d tokens\n\n",
+		report.Baseline.WorkflowInputTokens,
+		report.Baseline.WorkflowOutputTokens,
+	)
+	if len(report.Warnings) > 0 {
+		fmt.Fprintf(&b, "## Warnings\n\n")
+		for _, warning := range report.Warnings {
+			fmt.Fprintf(&b, "- %s\n", warning)
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+	if len(report.Findings) == 0 {
+		fmt.Fprintf(&b, "No persistent context-weight outliers were detected.\n")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "## Findings\n\n")
+	for _, finding := range report.Findings {
+		fmt.Fprintf(&b, "### `%s / %s`\n\n", finding.Source, finding.Workflow)
+		fmt.Fprintf(&b, "- Samples: %d\n", finding.Samples)
+		fmt.Fprintf(&b, "- Average input tokens: %d\n", finding.AverageInputTokens)
+		fmt.Fprintf(&b, "- Average output tokens: %d\n", finding.AverageOutputTokens)
+		fmt.Fprintf(&b, "- Repeated high-footprint runs: %d\n", finding.RepeatedHighFootprintRuns)
+		if len(finding.Reasons) > 0 {
+			fmt.Fprintf(&b, "- Evidence: %s\n", strings.Join(finding.Reasons, "; "))
+		}
+		if len(finding.LargestPhases) > 0 {
+			fmt.Fprintf(&b, "- Largest phases:\n")
+			for _, phase := range finding.LargestPhases {
+				fmt.Fprintf(&b, "  - `%s` (%s): avg input=%d, avg output=%d over %d sample(s)\n",
+					phase.Name, phase.Type, phase.AverageInputTokens, phase.AverageOutputTokens, phase.Samples)
+			}
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+	return b.String()
+}
+
+func contextWeightIssueTitle(finding ContextWeightFinding) string {
+	return fmt.Sprintf("harness: context-weight audit for %s", finding.Workflow)
+}
+
+func renderContextWeightIssueBody(finding ContextWeightFinding, baseline ContextWeightBaseline) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s%s -->\n", contextWeightFindingMarkerPrefix, finding.Fingerprint)
+	fmt.Fprintf(&b, "## Context-weight finding\n\n")
+	fmt.Fprintf(&b, "- Source: `%s`\n", finding.Source)
+	fmt.Fprintf(&b, "- Workflow: `%s`\n", finding.Workflow)
+	fmt.Fprintf(&b, "- Samples reviewed: %d\n", finding.Samples)
+	fmt.Fprintf(&b, "- Average estimated input tokens: %d (repo median baseline %d)\n", finding.AverageInputTokens, baseline.WorkflowInputTokens)
+	fmt.Fprintf(&b, "- Average estimated output tokens: %d (repo median baseline %d)\n", finding.AverageOutputTokens, baseline.WorkflowOutputTokens)
+	fmt.Fprintf(&b, "- Repeated high-footprint runs: %d\n\n", finding.RepeatedHighFootprintRuns)
+
+	fmt.Fprintf(&b, "This issue was generated from persisted `.xylem/phases/*/summary.json` artifacts. It measures the current runner prompt footprint and should stay aligned with #60 rather than assuming `ctxmgr` is already wired into prompt assembly.\n\n")
+
+	if len(finding.Reasons) > 0 {
+		fmt.Fprintf(&b, "## Evidence\n\n")
+		for _, reason := range finding.Reasons {
+			fmt.Fprintf(&b, "- %s\n", reason)
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+	if len(finding.LargestPhases) > 0 {
+		fmt.Fprintf(&b, "## Largest offending phases\n\n")
+		fmt.Fprintf(&b, "| Phase | Type | Avg input tokens | Avg output tokens | Samples |\n")
+		fmt.Fprintf(&b, "|-------|------|------------------|-------------------|---------|\n")
+		for _, phase := range finding.LargestPhases {
+			fmt.Fprintf(&b, "| %s | %s | %d | %d | %d |\n",
+				phase.Name, phase.Type, phase.AverageInputTokens, phase.AverageOutputTokens, phase.Samples)
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+	fmt.Fprintf(&b, "## Suggested remediations\n\n")
+	for _, remediation := range finding.Remediations {
+		fmt.Fprintf(&b, "- %s\n", remediation)
+	}
+	return b.String()
+}
+
+func loadOpenContextWeightIssues(ctx context.Context, runner issueRunner, repo string) (map[string]contextWeightIssue, error) {
+	out, err := runner.RunOutput(ctx, "gh", "issue", "list", "--repo", repo, "--state", "open", "--limit", "100", "--json", "number,title,body")
+	if err != nil {
+		return nil, fmt.Errorf("load open context-weight issues: %w", err)
+	}
+	var issues []contextWeightIssue
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return nil, fmt.Errorf("load open context-weight issues: parse gh issue list output: %w", err)
+	}
+	byFingerprint := make(map[string]contextWeightIssue, len(issues))
+	for _, issue := range issues {
+		fingerprint := parseContextWeightMarker(issue.Body)
+		if fingerprint == "" {
+			continue
+		}
+		byFingerprint[fingerprint] = issue
+	}
+	return byFingerprint, nil
+}
+
+func parseContextWeightMarker(body string) string {
+	start := strings.Index(body, contextWeightFindingMarkerPrefix)
+	if start == -1 {
+		return ""
+	}
+	start += len(contextWeightFindingMarkerPrefix)
+	end := strings.Index(body[start:], " -->")
+	if end == -1 {
+		return ""
+	}
+	return strings.TrimSpace(body[start : start+end])
+}
+
+func parseIssueNumberFromCreateOutput(raw string) (int, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return 0, fmt.Errorf("parse created issue: empty output")
+	}
+	if n, err := strconv.Atoi(trimmed); err == nil {
+		return n, nil
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("parse created issue url %q: %w", trimmed, err)
+	}
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(segments) == 0 {
+		return 0, fmt.Errorf("parse created issue url %q: missing path segments", trimmed)
+	}
+	issueNum, err := strconv.Atoi(segments[len(segments)-1])
+	if err != nil {
+		return 0, fmt.Errorf("parse created issue url %q: %w", trimmed, err)
+	}
+	return issueNum, nil
+}
+
+func loadContextWeightIssueState(path string) (*contextWeightIssueState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &contextWeightIssueState{Findings: make(map[string]contextWeightIssueRecord)}, nil
+		}
+		return nil, fmt.Errorf("load context-weight issue state: %w", err)
+	}
+	var state contextWeightIssueState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("load context-weight issue state: unmarshal: %w", err)
+	}
+	if state.Findings == nil {
+		state.Findings = make(map[string]contextWeightIssueRecord)
+	}
+	return &state, nil
+}
+
+func saveContextWeightIssueState(path string, state *contextWeightIssueState) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("save context-weight issue state: create dir: %w", err)
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("save context-weight issue state: marshal: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("save context-weight issue state: write: %w", err)
+	}
+	return nil
+}
+
+func medianInt(values []int) int {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]int(nil), values...)
+	sort.Ints(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[mid]
+	}
+	return (sorted[mid-1] + sorted[mid]) / 2
+}

--- a/cli/internal/review/context_weight_test.go
+++ b/cli/internal/review/context_weight_test.go
@@ -1,0 +1,330 @@
+package review
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+)
+
+type mockIssueRunner struct {
+	calls       [][]string
+	issueList   []contextWeightIssue
+	createCount int
+}
+
+func (m *mockIssueRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	m.calls = append(m.calls, call)
+	if name != "gh" || len(args) < 2 {
+		return []byte{}, nil
+	}
+	if args[0] == "issue" && args[1] == "list" {
+		return json.Marshal(m.issueList)
+	}
+	if args[0] == "issue" && args[1] == "create" {
+		m.createCount++
+		return []byte("https://github.com/owner/repo/issues/91"), nil
+	}
+	return []byte{}, nil
+}
+
+func TestGenerateContextWeightAuditDetectsPersistentOutlier(t *testing.T) {
+	stateDir := t.TempDir()
+	base := time.Date(2026, time.April, 9, 12, 0, 0, 0, time.UTC)
+
+	for i := range 3 {
+		writeRunArtifacts(t, stateDir, runFixture{
+			vesselID:    "stable-" + string(rune('a'+i)),
+			source:      "github-issue",
+			workflow:    "stable",
+			state:       "completed",
+			startedAt:   base.Add(time.Duration(i) * time.Minute),
+			endedAt:     base.Add(time.Duration(i)*time.Minute + time.Minute),
+			totalInput:  120 + i*10,
+			totalOutput: 40 + i*5,
+			phases: []runner.PhaseSummary{{
+				Name:            "plan",
+				Type:            "prompt",
+				Status:          "completed",
+				InputTokensEst:  120 + i*10,
+				OutputTokensEst: 40 + i*5,
+			}},
+		})
+		writeRunArtifacts(t, stateDir, runFixture{
+			vesselID:    "peer-" + string(rune('a'+i)),
+			source:      "github-issue",
+			workflow:    "peer",
+			state:       "completed",
+			startedAt:   base.Add(time.Duration(10+i) * time.Minute),
+			endedAt:     base.Add(time.Duration(10+i)*time.Minute + time.Minute),
+			totalInput:  150 + i*10,
+			totalOutput: 60 + i*5,
+			phases: []runner.PhaseSummary{{
+				Name:            "plan",
+				Type:            "prompt",
+				Status:          "completed",
+				InputTokensEst:  150 + i*10,
+				OutputTokensEst: 60 + i*5,
+			}},
+		})
+		writeRunArtifacts(t, stateDir, runFixture{
+			vesselID:    "heavy-" + string(rune('a'+i)),
+			source:      "github-issue",
+			workflow:    "heavy",
+			state:       "completed",
+			startedAt:   base.Add(time.Duration(20+i) * time.Minute),
+			endedAt:     base.Add(time.Duration(20+i)*time.Minute + time.Minute),
+			totalInput:  620 + i*20,
+			totalOutput: 220 + i*10,
+			phases: []runner.PhaseSummary{
+				{
+					Name:            "plan",
+					Type:            "prompt",
+					Status:          "completed",
+					InputTokensEst:  430 + i*10,
+					OutputTokensEst: 140 + i*5,
+				},
+				{
+					Name:            "implement",
+					Type:            "prompt",
+					Status:          "completed",
+					InputTokensEst:  190 + i*10,
+					OutputTokensEst: 80 + i*5,
+				},
+			},
+		})
+	}
+
+	result, err := GenerateContextWeightAudit(stateDir, ContextWeightOptions{
+		LookbackRuns: 20,
+		MinSamples:   3,
+		OutputDir:    "reviews",
+		Now:          base.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GenerateContextWeightAudit() error = %v", err)
+	}
+
+	if len(result.Report.Findings) != 1 {
+		t.Fatalf("findings = %d, want 1", len(result.Report.Findings))
+	}
+	finding := result.Report.Findings[0]
+	if finding.Workflow != "heavy" {
+		t.Fatalf("workflow = %q, want %q", finding.Workflow, "heavy")
+	}
+	if finding.AverageInputTokens < 600 {
+		t.Fatalf("AverageInputTokens = %d, want >= 600", finding.AverageInputTokens)
+	}
+	if finding.RepeatedHighFootprintRuns != 3 {
+		t.Fatalf("RepeatedHighFootprintRuns = %d, want 3", finding.RepeatedHighFootprintRuns)
+	}
+	if len(finding.LargestPhases) == 0 || finding.LargestPhases[0].Name != "plan" {
+		t.Fatalf("largest phase = %+v, want plan first", finding.LargestPhases)
+	}
+	if finding.Fingerprint == "" {
+		t.Fatal("Fingerprint = empty, want populated fingerprint")
+	}
+}
+
+func TestGenerateContextWeightAuditIgnoresOneOffSpike(t *testing.T) {
+	stateDir := t.TempDir()
+	base := time.Date(2026, time.April, 9, 13, 0, 0, 0, time.UTC)
+
+	for i := range 3 {
+		writeRunArtifacts(t, stateDir, runFixture{
+			vesselID:    "stable-" + string(rune('a'+i)),
+			source:      "github-issue",
+			workflow:    "stable",
+			state:       "completed",
+			startedAt:   base.Add(time.Duration(i) * time.Minute),
+			endedAt:     base.Add(time.Duration(i)*time.Minute + time.Minute),
+			totalInput:  100,
+			totalOutput: 30,
+		})
+		writeRunArtifacts(t, stateDir, runFixture{
+			vesselID:    "peer-" + string(rune('a'+i)),
+			source:      "github-issue",
+			workflow:    "peer",
+			state:       "completed",
+			startedAt:   base.Add(time.Duration(10+i) * time.Minute),
+			endedAt:     base.Add(time.Duration(10+i)*time.Minute + time.Minute),
+			totalInput:  120,
+			totalOutput: 35,
+		})
+	}
+
+	inputs := []int{100, 100, 350}
+	for i, input := range inputs {
+		writeRunArtifacts(t, stateDir, runFixture{
+			vesselID:    "spiky-" + string(rune('a'+i)),
+			source:      "github-issue",
+			workflow:    "spiky",
+			state:       "completed",
+			startedAt:   base.Add(time.Duration(20+i) * time.Minute),
+			endedAt:     base.Add(time.Duration(20+i)*time.Minute + time.Minute),
+			totalInput:  input,
+			totalOutput: 40,
+		})
+	}
+
+	result, err := GenerateContextWeightAudit(stateDir, ContextWeightOptions{
+		LookbackRuns: 20,
+		MinSamples:   3,
+		OutputDir:    "reviews",
+		Now:          base.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GenerateContextWeightAudit() error = %v", err)
+	}
+
+	for _, finding := range result.Report.Findings {
+		if finding.Workflow == "spiky" {
+			t.Fatalf("unexpected finding for one-off spike: %+v", finding)
+		}
+	}
+}
+
+func TestGenerateContextWeightAuditIgnoresZeroTokenRunsInBaseline(t *testing.T) {
+	stateDir := t.TempDir()
+	base := time.Date(2026, time.April, 9, 13, 30, 0, 0, time.UTC)
+
+	for i := range 3 {
+		writeRunArtifacts(t, stateDir, runFixture{
+			vesselID:    "command-only-" + string(rune('a'+i)),
+			source:      "scheduled",
+			workflow:    ContextWeightAuditWorkflow,
+			state:       "completed",
+			startedAt:   base.Add(time.Duration(i) * time.Minute),
+			endedAt:     base.Add(time.Duration(i)*time.Minute + time.Minute),
+			totalInput:  0,
+			totalOutput: 0,
+			phases: []runner.PhaseSummary{{
+				Name:   "publish",
+				Type:   "command",
+				Status: "completed",
+			}},
+		})
+		writeRunArtifacts(t, stateDir, runFixture{
+			vesselID:    "stable-" + string(rune('a'+i)),
+			source:      "github-issue",
+			workflow:    "stable",
+			state:       "completed",
+			startedAt:   base.Add(time.Duration(10+i) * time.Minute),
+			endedAt:     base.Add(time.Duration(10+i)*time.Minute + time.Minute),
+			totalInput:  120 + i*10,
+			totalOutput: 40 + i*5,
+			phases: []runner.PhaseSummary{{
+				Name:            "plan",
+				Type:            "prompt",
+				Status:          "completed",
+				InputTokensEst:  120 + i*10,
+				OutputTokensEst: 40 + i*5,
+			}},
+		})
+		writeRunArtifacts(t, stateDir, runFixture{
+			vesselID:    "peer-" + string(rune('a'+i)),
+			source:      "github-issue",
+			workflow:    "peer",
+			state:       "completed",
+			startedAt:   base.Add(time.Duration(15+i) * time.Minute),
+			endedAt:     base.Add(time.Duration(15+i)*time.Minute + time.Minute),
+			totalInput:  150 + i*10,
+			totalOutput: 60 + i*5,
+			phases: []runner.PhaseSummary{{
+				Name:            "plan",
+				Type:            "prompt",
+				Status:          "completed",
+				InputTokensEst:  150 + i*10,
+				OutputTokensEst: 60 + i*5,
+			}},
+		})
+		writeRunArtifacts(t, stateDir, runFixture{
+			vesselID:    "heavy-" + string(rune('a'+i)),
+			source:      "github-issue",
+			workflow:    "heavy",
+			state:       "completed",
+			startedAt:   base.Add(time.Duration(20+i) * time.Minute),
+			endedAt:     base.Add(time.Duration(20+i)*time.Minute + time.Minute),
+			totalInput:  620 + i*20,
+			totalOutput: 220 + i*10,
+			phases: []runner.PhaseSummary{{
+				Name:            "plan",
+				Type:            "prompt",
+				Status:          "completed",
+				InputTokensEst:  620 + i*20,
+				OutputTokensEst: 220 + i*10,
+			}},
+		})
+	}
+
+	result, err := GenerateContextWeightAudit(stateDir, ContextWeightOptions{
+		LookbackRuns: 20,
+		MinSamples:   3,
+		OutputDir:    "reviews",
+		Now:          base.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GenerateContextWeightAudit() error = %v", err)
+	}
+
+	if result.Report.Baseline.WorkflowInputTokens < 100 {
+		t.Fatalf("WorkflowInputTokens baseline = %d, want command-only runs excluded", result.Report.Baseline.WorkflowInputTokens)
+	}
+	if len(result.Report.Findings) != 1 || result.Report.Findings[0].Workflow != "heavy" {
+		t.Fatalf("findings = %+v, want only heavy workflow", result.Report.Findings)
+	}
+}
+
+func TestPublishContextWeightIssuesDedupsRepeatedFindings(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 9, 14, 0, 0, 0, time.UTC)
+	report := &ContextWeightReport{
+		GeneratedAt: now,
+		Baseline: ContextWeightBaseline{
+			WorkflowInputTokens:  150,
+			WorkflowOutputTokens: 50,
+		},
+		Findings: []ContextWeightFinding{{
+			Fingerprint:               "deadbeef",
+			Source:                    "github-issue",
+			Workflow:                  "heavy",
+			Samples:                   3,
+			AverageInputTokens:        600,
+			AverageOutputTokens:       200,
+			RepeatedHighFootprintRuns: 3,
+			LargestPhases:             []ContextWeightPhase{{Name: "plan", Type: "prompt", Samples: 3, AverageInputTokens: 400, AverageOutputTokens: 120}},
+			Reasons:                   []string{"average input tokens 600 are 4.0x the repo baseline 150"},
+			Remediations:              []string{"Trim the heaviest phase."},
+		}},
+	}
+	runner := &mockIssueRunner{}
+
+	first, err := PublishContextWeightIssues(context.Background(), stateDir, "owner/repo", runner, report, "reviews", now)
+	if err != nil {
+		t.Fatalf("first PublishContextWeightIssues() error = %v", err)
+	}
+	if runner.createCount != 1 {
+		t.Fatalf("createCount after first publish = %d, want 1", runner.createCount)
+	}
+	if len(first) != 1 || !first[0].Created {
+		t.Fatalf("first publish = %+v, want created issue", first)
+	}
+
+	second, err := PublishContextWeightIssues(context.Background(), stateDir, "owner/repo", runner, report, "reviews", now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("second PublishContextWeightIssues() error = %v", err)
+	}
+	if runner.createCount != 1 {
+		t.Fatalf("createCount after second publish = %d, want 1", runner.createCount)
+	}
+	if len(second) != 1 || second[0].Created {
+		t.Fatalf("second publish = %+v, want deduped existing issue", second)
+	}
+	if !strings.Contains(renderContextWeightIssueBody(report.Findings[0], report.Baseline), "xylem:context-weight-fingerprint=deadbeef") {
+		t.Fatal("issue body missing fingerprint marker")
+	}
+}

--- a/cli/internal/review/review_test.go
+++ b/cli/internal/review/review_test.go
@@ -202,6 +202,8 @@ type runFixture struct {
 	startedAt    time.Time
 	endedAt      time.Time
 	phases       []runner.PhaseSummary
+	totalInput   int
+	totalOutput  int
 	totalCost    float64
 	manifest     *evidence.Manifest
 	costReport   *cost.CostReport
@@ -211,17 +213,28 @@ type runFixture struct {
 
 func writeRunArtifacts(t *testing.T, stateDir string, fixture runFixture) {
 	t.Helper()
+	totalInput := fixture.totalInput
+	totalOutput := fixture.totalOutput
+	if totalInput == 0 && totalOutput == 0 {
+		for _, phase := range fixture.phases {
+			totalInput += phase.InputTokensEst
+			totalOutput += phase.OutputTokensEst
+		}
+	}
 	summary := runner.VesselSummary{
-		VesselID:        fixture.vesselID,
-		Source:          fixture.source,
-		Workflow:        fixture.workflow,
-		State:           fixture.state,
-		StartedAt:       fixture.startedAt,
-		EndedAt:         fixture.endedAt,
-		DurationMS:      fixture.endedAt.Sub(fixture.startedAt).Milliseconds(),
-		Phases:          fixture.phases,
-		TotalCostUSDEst: fixture.totalCost,
-		Note:            "fixture",
+		VesselID:             fixture.vesselID,
+		Source:               fixture.source,
+		Workflow:             fixture.workflow,
+		State:                fixture.state,
+		StartedAt:            fixture.startedAt,
+		EndedAt:              fixture.endedAt,
+		DurationMS:           fixture.endedAt.Sub(fixture.startedAt).Milliseconds(),
+		Phases:               fixture.phases,
+		TotalInputTokensEst:  totalInput,
+		TotalOutputTokensEst: totalOutput,
+		TotalTokensEst:       totalInput + totalOutput,
+		TotalCostUSDEst:      fixture.totalCost,
+		Note:                 "fixture",
 	}
 	artifacts := &runner.ReviewArtifacts{}
 	if fixture.manifest != nil {

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
@@ -134,6 +135,23 @@ func (s *Scanner) buildSources() []sourceEntry {
 				},
 				configName: name,
 			})
+		case "scheduled":
+			scheduledTasks := convertScheduledTasks(srcCfg.Tasks)
+			scheduledDur, err := time.ParseDuration(srcCfg.Schedule)
+			if err != nil {
+				log.Printf("warn: skip scheduled source %q: parse schedule %q: %v", name, srcCfg.Schedule, err)
+				continue
+			}
+			entries = append(entries, sourceEntry{
+				src: &source.Scheduled{
+					Repo:       srcCfg.Repo,
+					StateDir:   s.Config.StateDir,
+					ConfigName: name,
+					Schedule:   scheduledDur,
+					Tasks:      scheduledTasks,
+				},
+				configName: name,
+			})
 		}
 	}
 	return entries
@@ -170,6 +188,16 @@ func convertMergeTasks(cfgTasks map[string]config.Task) map[string]source.MergeT
 	tasks := make(map[string]source.MergeTask, len(cfgTasks))
 	for name, t := range cfgTasks {
 		tasks[name] = source.MergeTask{
+			Workflow: t.Workflow,
+		}
+	}
+	return tasks
+}
+
+func convertScheduledTasks(cfgTasks map[string]config.Task) map[string]source.ScheduledTask {
+	tasks := make(map[string]source.ScheduledTask, len(cfgTasks))
+	for name, t := range cfgTasks {
+		tasks[name] = source.ScheduledTask{
 			Workflow: t.Workflow,
 		}
 	}

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/review"
 )
 
 type mockRunner struct {
@@ -853,5 +854,62 @@ func TestScanMerge(t *testing.T) {
 	}
 	if vessels[0].Workflow != "post-merge" {
 		t.Errorf("expected workflow post-merge, got %q", vessels[0].Workflow)
+	}
+}
+
+func TestScanScheduledSourceHonorsCadence(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		StateDir:    dir,
+		Claude:      config.ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]config.SourceConfig{
+			"audit": {
+				Type:     "scheduled",
+				Repo:     "owner/repo",
+				Schedule: "24h",
+				Tasks: map[string]config.Task{
+					"context": {Workflow: review.ContextWeightAuditWorkflow},
+				},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	s := New(cfg, q, r)
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("first scan error: %v", err)
+	}
+	if result.Added != 1 {
+		t.Fatalf("first scan added = %d, want 1", result.Added)
+	}
+
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	if vessels[0].Source != "scheduled" {
+		t.Fatalf("vessel.Source = %q, want %q", vessels[0].Source, "scheduled")
+	}
+	if vessels[0].Workflow != review.ContextWeightAuditWorkflow {
+		t.Fatalf("vessel.Workflow = %q, want %q", vessels[0].Workflow, review.ContextWeightAuditWorkflow)
+	}
+	if vessels[0].Meta["config_source"] != "audit" {
+		t.Fatalf("config_source = %q, want %q", vessels[0].Meta["config_source"], "audit")
+	}
+
+	result, err = s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("second scan error: %v", err)
+	}
+	if result.Added != 0 {
+		t.Fatalf("second scan added = %d, want 0", result.Added)
 	}
 }

--- a/cli/internal/source/scheduled.go
+++ b/cli/internal/source/scheduled.go
@@ -1,0 +1,189 @@
+package source
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+type ScheduledTask struct {
+	Workflow string
+}
+
+type Scheduled struct {
+	Repo       string
+	StateDir   string
+	ConfigName string
+	Schedule   time.Duration
+	Tasks      map[string]ScheduledTask
+}
+
+type scheduleState struct {
+	LastEnqueuedBuckets map[string]int64 `json:"last_enqueued_buckets,omitempty"`
+}
+
+var safeScheduledPathComponent = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+func (s *Scheduled) Name() string { return "scheduled" }
+
+func (s *Scheduled) Scan(_ context.Context) ([]queue.Vessel, error) {
+	if s.Schedule <= 0 {
+		return nil, fmt.Errorf("scheduled source %q: schedule must be greater than 0", s.ConfigName)
+	}
+
+	state, err := s.loadState()
+	if err != nil {
+		return nil, err
+	}
+
+	now := sourceNow()
+	bucket := now.UnixNano() / s.Schedule.Nanoseconds()
+	taskNames := make([]string, 0, len(s.Tasks))
+	for taskName := range s.Tasks {
+		taskNames = append(taskNames, taskName)
+	}
+	sort.Strings(taskNames)
+
+	vessels := make([]queue.Vessel, 0, len(taskNames))
+	for _, taskName := range taskNames {
+		if state.LastEnqueuedBuckets[taskName] >= bucket {
+			continue
+		}
+		task := s.Tasks[taskName]
+		ref := fmt.Sprintf("scheduled://%s/%s@%d", s.ConfigName, taskName, bucket)
+		id := fmt.Sprintf("scheduled-%s-%s-%d", sanitizeScheduledComponent(s.ConfigName), sanitizeScheduledComponent(taskName), bucket)
+		vessels = append(vessels, queue.Vessel{
+			ID:       id,
+			Source:   s.Name(),
+			Ref:      ref,
+			Workflow: task.Workflow,
+			Meta: map[string]string{
+				"scheduled_config_name": s.ConfigName,
+				"scheduled_task_name":   taskName,
+				"scheduled_bucket":      fmt.Sprintf("%d", bucket),
+				"scheduled_repo":        s.Repo,
+				"scheduled_fingerprint": scheduledFingerprint(s.ConfigName, taskName, task.Workflow),
+			},
+			State:     queue.StatePending,
+			CreatedAt: now,
+		})
+	}
+
+	return vessels, nil
+}
+
+func (s *Scheduled) OnEnqueue(_ context.Context, vessel queue.Vessel) error {
+	taskName := strings.TrimSpace(vessel.Meta["scheduled_task_name"])
+	bucketRaw := strings.TrimSpace(vessel.Meta["scheduled_bucket"])
+	if taskName == "" || bucketRaw == "" {
+		return nil
+	}
+	parsedBucket, parseErr := parseInt64(bucketRaw)
+	if parseErr != nil {
+		return fmt.Errorf("scheduled source %q: parse bucket %q: %w", s.ConfigName, bucketRaw, parseErr)
+	}
+
+	state, err := s.loadState()
+	if err != nil {
+		return err
+	}
+	if state.LastEnqueuedBuckets == nil {
+		state.LastEnqueuedBuckets = make(map[string]int64)
+	}
+	state.LastEnqueuedBuckets[taskName] = parsedBucket
+	if err := s.saveState(state); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Scheduled) OnStart(_ context.Context, _ queue.Vessel) error            { return nil }
+func (s *Scheduled) OnComplete(_ context.Context, _ queue.Vessel) error         { return nil }
+func (s *Scheduled) OnFail(_ context.Context, _ queue.Vessel) error             { return nil }
+func (s *Scheduled) OnTimedOut(_ context.Context, _ queue.Vessel) error         { return nil }
+func (s *Scheduled) RemoveRunningLabel(_ context.Context, _ queue.Vessel) error { return nil }
+
+func (s *Scheduled) BranchName(vessel queue.Vessel) string {
+	taskName := sanitizeScheduledComponent(vessel.Meta["scheduled_task_name"])
+	if taskName == "" {
+		taskName = "task"
+	}
+	return fmt.Sprintf("scheduled/%s-%s", taskName, sanitizeScheduledComponent(vessel.ID))
+}
+
+func (s *Scheduled) loadState() (*scheduleState, error) {
+	path := s.statePath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &scheduleState{LastEnqueuedBuckets: make(map[string]int64)}, nil
+		}
+		return nil, fmt.Errorf("scheduled source %q: read state: %w", s.ConfigName, err)
+	}
+	var state scheduleState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("scheduled source %q: unmarshal state: %w", s.ConfigName, err)
+	}
+	if state.LastEnqueuedBuckets == nil {
+		state.LastEnqueuedBuckets = make(map[string]int64)
+	}
+	return &state, nil
+}
+
+func (s *Scheduled) saveState(state *scheduleState) error {
+	path := s.statePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("scheduled source %q: create state dir: %w", s.ConfigName, err)
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("scheduled source %q: marshal state: %w", s.ConfigName, err)
+	}
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("scheduled source %q: write temp state: %w", s.ConfigName, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("scheduled source %q: rename temp state: %w", s.ConfigName, err)
+	}
+	return nil
+}
+
+func (s *Scheduled) statePath() string {
+	return filepath.Join(s.StateDir, "schedules", sanitizeScheduledComponent(s.ConfigName)+".json")
+}
+
+func sanitizeScheduledComponent(s string) string {
+	clean := strings.TrimSpace(s)
+	if clean == "" {
+		return "scheduled"
+	}
+	clean = safeScheduledPathComponent.ReplaceAllString(clean, "-")
+	clean = strings.Trim(clean, "-")
+	if clean == "" {
+		return "scheduled"
+	}
+	return clean
+}
+
+func scheduledFingerprint(configName, taskName, workflow string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{configName, taskName, workflow}, "\n")))
+	return fmt.Sprintf("%x", sum[:8])
+}
+
+func parseInt64(raw string) (int64, error) {
+	var value int64
+	if _, err := fmt.Sscanf(raw, "%d", &value); err != nil {
+		return 0, err
+	}
+	return value, nil
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -276,8 +276,9 @@ xylem drain [flags]
    - Executes workflow phases sequentially in the worktree. Prompt phases use the resolved provider (`claude` or `copilot`), and command phases run shell commands directly.
    - Runs quality gates between phases (command gates with retries, label gates with polling).
 4. Marks vessels as `completed`, `failed`, `waiting`, or `timed_out` based on outcome.
-5. If `harness.review` is configured for automatic cadence, regenerates the latest harness review as a best-effort post-drain step.
-6. Prints a summary line and exits.
+5. Executes any built-in scheduled vessels already sitting in the queue (for example, `context-weight-audit`) without creating a worktree or launching an LLM session.
+6. If `harness.review` is configured for automatic cadence, regenerates the latest harness review as a best-effort post-drain step.
+7. Prints a summary line and exits.
 
 **Graceful shutdown**: `drain` handles `SIGINT` and `SIGTERM`. When a signal is received, running sessions are allowed to finish, but no new pending vessels are started.
 
@@ -382,7 +383,8 @@ The daemon uses the shorter of the two intervals as its tick interval and checks
 1. Parses scan and drain intervals from config (falling back to defaults).
 2. Enters a loop that alternates between scanning and draining based on elapsed time since each operation last ran.
 3. After each tick, logs a summary of the queue state (pending, running, completed, failed counts).
-4. Automatic harness review generation follows the same best-effort cadence as `xylem drain` because daemon draining uses the same post-drain hook.
+4. Daemon drains also execute built-in scheduled vessels such as `context-weight-audit` before launching normal workflow runs.
+5. Automatic harness review generation follows the same best-effort cadence as `xylem drain` because daemon draining uses the same post-drain hook.
 
 **Graceful shutdown**: Handles `SIGINT` and `SIGTERM`. On signal, the daemon logs a shutdown message and exits cleanly. Running sessions finish before the process terminates.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,8 +128,9 @@ Each key under `sources` is an arbitrary name (used in logs and vessel metadata)
 
 | Field | Type | Default | Required | Description |
 |-------|------|---------|----------|-------------|
-| `type` | string | -- | Yes | Source type. Supported values: `"github"`, `"github-pr"`, `"github-pr-events"`, `"github-merge"`. |
+| `type` | string | -- | Yes | Source type. Supported values: `"github"`, `"github-pr"`, `"github-pr-events"`, `"github-merge"`, `"scheduled"`. |
 | `repo` | string | -- | Yes (GitHub sources) | GitHub repository in `owner/name` format. Validated strictly -- both owner and name must be non-empty. |
+| `schedule` | string | -- | Required for `scheduled` | Positive Go duration string (for example `1h`, `24h`) that controls how often xylem enqueues the source's tasks. |
 | `exclude` | list of strings | `[]` | No | Labels that prevent an issue from being queued. If an issue has any of these labels, it is skipped. |
 | `llm` | string | `""` | No | Provider override for this source. Valid values: `claude`, `copilot`. When set, all tasks in this source use this provider instead of the top-level `llm`. |
 | `model` | string | `""` | No | Model override for this source. When set, all tasks in this source use this model instead of the top-level or provider-default model. |
@@ -152,6 +153,24 @@ Each key under `tasks` is an arbitrary name. The value defines which issues matc
 - `github-pr`: requires `labels`, supports `status_labels`
 - `github-pr-events`: requires `workflow` and `on`
 - `github-merge`: requires `workflow`
+- `scheduled`: requires `workflow`; tasks are enqueued once per configured time bucket and do not use labels
+
+### `scheduled`
+
+`scheduled` sources create recurring vessels on a fixed cadence instead of scanning GitHub labels or events. Xylem persists the last-enqueued schedule bucket under `<state_dir>/schedules/` so repeated scans in the same window do not duplicate work.
+
+```yaml
+sources:
+  context-weight-audit:
+    type: scheduled
+    repo: owner/repo
+    schedule: 24h
+    tasks:
+      audit:
+        workflow: context-weight-audit
+```
+
+The built-in `context-weight-audit` workflow reads persisted run summaries from `<state_dir>/phases/`, writes `context-weight-audit.{json,md}` under `<state_dir>/<harness.review.output_dir>/`, and opens de-duplicated GitHub hygiene issues for repeated high-footprint findings.
 
 ### `status_labels`
 
@@ -330,7 +349,7 @@ harness:
     output_dir: "reviews"
 ```
 
-`xylem review` writes `harness-review.json` and `harness-review.md` under `<state_dir>/<output_dir>/`. Automatic reviews are best-effort: failed review generation never fails `drain` or `daemon`.
+`xylem review` writes `harness-review.json` and `harness-review.md` under `<state_dir>/<output_dir>/`. Automatic reviews are best-effort: failed review generation never fails `drain` or `daemon`. Built-in context-weight audits also write `context-weight-audit.json`, `context-weight-audit.md`, and a durable issue-dedup state file in the same directory when a scheduled `context-weight-audit` vessel runs.
 
 ### Observability settings
 


### PR DESCRIPTION
## Summary
- add scheduled source support and execute built-in context-weight-audit vessels during drain and daemon runs
- generate context-weight audit reports from persisted run summaries and open de-duplicated GitHub issues with workflow and phase evidence plus remediation guidance
- cover cadence, aggregation, thresholding, deduplication, and zero-token baseline exclusion in tests

Closes https://github.com/nicholls-inc/xylem/issues/160