### PR TITLE
fix: runner: pre-verify restore suppresses transient protected-surface deletions (#174)

### DIFF
--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -2110,6 +2110,33 @@ func (r *Runner) verifyProtectedSurfaces(vessel queue.Vessel, p workflow.Phase, 
 		return nil
 	}
 
+	// Pre-verify restore: if the phase temporarily removed protected files
+	// (e.g., resolve-conflicts workflow runs `gh pr checkout` on a PR branch
+	// that predates the .xylem/ tracking commit (#157), then git switches
+	// branches and drops tracked files that the target branch doesn't have),
+	// restore them from the canonical source root before comparing the
+	// after-snapshot. Only MISSING files are restored (those with
+	// violation.After == "deleted" against the source root); modifications
+	// are untouched and will still be caught by the Compare below.
+	//
+	// This closes the loop on issue #174: Fix B's post-phase self-heal was
+	// correctly running but only AFTER the violation was recorded, so
+	// vessels still failed. Restoring before the snapshot eliminates the
+	// spurious "deleted" category while preserving all other enforcement.
+	//
+	// Uses context.Background() because the vessel's ctx may already be
+	// cancelling (e.g., phase timeout) — cleanup work should survive.
+	if sourceRoot, srcErr := r.protectedSurfaceSourceRoot(context.Background(), worktreePath); srcErr == nil {
+		restored, restoreErr := restoreMissingProtectedSurfacesFromRoot(worktreePath, sourceRoot, patterns)
+		if restoreErr != nil {
+			log.Printf("%sphase %q pre-verify restore failed: %v",
+				vesselLabel(vessel), p.Name, restoreErr)
+		} else if restored > 0 {
+			log.Printf("%sphase %q pre-verify restored %d protected surface file(s) from source root",
+				vesselLabel(vessel), p.Name, restored)
+		}
+	}
+
 	after, err := surface.TakeSnapshot(worktreePath, patterns)
 	if err != nil {
 		log.Printf("%sphase %q protected surface verification skipped: %v",
@@ -2191,13 +2218,110 @@ func copyProtectedSurfaceFile(sourceRoot, worktreePath, relPath string) error {
 	if err != nil {
 		return fmt.Errorf("read source file: %w", err)
 	}
+	// Idempotency: a prior call may have left the destination chmod'd
+	// 0o444 (read-only). Make it writable before os.WriteFile so repeated
+	// restores across multiple pre-verify cycles succeed.
+	if dstInfo, statErr := os.Stat(dstPath); statErr == nil && dstInfo.Mode().Perm()&0o200 == 0 {
+		if chmodErr := os.Chmod(dstPath, 0o644); chmodErr != nil {
+			return fmt.Errorf("chmod writable for rewrite: %w", chmodErr)
+		}
+	}
 	if err := os.WriteFile(dstPath, data, info.Mode()); err != nil {
 		return fmt.Errorf("write restored file: %w", err)
 	}
 	if err := os.Chmod(dstPath, 0o444); err != nil {
 		return fmt.Errorf("mark restored file read-only: %w", err)
 	}
+	// Add the restored path to the worktree's .git/info/exclude so that
+	// subsequent `git add -A` (e.g., in resolve-conflicts's push phase) does
+	// NOT stage the restored file into the PR commit. This only affects
+	// untracked files; a file that's already tracked on the PR branch is
+	// unaffected by exclude entries.
+	//
+	// Fail-soft: exclude is a best-effort pollution guard, not a safety
+	// invariant. If it fails (e.g., .git dir missing in a test or some
+	// corner case), the file restore still succeeds — worst case a later
+	// `git add -A` stages the restored file into a PR commit, which is no
+	// worse than the pre-fix behavior of failing the vessel outright.
+	if err := addWorktreeExcludeEntry(worktreePath, relPath); err != nil {
+		log.Printf("warn: copyProtectedSurfaceFile: add exclude entry for %s: %v", relPath, err)
+	}
 	return nil
+}
+
+// addWorktreeExcludeEntry appends a path to the worktree's .git/info/exclude
+// file if not already present. For linked worktrees (the xylem vessel case),
+// $GIT_DIR points to .git/worktrees/<name>, and info/exclude there is
+// per-worktree — it does NOT affect sibling worktrees.
+//
+// Idempotent: a second call with the same relPath no-ops because the exact
+// line is already present.
+func addWorktreeExcludeEntry(worktreePath, relPath string) error {
+	gitdir, err := resolveWorktreeGitdir(worktreePath)
+	if err != nil {
+		return fmt.Errorf("resolve gitdir: %w", err)
+	}
+	excludePath := filepath.Join(gitdir, "info", "exclude")
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0o755); err != nil {
+		return fmt.Errorf("mkdir info: %w", err)
+	}
+
+	// Use a leading slash so the pattern anchors at the worktree root,
+	// matching exactly this file (not any subdirectory with the same name).
+	line := "/" + relPath
+
+	existing, err := os.ReadFile(excludePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read exclude: %w", err)
+	}
+	for _, e := range strings.Split(string(existing), "\n") {
+		if strings.TrimSpace(e) == line {
+			return nil
+		}
+	}
+
+	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open exclude: %w", err)
+	}
+	defer f.Close()
+
+	prefix := ""
+	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
+		prefix = "\n"
+	}
+	if _, err := f.WriteString(prefix + line + "\n"); err != nil {
+		return fmt.Errorf("write exclude: %w", err)
+	}
+	return nil
+}
+
+// resolveWorktreeGitdir returns the $GIT_DIR for a worktree. For the main
+// repo, .git is a directory and that IS the gitdir. For linked worktrees,
+// .git is a file containing "gitdir: <absolute-or-relative-path>".
+func resolveWorktreeGitdir(worktreePath string) (string, error) {
+	gitPath := filepath.Join(worktreePath, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return gitPath, nil
+	}
+	data, err := os.ReadFile(gitPath)
+	if err != nil {
+		return "", err
+	}
+	line := strings.TrimSpace(string(data))
+	const prefix = "gitdir:"
+	if !strings.HasPrefix(line, prefix) {
+		return "", fmt.Errorf("unexpected .git file content: %q", line)
+	}
+	gitdir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	if !filepath.IsAbs(gitdir) {
+		gitdir = filepath.Join(worktreePath, gitdir)
+	}
+	return gitdir, nil
 }
 
 func (r *Runner) restoreDeletedProtectedSurfaces(ctx context.Context, worktreePath string, violations []surface.Violation) error {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -5199,6 +5199,350 @@ func TestVerifyProtectedSurfacesSelfHealsDeletedFileFromDefaultBranch(t *testing
 	}
 }
 
+// TestVerifyProtectedSurfacesSuppressesTransientDeletionsViaPreVerifyRestore
+// documents the fix for issue #174: when a phase temporarily removes protected
+// files (e.g., resolve-conflicts's gh pr checkout on a pre-#157 PR branch),
+// the pre-verify restore step should copy them back from the source root
+// BEFORE taking the after-snapshot, so the Compare sees them present and
+// emits zero "deleted" violations. Modifications (present-but-different) are
+// still caught because restore only fires on absent files.
+func TestVerifyProtectedSurfacesSuppressesTransientDeletionsViaPreVerifyRestore(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeDir := filepath.Join(repoRoot, ".claude", "worktrees", "review", "pr-test")
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.git) = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".xylem", "workflows"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(workflows) = %v", err)
+	}
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(worktree) = %v", err)
+	}
+	// Give the worktree a .git directory so the exclude-entry path in
+	// copyProtectedSurfaceFile can succeed (mirrors a regular worktree).
+	if err := os.MkdirAll(filepath.Join(worktreeDir, ".git", "info"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(worktree .git) = %v", err)
+	}
+	// Source root has the canonical files.
+	canonicalConfig := []byte("repo: owner/repo\n")
+	canonicalWorkflow := []byte("name: fix-bug\n")
+	if err := os.WriteFile(filepath.Join(repoRoot, ".xylem.yml"), canonicalConfig, 0o644); err != nil {
+		t.Fatalf("WriteFile(.xylem.yml) = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, ".xylem", "workflows", "fix-bug.yaml"), canonicalWorkflow, 0o644); err != nil {
+		t.Fatalf("WriteFile(workflow) = %v", err)
+	}
+
+	// Seed the worktree with the same files — these represent the pre-phase
+	// snapshot state.
+	if err := os.MkdirAll(filepath.Join(worktreeDir, ".xylem", "workflows"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(worktree workflows) = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".xylem.yml"), canonicalConfig, 0o644); err != nil {
+		t.Fatalf("WriteFile(worktree .xylem.yml) = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".xylem", "workflows", "fix-bug.yaml"), canonicalWorkflow, 0o644); err != nil {
+		t.Fatalf("WriteFile(worktree workflow) = %v", err)
+	}
+
+	cfg := makeTestConfig(repoRoot, 1)
+	cfg.StateDir = filepath.Join(repoRoot, ".xylem-state")
+	cmdRunner := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name != "git" {
+				return nil, nil, false
+			}
+			// Source-root resolution: return the canonical repo root's .git
+			if len(args) == 5 &&
+				args[0] == "-C" &&
+				args[1] == worktreeDir &&
+				args[2] == "rev-parse" &&
+				args[3] == "--path-format=absolute" &&
+				args[4] == "--git-common-dir" {
+				return []byte(filepath.Join(repoRoot, ".git")), nil, true
+			}
+			return nil, nil, false
+		},
+	}
+
+	r := New(cfg, queue.New(filepath.Join(repoRoot, "queue.jsonl")), &mockWorktree{path: worktreeDir}, cmdRunner)
+
+	// Take the before-snapshot while the files are present.
+	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), worktreeDir)
+	if err != nil {
+		t.Fatalf("takeProtectedSurfaceSnapshot() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("takeProtectedSurfaceSnapshot() checkProtectedSurfaces = false, want true")
+	}
+	if len(before.Files) < 2 {
+		t.Fatalf("before.Files = %d, want >= 2", len(before.Files))
+	}
+
+	// Simulate a phase that transiently removes the protected files (e.g.,
+	// resolve-conflicts workflow's gh pr checkout on a pre-#157 PR branch).
+	if err := os.Remove(filepath.Join(worktreeDir, ".xylem.yml")); err != nil {
+		t.Fatalf("Remove(.xylem.yml) = %v", err)
+	}
+	if err := os.Remove(filepath.Join(worktreeDir, ".xylem", "workflows", "fix-bug.yaml")); err != nil {
+		t.Fatalf("Remove(workflow) = %v", err)
+	}
+
+	// verifyProtectedSurfaces should NOT return a violation: pre-verify
+	// restore copies the missing files from the source root, the
+	// after-snapshot sees them present, and Compare finds no diffs.
+	err = r.verifyProtectedSurfaces(
+		queue.Vessel{ID: "issue-transient-delete", Source: "github-pr", Workflow: "resolve-conflicts"},
+		workflow.Phase{Name: "analyze"},
+		worktreeDir,
+		before,
+	)
+	if err != nil {
+		t.Fatalf("verifyProtectedSurfaces() returned violation %v, want nil (pre-verify restore should suppress transient deletions)", err)
+	}
+
+	// Sanity: verify the files were actually restored to the worktree.
+	data, readErr := os.ReadFile(filepath.Join(worktreeDir, ".xylem.yml"))
+	if readErr != nil {
+		t.Fatalf("restored .xylem.yml missing after verify: %v", readErr)
+	}
+	if string(data) != string(canonicalConfig) {
+		t.Fatalf("restored .xylem.yml = %q, want %q", string(data), string(canonicalConfig))
+	}
+	if _, statErr := os.Stat(filepath.Join(worktreeDir, ".xylem", "workflows", "fix-bug.yaml")); statErr != nil {
+		t.Fatalf("restored workflow missing after verify: %v", statErr)
+	}
+}
+
+// TestVerifyProtectedSurfacesStillCatchesModificationsAfterPreVerifyRestore
+// ensures the pre-verify restore does NOT mask modifications: a file that's
+// present-but-different should still cause a violation because the restore
+// only touches absent files.
+func TestVerifyProtectedSurfacesStillCatchesModificationsAfterPreVerifyRestore(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeDir := filepath.Join(repoRoot, ".claude", "worktrees", "review", "pr-mod")
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.git) = %v", err)
+	}
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(worktree) = %v", err)
+	}
+	canonical := []byte("canonical content\n")
+	if err := os.WriteFile(filepath.Join(repoRoot, ".xylem.yml"), canonical, 0o644); err != nil {
+		t.Fatalf("WriteFile source = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".xylem.yml"), canonical, 0o644); err != nil {
+		t.Fatalf("WriteFile worktree = %v", err)
+	}
+
+	cfg := makeTestConfig(repoRoot, 1)
+	cfg.StateDir = filepath.Join(repoRoot, ".xylem-state")
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	cmdRunner := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name == "git" && len(args) >= 5 && args[2] == "rev-parse" && args[4] == "--git-common-dir" {
+				return []byte(filepath.Join(repoRoot, ".git")), nil, true
+			}
+			return nil, nil, false
+		},
+	}
+	r := New(cfg, queue.New(filepath.Join(repoRoot, "queue.jsonl")), &mockWorktree{path: worktreeDir}, cmdRunner)
+	r.AuditLog = auditLog
+
+	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), worktreeDir)
+	if err != nil || !ok {
+		t.Fatalf("takeProtectedSurfaceSnapshot error = %v ok = %v", err, ok)
+	}
+
+	// Simulate a phase that MODIFIES the file (doesn't delete it).
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".xylem.yml"), []byte("modified by rogue agent\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile modify = %v", err)
+	}
+
+	err = r.verifyProtectedSurfaces(
+		queue.Vessel{ID: "issue-mod-check", Source: "github-issue", Workflow: "fix-bug"},
+		workflow.Phase{Name: "implement"},
+		worktreeDir,
+		before,
+	)
+	if err == nil {
+		t.Fatal("verifyProtectedSurfaces() returned nil, want violation for modified file")
+	}
+	if !strings.Contains(err.Error(), "violated protected surfaces") {
+		t.Fatalf("error = %q, want containing 'violated protected surfaces'", err)
+	}
+	if !strings.Contains(err.Error(), ".xylem.yml") {
+		t.Fatalf("error = %q, want containing '.xylem.yml' path", err)
+	}
+}
+
+// TestCopyProtectedSurfaceFileAddsWorktreeExcludeEntry verifies that the
+// pre-verify restore's copyProtectedSurfaceFile helper appends the restored
+// path to .git/info/exclude, so subsequent `git add -A` in the push phase
+// of resolve-conflicts won't stage the restored file into the PR commit.
+func TestCopyProtectedSurfaceFileAddsWorktreeExcludeEntry(t *testing.T) {
+	sourceRoot := t.TempDir()
+	worktreePath := t.TempDir()
+
+	// Source has the canonical file
+	if err := os.MkdirAll(filepath.Join(sourceRoot, ".xylem"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(source .xylem) = %v", err)
+	}
+	canonical := []byte("harness content\n")
+	if err := os.WriteFile(filepath.Join(sourceRoot, ".xylem", "HARNESS.md"), canonical, 0o644); err != nil {
+		t.Fatalf("WriteFile source = %v", err)
+	}
+
+	// Worktree has a .git directory (simulating a regular worktree — for
+	// linked worktrees the .git file path resolution is exercised by the
+	// integration path).
+	if err := os.MkdirAll(filepath.Join(worktreePath, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.git) = %v", err)
+	}
+
+	if err := copyProtectedSurfaceFile(sourceRoot, worktreePath, ".xylem/HARNESS.md"); err != nil {
+		t.Fatalf("copyProtectedSurfaceFile() = %v", err)
+	}
+
+	// The file should exist at the destination
+	if _, err := os.Stat(filepath.Join(worktreePath, ".xylem", "HARNESS.md")); err != nil {
+		t.Fatalf("restored file missing: %v", err)
+	}
+
+	// .git/info/exclude should contain the path with leading slash
+	excludeData, err := os.ReadFile(filepath.Join(worktreePath, ".git", "info", "exclude"))
+	if err != nil {
+		t.Fatalf("ReadFile(exclude) = %v", err)
+	}
+	expected := "/.xylem/HARNESS.md"
+	if !strings.Contains(string(excludeData), expected) {
+		t.Fatalf("exclude = %q, want containing %q", string(excludeData), expected)
+	}
+
+	// Second call should be idempotent — no duplicate entry
+	if err := copyProtectedSurfaceFile(sourceRoot, worktreePath, ".xylem/HARNESS.md"); err != nil {
+		t.Fatalf("second copyProtectedSurfaceFile() = %v", err)
+	}
+	excludeData, err = os.ReadFile(filepath.Join(worktreePath, ".git", "info", "exclude"))
+	if err != nil {
+		t.Fatalf("ReadFile(exclude) second = %v", err)
+	}
+	count := strings.Count(string(excludeData), expected)
+	if count != 1 {
+		t.Fatalf("exclude contains %d copies of %q, want 1 (must be idempotent)", count, expected)
+	}
+}
+
+// TestResolveWorktreeGitdirHandlesLinkedWorktree verifies that for a linked
+// worktree (where .git is a file pointing at the per-worktree gitdir), the
+// gitdir resolution follows the pointer correctly. This is critical for the
+// xylem vessel case where worktrees are created via `git worktree add`.
+func TestResolveWorktreeGitdirHandlesLinkedWorktree(t *testing.T) {
+	mainRepo := t.TempDir()
+	linkedWorktree := t.TempDir()
+	perWorktreeGitdir := filepath.Join(mainRepo, ".git", "worktrees", "linked")
+	if err := os.MkdirAll(perWorktreeGitdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(per-worktree gitdir) = %v", err)
+	}
+
+	// Write the .git FILE pointing at the per-worktree gitdir
+	gitFilePath := filepath.Join(linkedWorktree, ".git")
+	if err := os.WriteFile(gitFilePath, []byte("gitdir: "+perWorktreeGitdir+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(.git) = %v", err)
+	}
+
+	got, err := resolveWorktreeGitdir(linkedWorktree)
+	if err != nil {
+		t.Fatalf("resolveWorktreeGitdir() = %v", err)
+	}
+	if got != perWorktreeGitdir {
+		t.Fatalf("resolveWorktreeGitdir() = %q, want %q", got, perWorktreeGitdir)
+	}
+
+	// Regular worktree (.git directory) should return the .git path itself
+	regularRepo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(regularRepo, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(regular .git) = %v", err)
+	}
+	got, err = resolveWorktreeGitdir(regularRepo)
+	if err != nil {
+		t.Fatalf("resolveWorktreeGitdir(regular) = %v", err)
+	}
+	if got != filepath.Join(regularRepo, ".git") {
+		t.Fatalf("resolveWorktreeGitdir(regular) = %q, want %q", got, filepath.Join(regularRepo, ".git"))
+	}
+}
+
+// TestVerifyProtectedSurfacesStillCatchesMutualDeletion verifies that when
+// BOTH the worktree and source root lack a file, the pre-verify restore is
+// a no-op and the outer Compare still raises a violation (because the
+// before-snapshot had the file). This ensures the suppression logic doesn't
+// over-reach and mask legitimate removal from the canonical source.
+func TestVerifyProtectedSurfacesStillCatchesMutualDeletion(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeDir := filepath.Join(repoRoot, ".claude", "worktrees", "review", "pr-mutual")
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.git) = %v", err)
+	}
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(worktree) = %v", err)
+	}
+	// Source root + worktree both have the file initially
+	canonical := []byte("before\n")
+	if err := os.WriteFile(filepath.Join(repoRoot, ".xylem.yml"), canonical, 0o644); err != nil {
+		t.Fatalf("WriteFile source = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".xylem.yml"), canonical, 0o644); err != nil {
+		t.Fatalf("WriteFile worktree = %v", err)
+	}
+
+	cfg := makeTestConfig(repoRoot, 1)
+	cfg.StateDir = filepath.Join(repoRoot, ".xylem-state")
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	cmdRunner := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name == "git" && len(args) >= 5 && args[2] == "rev-parse" && args[4] == "--git-common-dir" {
+				return []byte(filepath.Join(repoRoot, ".git")), nil, true
+			}
+			return nil, nil, false
+		},
+	}
+	r := New(cfg, queue.New(filepath.Join(repoRoot, "queue.jsonl")), &mockWorktree{path: worktreeDir}, cmdRunner)
+	r.AuditLog = auditLog
+
+	// Before snapshot captures the file present
+	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), worktreeDir)
+	if err != nil || !ok {
+		t.Fatalf("takeProtectedSurfaceSnapshot = %v %v", err, ok)
+	}
+
+	// Now delete the file from BOTH worktree and source root (simulating a
+	// phase that legitimately tried to remove it from everywhere — e.g., a
+	// rogue agent doing `rm -rf /.xylem/`).
+	if err := os.Remove(filepath.Join(worktreeDir, ".xylem.yml")); err != nil {
+		t.Fatalf("Remove worktree = %v", err)
+	}
+	if err := os.Remove(filepath.Join(repoRoot, ".xylem.yml")); err != nil {
+		t.Fatalf("Remove source = %v", err)
+	}
+
+	// verifyProtectedSurfaces should STILL raise a violation because the
+	// pre-verify restore has nothing to restore from (source root is empty)
+	// and the outer Compare sees the before-snapshot had the file.
+	err = r.verifyProtectedSurfaces(
+		queue.Vessel{ID: "issue-mutual-del", Source: "github-issue", Workflow: "fix-bug"},
+		workflow.Phase{Name: "implement"},
+		worktreeDir,
+		before,
+	)
+	if err == nil {
+		t.Fatal("verifyProtectedSurfaces() = nil, want violation for mutual deletion")
+	}
+	if !strings.Contains(err.Error(), "violated protected surfaces") {
+		t.Fatalf("error = %q, want containing 'violated protected surfaces'", err)
+	}
+}
+
 func TestSmoke_WS6_S19_OrchestratedVesselRunStateNoRace(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 2)


### PR DESCRIPTION
## Summary

Resolves #174. Completes the Fix B cycle (PR #172) by moving the protected-surface restore to run BEFORE the after-snapshot, so transient deletions from git merge/checkout operations on PR branches that predate #157 are silently repaired without emitting a violation.

## Background

Loop 6 verified live on \`pr-164-resolve-conflicts\` that Fix B (PR #172) was doing its job — the worktree post-failure had \`.xylem/HARNESS.md\` restored as \`-r--r--r--\` (4441 bytes) with all files staged as \`A\` via \`git checkout origin/main -- <path>\`. But the self-heal ran AFTER the violation was recorded, so the vessel was marked failed anyway.

This PR moves the restore upstream of the violation check.

## Changes

1. **Pre-verify restore** in \`verifyProtectedSurfaces\` — calls \`restoreMissingProtectedSurfacesFromRoot\` before \`surface.TakeSnapshot\`. Files absent from the worktree but present in the canonical source root get copied back. The subsequent Compare sees them present and emits no "deleted" violations.

2. **Idempotency in \`copyProtectedSurfaceFile\`** — chmods writable before re-writing, then back to 0o444. Critical because pre-verify restore runs on every phase.

3. **\`git add -A\` pollution guard via \`.git/info/exclude\`** — after each restore, \`copyProtectedSurfaceFile\` appends the restored path to the worktree's \`.git/info/exclude\`. This prevents \`resolve-conflicts\`'s push phase (\`git add -A && git commit\`) from staging the restored untracked files into the PR commit. For linked worktrees (the xylem vessel case), the exclude file is per-worktree because \`$GIT_DIR\` points to \`.git/worktrees/<name>\`, not the shared common-dir.

4. **New helpers:**
   - \`addWorktreeExcludeEntry\` — idempotent append to \`.git/info/exclude\`
   - \`resolveWorktreeGitdir\` — follows \`.git\` file pointer for linked worktrees

5. **Fail-soft exclude**: if the exclude file can't be written (e.g., \`.git\` dir missing in edge cases), the restore still succeeds and logs a warning. "Exclude is a best-effort pollution guard, not a safety invariant."

## Preserved behavior (verified by tests)

- **Modifications** (present-but-different hash) still raise violations — restore only touches absent files
- **Mutual deletions** (both worktree AND source root lack the file) still raise violations — restore has nothing to copy
- **Source-root resolution failures** fail-soft to original verifier behavior

## Tests (5 new)

- \`TestVerifyProtectedSurfacesSuppressesTransientDeletionsViaPreVerifyRestore\` — headline fix
- \`TestVerifyProtectedSurfacesStillCatchesModificationsAfterPreVerifyRestore\` — non-regression
- \`TestVerifyProtectedSurfacesStillCatchesMutualDeletion\` — non-regression  
- \`TestCopyProtectedSurfaceFileAddsWorktreeExcludeEntry\` — idempotent exclude write
- \`TestResolveWorktreeGitdirHandlesLinkedWorktree\` — linked + regular worktree gitdir resolution

## Verification

- **crosscheck:byfuglien** verifier: **VERIFIED** after I addressed the Q5 ship-blocker (originally flagged by the verifier — \`git add -A\` would stage restored untracked files into the PR; fixed via \`.git/info/exclude\` mechanism above)
- \`go test ./...\` — all packages green
- \`go vet ./...\` clean
- \`goimports -l .\` empty
- \`golangci-lint run --path-mode=abs ./internal/runner/...\` 0 issues

## Unblocks

**PR #143** and **PR #164** — both CONFLICTING on branches cut before #157. With this fix, the next \`resolve-conflicts\` vessel targeting them should no longer fail at the analyze phase due to the deletion cascade. The resolve phase's self-heal is now redundant for the deletion case but still handles the (rare) modification case.

## Test plan

- [x] \`go build ./cmd/xylem\`
- [x] \`go test ./...\` (all green)
- [x] \`go vet ./...\`
- [x] \`goimports -l .\` (empty)
- [x] \`golangci-lint run\` (0 issues)
- [x] New regression tests exercise suppression, non-masking, exclude, and linked-worktree edge cases
- [ ] Post-merge: next resolve-conflicts vessel on PR #143 or #164 should pass analyze phase and attempt the resolve phase

## Related

- #169 (env propagation, loop 3)
- #170 → #172 (protected surface self-heal, loop 4; Fix B's post-phase restore)
- #171 → #173 (drain concurrency, autonomous vessel loop 5→6)
- **#174 (this PR: pre-verify restore completing Fix B)**

Filed autonomously by the hourly /xylem-status rescue loop on 2026-04-09 (loop 7). Verified by crosscheck:byfuglien semi-formal reasoning with one iteration to fix the Q5 PR-pollution ship-blocker.