### PR TITLE
fix: daemon: auto-upgrade overdue escape hatch for saturated drain

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -167,13 +167,40 @@ type upgradeFunc func()
 // excessive git fetches and rebuilds.
 const defaultUpgradeInterval = 5 * time.Minute
 
+// upgradeOverdueMultiplier controls the forced-upgrade escape hatch: after
+// this many upgradeIntervals have elapsed without a successful upgrade
+// (because the daemon was never idle enough to fire the normal path), the
+// next drain tick is PAUSED — new vessels are not dequeued — so that the
+// currently in-flight vessels can finish naturally and the upgrade condition
+// (`in_flight == 0`) is eventually satisfied.
+//
+// At the default 5m upgradeInterval + 3x multiplier = 15 minutes of
+// "upgrade pending" before drain starts gracefully parking. This preserves
+// the safety invariant (no exec() while subprocesses are alive) while
+// guaranteeing that a continuously-saturated scheduled source can never
+// permanently lock the daemon on a stale binary.
+//
+// 3 is chosen so that a single healthy upgrade cycle (5m interval, fires
+// reliably) is not perturbed, but a degraded "always saturated" condition
+// is resolved in bounded time.
+const upgradeOverdueMultiplier = 3
+
 // daemonLoop is the core loop extracted for testability. It accepts an
 // externally-controlled context so tests can cancel it without signals,
 // and injectable scan/drain/check functions so tests can use stubs.
 //
-// If upgrade is non-nil, it is called only when the daemon is fully idle:
-// there is no active drain tick and the shared runner reports zero in-flight
-// vessels. Pass nil/zero upgrade/upgradeInterval to disable.
+// If upgrade is non-nil, it is called under one of two conditions:
+//
+//  1. Normal path: daemon is fully idle (no active drain, zero in-flight
+//     vessels) and upgradeInterval has elapsed since the last upgrade.
+//
+//  2. Overdue path: upgrade has been pending for
+//     upgradeInterval*upgradeOverdueMultiplier without firing because the
+//     daemon was never idle enough. In this case, new drain ticks are
+//     paused (no new dequeue) so in-flight vessels can drain naturally.
+//     Once in_flight reaches zero, the normal path fires.
+//
+// Pass nil/zero upgrade/upgradeInterval to disable.
 func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, scan scanFunc, drain drainFunc, check checkFunc, upgrade upgradeFunc, scanInterval, drainInterval, upgradeInterval time.Duration) error {
 	tickInterval := scanInterval
 	if drainInterval < tickInterval {
@@ -231,15 +258,35 @@ func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, sc
 			check(ctx)
 		}
 
-		if upgrade != nil && upgradeInterval > 0 &&
-			atomic.LoadInt32(&draining) == 0 &&
-			trackerInFlightCount(tracker) == 0 &&
-			now.Sub(lastUpgrade) >= upgradeInterval {
+		// Compute upgrade state once per tick so both the upgrade check and
+		// the drain-pause decision share a single snapshot of conditions.
+		upgradeReady := upgrade != nil && upgradeInterval > 0
+		upgradeElapsed := now.Sub(lastUpgrade)
+		upgradePending := upgradeReady && upgradeElapsed >= upgradeInterval
+		upgradeOverdue := upgradeReady && upgradeElapsed >= upgradeInterval*time.Duration(upgradeOverdueMultiplier)
+		inFlight := trackerInFlightCount(tracker)
+		drainIdle := atomic.LoadInt32(&draining) == 0
+
+		if upgradePending && drainIdle && inFlight == 0 {
+			// Normal path: daemon is fully idle and upgrade is due.
 			lastUpgrade = now
 			upgrade()
+		} else if upgradeOverdue && drainIdle && inFlight > 0 {
+			// Overdue: log that we're pausing new dequeue to let in-flight
+			// vessels drain naturally, creating an idle window for the
+			// normal upgrade path on a subsequent tick. This does NOT kill
+			// running vessels — we wait for them to complete on their own.
+			log.Printf("daemon: auto-upgrade overdue by %s (in_flight=%d, pausing new drain dequeue until idle)",
+				upgradeElapsed, inFlight)
 		}
 
-		if now.Sub(lastDrain) >= drainInterval {
+		// Drain dequeue is suppressed while an upgrade is overdue and
+		// in-flight vessels still exist. This creates the idle window the
+		// normal upgrade path needs, without exec()ing while subprocesses
+		// are alive. When in_flight reaches zero, the next tick fires the
+		// normal upgrade path above and dequeue resumes.
+		drainPaused := upgradeOverdue && inFlight > 0
+		if !drainPaused && now.Sub(lastDrain) >= drainInterval {
 			if atomic.CompareAndSwapInt32(&draining, 0, 1) {
 				lastDrain = now
 				drainWg.Add(1)

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -492,6 +492,94 @@ func TestSmoke_S36_DaemonLoopUpgradeWaitsForTrackerIdle(t *testing.T) {
 	assert.GreaterOrEqual(t, upgradeTime.Sub(launchTime), 60*time.Millisecond)
 }
 
+// TestDaemonLoopUpgradeOverduePausesDrainToCreateIdleWindow verifies the
+// overdue path: when upgrade has been pending for upgradeInterval*3 without
+// firing (because in-flight vessels kept in_flight > 0 continuously), new
+// drain ticks are paused so in-flight vessels can drain naturally. Once
+// in_flight reaches zero, the normal upgrade path fires.
+//
+// This is the regression test for the loop 8 diagnosis: scheduled sources
+// that continuously fill concurrency slots previously locked the daemon on
+// its current binary forever because the normal upgrade path required
+// in_flight == 0, which the scheduled source prevented.
+func TestDaemonLoopUpgradeOverduePausesDrainToCreateIdleWindow(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	tracker := &trackerStub{}
+
+	var (
+		drainCalls  atomic.Int32
+		upgradeSeen atomic.Int32
+	)
+
+	// Saturating drain: every drain call starts a "long" in-flight vessel
+	// (relative to upgradeInterval) and returns Launched=1. Without the
+	// overdue pause, this would keep in_flight > 0 indefinitely and the
+	// normal upgrade path would never fire.
+	drain := func(_ context.Context) (runner.DrainResult, error) {
+		drainCalls.Add(1)
+		// Each vessel lasts ~50ms. Drain interval is 5ms, so without pause
+		// the tracker stays above zero for the entire test window.
+		tracker.Start(50 * time.Millisecond)
+		return runner.DrainResult{Launched: 1}, nil
+	}
+
+	upgrade := func() {
+		upgradeSeen.Add(1)
+	}
+
+	// upgradeInterval=5ms → overdue threshold = 15ms. Drain interval=5ms so
+	// drain is triggered frequently. The tracker starts a 50ms vessel on
+	// each drain call, but once upgrade is overdue (>15ms elapsed), drain
+	// should be paused — no new tracker.Start calls — allowing the existing
+	// in-flight vessels to complete, which then lets upgrade fire.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, time.Hour, 5*time.Millisecond, 5*time.Millisecond)
+	require.NoError(t, err)
+
+	// Upgrade MUST have fired at least once despite the continuously saturating drain.
+	// Previously this would have been 0 because in_flight never reached 0 naturally.
+	assert.GreaterOrEqual(t, upgradeSeen.Load(), int32(1),
+		"upgrade must fire via overdue-pause path even when drain is saturating")
+	// Drain must have been invoked multiple times before the pause kicked in.
+	assert.GreaterOrEqual(t, drainCalls.Load(), int32(1),
+		"drain must have been called at least once")
+}
+
+// TestDaemonLoopUpgradeOverdueDoesNotFireUnderNormalConditions verifies that
+// the overdue path does NOT trigger under normal conditions where upgrade
+// fires naturally on the idle path.
+func TestDaemonLoopUpgradeOverdueDoesNotFireUnderNormalConditions(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	tracker := &trackerStub{}
+
+	var (
+		upgradeSeen atomic.Int32
+	)
+
+	// Idle drain: no vessels ever started, so in_flight stays at 0 and
+	// the normal upgrade path fires on every cycle.
+	drain := func(_ context.Context) (runner.DrainResult, error) {
+		return runner.DrainResult{}, nil
+	}
+	upgrade := func() {
+		upgradeSeen.Add(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// upgradeInterval=2ms; over 100ms, normal path should fire many times.
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, time.Hour, 2*time.Millisecond, 2*time.Millisecond)
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, upgradeSeen.Load(), int32(5),
+		"normal-path upgrade should fire multiple times under idle conditions")
+}
+
 func TestParseUpgradeInterval(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

Fixes a critical auto-upgrade deadlock where scheduled sources keeping concurrency slots continuously full would permanently lock the daemon on its current binary. Observed in production on 2026-04-09 loop 8 — daemon ran **1h55m without a single upgrade attempt** despite 4 new merges (#175, #176, #177, #180) sitting in origin/main ready for pickup.

## Root cause

\`cli/cmd/xylem/daemon.go:234-240\` requires \`in_flight == 0\` AND \`draining == 0\` for the auto-upgrade path to fire. Since PR #173 made drain ticks non-blocking (drain returns even with in-flight vessels), and PR #177's scheduled-vessel source continuously creates work (unblock-wave → resolve-conflicts → merge-pr cascades on every merge), \`in_flight\` never drops to zero naturally. The normal upgrade path waits forever.

## Fix

Add an **overdue escape hatch** at \`3 * upgradeInterval\` (default 15m):

- When upgrade has been pending for that long AND \`in_flight > 0\`, pause new drain dequeues.
- Paused dequeue allows in-flight vessels to complete naturally without the scheduled source backfilling slots.
- Once \`in_flight\` reaches zero, the normal upgrade path fires on the next tick.

### Safety properties preserved

- **No exec() while subprocesses are alive**: the overdue path does NOT fire upgrade directly — it only pauses dequeue. Upgrade still fires only via the normal path (\`in_flight == 0\`).
- **No latency regression**: under normal idle-cycling conditions, the normal path fires with zero impact.
- **Bounded delay**: overdue threshold is 15m + longest in-flight vessel's remaining runtime.

## Changes

- \`daemon.go\`: compute upgrade state once per tick (upgradePending/Overdue, drainIdle, inFlight), log overdue pause, skip drain dequeue while overdue.
- New const \`upgradeOverdueMultiplier = 3\` with rationale.
- Updated \`daemonLoop\` doc comment for both paths.

## Regression tests

- **\`TestDaemonLoopUpgradeOverduePausesDrainToCreateIdleWindow\`**: saturating drain with 50ms vessels; asserts upgrade fires at least once via the overdue-pause path.
- **\`TestDaemonLoopUpgradeOverdueDoesNotFireUnderNormalConditions\`**: idle drain; asserts normal path fires >=5 times in 100ms (overdue path should not interfere with healthy cycling).
- Existing tests still pass: \`TestDaemonLoopPeriodicUpgradeFiresAtDrainEnd\`, \`TestDaemonLoopPeriodicUpgradeRespectsInterval\`, \`TestDaemonLoopPeriodicUpgradeNilDisables\`, \`TestDaemonLoopUpgradeWaitsForDrainCompletion\`, \`TestSmoke_S35\`, \`TestSmoke_S36\`.

## Test plan

- [x] \`go build ./cmd/xylem\`
- [x] \`go test ./...\` (all packages green)
- [x] \`go vet ./...\`
- [x] \`goimports -l .\` (empty)
- [x] \`golangci-lint run\` (0 issues)
- [ ] **Post-merge**: daemon restart (manual, since the currently-running daemon is the locked one) will pick up this fix + all 4 other merged PRs (#175/176/177/180). Future saturation deadlocks will self-resolve via the overdue path.

## Important note on deployment

**The currently-running daemon cannot auto-pick-up this fix** — it's the very daemon exhibiting the deadlock. When the user (@hnipps) next interacts, the daemon will need to be manually restarted (\`xylem daemon\`) to get off the pre-#180 binary and onto the new one containing this fix + #180's pre-verify restore + #175/#176/#177.

After that manual restart, the daemon is self-healing: future saturation deadlocks trigger the overdue path automatically.

## Not addressed

The scheduled-source additive protected-surface violations (vessel creating new \`.xylem/workflows/*.yaml\` files) are a separate bug — filed as a follow-up issue.

## Related

- #169 (env propagation, loop 3)
- #172 (protected surface self-heal, loop 4)
- #173 (drain concurrency, loop 5/6) — root cause of the saturation-exit bypass
- #180 (pre-verify restore, loop 7)
- Loop 8 diagnosis showed auto-upgrade silent for 1h55m on production daemon

Filed autonomously by the hourly /xylem-status rescue loop on 2026-04-09 (loop 8).