### PR TITLE
Allow workflow-scoped additive writes under protected .xylem surfaces

### DIFF
--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -2150,6 +2150,11 @@ func (r *Runner) verifyProtectedSurfaces(vessel queue.Vessel, p workflow.Phase, 
 	}
 
 	violations := surface.Compare(before, after)
+	allowAdditive, err := r.workflowAllowsAdditiveProtectedWrites(vessel, violations)
+	if err != nil {
+		return fmt.Errorf("resolve protected surface policy: %w", err)
+	}
+	violations = filterAdditiveProtectedSurfaceViolations(violations, allowAdditive)
 	if len(violations) == 0 {
 		return nil
 	}
@@ -2162,6 +2167,45 @@ func (r *Runner) verifyProtectedSurfaces(vessel queue.Vessel, p workflow.Phase, 
 		log.Printf("%sphase %q protected surface self-heal failed: %v", vesselLabel(vessel), p.Name, err)
 	}
 	return fmt.Errorf("%s", errMsg)
+}
+
+func (r *Runner) workflowAllowsAdditiveProtectedWrites(vessel queue.Vessel, violations []surface.Violation) (bool, error) {
+	if !containsAdditiveProtectedSurfaceViolation(violations) {
+		return false, nil
+	}
+	if strings.TrimSpace(vessel.Workflow) == "" {
+		return false, nil
+	}
+
+	sk, err := r.loadWorkflow(vessel.Workflow)
+	if err != nil {
+		return false, fmt.Errorf("load workflow %q: %w", vessel.Workflow, err)
+	}
+	return sk.AllowAdditiveProtectedWrites, nil
+}
+
+func containsAdditiveProtectedSurfaceViolation(violations []surface.Violation) bool {
+	for _, violation := range violations {
+		if violation.Before == "absent" {
+			return true
+		}
+	}
+	return false
+}
+
+func filterAdditiveProtectedSurfaceViolations(violations []surface.Violation, allowAdditive bool) []surface.Violation {
+	if !allowAdditive || len(violations) == 0 {
+		return violations
+	}
+
+	filtered := make([]surface.Violation, 0, len(violations))
+	for _, violation := range violations {
+		if violation.Before == "absent" {
+			continue
+		}
+		filtered = append(filtered, violation)
+	}
+	return filtered
 }
 
 func (r *Runner) protectedSurfaceSourceRoot(ctx context.Context, worktreePath string) (string, error) {

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +18,42 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"pgregory.net/rapid"
 )
+
+func TestProp_FilterAdditiveProtectedSurfaceViolationsDropsOnlyAdditions(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		allowAdditive := rapid.Bool().Draw(t, "allowAdditive")
+		count := rapid.IntRange(0, 12).Draw(t, "count")
+
+		violations := make([]surface.Violation, 0, count)
+		want := make([]surface.Violation, 0, count)
+		for i := range count {
+			before := rapid.SampledFrom([]string{
+				"absent",
+				"deleted",
+				"aaaaaaaaaaaaaaaa",
+				"bbbbbbbbbbbbbbbb",
+			}).Draw(t, fmt.Sprintf("before-%d", i))
+			violation := surface.Violation{
+				Path:   fmt.Sprintf(".xylem/generated/%d.yaml", i),
+				Before: before,
+				After: rapid.SampledFrom([]string{
+					"deleted",
+					"1111111111111111",
+					"2222222222222222",
+				}).Draw(t, fmt.Sprintf("after-%d", i)),
+			}
+			violations = append(violations, violation)
+			if !allowAdditive || violation.Before != "absent" {
+				want = append(want, violation)
+			}
+		}
+
+		got := filterAdditiveProtectedSurfaceViolations(violations, allowAdditive)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("filterAdditiveProtectedSurfaceViolations() = %#v, want %#v", got, want)
+		}
+	})
+}
 
 func TestProp_BudgetEnforcementNeverLeaksAcrossVessels(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -5413,6 +5413,97 @@ func TestVerifyProtectedSurfacesStillCatchesModificationsAfterPreVerifyRestore(t
 	}
 }
 
+func TestSmoke_S21_SurfacePostVerificationAllowsOptedInAdditiveWrites(t *testing.T) {
+	repoRoot := t.TempDir()
+	withTestWorkingDir(t, repoRoot)
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".xylem", "workflows"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".xylem", "prompts", "doctor"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".xylem", "prompts", "doctor", "analyze.md"), []byte("analyze"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".xylem", "workflows", "doctor.yaml"), []byte(`name: doctor
+allow_additive_protected_writes: true
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/doctor/analyze.md
+    max_turns: 1
+`), 0o644))
+
+	worktreeDir := filepath.Join(repoRoot, "worktree")
+	require.NoError(t, os.MkdirAll(worktreeDir, 0o755))
+
+	cfg := makeTestConfig(repoRoot, 1)
+	cfg.StateDir = filepath.Join(repoRoot, ".xylem-state")
+	require.NoError(t, os.MkdirAll(cfg.StateDir, 0o755))
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	r := New(cfg, queue.New(filepath.Join(repoRoot, "queue.jsonl")), &mockWorktree{path: worktreeDir}, &mockCmdRunner{})
+	r.AuditLog = auditLog
+
+	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), worktreeDir)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, os.MkdirAll(filepath.Join(worktreeDir, ".xylem", "workflows"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeDir, ".xylem", "workflows", "doctor.yaml"), []byte("name: doctor\n"), 0o644))
+
+	err = r.verifyProtectedSurfaces(
+		queue.Vessel{ID: "issue-additive-allowed", Source: "manual", Workflow: "doctor"},
+		workflow.Phase{Name: "implement"},
+		worktreeDir,
+		before,
+	)
+	require.NoError(t, err)
+
+	entries, err := auditLog.Entries()
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestSmoke_S23_AuditLogRecordsDeniedAdditiveProtectedWriteWithoutWorkflowOptIn(t *testing.T) {
+	repoRoot := t.TempDir()
+	withTestWorkingDir(t, repoRoot)
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".xylem", "workflows"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".xylem", "prompts", "doctor"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".xylem", "prompts", "doctor", "analyze.md"), []byte("analyze"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".xylem", "workflows", "doctor.yaml"), []byte(`name: doctor
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/doctor/analyze.md
+    max_turns: 1
+`), 0o644))
+
+	worktreeDir := filepath.Join(repoRoot, "worktree")
+	require.NoError(t, os.MkdirAll(worktreeDir, 0o755))
+
+	cfg := makeTestConfig(repoRoot, 1)
+	cfg.StateDir = filepath.Join(repoRoot, ".xylem-state")
+	require.NoError(t, os.MkdirAll(cfg.StateDir, 0o755))
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	r := New(cfg, queue.New(filepath.Join(repoRoot, "queue.jsonl")), &mockWorktree{path: worktreeDir}, &mockCmdRunner{})
+	r.AuditLog = auditLog
+
+	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), worktreeDir)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, os.MkdirAll(filepath.Join(worktreeDir, ".xylem", "workflows"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeDir, ".xylem", "workflows", "doctor.yaml"), []byte("name: doctor\n"), 0o644))
+
+	err = r.verifyProtectedSurfaces(
+		queue.Vessel{ID: "issue-additive-denied", Source: "manual", Workflow: "doctor"},
+		workflow.Phase{Name: "implement"},
+		worktreeDir,
+		before,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "violated protected surfaces")
+	assert.Contains(t, err.Error(), ".xylem/workflows/doctor.yaml")
+	assert.Contains(t, err.Error(), "before: absent")
+
+	entries, err := auditLog.Entries()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "file_write", entries[0].Intent.Action)
+	assert.Equal(t, ".xylem/workflows/doctor.yaml", entries[0].Intent.Resource)
+	assert.Equal(t, intermediary.Deny, entries[0].Decision)
+}
+
 // TestCopyProtectedSurfaceFileAddsWorktreeExcludeEntry verifies that the
 // pre-verify restore's copyProtectedSurfaceFile helper appends the restored
 // path to .git/info/exclude, so subsequent `git add -A` in the push phase

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -19,11 +19,12 @@ var validPhaseName = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 // Workflow defines a multi-phase execution plan loaded from a YAML file.
 type Workflow struct {
-	Name        string  `yaml:"name"`
-	Description string  `yaml:"description,omitempty"`
-	LLM         *string `yaml:"llm,omitempty"`
-	Model       *string `yaml:"model,omitempty"`
-	Phases      []Phase `yaml:"phases"`
+	Name                         string  `yaml:"name"`
+	Description                  string  `yaml:"description,omitempty"`
+	LLM                          *string `yaml:"llm,omitempty"`
+	Model                        *string `yaml:"model,omitempty"`
+	AllowAdditiveProtectedWrites bool    `yaml:"allow_additive_protected_writes,omitempty"`
+	Phases                       []Phase `yaml:"phases"`
 }
 
 // Phase represents a single step in a workflow's execution pipeline.

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -188,6 +188,41 @@ phases:
 	assert.Equal(t, "", e.TrustBoundary)
 }
 
+func TestLoadWorkflowAllowAdditiveProtectedWritesDefaultsFalse(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	assert.False(t, got.AllowAdditiveProtectedWrites)
+}
+
+func TestLoadWorkflowAllowAdditiveProtectedWritesParsesTrue(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+allow_additive_protected_writes: true
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	assert.True(t, got.AllowAdditiveProtectedWrites)
+}
+
 func TestLoadWorkflowGateWithEvidenceAndEmptyLevel(t *testing.T) {
 	dir := t.TempDir()
 	chdirTemp(t, dir)
@@ -266,6 +301,7 @@ phases:
 			workflowName: "deploy",
 			yaml: `name: deploy
 description: Deploy with gates
+allow_additive_protected_writes: true
 phases:
   - name: build
     prompt_file: prompts/build.md
@@ -290,6 +326,9 @@ phases:
 				t.Helper()
 				if s.Phases[0].Gate.Type != "command" {
 					t.Fatalf("gate type = %q, want command", s.Phases[0].Gate.Type)
+				}
+				if !s.AllowAdditiveProtectedWrites {
+					t.Fatal("AllowAdditiveProtectedWrites = false, want true")
 				}
 				if s.Phases[0].Gate.Retries != 2 {
 					t.Fatalf("gate retries = %d, want 2", s.Phases[0].Gate.Retries)


### PR DESCRIPTION
## Summary

Implements [issue #185](https://github.com/nicholls-inc/xylem/issues/185) by allowing workflows to opt into legitimate additive writes under protected `.xylem/` paths while continuing to deny protected-surface mutations and non-opted-in additive writes.

## Smoke scenarios covered

- `S21` — Surface post-verification detects mutation — vessel fails
- `S23` — Audit log records surface violations

## Changes summary

- **Modified:** `cli/internal/workflow/workflow.go` — added `workflow.Workflow.AllowAdditiveProtectedWrites` with YAML field `allow_additive_protected_writes`.
- **Modified:** `cli/internal/runner/runner.go` — updated `(*Runner).verifyProtectedSurfaces`; added `(*Runner).workflowAllowsAdditiveProtectedWrites`, `containsAdditiveProtectedSurfaceViolation`, and `filterAdditiveProtectedSurfaceViolations`.
- **Modified:** `cli/internal/workflow/workflow_test.go` — added workflow load/parse coverage for the new opt-in flag.
- **Modified:** `cli/internal/runner/runner_test.go` — added regression coverage for opted-in additive writes and deny-path audit logging when the opt-in is absent.
- **Modified:** `cli/internal/runner/runner_prop_test.go` — added a property test proving additive filtering only drops additive violations.

## Test plan

- `cd cli && goimports -w .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #185