### PR TITLE
fix: runner: suppress protected-surface modifications that align with source root

### DIFF
--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -2155,6 +2155,43 @@ func (r *Runner) verifyProtectedSurfaces(vessel queue.Vessel, p workflow.Phase, 
 		return fmt.Errorf("resolve protected surface policy: %w", err)
 	}
 	violations = filterAdditiveProtectedSurfaceViolations(violations, allowAdditive)
+
+	// Source-root alignment filter: drop modification violations where the
+	// after-hash matches the canonical source root's current hash for that
+	// path. This handles the resolve-conflicts cascade where the phase runs
+	// `git merge origin/main --no-commit` on a PR branch that predates the
+	// .xylem/ control-plane tracking commit (#157). The merge brings the PR
+	// branch's view of .xylem/ files INTO ALIGNMENT with main's canonical
+	// state — exactly the outcome the control plane wants. Flagging this as
+	// a violation blocks PR #143, PR #164, and any other PR cut from a
+	// pre-#157 commit that needs a conflict resolution merge.
+	//
+	// Rationale: the protected-surface policy exists to prevent vessels
+	// from DIVERGING the control plane from its canonical state. A
+	// modification that CONVERGES to the canonical state is the opposite —
+	// it's the intended normalization. We suppress it and log for audit.
+	//
+	// This does NOT mask legitimate violations where the agent modifies a
+	// file to some other content (neither the branch's original hash nor
+	// the canonical source root's hash): those still raise violations.
+	//
+	// GUARD: we only apply the filter when the source root is DIFFERENT
+	// from the worktree path. If they're the same (as in tests where
+	// `git rev-parse --git-common-dir` fails and the helper falls back to
+	// returning worktreePath), the source snapshot would be the same as
+	// the after snapshot — every modification would "align" and every
+	// violation would be suppressed. The existing SuppressesTransient /
+	// StillCatchesMutation tests would break. Requiring a distinct source
+	// root ensures we only suppress real merge-alignment cases.
+	//
+	// Source snapshot uses context.Background() because the vessel's ctx
+	// may be cancelling; the snapshot is a fast read-only filesystem walk.
+	if sourceRoot, srcErr := r.protectedSurfaceSourceRoot(context.Background(), worktreePath); srcErr == nil && sourceRoot != worktreePath {
+		if sourceSnapshot, sErr := surface.TakeSnapshot(sourceRoot, patterns); sErr == nil {
+			violations = filterViolationsAlignedWithSourceRoot(vessel, p, violations, sourceSnapshot)
+		}
+	}
+
 	if len(violations) == 0 {
 		return nil
 	}
@@ -2204,6 +2241,57 @@ func filterAdditiveProtectedSurfaceViolations(violations []surface.Violation, al
 			continue
 		}
 		filtered = append(filtered, violation)
+	}
+	return filtered
+}
+
+// filterViolationsAlignedWithSourceRoot drops modification violations whose
+// after-hash exactly matches the canonical source root's current hash for
+// that path. See the extended comment at the call site in verifyProtectedSurfaces
+// for rationale.
+//
+// A violation is suppressed if ALL of:
+//   - it has a real before-hash (not "absent" — those are additions, handled
+//     separately by filterAdditiveProtectedSurfaceViolations)
+//   - it has a real after-hash (not "deleted" — those are handled by the
+//     post-phase self-heal and pre-verify restore code paths)
+//   - the path exists in the source snapshot
+//   - the after-hash exactly equals the source snapshot's hash for that path
+//
+// All other violations pass through unchanged, preserving detection of
+// rogue modifications and any deletion/addition patterns that weren't
+// already covered upstream.
+func filterViolationsAlignedWithSourceRoot(vessel queue.Vessel, p workflow.Phase, violations []surface.Violation, sourceSnapshot surface.Snapshot) []surface.Violation {
+	if len(violations) == 0 {
+		return violations
+	}
+	sourceHashByPath := make(map[string]string, len(sourceSnapshot.Files))
+	for _, f := range sourceSnapshot.Files {
+		sourceHashByPath[f.Path] = f.Hash
+	}
+	filtered := make([]surface.Violation, 0, len(violations))
+	for _, v := range violations {
+		if v.Before == "absent" || v.After == "deleted" {
+			// Not a modification — pass through (additions and deletions
+			// are handled by other filters / self-heal paths).
+			filtered = append(filtered, v)
+			continue
+		}
+		sourceHash, ok := sourceHashByPath[v.Path]
+		if !ok {
+			// Path not tracked in source root — can't determine alignment,
+			// preserve as violation to be safe.
+			filtered = append(filtered, v)
+			continue
+		}
+		if v.After == sourceHash {
+			// Modification brings file INTO ALIGNMENT with canonical source.
+			// Suppress and log for audit visibility.
+			log.Printf("%sphase %q: suppressing alignment violation on %s (after-hash matches source root)",
+				vesselLabel(vessel), p.Name, v.Path)
+			continue
+		}
+		filtered = append(filtered, v)
 	}
 	return filtered
 }

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -5671,6 +5671,171 @@ func TestVerifyProtectedSurfacesStillCatchesMutualDeletion(t *testing.T) {
 	}
 }
 
+// TestVerifyProtectedSurfacesSuppressesAlignmentModifications documents the
+// loop 9 fix for the final Fix B cascade: when a resolve-conflicts vessel
+// runs `git merge origin/main --no-commit` on a pre-#157 PR branch, the
+// protected prompts get updated from the branch's old content to main's
+// canonical content. The verifier previously flagged this as a modification
+// violation (b72aa068 → 1d19afcf), blocking PR #143 and #164 from ever
+// resolving. This test verifies the alignment filter suppresses such
+// violations when the after-hash matches the source root's current hash.
+func TestVerifyProtectedSurfacesSuppressesAlignmentModifications(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeDir := filepath.Join(repoRoot, ".claude", "worktrees", "review", "pr-align")
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.git) = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(worktreeDir, ".git", "info"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(worktree .git) = %v", err)
+	}
+
+	// Source root has the NEW (canonical) version of the protected file.
+	canonicalContent := []byte("# hardened prompt (PR #172 version)\n")
+	if err := os.WriteFile(filepath.Join(repoRoot, ".xylem.yml"), canonicalContent, 0o644); err != nil {
+		t.Fatalf("WriteFile source = %v", err)
+	}
+
+	// Worktree starts with the OLD version (simulating a PR branch cut before #172).
+	oldContent := []byte("# old prompt (pre-#172 version)\n")
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".xylem.yml"), oldContent, 0o644); err != nil {
+		t.Fatalf("WriteFile worktree = %v", err)
+	}
+
+	cfg := makeTestConfig(repoRoot, 1)
+	cfg.StateDir = filepath.Join(repoRoot, ".xylem-state")
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	cmdRunner := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name == "git" && len(args) >= 5 && args[2] == "rev-parse" && args[4] == "--git-common-dir" {
+				return []byte(filepath.Join(repoRoot, ".git")), nil, true
+			}
+			return nil, nil, false
+		},
+	}
+	r := New(cfg, queue.New(filepath.Join(repoRoot, "queue.jsonl")), &mockWorktree{path: worktreeDir}, cmdRunner)
+	r.AuditLog = auditLog
+
+	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), worktreeDir)
+	if err != nil || !ok {
+		t.Fatalf("takeProtectedSurfaceSnapshot = %v %v", err, ok)
+	}
+
+	// Phase simulation: git merge origin/main --no-commit updates the file
+	// to match main's version (exactly the source root's content).
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".xylem.yml"), canonicalContent, 0o644); err != nil {
+		t.Fatalf("WriteFile simulated merge = %v", err)
+	}
+
+	// verifyProtectedSurfaces should NOT return a violation — the modification
+	// brought the file into alignment with the source root.
+	err = r.verifyProtectedSurfaces(
+		queue.Vessel{ID: "pr-143-resolve-conflicts-retry", Source: "github-pr", Workflow: "resolve-conflicts"},
+		workflow.Phase{Name: "analyze"},
+		worktreeDir,
+		before,
+	)
+	if err != nil {
+		t.Fatalf("verifyProtectedSurfaces() = %v, want nil (alignment should be suppressed)", err)
+	}
+}
+
+// TestVerifyProtectedSurfacesStillCatchesRogueModifications ensures the
+// alignment filter does NOT mask modifications to content that doesn't
+// match the source root — those are still rogue modifications and should
+// raise violations.
+func TestVerifyProtectedSurfacesStillCatchesRogueModifications(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeDir := filepath.Join(repoRoot, ".claude", "worktrees", "review", "pr-rogue")
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.git) = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(worktreeDir, ".git", "info"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(worktree .git) = %v", err)
+	}
+
+	canonicalContent := []byte("# canonical\n")
+	if err := os.WriteFile(filepath.Join(repoRoot, ".xylem.yml"), canonicalContent, 0o644); err != nil {
+		t.Fatalf("WriteFile source = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".xylem.yml"), canonicalContent, 0o644); err != nil {
+		t.Fatalf("WriteFile worktree = %v", err)
+	}
+
+	cfg := makeTestConfig(repoRoot, 1)
+	cfg.StateDir = filepath.Join(repoRoot, ".xylem-state")
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	cmdRunner := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name == "git" && len(args) >= 5 && args[2] == "rev-parse" && args[4] == "--git-common-dir" {
+				return []byte(filepath.Join(repoRoot, ".git")), nil, true
+			}
+			return nil, nil, false
+		},
+	}
+	r := New(cfg, queue.New(filepath.Join(repoRoot, "queue.jsonl")), &mockWorktree{path: worktreeDir}, cmdRunner)
+	r.AuditLog = auditLog
+
+	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), worktreeDir)
+	if err != nil || !ok {
+		t.Fatalf("takeProtectedSurfaceSnapshot = %v %v", err, ok)
+	}
+
+	// Rogue modification: agent writes content that matches NEITHER the
+	// before state (canonical) NOR any other source-root state.
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".xylem.yml"), []byte("# evil rogue content\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile rogue = %v", err)
+	}
+
+	err = r.verifyProtectedSurfaces(
+		queue.Vessel{ID: "issue-rogue-mod", Source: "github-issue", Workflow: "fix-bug"},
+		workflow.Phase{Name: "implement"},
+		worktreeDir,
+		before,
+	)
+	if err == nil {
+		t.Fatal("verifyProtectedSurfaces() = nil, want violation for rogue modification that does NOT match source root")
+	}
+	if !strings.Contains(err.Error(), "violated protected surfaces") {
+		t.Fatalf("error = %q, want containing 'violated protected surfaces'", err)
+	}
+}
+
+// TestFilterViolationsAlignedWithSourceRootUnit is a focused unit test on the
+// filter helper to verify edge cases: absent Before, deleted After, path not
+// in source snapshot, multi-violation mix.
+func TestFilterViolationsAlignedWithSourceRootUnit(t *testing.T) {
+	source := surface.Snapshot{Files: []surface.FileHash{
+		{Path: ".xylem.yml", Hash: "src-yml-hash"},
+		{Path: ".xylem/workflows/fix-bug.yaml", Hash: "src-wf-hash"},
+	}}
+	violations := []surface.Violation{
+		// Aligned: suppress
+		{Path: ".xylem.yml", Before: "old-yml", After: "src-yml-hash"},
+		// Rogue mod: keep
+		{Path: ".xylem/workflows/fix-bug.yaml", Before: "old-wf", After: "rogue-wf-hash"},
+		// Addition: keep (not a modification, filter passes through)
+		{Path: ".xylem/prompts/new/file.md", Before: "absent", After: "added-hash"},
+		// Deletion: keep (not a modification, filter passes through)
+		{Path: ".xylem/HARNESS.md", Before: "old-harness", After: "deleted"},
+		// Path not in source: keep (can't verify alignment)
+		{Path: ".xylem/workflows/unknown.yaml", Before: "old", After: "new"},
+	}
+	vessel := queue.Vessel{ID: "unit-test", Workflow: "resolve-conflicts"}
+	phase := workflow.Phase{Name: "analyze"}
+
+	filtered := filterViolationsAlignedWithSourceRoot(vessel, phase, violations, source)
+
+	if len(filtered) != 4 {
+		t.Fatalf("filtered count = %d, want 4 (1 aligned suppressed, 4 kept)", len(filtered))
+	}
+	// Ensure the aligned one is NOT in the filtered list
+	for _, v := range filtered {
+		if v.Path == ".xylem.yml" {
+			t.Fatalf("filtered still contains aligned violation on .xylem.yml")
+		}
+	}
+}
+
 func TestSmoke_S19_VesselRunStateIsOwnedByRunVesselOrchestratedNotSharedAcrossGoroutines(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 2)


### PR DESCRIPTION
## Summary

Completes the Fix B cascade chain for PR #143/#164. After loop 7's pre-verify restore (PR #180) handled deletions and loop 8's overdue escape hatch (PR #184) unblocked auto-upgrade, I forced a retry of \`pr-143-resolve-conflicts\` on the fresh binary to validate Fix B in production. It **still failed**:

\`\`\`
phase \"analyze\" violated protected surfaces:
  .xylem/prompts/resolve-conflicts/analyze.md
    (before: b72aa068..., after: 1d19afcf...)
  .xylem/prompts/resolve-conflicts/resolve.md
    (before: 41b7709d..., after: 4f223704...)
\`\`\`

The violation is a **MODIFICATION**, not a deletion. When \`git merge origin/main --no-commit\` runs on PR #143's branch (cut before PR #172's prompt hardening), the merge brings the prompts **into alignment with main's canonical state**. This is the EXPECTED outcome but the verifier flags it as a violation.

## Fix

Add a source-root alignment filter: drop modification violations where \`violation.After\` exactly matches the canonical source root's current hash for that path. The protected-surface policy exists to prevent **divergence** from canonical state — a modification that **converges** to canonical is the opposite and should be allowed.

### Guard against false positives in tests

Only apply the filter when \`sourceRoot != worktreePath\` — otherwise the existing tests (where \`git rev-parse --git-common-dir\` falls back to the worktree path) would have every modification trivially \"align\" with itself, suppressing all violations.

## What this does NOT mask

- **Rogue modifications** (after-hash ≠ source root hash) — still raise violations
- **Deletions** — still handled by pre-verify restore (PR #180)
- **Mutual deletions** — still raise violations
- **Additions** — still handled by workflow-scoped allow-list (PR #186)

## Regression tests (3 new)

- \`TestVerifyProtectedSurfacesSuppressesAlignmentModifications\` — end-to-end acid test simulation
- \`TestVerifyProtectedSurfacesStillCatchesRogueModifications\` — non-regression on rogue content
- \`TestFilterViolationsAlignedWithSourceRootUnit\` — focused unit test on edge cases

## Non-regression verified

All existing surface tests still pass:
- \`TestSmoke_S4\`, \`TestSmoke_S20\`, \`TestSmoke_S21\`, \`TestSmoke_S23\` — existing violation detection
- \`TestDrainOrchestratedProtectedSurfaceViolationFails\` — orchestrator path
- \`TestVerifyProtectedSurfacesSuppressesTransientDeletionsViaPreVerifyRestore\` — loop 7
- \`TestVerifyProtectedSurfacesStillCatchesModificationsAfterPreVerifyRestore\` — loop 7
- \`TestVerifyProtectedSurfacesStillCatchesMutualDeletion\` — loop 7

## Test plan

- [x] \`go build ./cmd/xylem\`
- [x] \`go test ./...\` (all packages green)
- [x] \`go vet ./...\`
- [x] \`goimports -l .\` (empty)
- [x] \`golangci-lint run\` (0 issues)
- [ ] **Post-merge**: a fresh \`pr-143-resolve-conflicts\` retry should pass the analyze phase, proceed through resolve + push, and produce a conflict-resolution commit on PR #143's branch. Same for PR #164.

## Unblocks

- **PR #143** (feat/issue-137-137, Pipe daemon logs — 8+ hours stuck)
- **PR #164** (fix/issue-152-152, live-system verification gates)
- Any future PR branches cut before #157 that need conflict resolution

## Related

- #169 (loop 3), #172 (loop 4), #173 (loop 5/6), #180 (loop 7), #184 (loop 8), #186 (autonomous vessel from my loop 8 filing of #185)

Filed autonomously by the hourly /xylem-status rescue loop on 2026-04-09 (loop 9). This is the 6th PR I've shipped this rescue session — the autonomous ecosystem is bidirectional now: I'm filing issues, vessels are picking them up and producing PRs, the daemon is auto-merging, I'm diagnosing the remaining gaps and shipping runner-level fixes.