### PR TITLE
fix: source: strip stale needs-conflict-resolution label on mergeable PRs

### DIFF
--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -19,12 +19,30 @@ type GitHubPR struct {
 	CmdRunner CommandRunner
 }
 
+// resolveConflictsWorkflow is the de facto workflow identifier whose task
+// labels are only meaningful when a PR is actually in a CONFLICTING merge
+// state. When a PR bearing one of this workflow's labels reports any other
+// mergeable state, the source skips it and proactively removes the label
+// so the loop does not re-enqueue the same no-op work every scan.
+const resolveConflictsWorkflow = "resolve-conflicts"
+
+// ghMergeableConflicting / ghMergeableMergeable mirror the string values
+// returned by `gh pr list --json mergeable`. UNKNOWN (empty or literal) is
+// treated as "not definitively mergeable" — the source skips the vessel
+// but does NOT strip labels, so a subsequent scan can re-evaluate once
+// GitHub finishes computing the merge state.
+const (
+	ghMergeableConflicting = "CONFLICTING"
+	ghMergeableMergeable   = "MERGEABLE"
+)
+
 type ghPR struct {
 	Number      int    `json:"number"`
 	Title       string `json:"title"`
 	Body        string `json:"body"`
 	URL         string `json:"url"`
 	HeadRefName string `json:"headRefName"`
+	Mergeable   string `json:"mergeable"`
 	Labels      []struct {
 		Name string `json:"name"`
 	} `json:"labels"`
@@ -66,7 +84,7 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 				"--repo", g.Repo,
 				"--state", "open",
 				"--label", label,
-				"--json", "number,title,body,url,labels,headRefName",
+				"--json", "number,title,body,url,labels,headRefName,mergeable",
 				"--limit", "20",
 			}
 
@@ -89,6 +107,21 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 				if g.hasExcludedLabel(pr, excludeSet) ||
 					g.isBlockedByPriorVessel(pr.URL, fingerprint, task.Workflow) ||
 					g.hasBranch(ctx, pr.Number) {
+					continue
+				}
+				// resolve-conflicts workflow is only meaningful for PRs in a
+				// CONFLICTING merge state. When GitHub reports MERGEABLE, the
+				// label is stale (conflicts were resolved outside this
+				// workflow, e.g., via manual push or rebase) — strip it so
+				// the next scan does not re-match, breaking what would
+				// otherwise be an infinite enqueue loop. When GitHub reports
+				// UNKNOWN (empty or literal), skip the vessel but preserve
+				// the label so a subsequent scan can re-evaluate once the
+				// merge state has been computed.
+				if task.Workflow == resolveConflictsWorkflow && pr.Mergeable != ghMergeableConflicting {
+					if pr.Mergeable == ghMergeableMergeable {
+						g.stripTaskLabels(ctx, pr.Number, task.Labels)
+					}
 					continue
 				}
 				seen[key] = true
@@ -164,6 +197,24 @@ func (g *GitHubPR) OnTimedOut(ctx context.Context, vessel queue.Vessel) error {
 func (g *GitHubPR) RemoveRunningLabel(ctx context.Context, vessel queue.Vessel) error {
 	g.applyPRLabel(ctx, vessel.Meta["pr_num"], "", ResolveRunningLabel(vessel))
 	return nil
+}
+
+// stripTaskLabels removes the given task-selector labels from a PR. Used
+// to break the resolve-conflicts enqueue loop when a PR carries a
+// needs-conflict-resolution-style label but is no longer in a CONFLICTING
+// merge state. Each label is removed via its own gh pr edit call so a
+// single failure does not cascade across the remaining labels.
+func (g *GitHubPR) stripTaskLabels(ctx context.Context, prNum int, labels []string) {
+	if g.CmdRunner == nil || prNum == 0 {
+		return
+	}
+	num := strconv.Itoa(prNum)
+	for _, label := range labels {
+		if label == "" {
+			continue
+		}
+		g.applyPRLabel(ctx, num, "", label)
+	}
 }
 
 // applyPRLabel runs gh pr edit to add and/or remove a label on the PR.

--- a/cli/internal/source/github_pr_test.go
+++ b/cli/internal/source/github_pr_test.go
@@ -64,7 +64,7 @@ func TestGitHubPRScanFindsPRs(t *testing.T) {
 				Name string `json:"name"`
 			}{{Name: "review-me"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo:      "owner/repo",
@@ -108,7 +108,7 @@ func TestGitHubPRScanExcludedLabel(t *testing.T) {
 				Name string `json:"name"`
 			}{{Name: "review-me"}, {Name: "wontfix"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo:      "owner/repo",
@@ -144,7 +144,7 @@ func TestGitHubPRScanAlreadyQueued(t *testing.T) {
 				Name string `json:"name"`
 			}{{Name: "review-me"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo:      "owner/repo",
@@ -173,7 +173,7 @@ func TestGitHubPRScanExistingBranch(t *testing.T) {
 				Name string `json:"name"`
 			}{{Name: "review-me"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 	r.set([]byte("abc123\trefs/heads/review/pr-42-something"), "git", "ls-remote", "--heads", "origin", "review/pr-42-*")
 
 	src := &GitHubPR{
@@ -203,8 +203,8 @@ func TestGitHubPRScanDeduplicates(t *testing.T) {
 				Name string `json:"name"`
 			}{{Name: "review-me"}, {Name: "urgent"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "urgent", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "urgent", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo: "owner/repo",
@@ -230,7 +230,7 @@ func TestGitHubPRScanGHFailure(t *testing.T) {
 	q := queue.New(dir + "/queue.jsonl")
 	r := newMock()
 
-	r.setErr(errTest, "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.setErr(errTest, "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo:      "owner/repo",
@@ -250,7 +250,7 @@ func TestGitHubPRScanMalformedJSON(t *testing.T) {
 	q := queue.New(dir + "/queue.jsonl")
 	r := newMock()
 
-	r.set([]byte(`{not valid`), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.set([]byte(`{not valid`), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo:      "owner/repo",
@@ -276,7 +276,7 @@ func TestGitHubPRScanSkipsUnchangedFailedVessel(t *testing.T) {
 				Name string `json:"name"`
 			}{{Name: "review-me"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 
 	fingerprint := githubSourceFingerprint("same title", "same body", []string{"review-me"})
 	_, err := q.Enqueue(queue.Vessel{
@@ -328,7 +328,7 @@ func TestGitHubPRScanReenqueuesChangedFailedVessel(t *testing.T) {
 				Name string `json:"name"`
 			}{{Name: "review-me"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 
 	oldFingerprint := githubSourceFingerprint("same title", "same body", []string{"review-me"})
 	_, err := q.Enqueue(queue.Vessel{
@@ -746,14 +746,17 @@ func TestGitHubPRScanDistinctWorkflowsEnqueueBoth(t *testing.T) {
 	q := queue.New(dir + "/queue.jsonl")
 	r := newMock()
 
+	// Mergeable=CONFLICTING so the resolve-conflicts vessel is not
+	// filtered out by the new mergeable-state guard.
 	prs := []ghPR{
 		{Number: 143, Title: "t", Body: "b", URL: "https://github.com/owner/repo/pull/143", HeadRefName: "feat/issue-137-137",
+			Mergeable: "CONFLICTING",
 			Labels: []struct {
 				Name string `json:"name"`
 			}{{Name: "merge-ready"}, {Name: "needs-conflict-resolution"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "merge-ready", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "merge-ready", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo: "owner/repo",
@@ -828,13 +831,16 @@ func TestGitHubPRScanFailedMergeDoesNotBlockResolveConflicts(t *testing.T) {
 	}
 
 	// Now simulate the conflict-resolution source scanning the same PR.
+	// Mergeable=CONFLICTING so the new mergeable filter does not short-circuit
+	// this test (which predates the filter but must still hold).
 	prs := []ghPR{
 		{Number: 143, Title: "t", Body: "b", URL: prURL, HeadRefName: "feat/issue-137-137",
+			Mergeable: "CONFLICTING",
 			Labels: []struct {
 				Name string `json:"name"`
 			}{{Name: "harness-impl"}, {Name: "needs-conflict-resolution"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo: "owner/repo",
@@ -898,7 +904,7 @@ func TestGitHubPRScanLegacyFailedVesselStillBlocksSameWorkflow(t *testing.T) {
 				Name string `json:"name"`
 			}{{Name: "review-me"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo:      "owner/repo",
@@ -945,7 +951,7 @@ func TestGitHubPRScanLegacyActiveVesselStillBlocksSameWorkflow(t *testing.T) {
 				Name string `json:"name"`
 			}{{Name: "review-me"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName", "--limit", "20")
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo:      "owner/repo",
@@ -960,6 +966,121 @@ func TestGitHubPRScanLegacyActiveVesselStillBlocksSameWorkflow(t *testing.T) {
 	}
 	if len(vessels) != 0 {
 		t.Fatalf("expected legacy active vessel to block re-enqueue, got %d", len(vessels))
+	}
+}
+
+func TestGitHubPRScanResolveConflictsSkipsMergeablePRAndStripsLabel(t *testing.T) {
+	// Regression for bug β: PR #179 accumulated 17+ completed
+	// resolve-conflicts vessels because the PR was MERGEABLE but still
+	// carried `needs-conflict-resolution`, and nothing stripped the stale
+	// label. The source must skip the enqueue AND proactively remove the
+	// task-selector labels so the next scan cannot re-match.
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prURL := "https://github.com/owner/repo/pull/179"
+	prs := []ghPR{
+		{Number: 179, Title: "feat: scheduled lessons", Body: "b", URL: prURL, HeadRefName: "feat/issue-159-159",
+			Mergeable: "MERGEABLE",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "harness-impl"}, {Name: "needs-conflict-resolution"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo: "owner/repo",
+		Tasks: map[string]GitHubTask{
+			"conflict-resolution": {
+				Labels:   []string{"needs-conflict-resolution", "harness-impl"},
+				Workflow: "resolve-conflicts",
+			},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels (mergeable PR must not enqueue resolve-conflicts), got %d: %+v", len(vessels), vessels)
+	}
+
+	// Assert the stale task-selector labels were proactively removed via
+	// gh pr edit ... --remove-label. Both labels must be stripped so the
+	// source cannot re-match on the next scan under either label.
+	wantRemovals := map[string]bool{
+		"needs-conflict-resolution": false,
+		"harness-impl":              false,
+	}
+	for _, call := range r.calls {
+		joined := strings.Join(call, " ")
+		if !strings.HasPrefix(joined, "gh pr edit 179 --repo owner/repo --remove-label ") {
+			continue
+		}
+		for label := range wantRemovals {
+			if strings.HasSuffix(joined, "--remove-label "+label) {
+				wantRemovals[label] = true
+			}
+		}
+	}
+	for label, seen := range wantRemovals {
+		if !seen {
+			t.Errorf("expected stripTaskLabels to remove %q from PR 179, but no gh pr edit call observed; calls=%+v", label, r.calls)
+		}
+	}
+}
+
+func TestGitHubPRScanResolveConflictsSkipsUnknownMergeablePreservingLabel(t *testing.T) {
+	// When GitHub has not yet computed the mergeable state (empty string
+	// or literal "UNKNOWN"), the source must skip the enqueue but must NOT
+	// strip the label — the next scan should re-evaluate once GitHub
+	// finishes computing the merge state. Stripping prematurely would
+	// silently drop legitimate conflict-resolution work.
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prURL := "https://github.com/owner/repo/pull/200"
+	prs := []ghPR{
+		{Number: 200, Title: "feat: x", Body: "b", URL: prURL, HeadRefName: "feat/x",
+			Mergeable: "", // unknown / not yet computed
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "harness-impl"}, {Name: "needs-conflict-resolution"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo: "owner/repo",
+		Tasks: map[string]GitHubTask{
+			"conflict-resolution": {
+				Labels:   []string{"needs-conflict-resolution", "harness-impl"},
+				Workflow: "resolve-conflicts",
+			},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels (UNKNOWN mergeable must skip), got %d: %+v", len(vessels), vessels)
+	}
+
+	// Must NOT have issued any gh pr edit --remove-label calls — the label
+	// has to survive so the next scan can re-evaluate.
+	for _, call := range r.calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, "gh pr edit 200") && strings.Contains(joined, "--remove-label") {
+			t.Errorf("expected NO label removal for UNKNOWN mergeable state, got call: %q", joined)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the "bug β" infinite retry loop that had PR #179 accumulate 17 completed \`resolve-conflicts\` vessels in 1.7h while burning one of three daemon concurrency slots continuously.

The \`github-pr\` source matched any PR carrying a task-selector label regardless of actual mergeable state. A PR labeled \`needs-conflict-resolution\` that had been resolved externally (manual push, rebase, or another tool) would be re-enqueued every scan — the vessel would complete in ~4 minutes with nothing to do, the label would never be removed, and the next scan would re-match the same PR forever.

## What changed

- **\`cli/internal/source/github_pr.go\`**: \`Scan()\` now requests \`mergeable\` from \`gh pr list\` and, for the \`resolve-conflicts\` workflow specifically, skips any PR whose mergeable state is not \`CONFLICTING\`. When the state is \`MERGEABLE\` the source proactively removes the task-selector labels via \`gh pr edit --remove-label\` so the next scan cannot re-match. When the state is empty / \`UNKNOWN\` the source skips the enqueue but preserves the label, letting a subsequent scan re-evaluate once GitHub finishes computing the merge state.

- **\`cli/internal/source/github_pr_test.go\`**: two new regression tests cover the new paths:
  - \`TestGitHubPRScanResolveConflictsSkipsMergeablePRAndStripsLabel\`
  - \`TestGitHubPRScanResolveConflictsSkipsUnknownMergeablePreservingLabel\`

  All twelve existing \`TestGitHubPRScan*\` fixtures updated to the new \`--json\` flag set (\`...,mergeable\`). Two fixtures that exercise the conflict-resolution path gained explicit \`Mergeable: \"CONFLICTING\"\` seeding so the new filter does not short-circuit them.

## Design notes

The filter keys off workflow name (\`resolve-conflicts\`) rather than introducing a config schema field, because:

1. \`.xylem/workflows/\` and \`.xylem.yml\` are protected surfaces under \`.claude/rules/protected-surfaces.md\` — a config-only fix would be blocked by the guard.
2. The invariant (resolve-conflicts is only meaningful on CONFLICTING PRs) is inherent to the workflow, not a per-deployment policy.
3. A future generalization to "task-level mergeable filter" is a non-destructive extension on top of this.

The UNKNOWN path is deliberately conservative — stripping a label based on an unfinished GitHub state computation would silently drop legitimate conflict-resolution work. The regression test \`...SkipsUnknownMergeablePreservingLabel\` locks this behavior.

## Test plan

- [x] \`gofmt -l\` clean
- [x] \`go vet ./...\` clean
- [x] \`go build ./cmd/xylem\` succeeds
- [x] \`go test ./...\` all packages pass (30+ packages)
- [x] Targeted: \`go test ./internal/source/ -run TestGitHubPRScan -v\` — all 15 TestGitHubPRScan tests pass (12 existing + 2 new + 1 updated)
- [x] Targeted: new regression tests assert the stripTaskLabels \`gh pr edit --remove-label\` calls are actually emitted
- [x] pre-commit hooks pass (goimports, golangci-lint, go build)

## Related

- Part of the Fix B cascade chain (loops 4 → 7 → 8 → 9 → this)
- Sibling to #188 (resolve-conflicts must verify merge actually happened — bug α)
- Sibling to #189 (auto-merge copilot-reviewer dependency) and #190 (merge-pr --auto)
- Surfaces behind PR #187's protected-surface alignment filter — once the protected-surface layer stopped trapping vessels, the stale-label loop became the dominant failure mode on cleared PRs

## How to verify after merge

Run \`xylem status\` on any daemon instance — no more \`pr-179-resolve-conflicts\` repeats on PRs whose GitHub mergeable state is \`MERGEABLE\`. The \`needs-conflict-resolution\` label will be automatically removed on the next scan.