### PR TITLE
Enable GitHub auto-merge when copilot review requests are blocked

### DIFF
--- a/cli/cmd/xylem/automerge.go
+++ b/cli/cmd/xylem/automerge.go
@@ -18,10 +18,15 @@ var xylemBranchPattern = regexp.MustCompile(`^(feat|fix|chore)/issue-\d+`)
 // copilotReviewerLogin is the GitHub bot that performs automated code review.
 const copilotReviewerLogin = "copilot-pull-request-reviewer"
 
+const (
+	harnessImplLabel  = "harness-impl"
+	readyToMergeLabel = "ready-to-merge"
+)
+
 // conflictResolutionLabels are the labels that trigger the resolve-conflicts
 // workflow via the conflict-resolution github-pr source. Auto-merge adds
 // these to any CONFLICTING xylem PR so the workflow picks it up.
-var conflictResolutionLabels = []string{"needs-conflict-resolution", "harness-impl"}
+var conflictResolutionLabels = []string{"needs-conflict-resolution", harnessImplLabel}
 
 // isBenignGhWarning reports whether a gh CLI error is a non-fatal warning
 // that should not block the intended operation. The most common case is the
@@ -50,8 +55,8 @@ func isBenignGhWarning(err error) bool {
 // response. This condition is terminal for a given (repo, reviewer)
 // pair: the reviewer will not spontaneously become a collaborator, so
 // retrying on every drain tick only spams the log. Callers should treat
-// this as "review cannot be requested from this bot; fall through to
-// waiting for an external approval".
+// this as "review cannot be requested from this bot; continue with
+// auto-merge and let branch protection wait for some other approval".
 func isReviewerNotCollaborator(err error) bool {
 	if err == nil {
 		return false
@@ -61,11 +66,12 @@ func isReviewerNotCollaborator(err error) bool {
 
 // prSummary is a minimal projection of `gh pr list` / `gh pr view` output.
 type prSummary struct {
-	Number            int    `json:"number"`
-	HeadRefName       string `json:"headRefName"`
-	Mergeable         string `json:"mergeable"`
-	State             string `json:"state"`
-	ReviewDecision    string `json:"reviewDecision"`
+	Number            int       `json:"number"`
+	HeadRefName       string    `json:"headRefName"`
+	Mergeable         string    `json:"mergeable"`
+	State             string    `json:"state"`
+	ReviewDecision    string    `json:"reviewDecision"`
+	AutoMergeRequest  *struct{} `json:"autoMergeRequest"`
 	StatusCheckRollup []struct {
 		Conclusion string `json:"conclusion"`
 		Status     string `json:"status"`
@@ -98,14 +104,14 @@ func (p prSummary) hasLabel(name string) bool {
 type autoMergeAction int
 
 const (
-	actionSkip             autoMergeAction = iota // not a xylem PR, or skip for other reasons
-	actionRequestReview                           // no reviewer assigned; request copilot review
-	actionWaitForReview                           // review requested but not yet complete
+	actionSkip             autoMergeAction = iota // not a merge-ready xylem PR, or skip for other reasons
+	actionRequestReview                           // request copilot review, then enable auto-merge
 	actionWaitForChecks                           // CI still running
 	actionWaitForMergeable                        // unknown mergeable state (github computing)
 	actionRouteConflict                           // conflicts — add labels so resolve-conflicts workflow picks it up
 	actionAddressReview                           // changes requested; another workflow handles
-	actionMerge                                   // approved + green + mergeable
+	actionEnableAutoMerge                         // enable GitHub auto-merge
+	actionWaitForAutoMerge                        // auto-merge already enabled; wait for GitHub
 )
 
 // decideAutoMergeAction returns the action to take for a given PR. It does
@@ -113,18 +119,18 @@ const (
 // unit-tested.
 //
 // Decision order:
-// 1. Non-xylem branch → skip
+// 1. Non-xylem branch or not merge-ready → skip
 // 2. Closed/merged → skip
 // 3. Conflicts + missing resolve-conflicts labels → add labels (routeConflict)
 // 4. Conflicts + labels already present → wait (workflow handles)
 // 5. Unknown mergeable state → wait (github computing)
 // 6. CI failing/running → wait (fix-pr-checks handles failures)
 // 7. Changes requested → wait (respond-to-pr-review handles)
-// 8. No copilot review requested or submitted → request review
-// 9. Review pending → wait
-// 10. Approved + mergeable + green → merge
+// 8. Auto-merge already enabled → wait for GitHub
+// 9. No copilot review requested or submitted → request review, then enable auto-merge
+// 10. Otherwise enable auto-merge and let branch protection enforce review
 func decideAutoMergeAction(pr prSummary) autoMergeAction {
-	if !xylemBranchPattern.MatchString(pr.HeadRefName) {
+	if !isMergeReadyXylemPR(pr) {
 		return actionSkip
 	}
 	if pr.State != "OPEN" && pr.State != "" {
@@ -135,7 +141,7 @@ func decideAutoMergeAction(pr prSummary) autoMergeAction {
 		// If the PR already has the labels that trigger resolve-conflicts
 		// workflow, just wait — the workflow is (or will be) processing it.
 		// Otherwise, add the labels so the workflow picks it up.
-		if pr.hasLabel("needs-conflict-resolution") && pr.hasLabel("harness-impl") {
+		if pr.hasLabel("needs-conflict-resolution") && pr.hasLabel(harnessImplLabel) {
 			return actionWaitForMergeable
 		}
 		return actionRouteConflict
@@ -150,15 +156,23 @@ func decideAutoMergeAction(pr prSummary) autoMergeAction {
 	if pr.ReviewDecision == "CHANGES_REQUESTED" {
 		return actionAddressReview
 	}
-	if pr.ReviewDecision == "APPROVED" {
-		return actionMerge
+	if autoMergeEnabled(pr) {
+		return actionWaitForAutoMerge
 	}
-	// No decision yet (REVIEW_REQUIRED or empty): check if copilot has been
-	// asked to review. If not, request it.
 	if !copilotReviewRequestedOrSubmitted(pr) {
 		return actionRequestReview
 	}
-	return actionWaitForReview
+	return actionEnableAutoMerge
+}
+
+func isMergeReadyXylemPR(pr prSummary) bool {
+	return xylemBranchPattern.MatchString(pr.HeadRefName) &&
+		pr.hasLabel(readyToMergeLabel) &&
+		pr.hasLabel(harnessImplLabel)
+}
+
+func autoMergeEnabled(pr prSummary) bool {
+	return pr.AutoMergeRequest != nil
 }
 
 // copilotReviewRequestedOrSubmitted returns true if copilot has either been
@@ -194,17 +208,18 @@ func allChecksGreen(pr prSummary) bool {
 
 // autoMergeXylemPRs runs one cycle of the auto-merge loop. For each open PR
 // it decides the appropriate action: request copilot review, wait for an
-// in-progress review/CI/conflict, or merge.
+// in-progress review/CI/conflict, or enable GitHub auto-merge.
 //
 // The existing `respond-to-pr-review`, `fix-pr-checks`, and
 // `resolve-conflicts` workflows handle the intermediate steps via the
 // `github-pr-events` source, so auto-merge only needs to (1) kick off the
-// review cycle and (2) merge when everything is green.
+// review cycle and (2) enable GitHub auto-merge when the PR is otherwise
+// merge-ready.
 //
 // Repo is the GitHub repo slug (e.g., "owner/name"). If empty, gh uses the
 // current directory's origin remote.
 func autoMergeXylemPRs(ctx context.Context, repo string) {
-	prs, err := listOpenPRs(ctx, repo)
+	prs, err := listOpenPRsFn(ctx, repo)
 	if err != nil {
 		log.Printf("daemon: auto-merge: list PRs: %v", err)
 		return
@@ -216,26 +231,24 @@ func autoMergeXylemPRs(ctx context.Context, repo string) {
 		case actionSkip:
 			continue
 		case actionRequestReview:
-			if err := requestCopilotReview(ctx, repo, pr.Number); err != nil {
+			if err := requestCopilotReviewFn(ctx, repo, pr.Number); err != nil {
 				if isBenignGhWarning(err) {
 					log.Printf("daemon: auto-merge: requested copilot review on PR #%d (gh warning ignored): %s", pr.Number, pr.HeadRefName)
-					continue
+				} else if isReviewerNotCollaborator(err) {
+					log.Printf("daemon: auto-merge: PR #%d skipping copilot review request (%q is not a collaborator on %s); enabling auto-merge anyway", pr.Number, copilotReviewerLogin, repo)
+				} else {
+					log.Printf("daemon: auto-merge: PR #%d request review failed: %v; enabling auto-merge anyway", pr.Number, err)
 				}
-				if isReviewerNotCollaborator(err) {
-					// Terminal: the reviewer bot is not a collaborator on
-					// this repo. Retrying every tick cannot succeed, so
-					// fall through to wait-for-review semantics and let
-					// an approval from any other source drive the PR to
-					// actionMerge. Log once per tick for observability.
-					log.Printf("daemon: auto-merge: PR #%d skipping copilot review request (%q is not a collaborator on %s); waiting for external approval", pr.Number, copilotReviewerLogin, repo)
-					continue
-				}
-				log.Printf("daemon: auto-merge: PR #%d request review failed: %v", pr.Number, err)
+			} else {
+				log.Printf("daemon: auto-merge: requested copilot review on PR #%d (%s)", pr.Number, pr.HeadRefName)
+			}
+			if err := enableAutoMergePRFn(ctx, repo, pr.Number); err != nil {
+				log.Printf("daemon: auto-merge: PR #%d enable auto-merge failed: %v", pr.Number, err)
 				continue
 			}
-			log.Printf("daemon: auto-merge: requested copilot review on PR #%d (%s)", pr.Number, pr.HeadRefName)
+			log.Printf("daemon: auto-merge: enabled auto-merge on PR #%d (%s)", pr.Number, pr.HeadRefName)
 		case actionRouteConflict:
-			if err := addPRLabels(ctx, repo, pr.Number, conflictResolutionLabels); err != nil {
+			if err := addPRLabelsFn(ctx, repo, pr.Number, conflictResolutionLabels); err != nil {
 				if isBenignGhWarning(err) {
 					log.Printf("daemon: auto-merge: routed PR #%d to resolve-conflicts workflow (gh warning ignored)", pr.Number)
 					continue
@@ -244,27 +257,34 @@ func autoMergeXylemPRs(ctx context.Context, repo string) {
 				continue
 			}
 			log.Printf("daemon: auto-merge: routed PR #%d to resolve-conflicts workflow (%s)", pr.Number, pr.HeadRefName)
-		case actionWaitForReview:
-			log.Printf("daemon: auto-merge: PR #%d waiting for copilot review to complete", pr.Number)
 		case actionWaitForChecks:
 			log.Printf("daemon: auto-merge: PR #%d waiting for CI checks", pr.Number)
 		case actionWaitForMergeable:
 			log.Printf("daemon: auto-merge: PR #%d waiting for mergeable state (conflicts being resolved or computing)", pr.Number)
 		case actionAddressReview:
 			log.Printf("daemon: auto-merge: PR #%d has changes requested, respond-to-pr-review workflow will handle", pr.Number)
-		case actionMerge:
-			if err := mergePR(ctx, repo, pr.Number); err != nil {
-				log.Printf("daemon: auto-merge: PR #%d merge failed: %v", pr.Number, err)
+		case actionEnableAutoMerge:
+			if err := enableAutoMergePRFn(ctx, repo, pr.Number); err != nil {
+				log.Printf("daemon: auto-merge: PR #%d enable auto-merge failed: %v", pr.Number, err)
 				continue
 			}
-			log.Printf("daemon: auto-merge: merged PR #%d (%s)", pr.Number, pr.HeadRefName)
+			log.Printf("daemon: auto-merge: enabled auto-merge on PR #%d (%s)", pr.Number, pr.HeadRefName)
+		case actionWaitForAutoMerge:
+			log.Printf("daemon: auto-merge: PR #%d waiting for GitHub auto-merge", pr.Number)
 		}
 	}
 }
 
+var (
+	listOpenPRsFn          = listOpenPRs
+	requestCopilotReviewFn = requestCopilotReview
+	addPRLabelsFn          = addPRLabels
+	enableAutoMergePRFn    = enableAutoMergePR
+)
+
 func listOpenPRs(ctx context.Context, repo string) ([]prSummary, error) {
 	args := []string{"pr", "list", "--state", "open", "--json",
-		"number,headRefName,mergeable,state,reviewDecision,statusCheckRollup,reviewRequests,latestReviews,labels",
+		"number,headRefName,mergeable,state,reviewDecision,autoMergeRequest,statusCheckRollup,reviewRequests,latestReviews,labels",
 		"--limit", "50"}
 	if repo != "" {
 		args = append(args, "--repo", repo)
@@ -338,8 +358,8 @@ func requestCopilotReview(ctx context.Context, repo string, number int) error {
 	return nil
 }
 
-func mergePR(ctx context.Context, repo string, number int) error {
-	args := []string{"pr", "merge", "--squash", "--admin", "--delete-branch"}
+func enableAutoMergePR(ctx context.Context, repo string, number int) error {
+	args := []string{"pr", "merge", "--auto", "--squash", "--delete-branch"}
 	if repo != "" {
 		args = append(args, "--repo", repo)
 	}

--- a/cli/cmd/xylem/automerge_prop_test.go
+++ b/cli/cmd/xylem/automerge_prop_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropDecideAutoMergeActionMatchesMergeReadiness(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		hasReadyLabel := rapid.Bool().Draw(t, "hasReadyLabel")
+		hasHarnessLabel := rapid.Bool().Draw(t, "hasHarnessLabel")
+		isXylemBranch := rapid.Bool().Draw(t, "isXylemBranch")
+
+		branch := "docs/not-xylem"
+		if isXylemBranch {
+			branch = "feat/issue-42-42"
+		}
+
+		var labels []struct {
+			Name string `json:"name"`
+		}
+		if hasReadyLabel {
+			labels = append(labels, struct {
+				Name string `json:"name"`
+			}{Name: readyToMergeLabel})
+		}
+		if hasHarnessLabel {
+			labels = append(labels, struct {
+				Name string `json:"name"`
+			}{Name: harnessImplLabel})
+		}
+
+		pr := prSummary{
+			HeadRefName: branch,
+			State:       "OPEN",
+			Mergeable:   "MERGEABLE",
+			Labels:      labels,
+			StatusCheckRollup: []struct {
+				Conclusion string `json:"conclusion"`
+				Status     string `json:"status"`
+			}{{Conclusion: "SUCCESS", Status: "COMPLETED"}},
+			ReviewDecision: "APPROVED",
+		}
+
+		want := actionSkip
+		if isXylemBranch && hasReadyLabel && hasHarnessLabel {
+			want = actionRequestReview
+		}
+
+		if got := decideAutoMergeAction(pr); got != want {
+			t.Fatalf("decideAutoMergeAction(%+v) = %v, want %v", pr, got, want)
+		}
+	})
+}
+
+func TestPropDecideAutoMergeActionWaitsWhenAutoMergeAlreadyEnabled(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		reviewDecision := rapid.SampledFrom([]string{"", "REVIEW_REQUIRED", "APPROVED"}).Draw(t, "reviewDecision")
+		withReviewRequest := rapid.Bool().Draw(t, "withReviewRequest")
+		withLatestReview := rapid.Bool().Draw(t, "withLatestReview")
+
+		pr := prSummary{
+			HeadRefName:      "feat/issue-42-42",
+			State:            "OPEN",
+			Mergeable:        "MERGEABLE",
+			ReviewDecision:   reviewDecision,
+			AutoMergeRequest: &struct{}{},
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: readyToMergeLabel}, {Name: harnessImplLabel}},
+			StatusCheckRollup: []struct {
+				Conclusion string `json:"conclusion"`
+				Status     string `json:"status"`
+			}{{Conclusion: "SUCCESS", Status: "COMPLETED"}},
+		}
+		if withReviewRequest {
+			pr.ReviewRequests = append(pr.ReviewRequests, struct {
+				Login string `json:"login"`
+			}{Login: copilotReviewerLogin})
+		}
+		if withLatestReview {
+			pr.LatestReviews = append(pr.LatestReviews, struct {
+				Author struct {
+					Login string `json:"login"`
+				} `json:"author"`
+				State string `json:"state"`
+			}{
+				Author: struct {
+					Login string `json:"login"`
+				}{Login: copilotReviewerLogin},
+				State: "COMMENTED",
+			})
+		}
+
+		if got := decideAutoMergeAction(pr); got != actionWaitForAutoMerge {
+			t.Fatalf("expected wait-for-auto-merge, got %v for %+v", got, pr)
+		}
+	})
+}

--- a/cli/cmd/xylem/automerge_test.go
+++ b/cli/cmd/xylem/automerge_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsBenignGhWarning(t *testing.T) {
@@ -80,13 +84,13 @@ func TestPRSummary_HasLabel(t *testing.T) {
 	pr := prSummary{
 		Labels: []struct {
 			Name string `json:"name"`
-		}{{Name: "needs-conflict-resolution"}, {Name: "harness-impl"}},
+		}{{Name: "needs-conflict-resolution"}, {Name: harnessImplLabel}},
 	}
 	if !pr.hasLabel("needs-conflict-resolution") {
 		t.Error("hasLabel('needs-conflict-resolution') = false, want true")
 	}
-	if !pr.hasLabel("harness-impl") {
-		t.Error("hasLabel('harness-impl') = false, want true")
+	if !pr.hasLabel(harnessImplLabel) {
+		t.Errorf("hasLabel(%q) = false, want true", harnessImplLabel)
 	}
 	if pr.hasLabel("nonexistent") {
 		t.Error("hasLabel('nonexistent') = true, want false")
@@ -158,6 +162,9 @@ func TestDecideAutoMergeAction(t *testing.T) {
 		Conclusion string `json:"conclusion"`
 		Status     string `json:"status"`
 	}{{Conclusion: "SUCCESS", Status: "COMPLETED"}}
+	mergeReadyLabels := []struct {
+		Name string `json:"name"`
+	}{{Name: readyToMergeLabel}, {Name: harnessImplLabel}}
 	copilotReviewed := []struct {
 		Author struct {
 			Login string `json:"login"`
@@ -181,8 +188,25 @@ func TestDecideAutoMergeAction(t *testing.T) {
 			want: actionSkip,
 		},
 		{
-			name: "xylem PR with conflicts and no labels is routed to resolve-conflicts",
-			pr:   prSummary{HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "CONFLICTING"},
+			name: "xylem PR without merge-ready labels is skipped",
+			pr: prSummary{
+				HeadRefName: "feat/issue-1-1",
+				State:       "OPEN",
+				Mergeable:   "MERGEABLE",
+				Labels: []struct {
+					Name string `json:"name"`
+				}{{Name: harnessImplLabel}},
+			},
+			want: actionSkip,
+		},
+		{
+			name: "xylem PR with conflicts and no conflict labels is routed to resolve-conflicts",
+			pr: prSummary{
+				HeadRefName: "feat/issue-1-1",
+				State:       "OPEN",
+				Mergeable:   "CONFLICTING",
+				Labels:      mergeReadyLabels,
+			},
 			want: actionRouteConflict,
 		},
 		{
@@ -191,19 +215,20 @@ func TestDecideAutoMergeAction(t *testing.T) {
 				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "CONFLICTING",
 				Labels: []struct {
 					Name string `json:"name"`
-				}{{Name: "needs-conflict-resolution"}, {Name: "harness-impl"}},
+				}{{Name: "needs-conflict-resolution"}, {Name: readyToMergeLabel}, {Name: harnessImplLabel}},
 			},
 			want: actionWaitForMergeable,
 		},
 		{
 			name: "xylem PR with unknown mergeable waits",
-			pr:   prSummary{HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "UNKNOWN"},
+			pr:   prSummary{HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "UNKNOWN", Labels: mergeReadyLabels},
 			want: actionWaitForMergeable,
 		},
 		{
 			name: "xylem PR with CI failing waits",
 			pr: prSummary{
 				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "MERGEABLE",
+				Labels: mergeReadyLabels,
 				StatusCheckRollup: []struct {
 					Conclusion string `json:"conclusion"`
 					Status     string `json:"status"`
@@ -215,37 +240,50 @@ func TestDecideAutoMergeAction(t *testing.T) {
 			name: "xylem PR with changes requested waits",
 			pr: prSummary{
 				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "MERGEABLE",
-				StatusCheckRollup: greenChecks, ReviewDecision: "CHANGES_REQUESTED",
+				Labels: mergeReadyLabels, StatusCheckRollup: greenChecks, ReviewDecision: "CHANGES_REQUESTED",
 			},
 			want: actionAddressReview,
 		},
 		{
-			name: "xylem PR without review requests copilot review",
+			name: "xylem PR without review requests asks for copilot review first",
 			pr: prSummary{
 				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "MERGEABLE",
-				StatusCheckRollup: greenChecks, ReviewDecision: "REVIEW_REQUIRED",
+				Labels: mergeReadyLabels, StatusCheckRollup: greenChecks, ReviewDecision: "REVIEW_REQUIRED",
 			},
 			want: actionRequestReview,
 		},
 		{
-			name: "xylem PR with copilot requested but not submitted waits",
+			name: "xylem PR with copilot requested enables auto-merge",
 			pr: prSummary{
 				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "MERGEABLE",
-				StatusCheckRollup: greenChecks, ReviewDecision: "REVIEW_REQUIRED",
+				Labels: mergeReadyLabels, StatusCheckRollup: greenChecks, ReviewDecision: "REVIEW_REQUIRED",
 				ReviewRequests: []struct {
 					Login string `json:"login"`
 				}{{Login: copilotReviewerLogin}},
 			},
-			want: actionWaitForReview,
+			want: actionEnableAutoMerge,
 		},
 		{
-			name: "xylem PR approved + green + mergeable is merged",
+			name: "xylem PR approved + green + mergeable enables auto-merge",
 			pr: prSummary{
 				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "MERGEABLE",
-				StatusCheckRollup: greenChecks, ReviewDecision: "APPROVED",
+				Labels: mergeReadyLabels, StatusCheckRollup: greenChecks, ReviewDecision: "APPROVED",
 				LatestReviews: copilotReviewed,
 			},
-			want: actionMerge,
+			want: actionEnableAutoMerge,
+		},
+		{
+			name: "xylem PR with auto-merge already enabled waits",
+			pr: prSummary{
+				HeadRefName:       "feat/issue-1-1",
+				State:             "OPEN",
+				Mergeable:         "MERGEABLE",
+				ReviewDecision:    "REVIEW_REQUIRED",
+				AutoMergeRequest:  &struct{}{},
+				Labels:            mergeReadyLabels,
+				StatusCheckRollup: greenChecks,
+			},
+			want: actionWaitForAutoMerge,
 		},
 	}
 	for _, tt := range tests {
@@ -255,4 +293,80 @@ func TestDecideAutoMergeAction(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSmoke_S1_AutoMergeContinuesWhenCopilotReviewerIsNotCollaborator(t *testing.T) {
+	origListOpenPRsFn := listOpenPRsFn
+	origRequestCopilotReviewFn := requestCopilotReviewFn
+	origAddPRLabelsFn := addPRLabelsFn
+	origEnableAutoMergePRFn := enableAutoMergePRFn
+	t.Cleanup(func() {
+		listOpenPRsFn = origListOpenPRsFn
+		requestCopilotReviewFn = origRequestCopilotReviewFn
+		addPRLabelsFn = origAddPRLabelsFn
+		enableAutoMergePRFn = origEnableAutoMergePRFn
+	})
+
+	mergeReadyPR := prSummary{
+		Number:         42,
+		HeadRefName:    "feat/issue-42-42",
+		Mergeable:      "MERGEABLE",
+		State:          "OPEN",
+		ReviewDecision: "REVIEW_REQUIRED",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: readyToMergeLabel}, {Name: harnessImplLabel}},
+		StatusCheckRollup: []struct {
+			Conclusion string `json:"conclusion"`
+			Status     string `json:"status"`
+		}{{Conclusion: "SUCCESS", Status: "COMPLETED"}},
+	}
+	require.Equal(t, actionRequestReview, decideAutoMergeAction(mergeReadyPR))
+
+	listCalls := 0
+	listOpenPRsFn = func(context.Context, string) ([]prSummary, error) {
+		listCalls++
+		return []prSummary{{
+			Number:            mergeReadyPR.Number,
+			HeadRefName:       mergeReadyPR.HeadRefName,
+			Mergeable:         mergeReadyPR.Mergeable,
+			State:             mergeReadyPR.State,
+			ReviewDecision:    mergeReadyPR.ReviewDecision,
+			Labels:            mergeReadyPR.Labels,
+			StatusCheckRollup: mergeReadyPR.StatusCheckRollup,
+		}}, nil
+	}
+
+	reviewCalls := 0
+	requestCopilotReviewFn = func(_ context.Context, repo string, number int) error {
+		reviewCalls++
+		assert.Equal(t, "nicholls-inc/xylem", repo)
+		assert.Equal(t, 42, number)
+		return errors.New(`exit status 1: {"message":"Reviews may only be requested from collaborators"}`)
+	}
+
+	labelCalls := 0
+	addPRLabelsFn = func(context.Context, string, int, []string) error {
+		labelCalls++
+		return nil
+	}
+
+	enableCalls := 0
+	enableAutoMergePRFn = func(_ context.Context, repo string, number int) error {
+		enableCalls++
+		if repo != "nicholls-inc/xylem" {
+			t.Fatalf("repo = %q, want nicholls-inc/xylem", repo)
+		}
+		if number != 42 {
+			t.Fatalf("number = %d, want 42", number)
+		}
+		return nil
+	}
+
+	autoMergeXylemPRs(context.Background(), "nicholls-inc/xylem")
+
+	assert.Equal(t, 1, listCalls)
+	assert.Equal(t, 1, reviewCalls)
+	assert.Equal(t, 0, labelCalls)
+	assert.Equal(t, 1, enableCalls)
 }

--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -102,8 +102,9 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	check := func(ctx context.Context) {
 		drainRunner.CheckWaitingVessels(ctx)
 		drainRunner.CheckHungVessels(ctx)
-		// Auto-merge: request copilot review on unreviewed xylem PRs,
-		// and merge PRs that are approved + CI-green + mergeable.
+		// Auto-merge: best-effort request copilot review on merge-ready
+		// harness PRs, then enable GitHub auto-merge once checks are green
+		// and the PR is mergeable.
 		if cfg.Daemon.AutoMerge {
 			autoMergeXylemPRs(ctx, cfg.Daemon.AutoMergeRepo)
 		}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -118,10 +118,10 @@ type DaemonConfig struct {
 	// auto_upgrade check while the loop is running. Only meaningful when
 	// AutoUpgrade is true. Defaults to 5m. Accepts any Go duration string.
 	UpgradeInterval string `yaml:"upgrade_interval,omitempty"`
-	// AutoMerge enables automatic copilot review cycle + merge of
-	// xylem-authored PRs. Only merges when the PR is approved, CI-green,
-	// and mergeable. Branches matching feat/issue-*, fix/issue-*, or
-	// chore/issue-* are considered xylem-authored.
+	// AutoMerge enables the automatic copilot review cycle + GitHub
+	// auto-merge for merge-ready xylem-authored PRs. The daemon only acts
+	// on PRs labeled ready-to-merge + harness-impl whose branches match
+	// feat/issue-*, fix/issue-*, or chore/issue-*.
 	AutoMerge bool `yaml:"auto_merge,omitempty"`
 	// AutoMergeRepo is the GitHub repo slug (owner/name) for auto-merge.
 	// If empty, gh CLI uses the current directory's origin remote.


### PR DESCRIPTION
## Summary
- Implements [issue #189](https://github.com/nicholls-inc/xylem/issues/189).
- Makes copilot review requests best-effort so merge-ready xylem PRs still attempt GitHub auto-merge when `copilot-pull-request-reviewer` is not a collaborator.
- Switches the daemon merge path to `gh pr merge --auto --squash --delete-branch` so GitHub branch protection can enforce approvals while auto-merge waits.

## Smoke scenarios covered
- `S1` — `AutoMergeContinuesWhenCopilotReviewerIsNotCollaborator`

## Changes summary
- **Modified** `cli/cmd/xylem/automerge.go` — added `harnessImplLabel`, `readyToMergeLabel`, `isReviewerNotCollaborator`, `autoMergeAction`, `decideAutoMergeAction`, `enableAutoMergePR`, and rewired `autoMergeXylemPRs` to request review best-effort, route conflicting PRs, and enable GitHub auto-merge.
- **Added** `cli/cmd/xylem/automerge_prop_test.go` — added property coverage for merge-readiness routing and the "auto-merge already enabled" invariant.
- **Modified** `cli/cmd/xylem/automerge_test.go` — added collaborator-error coverage, decision-table coverage for auto-merge actions, and `TestSmoke_S1_AutoMergeContinuesWhenCopilotReviewerIsNotCollaborator`.
- **Modified** `cli/cmd/xylem/daemon.go` and `cli/internal/config/config.go` — updated auto-merge documentation/comments to describe the GitHub auto-merge flow and merge-ready label gating.

## Test plan
- `cd cli && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #189