### PR TITLE
fix: merge-pr: use --auto instead of --admin (#190)

### DIFF
--- a/.xylem/workflows/merge-pr.yaml
+++ b/.xylem/workflows/merge-pr.yaml
@@ -8,4 +8,11 @@ phases:
       match: XYLEM_NOOP
   - name: merge
     type: command
-    run: "gh pr merge {{.Issue.Number}} --repo nicholls-inc/xylem --squash --delete-branch --admin"
+    # Use --auto so GitHub queues the merge for when required checks pass and
+    # review requirements are met, rather than failing immediately with
+    # "Pull request is not mergeable: the merge commit cannot be cleanly
+    # created" when checks are still pending. The previous --admin flag
+    # attempted to bypass protection but hit the same mergeability gate when
+    # a PR was behind main or had pending CI, producing exit status 1 and
+    # blocking further merge-pr vessels. --auto correctly waits.
+    run: "gh pr merge {{.Issue.Number}} --repo nicholls-inc/xylem --squash --delete-branch --auto"


### PR DESCRIPTION
## Summary

Fixes issue #190. The merge-pr workflow was passing \`--admin\` to \`gh pr merge\`, but --admin doesn't bypass the \"mergeable state cannot be cleanly created\" error when a PR has pending CI or is BEHIND main. GitHub CLI itself points at \`--auto\` as the fix:

\`\`\`
X Pull request #167 is not mergeable: the merge commit cannot be cleanly created.
To have the pull request merged after all the requirements have been met, add the \`--auto\` flag.
\`\`\`

## Fix

Replace \`--admin\` with \`--auto\` in \`.xylem/workflows/merge-pr.yaml\`. With \`--auto\`, GitHub queues the merge to fire automatically once all required checks pass and review requirements are met. The check phase already verifies PR eligibility; \`--auto\` just handles the timing gracefully.

## Evidence (loop 10→11 diagnosis)

- 10:47:31 UTC: merge-pr vessel dequeued for PR #167
- 10:48:37 UTC: merge command fails with exit 1 (1m6s total)
- Vessel marked failed, PR #167 stuck open

With PR #191's scanner treadmill fix no longer re-enqueueing vessels on non-CONFLICTING PRs, these stuck merge-pr failures would persist indefinitely without this patch.

## Test plan

- [x] YAML validates (pre-commit check-yaml passed)
- [x] No Go code changes — workflow YAML is loaded at runtime by the runner, no test load path for \`merge-pr.yaml\` specifically
- [ ] Post-merge: next merge-pr vessel on a MERGEABLE-BEHIND PR (e.g., #167 if its mergeable state returns) should successfully queue via GitHub auto-merge

## Not addressed

The broader meta-tension where vessels implementing harness fixes need to modify protected workflow/prompt files. Issues #188 and #190 both failed with protected-surface violations because their implement-harness vessels tried to edit merge-pr.yaml or the resolve-conflicts prompts. This PR ships the fix manually because that meta-tension is a separate design question — will file as a follow-up.

## Related

- #190 (this fix)
- #188 (sibling gate-bypass bug, still blocking PR #143)
- #191 (merged by parallel agent loop 10, scanner treadmill fix)
- PR #192 (merged loop 10→11, first PR via new auto-merge path from #189)

Filed autonomously by the hourly /xylem-status rescue loop on 2026-04-09 (loop 11 — first 30-min interval iteration).