### PR TITLE
Ensure merge-pr uses auto-merge in workflow and DTU coverage

### DIFF
--- a/cli/internal/dtu/dtu_prop_test.go
+++ b/cli/internal/dtu/dtu_prop_test.go
@@ -1,0 +1,108 @@
+package dtu
+
+import (
+	"fmt"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropRepositoryAutoMergeRespectsCheckStates(t *testing.T) {
+	t.Parallel()
+
+	checkStates := []CheckState{
+		CheckStatePending,
+		CheckStateSuccess,
+		CheckStateFailure,
+		CheckStateCancelled,
+		CheckStateSkipped,
+	}
+
+	rapid.Check(t, func(t *rapid.T) {
+		deleteHeadBranch := rapid.Bool().Draw(t, "delete_head_branch")
+		checkCount := rapid.IntRange(0, 5).Draw(t, "check_count")
+
+		checks := make([]Check, 0, checkCount)
+		blocked := false
+		for i := 0; i < checkCount; i++ {
+			state := rapid.SampledFrom(checkStates).Draw(t, fmt.Sprintf("check_state_%d", i))
+			if state != CheckStateSuccess && state != CheckStateSkipped {
+				blocked = true
+			}
+			checks = append(checks, Check{
+				ID:    int64(i + 1),
+				Name:  fmt.Sprintf("check-%d", i),
+				State: state,
+			})
+		}
+
+		repo := &Repository{
+			Owner:         "owner",
+			Name:          "repo",
+			DefaultBranch: "main",
+			Branches: []Branch{
+				{Name: "main", SHA: "1111111111111111111111111111111111111111"},
+				{Name: "feature/merge-me", SHA: "deadbeefcafebabe"},
+			},
+			PullRequests: []PullRequest{{
+				Number:     7,
+				Title:      "Merge me",
+				State:      PullRequestStateOpen,
+				BaseBranch: "main",
+				HeadBranch: "feature/merge-me",
+				HeadSHA:    "feedfacecafebeef",
+				Checks:     checks,
+			}},
+		}
+
+		if err := repo.MergePullRequest(7, MergePullRequestOptions{DeleteHeadBranch: deleteHeadBranch, AutoMerge: true}); err != nil {
+			t.Fatalf("MergePullRequest() error = %v", err)
+		}
+
+		pr := repo.PullRequestByNumber(7)
+		if pr == nil {
+			t.Fatal("PullRequestByNumber() = nil")
+		}
+
+		if blocked {
+			if pr.State != PullRequestStateOpen || pr.Merged {
+				t.Fatalf("queued pull request = %#v, want open queued auto-merge", pr)
+			}
+			if !pr.AutoMergeEnabled || pr.AutoMergeDeleteBranch != deleteHeadBranch {
+				t.Fatalf("queued pull request flags = %#v, want auto-merge enabled with delete=%t", pr, deleteHeadBranch)
+			}
+			if branch := repo.BranchByName("main"); branch == nil || branch.SHA != "1111111111111111111111111111111111111111" {
+				t.Fatalf("main branch = %#v, want original SHA preserved", branch)
+			}
+			if branch := repo.BranchByName(pr.HeadBranch); branch == nil {
+				t.Fatalf("head branch = %#v, want retained while merge is queued", branch)
+			}
+
+			for i := range pr.Checks {
+				pr.Checks[i].State = CheckStateSuccess
+			}
+			if err := repo.ApplyQueuedAutoMerge(7); err != nil {
+				t.Fatalf("ApplyQueuedAutoMerge() error = %v", err)
+			}
+		}
+
+		if pr.State != PullRequestStateMerged || !pr.Merged {
+			t.Fatalf("merged pull request = %#v, want merged state", pr)
+		}
+		if pr.AutoMergeEnabled || pr.AutoMergeDeleteBranch {
+			t.Fatalf("merged pull request flags = %#v, want cleared auto-merge flags", pr)
+		}
+		if branch := repo.BranchByName("main"); branch == nil || branch.SHA != pr.HeadSHA {
+			t.Fatalf("main branch = %#v, want SHA %q", branch, pr.HeadSHA)
+		}
+		if deleteHeadBranch {
+			if branch := repo.BranchByName(pr.HeadBranch); branch != nil {
+				t.Fatalf("head branch = %#v, want deleted", branch)
+			}
+		} else {
+			if branch := repo.BranchByName(pr.HeadBranch); branch == nil || branch.SHA != pr.HeadSHA {
+				t.Fatalf("head branch = %#v, want retained at SHA %q", branch, pr.HeadSHA)
+			}
+		}
+	})
+}

--- a/cli/internal/dtu/dtu_test.go
+++ b/cli/internal/dtu/dtu_test.go
@@ -451,7 +451,7 @@ func TestRepositoryMergePullRequestRetainsHeadBranchWhenNotDeleting(t *testing.T
 		}},
 	}
 
-	if err := repo.MergePullRequest(7, false); err != nil {
+	if err := repo.MergePullRequest(7, MergePullRequestOptions{}); err != nil {
 		t.Fatalf("MergePullRequest() error = %v", err)
 	}
 
@@ -490,7 +490,7 @@ func TestRepositoryMergePullRequestDeletesHeadBranchAndUpsertsBase(t *testing.T)
 		}},
 	}
 
-	if err := repo.MergePullRequest(8, true); err != nil {
+	if err := repo.MergePullRequest(8, MergePullRequestOptions{DeleteHeadBranch: true}); err != nil {
 		t.Fatalf("MergePullRequest() error = %v", err)
 	}
 
@@ -509,6 +509,157 @@ func TestRepositoryMergePullRequestDeletesHeadBranchAndUpsertsBase(t *testing.T)
 	}
 	if branch := repo.BranchByName("keep-me"); branch == nil {
 		t.Fatal("unrelated branch was removed")
+	}
+}
+
+func TestRepositoryMergePullRequestQueuesAutoMergeUntilChecksPass(t *testing.T) {
+	t.Parallel()
+
+	repo := &Repository{
+		Owner:         "owner",
+		Name:          "repo",
+		DefaultBranch: "main",
+		Branches: []Branch{
+			{Name: "main", SHA: "1111111111111111111111111111111111111111"},
+			{Name: "feature/merge-me", SHA: "deadbeefcafebabe"},
+		},
+		PullRequests: []PullRequest{{
+			Number:     9,
+			Title:      "Queue me",
+			State:      PullRequestStateOpen,
+			BaseBranch: "main",
+			HeadBranch: "feature/merge-me",
+			HeadSHA:    "feedfacecafebeef",
+			Checks:     []Check{{ID: 1, Name: "ci", State: CheckStatePending}},
+		}},
+	}
+
+	if err := repo.MergePullRequest(9, MergePullRequestOptions{DeleteHeadBranch: true, AutoMerge: true}); err != nil {
+		t.Fatalf("MergePullRequest() error = %v", err)
+	}
+
+	pr := repo.PullRequestByNumber(9)
+	if pr == nil {
+		t.Fatal("PullRequestByNumber() = nil")
+	}
+	if pr.State != PullRequestStateOpen || pr.Merged {
+		t.Fatalf("pull request = %#v, want open queued auto-merge", pr)
+	}
+	if !pr.AutoMergeEnabled || !pr.AutoMergeDeleteBranch {
+		t.Fatalf("pull request auto-merge flags = %#v, want enabled delete-branch queue", pr)
+	}
+	if branch := repo.BranchByName("main"); branch == nil || branch.SHA != "1111111111111111111111111111111111111111" {
+		t.Fatalf("main branch = %#v, want original SHA preserved", branch)
+	}
+	if branch := repo.BranchByName(pr.HeadBranch); branch == nil {
+		t.Fatalf("head branch = %#v, want branch retained while auto-merge is queued", branch)
+	}
+
+	pr.Checks[0].State = CheckStateSuccess
+	if err := repo.ApplyQueuedAutoMerge(9); err != nil {
+		t.Fatalf("ApplyQueuedAutoMerge() error = %v", err)
+	}
+	if pr.State != PullRequestStateMerged || !pr.Merged {
+		t.Fatalf("pull request after check success = %#v, want merged state", pr)
+	}
+	if pr.AutoMergeEnabled || pr.AutoMergeDeleteBranch {
+		t.Fatalf("pull request auto-merge flags after merge = %#v, want cleared", pr)
+	}
+	if branch := repo.BranchByName("main"); branch == nil || branch.SHA != pr.HeadSHA {
+		t.Fatalf("main branch = %#v, want SHA %q", branch, pr.HeadSHA)
+	}
+	if branch := repo.BranchByName(pr.HeadBranch); branch != nil {
+		t.Fatalf("head branch = %#v, want deleted after queued auto-merge", branch)
+	}
+}
+
+func TestStoreRecordObservationPRCheckMutationAppliesQueuedAutoMerge(t *testing.T) {
+	t.Parallel()
+
+	appliedAt := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	state := &State{
+		UniverseID: "universe-1",
+		Metadata:   ManifestMetadata{Name: "sample"},
+		Clock:      ClockState{Now: appliedAt.Format(time.RFC3339)},
+		Repositories: []Repository{{
+			Owner:         "owner",
+			Name:          "repo",
+			DefaultBranch: "main",
+			Branches: []Branch{
+				{Name: "main", SHA: "1111111111111111111111111111111111111111"},
+				{Name: "feature/merge-me", SHA: "deadbeefcafebabe"},
+			},
+			PullRequests: []PullRequest{{
+				Number:                12,
+				Title:                 "Queue me",
+				State:                 PullRequestStateOpen,
+				BaseBranch:            "main",
+				HeadBranch:            "feature/merge-me",
+				HeadSHA:               "feedfacecafebeef",
+				AutoMergeEnabled:      true,
+				AutoMergeDeleteBranch: true,
+				Checks:                []Check{{ID: 1, Name: "ci", State: CheckStatePending}},
+			}},
+		}},
+		ScheduledMutations: []ScheduledMutation{{
+			Name: "complete-check-and-merge",
+			Trigger: MutationTrigger{
+				Command:    ShimCommandGH,
+				ArgsPrefix: []string{"pr", "checks", "12"},
+			},
+			Operations: []MutationOperation{{
+				Type:   MutationOperationPRSetCheckState,
+				Repo:   "owner/repo",
+				Number: 12,
+				Check:  "ci",
+				State:  string(CheckStateSuccess),
+			}},
+		}},
+		Counters: Counters{NextCommentID: 1, NextReviewID: 1, NextCheckID: 2},
+	}
+
+	store, err := NewStoreWithClock(t.TempDir(), state.UniverseID, NewFixedClock(appliedAt))
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	result, err := store.RecordObservation(ShimInvocation{
+		Command: ShimCommandGH,
+		Args:    []string{"pr", "checks", "12", "--repo", "owner/repo", "--json", "name,state"},
+	})
+	if err != nil {
+		t.Fatalf("RecordObservation() error = %v", err)
+	}
+	if len(result.Applied) != 1 || result.Applied[0].Name != "complete-check-and-merge" {
+		t.Fatalf("Applied = %#v, want queued auto-merge mutation", result.Applied)
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	loadedRepo := loaded.Repository("owner", "repo")
+	if loadedRepo == nil {
+		t.Fatal("Repository() = nil")
+	}
+	pr := loadedRepo.PullRequestByNumber(12)
+	if pr == nil {
+		t.Fatal("PullRequestByNumber() = nil")
+	}
+	if pr.State != PullRequestStateMerged || !pr.Merged {
+		t.Fatalf("pull request = %#v, want merged state", pr)
+	}
+	if pr.AutoMergeEnabled || pr.AutoMergeDeleteBranch {
+		t.Fatalf("pull request auto-merge flags = %#v, want cleared after merge", pr)
+	}
+	if branch := loadedRepo.BranchByName("main"); branch == nil || branch.SHA != pr.HeadSHA {
+		t.Fatalf("main branch = %#v, want SHA %q", branch, pr.HeadSHA)
+	}
+	if branch := loadedRepo.BranchByName(pr.HeadBranch); branch != nil {
+		t.Fatalf("head branch = %#v, want deleted after queued auto-merge", branch)
 	}
 }
 

--- a/cli/internal/dtu/scheduler.go
+++ b/cli/internal/dtu/scheduler.go
@@ -223,6 +223,9 @@ func applyMutationOperations(state *State, mutation ScheduledMutation) error {
 			}
 			check := findOrAppendCheck(state, pr, operation.Check)
 			check.State = CheckState(operation.State)
+			if err := repo.ApplyQueuedAutoMerge(operation.Number); err != nil {
+				return fmt.Errorf("apply queued auto-merge for pull request %d in %s: %w", operation.Number, operation.Repo, err)
+			}
 		case MutationOperationPRAddComment:
 			pr := repo.PullRequestByNumber(operation.Number)
 			if pr == nil {

--- a/cli/internal/dtu/types.go
+++ b/cli/internal/dtu/types.go
@@ -401,8 +401,16 @@ func (r *Repository) DeleteBranch(name string) bool {
 	return false
 }
 
+// MergePullRequestOptions configures gh pr merge behavior inside the DTU model.
+type MergePullRequestOptions struct {
+	DeleteHeadBranch bool
+	AutoMerge        bool
+}
+
 // MergePullRequest updates pull-request and git-visible state to reflect a merge.
-func (r *Repository) MergePullRequest(number int, deleteHeadBranch bool) error {
+// When auto-merge is requested and merge-blocking checks are still present, the
+// pull request remains open with auto-merge enabled until checks pass.
+func (r *Repository) MergePullRequest(number int, opts MergePullRequestOptions) error {
 	if r == nil {
 		return fmt.Errorf("repository must not be nil")
 	}
@@ -424,8 +432,55 @@ func (r *Repository) MergePullRequest(number int, deleteHeadBranch bool) error {
 		return fmt.Errorf("pull request %d: head SHA is required", number)
 	}
 
+	if opts.AutoMerge {
+		pr.AutoMergeEnabled = true
+		pr.AutoMergeDeleteBranch = opts.DeleteHeadBranch
+		if pr.HasBlockingMergeChecks() {
+			return nil
+		}
+	}
+
+	return r.mergePullRequest(pr, opts.DeleteHeadBranch)
+}
+
+// ApplyQueuedAutoMerge finalizes a previously queued auto-merge once checks no
+// longer block the merge.
+func (r *Repository) ApplyQueuedAutoMerge(number int) error {
+	if r == nil {
+		return fmt.Errorf("repository must not be nil")
+	}
+	pr := r.PullRequestByNumber(number)
+	if pr == nil {
+		return fmt.Errorf("pull request %d not found", number)
+	}
+	if !pr.AutoMergeEnabled || pr.HasBlockingMergeChecks() {
+		return nil
+	}
+	return r.mergePullRequest(pr, pr.AutoMergeDeleteBranch)
+}
+
+func (r *Repository) mergePullRequest(pr *PullRequest, deleteHeadBranch bool) error {
+	if pr == nil {
+		return fmt.Errorf("pull request must not be nil")
+	}
+
+	baseBranch := strings.TrimSpace(pr.BaseBranch)
+	if baseBranch == "" {
+		return fmt.Errorf("pull request %d: base branch is required", pr.Number)
+	}
+	headBranch := strings.TrimSpace(pr.HeadBranch)
+	if headBranch == "" {
+		return fmt.Errorf("pull request %d: head branch is required", pr.Number)
+	}
+	headSHA := strings.TrimSpace(pr.HeadSHA)
+	if headSHA == "" {
+		return fmt.Errorf("pull request %d: head SHA is required", pr.Number)
+	}
+
 	pr.State = PullRequestStateMerged
 	pr.Merged = true
+	pr.AutoMergeEnabled = false
+	pr.AutoMergeDeleteBranch = false
 	r.UpsertBranch(Branch{Name: baseBranch, SHA: headSHA})
 
 	if deleteHeadBranch {
@@ -472,19 +527,38 @@ type Issue struct {
 
 // PullRequest describes a GitHub pull request.
 type PullRequest struct {
-	Number     int              `yaml:"number" json:"number"`
-	Title      string           `yaml:"title" json:"title"`
-	Body       string           `yaml:"body,omitempty" json:"body,omitempty"`
-	URL        string           `yaml:"url,omitempty" json:"url,omitempty"`
-	State      PullRequestState `yaml:"state,omitempty" json:"state,omitempty"`
-	Merged     bool             `yaml:"merged,omitempty" json:"merged,omitempty"`
-	Labels     []string         `yaml:"labels,omitempty" json:"labels,omitempty"`
-	BaseBranch string           `yaml:"base_branch" json:"base_branch"`
-	HeadBranch string           `yaml:"head_branch" json:"head_branch"`
-	HeadSHA    string           `yaml:"head_sha" json:"head_sha"`
-	Comments   []Comment        `yaml:"comments,omitempty" json:"comments,omitempty"`
-	Reviews    []Review         `yaml:"reviews,omitempty" json:"reviews,omitempty"`
-	Checks     []Check          `yaml:"checks,omitempty" json:"checks,omitempty"`
+	Number                int              `yaml:"number" json:"number"`
+	Title                 string           `yaml:"title" json:"title"`
+	Body                  string           `yaml:"body,omitempty" json:"body,omitempty"`
+	URL                   string           `yaml:"url,omitempty" json:"url,omitempty"`
+	State                 PullRequestState `yaml:"state,omitempty" json:"state,omitempty"`
+	Merged                bool             `yaml:"merged,omitempty" json:"merged,omitempty"`
+	AutoMergeEnabled      bool             `yaml:"auto_merge_enabled,omitempty" json:"auto_merge_enabled,omitempty"`
+	AutoMergeDeleteBranch bool             `yaml:"auto_merge_delete_branch,omitempty" json:"auto_merge_delete_branch,omitempty"`
+	Labels                []string         `yaml:"labels,omitempty" json:"labels,omitempty"`
+	BaseBranch            string           `yaml:"base_branch" json:"base_branch"`
+	HeadBranch            string           `yaml:"head_branch" json:"head_branch"`
+	HeadSHA               string           `yaml:"head_sha" json:"head_sha"`
+	Comments              []Comment        `yaml:"comments,omitempty" json:"comments,omitempty"`
+	Reviews               []Review         `yaml:"reviews,omitempty" json:"reviews,omitempty"`
+	Checks                []Check          `yaml:"checks,omitempty" json:"checks,omitempty"`
+}
+
+// HasBlockingMergeChecks reports whether any check still prevents a queued
+// auto-merge from completing.
+func (pr *PullRequest) HasBlockingMergeChecks() bool {
+	if pr == nil {
+		return false
+	}
+	for _, check := range pr.Checks {
+		switch check.State {
+		case CheckStateSuccess, CheckStateSkipped:
+			continue
+		default:
+			return true
+		}
+	}
+	return false
 }
 
 // Comment describes an issue or pull request comment.

--- a/cli/internal/dtushim/shim.go
+++ b/cli/internal/dtushim/shim.go
@@ -1302,7 +1302,10 @@ func runGHPRMerge(_ context.Context, store *dtu.Store, args []string, stderr io.
 				return fmt.Errorf("repository %q not found", opts.repo)
 			}
 		}
-		return repo.MergePullRequest(number, opts.deleteBranch)
+		return repo.MergePullRequest(number, dtu.MergePullRequestOptions{
+			DeleteHeadBranch: opts.deleteBranch,
+			AutoMerge:        opts.autoMerge,
+		})
 	})
 	if err != nil {
 		return writeError(stderr, 1, err)
@@ -1383,6 +1386,7 @@ type ghOptions struct {
 	body         string
 	limit        int
 	deleteBranch bool
+	autoMerge    bool
 	addLabels    []string
 	removeLabels []string
 }
@@ -1453,6 +1457,8 @@ func parseGHFlags(args []string) (ghOptions, error) {
 			i = next
 		case "--delete-branch", "-d":
 			opts.deleteBranch = true
+		case "--auto":
+			opts.autoMerge = true
 		case "--add-label":
 			value, next, err := requireValue(args, i, args[i])
 			if err != nil {

--- a/cli/internal/dtushim/shim_test.go
+++ b/cli/internal/dtushim/shim_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/dtu"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func testStore(t *testing.T, state *dtu.State) (*dtu.Store, string) {
@@ -178,6 +180,7 @@ func TestExecuteGHPRMergeUpdatesStateAndGitVisibility(t *testing.T) {
 	t.Parallel()
 
 	state := sampleState()
+	state.Repositories[0].PullRequests[0].Checks[0].State = dtu.CheckStateSuccess
 	state.Repositories[0].Branches = []dtu.Branch{
 		{Name: "main", SHA: "1111111111111111111111111111111111111111"},
 		{Name: "fix/issue-1-bug-one", SHA: "abc12345deadbeef"},
@@ -190,7 +193,7 @@ func TestExecuteGHPRMergeUpdatesStateAndGitVisibility(t *testing.T) {
 	code := Execute(
 		context.Background(),
 		"gh",
-		[]string{"pr", "merge", "10", "--repo", "owner/repo", "--delete-branch", "--squash", "--admin"},
+		[]string{"pr", "merge", "10", "--repo", "owner/repo", "--delete-branch", "--squash", "--auto"},
 		nil,
 		&mergeOut,
 		&mergeErr,
@@ -261,6 +264,46 @@ func TestExecuteGHPRMergeUpdatesStateAndGitVisibility(t *testing.T) {
 	if strings.Contains(headOut.String(), "fix/issue-1-bug-one") {
 		t.Fatalf("git ls-remote head output = %q, want deleted head branch to disappear", headOut.String())
 	}
+}
+
+func TestSmoke_S2_GHPRMergeWithAutoQueuesUntilChecksPass(t *testing.T) {
+	t.Parallel()
+
+	state := sampleState()
+	state.Repositories[0].PullRequests[0].Checks[0].State = dtu.CheckStatePending
+	state.Repositories[0].Branches = []dtu.Branch{
+		{Name: "main", SHA: "1111111111111111111111111111111111111111"},
+		{Name: "fix/issue-1-bug-one", SHA: "abc12345deadbeef"},
+	}
+	store, stateDir := testStore(t, state)
+	env := envForStore(store, stateDir, state.UniverseID)
+
+	var mergeOut, mergeErr bytes.Buffer
+	code := Execute(
+		context.Background(),
+		"gh",
+		[]string{"pr", "merge", "10", "--repo", "owner/repo", "--delete-branch", "--squash", "--auto"},
+		nil,
+		&mergeOut,
+		&mergeErr,
+		env,
+	)
+	require.Zero(t, code, "stderr = %q", mergeErr.String())
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	repo := loaded.RepositoryBySlug("owner/repo")
+	require.NotNil(t, repo)
+	pr := repo.PullRequestByNumber(10)
+	require.NotNil(t, pr)
+	assert.Equal(t, dtu.PullRequestStateOpen, pr.State)
+	assert.False(t, pr.Merged)
+	assert.True(t, pr.AutoMergeEnabled)
+	assert.True(t, pr.AutoMergeDeleteBranch)
+	main := repo.BranchByName("main")
+	require.NotNil(t, main)
+	assert.Equal(t, "1111111111111111111111111111111111111111", main.SHA)
+	assert.NotNil(t, repo.BranchByName(pr.HeadBranch))
 }
 
 func TestExecuteGHAPIAndIssueCommentUseStateStore(t *testing.T) {

--- a/cli/internal/workflow/merge_pr_workflow_test.go
+++ b/cli/internal/workflow/merge_pr_workflow_test.go
@@ -1,0 +1,38 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSmoke_S1_MergePRWorkflowUsesAutoFlag(t *testing.T) {
+	t.Parallel()
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller() failed")
+
+	workflowPath := filepath.Join(filepath.Dir(file), "..", "..", "..", ".xylem", "workflows", "merge-pr.yaml")
+	data, err := os.ReadFile(workflowPath)
+	require.NoError(t, err, "ReadFile(%q)", workflowPath)
+
+	var wf Workflow
+	require.NoError(t, yaml.Unmarshal(data, &wf), "yaml.Unmarshal(%q)", workflowPath)
+
+	var mergePhase *Phase
+	for i := range wf.Phases {
+		if wf.Phases[i].Name == "merge" {
+			mergePhase = &wf.Phases[i]
+			break
+		}
+	}
+	require.NotNil(t, mergePhase, "workflow %q missing merge phase", wf.Name)
+	assert.Equal(t, "command", mergePhase.Type)
+	assert.Contains(t, mergePhase.Run, "--auto")
+	assert.NotContains(t, mergePhase.Run, "--admin")
+}


### PR DESCRIPTION
## Summary
- Implements https://github.com/nicholls-inc/xylem/issues/190
- Keeps the checked-in `merge-pr` workflow on `gh pr merge --auto` and adds regression coverage so the DTU model and shim reflect queued auto-merge behavior while checks are pending.

## Smoke scenarios covered
- **S1** `MergePRWorkflowUsesAutoFlag` — verifies `.xylem/workflows/merge-pr.yaml` keeps `--auto` and does not regress to `--admin`.
- **S2** `GHPRMergeWithAutoQueuesUntilChecksPass` — verifies the DTU `gh pr merge` shim queues auto-merge when checks are pending instead of merging immediately.

## Changes summary
- **Modified** `cli/internal/dtu/types.go` to introduce `MergePullRequestOptions`, track `PullRequest.AutoMergeEnabled` / `PullRequest.AutoMergeDeleteBranch`, add `PullRequest.HasBlockingMergeChecks`, and add `Repository.ApplyQueuedAutoMerge` plus the shared merge-finalization path.
- **Modified** `cli/internal/dtu/scheduler.go` so PR check-state mutations trigger queued auto-merge completion once checks pass.
- **Modified** `cli/internal/dtu/dtu_test.go` to cover queued auto-merge and scheduled check completion behavior.
- **Added** `cli/internal/dtu/dtu_prop_test.go` with property coverage for auto-merge across varying check states and delete-branch options.
- **Modified** `cli/internal/dtushim/shim.go` and `cli/internal/dtushim/shim_test.go` to parse `gh pr merge --auto` and model the queued merge behavior in shim tests.
- **Added** `cli/internal/workflow/merge_pr_workflow_test.go` to assert the merge workflow command includes `--auto` and excludes `--admin`.

## Test plan
- `cd cli && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #190