### PR TITLE
Allow trusted workflows to modify referenced canonical protected files

### DIFF
--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -2274,11 +2275,12 @@ func (r *Runner) verifyProtectedSurfaces(vessel queue.Vessel, p workflow.Phase, 
 	}
 
 	violations := surface.Compare(before, after)
-	allowAdditive, err := r.workflowAllowsAdditiveProtectedWrites(vessel, violations)
+	policy, err := r.workflowProtectedWritePolicy(vessel, violations)
 	if err != nil {
 		return fmt.Errorf("resolve protected surface policy: %w", err)
 	}
-	violations = filterAdditiveProtectedSurfaceViolations(violations, allowAdditive)
+	violations = filterAdditiveProtectedSurfaceViolations(violations, policy.allowAdditive)
+	violations = filterCanonicalProtectedSurfaceViolations(vessel, p, violations, policy.allowCanonical)
 
 	// Source-root alignment filter: drop modification violations where the
 	// after-hash matches the canonical source root's current hash for that
@@ -2330,24 +2332,44 @@ func (r *Runner) verifyProtectedSurfaces(vessel queue.Vessel, p workflow.Phase, 
 	return fmt.Errorf("%s", errMsg)
 }
 
-func (r *Runner) workflowAllowsAdditiveProtectedWrites(vessel queue.Vessel, violations []surface.Violation) (bool, error) {
-	if !containsAdditiveProtectedSurfaceViolation(violations) {
-		return false, nil
+type protectedSurfaceWorkflowPolicy struct {
+	allowAdditive  bool
+	allowCanonical bool
+}
+
+func (r *Runner) workflowProtectedWritePolicy(vessel queue.Vessel, violations []surface.Violation) (protectedSurfaceWorkflowPolicy, error) {
+	needsAdditivePolicy := containsAdditiveProtectedSurfaceViolation(violations)
+	needsCanonicalPolicy := containsCanonicalProtectedSurfaceModification(violations) &&
+		strings.TrimSpace(vessel.Meta["issue_body"]) != ""
+	if !needsAdditivePolicy && !needsCanonicalPolicy {
+		return protectedSurfaceWorkflowPolicy{}, nil
 	}
 	if strings.TrimSpace(vessel.Workflow) == "" {
-		return false, nil
+		return protectedSurfaceWorkflowPolicy{}, nil
 	}
 
 	sk, err := r.loadWorkflow(vessel.Workflow)
 	if err != nil {
-		return false, fmt.Errorf("load workflow %q: %w", vessel.Workflow, err)
+		return protectedSurfaceWorkflowPolicy{}, fmt.Errorf("load workflow %q: %w", vessel.Workflow, err)
 	}
-	return sk.AllowAdditiveProtectedWrites, nil
+	return protectedSurfaceWorkflowPolicy{
+		allowAdditive:  sk.AllowAdditiveProtectedWrites,
+		allowCanonical: sk.AllowCanonicalProtectedWrites,
+	}, nil
 }
 
 func containsAdditiveProtectedSurfaceViolation(violations []surface.Violation) bool {
 	for _, violation := range violations {
 		if violation.Before == "absent" {
+			return true
+		}
+	}
+	return false
+}
+
+func containsCanonicalProtectedSurfaceModification(violations []surface.Violation) bool {
+	for _, violation := range violations {
+		if isProtectedSurfaceModification(violation) {
 			return true
 		}
 	}
@@ -2367,6 +2389,41 @@ func filterAdditiveProtectedSurfaceViolations(violations []surface.Violation, al
 		filtered = append(filtered, violation)
 	}
 	return filtered
+}
+
+func filterCanonicalProtectedSurfaceViolations(vessel queue.Vessel, p workflow.Phase, violations []surface.Violation, allowCanonical bool) []surface.Violation {
+	if !allowCanonical || len(violations) == 0 {
+		return violations
+	}
+
+	issueBody := strings.TrimSpace(vessel.Meta["issue_body"])
+	if issueBody == "" {
+		return violations
+	}
+
+	filtered := make([]surface.Violation, 0, len(violations))
+	for _, violation := range violations {
+		if !isProtectedSurfaceModification(violation) || !issueBodyMentionsProtectedPath(issueBody, violation.Path) {
+			filtered = append(filtered, violation)
+			continue
+		}
+		log.Printf("%sphase %q: suppressing canonical protected-surface violation on %s (workflow opt-in + issue body reference)",
+			vesselLabel(vessel), p.Name, violation.Path)
+	}
+	return filtered
+}
+
+func isProtectedSurfaceModification(violation surface.Violation) bool {
+	return violation.Before != "absent" && violation.After != "deleted"
+}
+
+func issueBodyMentionsProtectedPath(issueBody, path string) bool {
+	normalizedPath := filepath.ToSlash(strings.TrimSpace(path))
+	if normalizedPath == "" {
+		return false
+	}
+	re := regexp.MustCompile(`(^|[^A-Za-z0-9._/-])` + regexp.QuoteMeta(normalizedPath) + `([^A-Za-z0-9._/-]|$)`)
+	return re.FindStringIndex(issueBody) != nil
 }
 
 // filterViolationsAlignedWithSourceRoot drops modification violations whose

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -55,6 +55,25 @@ func TestProp_FilterAdditiveProtectedSurfaceViolationsDropsOnlyAdditions(t *test
 	})
 }
 
+func TestProp_IssueBodyMentionsProtectedPathHonorsTokenBoundaries(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		pathSuffix := rapid.StringMatching(`[a-z0-9._/-]{1,24}`).Draw(t, "pathSuffix")
+		path := ".xylem/" + pathSuffix
+		validBoundary := rapid.SampledFrom([]string{"", " ", "\n", "`", "(", "[", ":", "="}).Draw(t, "validBoundary")
+		invalidBoundary := rapid.SampledFrom([]string{"a", "0", ".", "/", "_", "-"}).Draw(t, "invalidBoundary")
+
+		if !issueBodyMentionsProtectedPath(validBoundary+path+validBoundary, path) {
+			t.Fatalf("issueBodyMentionsProtectedPath() = false, want true for bounded path %q", path)
+		}
+		if issueBodyMentionsProtectedPath(invalidBoundary+path+validBoundary, path) {
+			t.Fatalf("issueBodyMentionsProtectedPath() = true, want false for prefixed path %q", path)
+		}
+		if issueBodyMentionsProtectedPath(validBoundary+path+invalidBoundary, path) {
+			t.Fatalf("issueBodyMentionsProtectedPath() = true, want false for suffixed path %q", path)
+		}
+	})
+}
+
 func TestProp_BudgetEnforcementNeverLeaksAcrossVessels(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		outputLen := rapid.IntRange(20, 800).Draw(t, "outputLen")

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -5495,6 +5495,103 @@ phases:
 	assert.Empty(t, entries)
 }
 
+func setupCanonicalProtectedWriteSmokeTest(t *testing.T) (*Runner, *intermediary.AuditLog, string, string, surface.Snapshot) {
+	t.Helper()
+
+	repoRoot := t.TempDir()
+	withTestWorkingDir(t, repoRoot)
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".xylem", "workflows"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".xylem", "prompts", "doctor"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".xylem", "prompts", "doctor", "analyze.md"), []byte("analyze"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".xylem", "workflows", "doctor.yaml"), []byte(`name: doctor
+allow_canonical_protected_writes: true
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/doctor/analyze.md
+    max_turns: 1
+`), 0o644))
+
+	worktreeDir := filepath.Join(repoRoot, "worktree")
+	protectedRelPath := ".xylem/workflows/doctor.yaml"
+	protectedPath := filepath.Join(worktreeDir, filepath.FromSlash(protectedRelPath))
+	require.NoError(t, os.MkdirAll(filepath.Dir(protectedPath), 0o755))
+	require.NoError(t, os.WriteFile(protectedPath, []byte("name: doctor\nphases: []\n"), 0o644))
+
+	cfg := makeTestConfig(repoRoot, 1)
+	cfg.StateDir = filepath.Join(repoRoot, ".xylem-state")
+	require.NoError(t, os.MkdirAll(cfg.StateDir, 0o755))
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	r := New(cfg, queue.New(filepath.Join(repoRoot, "queue.jsonl")), &mockWorktree{path: worktreeDir}, &mockCmdRunner{})
+	r.AuditLog = auditLog
+
+	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), worktreeDir)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	return r, auditLog, worktreeDir, protectedPath, before
+}
+
+func TestSmoke_S21_SurfacePostVerificationAllowsReferencedCanonicalProtectedWrite(t *testing.T) {
+	r, auditLog, worktreeDir, protectedPath, before := setupCanonicalProtectedWriteSmokeTest(t)
+
+	modifiedContents := "name: doctor\nupdated: true\n"
+	require.NoError(t, os.WriteFile(protectedPath, []byte(modifiedContents), 0o644))
+
+	err := r.verifyProtectedSurfaces(
+		queue.Vessel{
+			ID:       "issue-canonical-allowed",
+			Source:   "github-issue",
+			Workflow: "doctor",
+			Meta: map[string]string{
+				"issue_body": "Please fix `.xylem/workflows/doctor.yaml` so the harness workflow stops failing.",
+			},
+		},
+		workflow.Phase{Name: "implement"},
+		worktreeDir,
+		before,
+	)
+	require.NoError(t, err)
+
+	data, readErr := os.ReadFile(protectedPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, modifiedContents, string(data))
+
+	entries, err := auditLog.Entries()
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestSmoke_S23_AuditLogRecordsDeniedCanonicalProtectedWriteWithoutIssuePathReference(t *testing.T) {
+	r, auditLog, worktreeDir, protectedPath, before := setupCanonicalProtectedWriteSmokeTest(t)
+
+	modifiedContents := "name: doctor\nupdated: true\n"
+	require.NoError(t, os.WriteFile(protectedPath, []byte(modifiedContents), 0o644))
+
+	err := r.verifyProtectedSurfaces(
+		queue.Vessel{
+			ID:       "issue-canonical-denied",
+			Source:   "github-issue",
+			Workflow: "doctor",
+			Meta: map[string]string{
+				"issue_body": "Please fix the harness workflow bug.",
+			},
+		},
+		workflow.Phase{Name: "implement"},
+		worktreeDir,
+		before,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "violated protected surfaces")
+	assert.Contains(t, err.Error(), ".xylem/workflows/doctor.yaml")
+
+	entries, err := auditLog.Entries()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "file_write", entries[0].Intent.Action)
+	assert.Equal(t, ".xylem/workflows/doctor.yaml", entries[0].Intent.Resource)
+	assert.Equal(t, intermediary.Deny, entries[0].Decision)
+}
+
 func TestSmoke_S23_AuditLogRecordsDeniedAdditiveProtectedWriteWithoutWorkflowOptIn(t *testing.T) {
 	repoRoot := t.TempDir()
 	withTestWorkingDir(t, repoRoot)

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -19,12 +19,13 @@ var validPhaseName = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 // Workflow defines a multi-phase execution plan loaded from a YAML file.
 type Workflow struct {
-	Name                         string  `yaml:"name"`
-	Description                  string  `yaml:"description,omitempty"`
-	LLM                          *string `yaml:"llm,omitempty"`
-	Model                        *string `yaml:"model,omitempty"`
-	AllowAdditiveProtectedWrites bool    `yaml:"allow_additive_protected_writes,omitempty"`
-	Phases                       []Phase `yaml:"phases"`
+	Name                          string  `yaml:"name"`
+	Description                   string  `yaml:"description,omitempty"`
+	LLM                           *string `yaml:"llm,omitempty"`
+	Model                         *string `yaml:"model,omitempty"`
+	AllowAdditiveProtectedWrites  bool    `yaml:"allow_additive_protected_writes,omitempty"`
+	AllowCanonicalProtectedWrites bool    `yaml:"allow_canonical_protected_writes,omitempty"`
+	Phases                        []Phase `yaml:"phases"`
 }
 
 // Phase represents a single step in a workflow's execution pipeline.

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -223,6 +223,50 @@ phases:
 	assert.True(t, got.AllowAdditiveProtectedWrites)
 }
 
+func TestLoadWorkflowAllowCanonicalProtectedWrites(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{
+			name: "defaults false",
+			yaml: `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`,
+			want: false,
+		},
+		{
+			name: "parses true",
+			yaml: `name: test-workflow
+allow_canonical_protected_writes: true
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			chdirTemp(t, dir)
+			createPromptFile(t, dir, "prompts/analyze.md")
+
+			path := writeWorkflowFile(t, dir, "test-workflow", tt.yaml)
+
+			got, err := Load(path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got.AllowCanonicalProtectedWrites)
+		})
+	}
+}
+
 func TestLoadWorkflowGateWithEvidenceAndEmptyLevel(t *testing.T) {
 	dir := t.TempDir()
 	chdirTemp(t, dir)
@@ -390,6 +434,7 @@ phases:
 			yaml: `name: deploy
 description: Deploy with gates
 allow_additive_protected_writes: true
+allow_canonical_protected_writes: true
 phases:
   - name: build
     prompt_file: prompts/build.md
@@ -417,6 +462,9 @@ phases:
 				}
 				if !s.AllowAdditiveProtectedWrites {
 					t.Fatal("AllowAdditiveProtectedWrites = false, want true")
+				}
+				if !s.AllowCanonicalProtectedWrites {
+					t.Fatal("AllowCanonicalProtectedWrites = false, want true")
 				}
 				if s.Phases[0].Gate.Retries != 2 {
 					t.Fatalf("gate retries = %d, want 2", s.Phases[0].Gate.Retries)

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -90,7 +90,11 @@ phases:
 | `description` | No | Human-readable description of the workflow's purpose. |
 | `llm` | No | Default provider for prompt phases in this workflow. Valid values: `claude`, `copilot`. |
 | `model` | No | Default model for prompt phases in this workflow. Provider-specific string. |
+| `allow_additive_protected_writes` | No | Permits this workflow to create new files that match configured protected-surface patterns without failing post-phase verification. Existing protected files are still immutable. |
+| `allow_canonical_protected_writes` | No | Permits this workflow to modify existing protected files when the vessel's issue body explicitly names the same protected path being changed. |
 | `phases` | Yes | Ordered list of phases. At least one is required. |
+
+Protected-surface write allowances are intentionally narrow. `allow_additive_protected_writes` only covers new protected files, while `allow_canonical_protected_writes` still requires the triggering issue body to name the protected path being edited so a workflow cannot silently rewrite unrelated control-plane files.
 
 **Phase fields:**
 


### PR DESCRIPTION
## Summary
- Implements [#194](https://github.com/nicholls-inc/xylem/issues/194) by adding a workflow-level `allow_canonical_protected_writes` opt-in for existing protected files.
- Only suppresses protected-surface violations when the workflow opts in **and** the vessel issue body explicitly names the protected path being modified.
- Preserves the narrower additive-write allowance and documents both protected-surface escape hatches separately.

## Smoke scenarios covered
- S21: Surface post-verification detects mutation — vessel fails
- S23: Audit log records surface violations

## Changes summary
- Modified `cli/internal/workflow/workflow.go` and `cli/internal/workflow/workflow_test.go` to add `Workflow.AllowCanonicalProtectedWrites` and YAML parsing coverage.
- Modified `cli/internal/runner/runner.go` to replace additive-only policy resolution with `workflowProtectedWritePolicy` and add `containsCanonicalProtectedSurfaceModification`, `filterCanonicalProtectedSurfaceViolations`, `isProtectedSurfaceModification`, and `issueBodyMentionsProtectedPath`.
- Modified `cli/internal/runner/runner_test.go` and `cli/internal/runner/runner_prop_test.go` to cover referenced canonical protected writes, denied canonical edits without an issue-path reference, and token-boundary matching.
- Modified `docs/workflows.md` to document `allow_additive_protected_writes` and `allow_canonical_protected_writes`.

## Test plan
- `cd cli && goimports -w .`
- `cd cli && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #194