### PR TITLE
Harden resolve-conflicts gates against false-positive merges

### DIFF
--- a/.xylem/workflows/resolve-conflicts.yaml
+++ b/.xylem/workflows/resolve-conflicts.yaml
@@ -15,7 +15,7 @@ phases:
     model: gpt-5.4
     gate:
       type: command
-      run: "cd cli && go vet ./... && go build ./cmd/xylem && go test ./..."
+      run: "git fetch origin main && test \"$(git branch --show-current)\" = \"$(gh pr view {{.Issue.Number}} --json headRefName --jq '.headRefName')\" && git merge-base --is-ancestor origin/main HEAD && cd cli && go vet ./... && go build ./cmd/xylem && go test ./..."
       retries: 2
   - name: push
     prompt_file: .xylem/prompts/resolve-conflicts/push.md

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -609,16 +609,8 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 			if p.Type == "command" {
 				// Command phase: render and execute shell command
-				rendered, err := phase.RenderPrompt(p.Run, td)
+				rendered, err := renderCommandTemplate(p.Name, "command", p.Run, td)
 				if err != nil {
-					finishCurrentPhaseSpan(err)
-					r.failVessel(vessel.ID, fmt.Sprintf("render command for phase %s: %v", p.Name, err))
-					if err := src.OnFail(ctx, vessel); err != nil {
-						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-					}
-					return "failed"
-				}
-				if err := validateCommandRender(p.Name, rendered); err != nil {
 					finishCurrentPhaseSpan(err)
 					r.failVessel(vessel.ID, err.Error())
 					if err := src.OnFail(ctx, vessel); err != nil {
@@ -839,7 +831,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 			switch p.Gate.Type {
 			case "command", "live":
-				gateResultExec := r.executeVerificationGate(ctx, phaseSpan, vessel, p, worktreePath, retryAttempt)
+				gateResultExec := r.executeVerificationGate(ctx, phaseSpan, vessel, p, td, worktreePath, retryAttempt)
 				gateOut, passed, gateErr := gateResultExec.output, gateResultExec.passed, gateResultExec.err
 				if gateErr != nil {
 					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error()))
@@ -1431,16 +1423,8 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		}
 
 		if p.Type == "command" {
-			rendered, err := phase.RenderPrompt(p.Run, td)
+			rendered, err := renderCommandTemplate(p.Name, "command", p.Run, td)
 			if err != nil {
-				finishCurrentPhaseSpan(err)
-				r.failVessel(vessel.ID, fmt.Sprintf("render command for phase %s: %v", p.Name, err))
-				if err := src.OnFail(ctx, vessel); err != nil {
-					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-				}
-				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
-			}
-			if err := validateCommandRender(p.Name, rendered); err != nil {
 				finishCurrentPhaseSpan(err)
 				r.failVessel(vessel.ID, err.Error())
 				if err := src.OnFail(ctx, vessel); err != nil {
@@ -1660,7 +1644,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 
 		switch p.Gate.Type {
 		case "command", "live":
-			gateResultExec := r.executeVerificationGate(ctx, phaseSpan, vessel, p, worktreePath, retryAttempt)
+			gateResultExec := r.executeVerificationGate(ctx, phaseSpan, vessel, p, td, worktreePath, retryAttempt)
 			gateOut, passed, gateErr := gateResultExec.output, gateResultExec.passed, gateResultExec.err
 			if gateErr != nil {
 				r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate error: %v", p.Name, gateErr))
@@ -1847,15 +1831,19 @@ func finishGateStepSpan(tracer *observability.Tracer, span observability.SpanCon
 	span.End()
 }
 
-func (r *Runner) executeVerificationGate(ctx context.Context, phaseSpan observability.SpanContext, vessel queue.Vessel, p workflow.Phase, worktreePath string, retryAttempt int) gateExecutionResult {
+func (r *Runner) executeVerificationGate(ctx context.Context, phaseSpan observability.SpanContext, vessel queue.Vessel, p workflow.Phase, td phase.TemplateData, worktreePath string, retryAttempt int) gateExecutionResult {
 	if p.Gate == nil {
 		return gateExecutionResult{passed: true}
 	}
 
 	switch p.Gate.Type {
 	case "command":
+		rendered, err := renderCommandTemplate(p.Name, "gate command", p.Gate.Run, td)
+		if err != nil {
+			return gateExecutionResult{err: err}
+		}
 		gateSpan := startGateSpan(r.Tracer, phaseSpan, ctx, p.Gate.Type)
-		gateOut, passed, gateErr := gate.RunCommandGate(ctx, r.Runner, worktreePath, p.Gate.Run)
+		gateOut, passed, gateErr := gate.RunCommandGate(ctx, r.Runner, worktreePath, rendered)
 		finishGateSpan(r.Tracer, gateSpan, observability.GateSpanData{
 			Type:         p.Gate.Type,
 			Passed:       passed,
@@ -2882,30 +2870,41 @@ func vesselLabel(v queue.Vessel) string {
 	return fmt.Sprintf("[%s] ", v.ID)
 }
 
+func renderCommandTemplate(phaseName, kind, command string, td phase.TemplateData) (string, error) {
+	rendered, err := phase.RenderPrompt(command, td)
+	if err != nil {
+		return "", fmt.Errorf("render %s for phase %s: %w", kind, phaseName, err)
+	}
+	if err := validateCommandRender(fmt.Sprintf("%s for phase %s", kind, phaseName), rendered); err != nil {
+		return "", err
+	}
+	return rendered, nil
+}
+
 // validateCommandRender checks the rendered command string for unresolved
 // template variables (leftover "{{" sequences). This catches cases where
 // template data has zero values that cause confusing downstream failures.
-func validateCommandRender(phaseName, rendered string) error {
+func validateCommandRender(subject, rendered string) error {
 	if strings.Contains(rendered, "{{") {
-		return fmt.Errorf("command phase %s: unresolved template variable in: %s", phaseName, rendered)
+		return fmt.Errorf("%s: unresolved template variable in: %s", subject, rendered)
 	}
 	return nil
 }
 
 // validateIssueDataForWorkflow returns an error when the workflow contains
-// command phases that reference .Issue template variables but the issue data
-// has a zero Number. This prevents commands like `gh pr merge 0` from
-// executing with confusing results.
+// command phases or command gates that reference .Issue template variables but
+// the issue data has a zero Number. This prevents commands like
+// `gh pr merge 0` from executing with confusing results.
 func validateIssueDataForWorkflow(vessel queue.Vessel, data phase.IssueData, wf *workflow.Workflow) error {
 	if wf == nil {
 		return nil
 	}
 	for _, p := range wf.Phases {
-		if p.Type != "command" {
-			continue
-		}
-		if strings.Contains(p.Run, ".Issue.") && data.Number == 0 {
+		if p.Type == "command" && strings.Contains(p.Run, ".Issue.") && data.Number == 0 {
 			return fmt.Errorf("command phase %s references .Issue but issue data is unavailable for vessel %s (Number is 0)", p.Name, vessel.ID)
+		}
+		if p.Gate != nil && p.Gate.Type == "command" && strings.Contains(p.Gate.Run, ".Issue.") && data.Number == 0 {
+			return fmt.Errorf("command gate for phase %s references .Issue but issue data is unavailable for vessel %s (Number is 0)", p.Name, vessel.ID)
 		}
 	}
 	return nil

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
+	"github.com/nicholls-inc/xylem/cli/internal/phase"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/surface"
@@ -169,6 +170,52 @@ func TestProp_BudgetExceededIsMonotonic(t *testing.T) {
 			if exceeded && !tracker.BudgetExceeded() {
 				t.Fatal("BudgetExceeded reverted to false")
 			}
+		}
+	})
+}
+
+func TestProp_ValidateIssueDataForWorkflowRequiresIssueNumberForCommandTemplates(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		phaseUsesIssue := rapid.Bool().Draw(t, "phaseUsesIssue")
+		gateUsesIssue := rapid.Bool().Draw(t, "gateUsesIssue")
+		phaseType := rapid.SampledFrom([]string{"", "command"}).Draw(t, "phaseType")
+		issueNumber := rapid.IntRange(0, 3).Draw(t, "issueNumber")
+
+		phaseRun := "echo ready"
+		if phaseUsesIssue {
+			phaseRun = "gh pr merge {{.Issue.Number}}"
+		}
+
+		var gateCfg *workflow.Gate
+		if rapid.Bool().Draw(t, "hasGate") {
+			gateRun := "echo gate"
+			if gateUsesIssue {
+				gateRun = "gh pr view {{.Issue.Number}} --json mergeable"
+			}
+			gateCfg = &workflow.Gate{
+				Type: "command",
+				Run:  gateRun,
+			}
+		}
+
+		p := workflow.Phase{
+			Name:       "resolve",
+			Type:       phaseType,
+			Run:        phaseRun,
+			PromptFile: ".xylem/prompts/resolve-conflicts/resolve.md",
+			MaxTurns:   10,
+			Gate:       gateCfg,
+		}
+		wf := &workflow.Workflow{Phases: []workflow.Phase{p}}
+		err := validateIssueDataForWorkflow(queue.Vessel{ID: "issue-1"}, phase.IssueData{Number: issueNumber}, wf)
+
+		wantErr := issueNumber == 0 &&
+			((phaseType == "command" && phaseUsesIssue) || (gateCfg != nil && gateUsesIssue))
+		if wantErr && err == nil {
+			t.Fatalf("validateIssueDataForWorkflow() error = nil, want error for phaseType=%q phaseUsesIssue=%t gateUsesIssue=%t", phaseType, phaseUsesIssue, gateUsesIssue)
+		}
+		if !wantErr && err != nil {
+			t.Fatalf("validateIssueDataForWorkflow() error = %v, want nil for phaseType=%q phaseUsesIssue=%t gateUsesIssue=%t issueNumber=%d", err, phaseType, phaseUsesIssue, gateUsesIssue, issueNumber)
 		}
 	})
 }

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -2570,6 +2570,139 @@ func TestDrainCommandGateFailsWithRetries(t *testing.T) {
 	}
 }
 
+func TestSmoke_S31_ResolveConflictsGateFailsBeforePushWhenOriginMainIsNotAncestor(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	vessel := makeVessel(164, "resolve-conflicts")
+	vessel.Meta["issue_title"] = "Resolve PR conflicts"
+	vessel.Meta["issue_body"] = "Merge origin/main into the PR branch."
+	_, _ = q.Enqueue(vessel)
+
+	writeWorkflowFile(t, dir, "resolve-conflicts", []testPhase{
+		{name: "analyze", promptContent: "Analyze conflicts", maxTurns: 5},
+		{
+			name:          "resolve",
+			promptContent: "Resolve conflicts\n{{.GateResult}}",
+			maxTurns:      5,
+			gate:          "      type: command\n      run: \"git fetch origin main && test \\\"$(git branch --show-current)\\\" = \\\"$(gh pr view {{.Issue.Number}} --json headRefName --jq '.headRefName')\\\" && git merge-base --is-ancestor origin/main HEAD && cd cli && go test ./...\"\n      retries: 0",
+		},
+		{name: "push", promptContent: "Push branch", maxTurns: 5},
+	})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		gateOutput: []byte("origin/main is not an ancestor of HEAD"),
+		gateErr:    &mockExitError{code: 1},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+	require.Len(t, cmdRunner.phaseCalls, 2)
+	assert.Contains(t, cmdRunner.phaseCalls[0].prompt, "Analyze conflicts")
+	assert.Contains(t, cmdRunner.phaseCalls[1].prompt, "Resolve conflicts")
+
+	stored := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, stored.State)
+	assert.Equal(t, "resolve", stored.FailedPhase)
+	assert.Contains(t, stored.GateOutput, "origin/main is not an ancestor")
+}
+
+func TestDrainCommandGateRendersTemplateData(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	vessel := makeVessel(42, "fix-bug")
+	vessel.Meta["issue_title"] = "Template gate"
+	vessel.Meta["issue_body"] = "Ensure gate commands render template data."
+	_, _ = q.Enqueue(vessel)
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{
+			name:          "implement",
+			promptContent: "Implement fix",
+			maxTurns:      5,
+			gate:          "      type: command\n      run: \"echo {{.Issue.Number}} {{.Vessel.ID}} {{.Phase.Name}}\"\n      retries: 0",
+		},
+	})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
+
+	var gateCommand string
+	for _, args := range cmdRunner.outputArgs {
+		if len(args) == 3 && args[0] == "sh" && args[1] == "-c" && strings.Contains(args[2], "echo 42 issue-42 implement") {
+			gateCommand = args[2]
+			break
+		}
+	}
+	require.NotEmpty(t, gateCommand)
+	assert.NotContains(t, gateCommand, "{{")
+}
+
+func TestSmoke_S32_ResolveConflictsGateRendersPRHeadAndAncestorChecks(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	vessel := makeVessel(42, "resolve-conflicts")
+	vessel.Meta["issue_title"] = "Resolve PR conflicts"
+	vessel.Meta["issue_body"] = "Merge origin/main into the PR branch."
+	_, _ = q.Enqueue(vessel)
+
+	writeWorkflowFile(t, dir, "resolve-conflicts", []testPhase{
+		{name: "analyze", promptContent: "Analyze conflicts", maxTurns: 5},
+		{
+			name:          "resolve",
+			promptContent: "Resolve conflicts",
+			maxTurns:      5,
+			gate:          "      type: command\n      run: \"git fetch origin main && test \\\"$(git branch --show-current)\\\" = \\\"$(gh pr view {{.Issue.Number}} --json headRefName --jq '.headRefName')\\\" && git merge-base --is-ancestor origin/main HEAD && cd cli && go test ./...\"\n      retries: 0",
+		},
+	})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
+
+	var gateCommand string
+	for _, args := range cmdRunner.outputArgs {
+		if len(args) == 3 && args[0] == "sh" && args[1] == "-c" && strings.Contains(args[2], "gh pr view 42 --json headRefName --jq '.headRefName'") {
+			gateCommand = args[2]
+			break
+		}
+	}
+	require.NotEmpty(t, gateCommand)
+	assert.Contains(t, gateCommand, "git fetch origin main")
+	assert.Contains(t, gateCommand, "git branch --show-current")
+	assert.Contains(t, gateCommand, "gh pr view 42 --json headRefName --jq '.headRefName'")
+	assert.NotContains(t, gateCommand, "{{")
+}
+
 func TestDrainLabelGateTransitionsToWaiting(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 2)
@@ -6232,6 +6365,55 @@ func TestValidateIssueDataForWorkflow_CommandPhaseValidNumber(t *testing.T) {
 	if err := validateIssueDataForWorkflow(vessel, data, wf); err != nil {
 		t.Fatalf("unexpected error for valid issue number: %v", err)
 	}
+}
+
+func TestValidateIssueDataForWorkflow_CommandGateZeroNumber(t *testing.T) {
+	vessel := queue.Vessel{
+		ID:     "issue-1",
+		Source: "github-issue",
+	}
+	data := phase.IssueData{Number: 0}
+	wf := &workflow.Workflow{
+		Phases: []workflow.Phase{
+			{
+				Name:       "resolve",
+				PromptFile: ".xylem/prompts/resolve-conflicts/resolve.md",
+				MaxTurns:   10,
+				Gate: &workflow.Gate{
+					Type: "command",
+					Run:  "gh pr view {{.Issue.Number}} --json mergeable",
+				},
+			},
+		},
+	}
+
+	err := validateIssueDataForWorkflow(vessel, data, wf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "command gate for phase resolve references .Issue")
+	assert.Contains(t, err.Error(), "Number is 0")
+}
+
+func TestValidateIssueDataForWorkflow_CommandGateValidNumber(t *testing.T) {
+	vessel := queue.Vessel{
+		ID:     "issue-1",
+		Source: "github-issue",
+	}
+	data := phase.IssueData{Number: 42}
+	wf := &workflow.Workflow{
+		Phases: []workflow.Phase{
+			{
+				Name:       "resolve",
+				PromptFile: ".xylem/prompts/resolve-conflicts/resolve.md",
+				MaxTurns:   10,
+				Gate: &workflow.Gate{
+					Type: "command",
+					Run:  "gh pr view {{.Issue.Number}} --json mergeable",
+				},
+			},
+		},
+	}
+
+	require.NoError(t, validateIssueDataForWorkflow(vessel, data, wf))
 }
 
 func TestValidateIssueDataForWorkflow_NonCommandPhase(t *testing.T) {

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -58,7 +58,7 @@ type GateEvidence struct {
 // Gate defines an inter-phase quality gate that must pass before the next phase begins.
 type Gate struct {
 	Type         string        `yaml:"type"`                    // "command" or "label"
-	Run          string        `yaml:"run,omitempty"`           // shell command (type=command)
+	Run          string        `yaml:"run,omitempty"`           // shell command (type=command), supports template variables
 	Retries      int           `yaml:"retries,omitempty"`       // default 0
 	RetryDelay   string        `yaml:"retry_delay,omitempty"`   // default "10s"
 	WaitFor      string        `yaml:"wait_for,omitempty"`      // label name (type=label)


### PR DESCRIPTION
## Summary
- Addresses [issue #188](https://github.com/nicholls-inc/xylem/issues/188) by making the `resolve-conflicts` workflow prove the PR branch is still the PR head and already contains `origin/main` before branch-local Go verification can pass.
- Renders command gate templates with phase data so the workflow can safely use `{{.Issue.Number}}` in gate commands and fail fast when required issue metadata is missing.

## Smoke scenarios covered
- S31 — Resolve conflicts gate fails before push when `origin/main` is not an ancestor of `HEAD`
- S32 — Resolve conflicts gate renders PR head and ancestor checks

## Changes summary
- **Modified** `.xylem/workflows/resolve-conflicts.yaml` to replace the branch-local-only gate with `git fetch origin main`, PR head verification via `gh pr view {{.Issue.Number}}`, `git merge-base --is-ancestor origin/main HEAD`, and the existing Go verification commands.
- **Modified** `cli/internal/runner/runner.go` to add `renderCommandTemplate`, pass `phase.TemplateData` into `executeVerificationGate`, and extend `validateIssueDataForWorkflow` so command gates get the same template validation as command phases.
- **Modified** `cli/internal/workflow/workflow.go` to document that command gates support template variables.
- **Modified** `cli/internal/runner/runner_test.go` to add the S31/S32 regression coverage plus a command-gate template rendering test.
- **Modified** `cli/internal/runner/runner_prop_test.go` to add property coverage for issue-number requirements across command phases and command gates.

## Test plan
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && goimports -l .`
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && go vet ./...`
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && golangci-lint run`
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && go build ./cmd/xylem`
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && go test ./...`

Fixes #188