### PR TITLE
Allow resolve-conflicts PR scans to re-enqueue after completed prior vessels

### DIFF
--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -260,12 +260,18 @@ func (g *GitHubPR) hasBranch(ctx context.Context, prNum int) bool {
 	return false
 }
 
-func (g *GitHubPR) hasMatchingFailedFingerprint(ref, fingerprint string) bool {
-	latest, err := g.Queue.FindLatestByRef(ref)
-	if err != nil || latest == nil {
+func priorVesselBlocksReenqueue(v *queue.Vessel, fingerprint string) bool {
+	if v == nil {
 		return false
 	}
-	return latest.State == queue.StateFailed && latest.Meta["source_input_fingerprint"] == fingerprint
+	switch v.State {
+	case queue.StatePending, queue.StateRunning, queue.StateWaiting:
+		return true
+	case queue.StateFailed:
+		return v.Meta["source_input_fingerprint"] == fingerprint
+	default:
+		return false
+	}
 }
 
 // isBlockedByPriorVessel reports whether a prior vessel already occupies
@@ -277,26 +283,35 @@ func (g *GitHubPR) hasMatchingFailedFingerprint(ref, fingerprint string) bool {
 // when it belongs to the SAME workflow as the current task.
 //
 // Blocking conditions:
-//   - A pending/running/waiting vessel at the qualified ref (via HasRef).
+//   - A pending/running/waiting vessel at the qualified ref.
 //   - A failed vessel at the qualified ref whose fingerprint equals the
-//     current PR input fingerprint (hasMatchingFailedFingerprint).
-//   - A legacy bare-URL vessel whose Workflow matches and is either
-//     active (pending/running/waiting) or terminally failed with a
-//     matching fingerprint.
+//     current PR input fingerprint.
+//   - If no qualified vessel exists yet, a legacy bare-URL vessel whose
+//     Workflow matches and is either active (pending/running/waiting)
+//     or terminally failed with a matching fingerprint.
 //
-// This preserves the dedup guarantees of the pre-qualification scheme
-// for in-flight workflows while allowing distinct workflows over the
-// same PR (e.g., merge-pr and resolve-conflicts) to coexist.
+// Completed/cancelled/timed_out vessels do not block. This is important
+// for resolve-conflicts retries: if a prior vessel completed without
+// actually changing the PR branch and GitHub still reports CONFLICTING,
+// the scanner must be able to enqueue a fresh vessel.
+//
+// Once a qualified-ref vessel exists, it is always newer than any
+// legacy bare-URL vessel for the same PR/workflow and therefore solely
+// determines whether the dedup slot is occupied. Falling back to an
+// older legacy vessel in that case would let stale pre-upgrade state
+// incorrectly block a newer completed/cancelled run.
+//
+// This preserves the dedup guarantees of the pre-qualification scheme for
+// in-flight workflows while allowing distinct workflows over the same PR
+// (e.g., merge-pr and resolve-conflicts) to coexist.
 func (g *GitHubPR) isBlockedByPriorVessel(prURL, fingerprint, workflow string) bool {
 	qualifiedRef := prWorkflowRef(prURL, workflow)
-	if g.Queue.HasRef(qualifiedRef) {
-		return true
-	}
-	if g.hasMatchingFailedFingerprint(qualifiedRef, fingerprint) {
-		return true
+	latest, err := g.Queue.FindLatestByRef(qualifiedRef)
+	if err == nil {
+		return priorVesselBlocksReenqueue(latest, fingerprint)
 	}
 	// Backward-compat: legacy queue entries were written with ref = prURL.
-	latest, err := g.Queue.FindLatestByRef(prURL)
+	latest, err = g.Queue.FindLatestByRef(prURL)
 	if err != nil || latest == nil {
 		return false
 	}
@@ -306,11 +321,5 @@ func (g *GitHubPR) isBlockedByPriorVessel(prURL, fingerprint, workflow string) b
 	if latest.Workflow != workflow {
 		return false
 	}
-	switch latest.State {
-	case queue.StatePending, queue.StateRunning, queue.StateWaiting:
-		return true
-	case queue.StateFailed:
-		return latest.Meta["source_input_fingerprint"] == fingerprint
-	}
-	return false
+	return priorVesselBlocksReenqueue(latest, fingerprint)
 }

--- a/cli/internal/source/github_pr_prop_test.go
+++ b/cli/internal/source/github_pr_prop_test.go
@@ -1,0 +1,51 @@
+package source
+
+import (
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"pgregory.net/rapid"
+)
+
+func genVesselState() *rapid.Generator[queue.VesselState] {
+	return rapid.SampledFrom([]queue.VesselState{
+		queue.StatePending,
+		queue.StateRunning,
+		queue.StateWaiting,
+		queue.StateFailed,
+		queue.StateCompleted,
+		queue.StateCancelled,
+		queue.StateTimedOut,
+	})
+}
+
+func TestPropPriorVesselBlocksReenqueueMatchesStateMachine(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		state := genVesselState().Draw(t, "state")
+		match := rapid.Bool().Draw(t, "match")
+		fingerprint := rapid.StringMatching(`[a-z0-9-]{1,16}`).Draw(t, "fingerprint")
+
+		metaFingerprint := fingerprint
+		if !match {
+			metaFingerprint = fingerprint + "-other"
+		}
+		vessel := &queue.Vessel{
+			State: state,
+			Meta:  map[string]string{"source_input_fingerprint": metaFingerprint},
+		}
+
+		got := priorVesselBlocksReenqueue(vessel, fingerprint)
+
+		want := false
+		switch state {
+		case queue.StatePending, queue.StateRunning, queue.StateWaiting:
+			want = true
+		case queue.StateFailed:
+			want = match
+		}
+
+		if got != want {
+			t.Fatalf("priorVesselBlocksReenqueue(state=%s, match=%v) = %v, want %v", state, match, got, want)
+		}
+	})
+}

--- a/cli/internal/source/github_pr_test.go
+++ b/cli/internal/source/github_pr_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockCmdRunner struct {
@@ -369,6 +371,46 @@ func TestGitHubPRScanReenqueuesChangedFailedVessel(t *testing.T) {
 	}
 	if vessels[0].Meta["source_input_fingerprint"] == oldFingerprint {
 		t.Fatal("expected updated fingerprint for changed PR input")
+	}
+}
+
+func TestPriorVesselBlocksReenqueue(t *testing.T) {
+	t.Parallel()
+
+	fingerprint := "match"
+	tests := []struct {
+		name        string
+		vessel      *queue.Vessel
+		fingerprint string
+		want        bool
+	}{
+		{name: "nil", vessel: nil, fingerprint: fingerprint, want: false},
+		{name: "pending", vessel: &queue.Vessel{State: queue.StatePending}, fingerprint: fingerprint, want: true},
+		{name: "running", vessel: &queue.Vessel{State: queue.StateRunning}, fingerprint: fingerprint, want: true},
+		{name: "waiting", vessel: &queue.Vessel{State: queue.StateWaiting}, fingerprint: fingerprint, want: true},
+		{
+			name:        "failed fingerprint match",
+			vessel:      &queue.Vessel{State: queue.StateFailed, Meta: map[string]string{"source_input_fingerprint": fingerprint}},
+			fingerprint: fingerprint,
+			want:        true,
+		},
+		{
+			name:        "failed fingerprint mismatch",
+			vessel:      &queue.Vessel{State: queue.StateFailed, Meta: map[string]string{"source_input_fingerprint": "other"}},
+			fingerprint: fingerprint,
+			want:        false,
+		},
+		{name: "completed", vessel: &queue.Vessel{State: queue.StateCompleted}, fingerprint: fingerprint, want: false},
+		{name: "cancelled", vessel: &queue.Vessel{State: queue.StateCancelled}, fingerprint: fingerprint, want: false},
+		{name: "timed out", vessel: &queue.Vessel{State: queue.StateTimedOut}, fingerprint: fingerprint, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := priorVesselBlocksReenqueue(tt.vessel, tt.fingerprint); got != tt.want {
+				t.Fatalf("priorVesselBlocksReenqueue() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -922,6 +964,115 @@ func TestGitHubPRScanLegacyFailedVesselStillBlocksSameWorkflow(t *testing.T) {
 	}
 }
 
+func TestSmoke_S1_CompletedQualifiedVesselDoesNotBlockResolveConflicts(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prURL := "https://github.com/owner/repo/pull/179"
+	fingerprint := githubSourceFingerprint("feat: scheduled lessons", "b", []string{"needs-conflict-resolution"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "pr-179-resolve-conflicts-old",
+		Source:    "github-pr",
+		Ref:       prWorkflowRef(prURL, "resolve-conflicts"),
+		Workflow:  "resolve-conflicts",
+		Meta:      map[string]string{"pr_num": "179", "source_input_fingerprint": fingerprint},
+		State:     queue.StateCompleted,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	prs := []ghPR{
+		{Number: 179, Title: "feat: scheduled lessons", Body: "b", URL: prURL, HeadRefName: "feat/issue-159-159",
+			Mergeable: "CONFLICTING",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "needs-conflict-resolution"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo: "owner/repo",
+		Tasks: map[string]GitHubTask{
+			"conflict-resolution": {Labels: []string{"needs-conflict-resolution"}, Workflow: "resolve-conflicts"},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+
+	assert.Equal(t, "resolve-conflicts", vessels[0].Workflow)
+	assert.Equal(t, prWorkflowRef(prURL, "resolve-conflicts"), vessels[0].Ref)
+	assert.Equal(t, "179", vessels[0].Meta["pr_num"])
+	assert.Equal(t, fingerprint, vessels[0].Meta["source_input_fingerprint"])
+	for _, call := range r.calls {
+		assert.NotContains(t, strings.Join(call, " "), "--remove-label")
+	}
+}
+
+func TestSmoke_S2_QualifiedCompletedVesselOverridesOlderLegacyFailedVessel(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prURL := "https://github.com/owner/repo/pull/179"
+	fingerprint := githubSourceFingerprint("feat: scheduled lessons", "b", []string{"needs-conflict-resolution"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "pr-179-resolve-conflicts-legacy",
+		Source:    "github-pr",
+		Ref:       prURL,
+		Workflow:  "resolve-conflicts",
+		Meta:      map[string]string{"pr_num": "179", "source_input_fingerprint": fingerprint},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC().Add(-2 * time.Minute),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("pr-179-resolve-conflicts-legacy", queue.StateFailed, "boom"))
+
+	_, err = q.Enqueue(queue.Vessel{
+		ID:        "pr-179-resolve-conflicts-qualified",
+		Source:    "github-pr",
+		Ref:       prWorkflowRef(prURL, "resolve-conflicts"),
+		Workflow:  "resolve-conflicts",
+		Meta:      map[string]string{"pr_num": "179", "source_input_fingerprint": fingerprint},
+		State:     queue.StateCompleted,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	prs := []ghPR{
+		{Number: 179, Title: "feat: scheduled lessons", Body: "b", URL: prURL, HeadRefName: "feat/issue-159-159",
+			Mergeable: "CONFLICTING",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "needs-conflict-resolution"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo: "owner/repo",
+		Tasks: map[string]GitHubTask{
+			"conflict-resolution": {Labels: []string{"needs-conflict-resolution"}, Workflow: "resolve-conflicts"},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+
+	assert.Equal(t, "resolve-conflicts", vessels[0].Workflow)
+	assert.Equal(t, prWorkflowRef(prURL, "resolve-conflicts"), vessels[0].Ref)
+	assert.Equal(t, "179", vessels[0].Meta["pr_num"])
+	assert.Equal(t, fingerprint, vessels[0].Meta["source_input_fingerprint"])
+}
+
 func TestGitHubPRScanLegacyActiveVesselStillBlocksSameWorkflow(t *testing.T) {
 	// Backward-compat guard: a legacy bare-URL pending/running vessel
 	// must continue to block re-enqueue of the same workflow. This
@@ -967,6 +1118,52 @@ func TestGitHubPRScanLegacyActiveVesselStillBlocksSameWorkflow(t *testing.T) {
 	if len(vessels) != 0 {
 		t.Fatalf("expected legacy active vessel to block re-enqueue, got %d", len(vessels))
 	}
+}
+
+func TestSmoke_S3_LegacyCompletedVesselDoesNotBlockSameWorkflow(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prURL := "https://github.com/owner/repo/pull/188"
+	fingerprint := githubSourceFingerprint("feat: x", "b", []string{"needs-conflict-resolution"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "pr-188-resolve-conflicts-old",
+		Source:    "github-pr",
+		Ref:       prURL,
+		Workflow:  "resolve-conflicts",
+		Meta:      map[string]string{"pr_num": "188", "source_input_fingerprint": fingerprint},
+		State:     queue.StateCompleted,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	prs := []ghPR{
+		{Number: 188, Title: "feat: x", Body: "b", URL: prURL, HeadRefName: "feat/x",
+			Mergeable: "CONFLICTING",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "needs-conflict-resolution"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+
+	src := &GitHubPR{
+		Repo: "owner/repo",
+		Tasks: map[string]GitHubTask{
+			"conflict-resolution": {Labels: []string{"needs-conflict-resolution"}, Workflow: "resolve-conflicts"},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+
+	assert.Equal(t, "resolve-conflicts", vessels[0].Workflow)
+	assert.Equal(t, prWorkflowRef(prURL, "resolve-conflicts"), vessels[0].Ref)
+	assert.Equal(t, "188", vessels[0].Meta["pr_num"])
+	assert.Equal(t, fingerprint, vessels[0].Meta["source_input_fingerprint"])
 }
 
 func TestGitHubPRScanResolveConflictsSkipsMergeablePRAndStripsLabel(t *testing.T) {


### PR DESCRIPTION
## Summary
+
+Implements [nicholls-inc/xylem#200](https://github.com/nicholls-inc/xylem/issues/200) by making github-pr scanner dedup state-aware for prior conflict-resolution vessels. Completed, cancelled, and timed-out prior vessels no longer occupy the dedup slot, while active vessels and failed vessels with the same input fingerprint still block re-enqueue.
+
+## Smoke scenarios covered
+
+- **S1** — Completed qualified vessel does not block resolve-conflicts
+- **S2** — Qualified completed vessel overrides older legacy failed vessel
+- **S3** — Legacy completed vessel does not block same workflow
+
+## Changes summary
+
+- **Modified:** `cli/internal/source/github_pr.go`
+  - Refactored `GitHubPR.isBlockedByPriorVessel` to load the latest qualified vessel and evaluate it by state instead of treating any prior qualified ref as blocking.
+  - Added `priorVesselBlocksReenqueue` to centralize the blocking rules for active and failed vessels.
+  - Preserved backward compatibility for legacy bare-URL refs while preventing stale legacy state from overriding newer qualified vessels.
+- **Modified:** `cli/internal/source/github_pr_test.go`
+  - Added table-driven coverage for `priorVesselBlocksReenqueue`.
+  - Added regression/smoke tests for completed qualified vessels, qualified-vs-legacy precedence, and completed legacy same-workflow vessels.
+- **Added:** `cli/internal/source/github_pr_prop_test.go`
+  - Added `TestPropPriorVesselBlocksReenqueueMatchesStateMachine` to verify the helper matches the vessel state machine across generated inputs.
+
+## Test plan
+
+- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && goimports -w .`
+- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && goimports -l .`
+- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && go vet ./...`
+- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && golangci-lint run`
+- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && go build ./cmd/xylem`
+- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && go test ./...`
+

Fixes #200