### PR TITLE
Fix daemon auto-upgrade to sync the daemon worktree before rebuild

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -68,14 +68,13 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	var upgrade upgradeFunc
 	upgradeInterval := time.Duration(0)
 	if cfg.Daemon.AutoUpgrade {
-		execPath, execErr := os.Executable()
-		if execErr != nil {
-			slog.Warn("daemon auto-upgrade skipped: resolve executable path", "error", execErr)
+		target, err := resolveDaemonUpgradeTarget(os.Getwd, os.Executable)
+		if err != nil {
+			slog.Warn("daemon auto-upgrade skipped", "error", err)
 		} else {
-			repoDir := filepath.Dir(filepath.Dir(execPath))
-			selfUpgrade(repoDir, execPath)
+			selfUpgrade(target.repoDir, target.executablePath)
 
-			upgrade = func() { selfUpgrade(repoDir, execPath) }
+			upgrade = func() { selfUpgrade(target.repoDir, target.executablePath) }
 			upgradeInterval = parseUpgradeInterval(cfg.Daemon)
 		}
 	}

--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"log/slog"
 	"os/signal"
 	"path/filepath"

--- a/cli/cmd/xylem/upgrade.go
+++ b/cli/cmd/xylem/upgrade.go
@@ -11,6 +11,45 @@ import (
 	"syscall"
 )
 
+var (
+	daemonGitPull  = gitPull
+	daemonGoBuild  = goBuild
+	daemonHashFile = hashFile
+	daemonExec     = func(path string, args []string, env []string) error {
+		return syscall.Exec(path, args, env)
+	}
+)
+
+type daemonUpgradeTarget struct {
+	repoDir        string
+	executablePath string
+}
+
+func resolveDaemonUpgradeTarget(getwd func() (string, error), executable func() (string, error)) (daemonUpgradeTarget, error) {
+	executablePath, err := executable()
+	if err != nil {
+		return daemonUpgradeTarget{}, fmt.Errorf("resolve executable path: %w", err)
+	}
+
+	workingDir, err := getwd()
+	if err != nil {
+		return daemonUpgradeTarget{}, fmt.Errorf("resolve working directory: %w", err)
+	}
+
+	return daemonUpgradeTargetFromPaths(workingDir, executablePath)
+}
+
+func daemonUpgradeTargetFromPaths(workingDir, executablePath string) (daemonUpgradeTarget, error) {
+	repoDir, err := filepath.Abs(workingDir)
+	if err != nil {
+		return daemonUpgradeTarget{}, fmt.Errorf("absolute working directory: %w", err)
+	}
+	return daemonUpgradeTarget{
+		repoDir:        repoDir,
+		executablePath: executablePath,
+	}, nil
+}
+
 // selfUpgrade pulls latest main, rebuilds the binary, and exec()s the new
 // binary if it changed. On success (binary changed), this function does not
 // return — the process image is replaced. On failure or no-change, it returns
@@ -18,12 +57,12 @@ import (
 func selfUpgrade(repoDir, executablePath string) {
 	slog.Info("daemon auto-upgrade pulling latest main")
 
-	if err := gitPull(repoDir); err != nil {
+	if err := daemonGitPull(repoDir); err != nil {
 		slog.Warn("daemon auto-upgrade git pull failed", "error", err)
 		return
 	}
 
-	oldHash, err := hashFile(executablePath)
+	oldHash, err := daemonHashFile(executablePath)
 	if err != nil {
 		slog.Warn("daemon auto-upgrade failed to hash current binary", "error", err)
 		return
@@ -32,13 +71,13 @@ func selfUpgrade(repoDir, executablePath string) {
 	// Build to a temp file to avoid corrupting the running binary on failure.
 	cliDir := filepath.Join(repoDir, "cli")
 	tmpBin := executablePath + ".upgrade"
-	if err := goBuild(cliDir, tmpBin); err != nil {
+	if err := daemonGoBuild(cliDir, tmpBin); err != nil {
 		slog.Warn("daemon auto-upgrade go build failed", "error", err)
 		os.Remove(tmpBin) //nolint:errcheck
 		return
 	}
 
-	newHash, err := hashFile(tmpBin)
+	newHash, err := daemonHashFile(tmpBin)
 	if err != nil {
 		slog.Warn("daemon auto-upgrade failed to hash rebuilt binary", "error", err)
 		os.Remove(tmpBin) //nolint:errcheck
@@ -59,7 +98,7 @@ func selfUpgrade(repoDir, executablePath string) {
 	}
 
 	slog.Info("daemon auto-upgrade execing rebuilt binary", "old_hash", oldHash[:12], "new_hash", newHash[:12])
-	execErr := syscall.Exec(executablePath, os.Args, os.Environ())
+	execErr := daemonExec(executablePath, os.Args, os.Environ())
 	// If we reach here, exec() failed.
 	slog.Warn("daemon auto-upgrade exec failed", "error", execErr)
 }

--- a/cli/cmd/xylem/upgrade_prop_test.go
+++ b/cli/cmd/xylem/upgrade_prop_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropDaemonUpgradeTargetAlwaysUsesWorkingDirectory(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		baseDir, err := os.MkdirTemp("", "xylem-prop-*")
+		if err != nil {
+			rt.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(baseDir)
+		resolvedBaseDir, err := filepath.EvalSymlinks(baseDir)
+		if err != nil {
+			rt.Fatalf("EvalSymlinks(%q) error = %v", baseDir, err)
+		}
+
+		oldWd, err := os.Getwd()
+		if err != nil {
+			rt.Fatalf("Getwd() error = %v", err)
+		}
+		if err := os.Chdir(baseDir); err != nil {
+			rt.Fatalf("Chdir(%q) error = %v", baseDir, err)
+		}
+		defer func() {
+			if err := os.Chdir(oldWd); err != nil {
+				t.Fatalf("restore working directory: %v", err)
+			}
+		}()
+
+		worktreeSegments := []string{
+			rapid.StringMatching(`[a-z0-9-]{1,8}`).Draw(rt, "worktree-seg-1"),
+			rapid.StringMatching(`[a-z0-9-]{1,8}`).Draw(rt, "worktree-seg-2"),
+			rapid.StringMatching(`[a-z0-9-]{1,8}`).Draw(rt, "worktree-seg-3"),
+		}
+		executableASegments := []string{
+			rapid.StringMatching(`[a-z0-9-]{1,8}`).Draw(rt, "binary-a-seg-1"),
+			rapid.StringMatching(`[a-z0-9-]{1,8}`).Draw(rt, "binary-a-seg-2"),
+			rapid.StringMatching(`[a-z0-9-]{1,8}`).Draw(rt, "binary-a-seg-3"),
+		}
+		executableBSegments := []string{
+			rapid.StringMatching(`[a-z0-9-]{1,8}`).Draw(rt, "binary-b-seg-1"),
+			rapid.StringMatching(`[a-z0-9-]{1,8}`).Draw(rt, "binary-b-seg-2"),
+			rapid.StringMatching(`[a-z0-9-]{1,8}`).Draw(rt, "binary-b-seg-3"),
+		}
+
+		workingDir := filepath.Join(worktreeSegments...)
+		executablePathA := filepath.Join(append([]string{resolvedBaseDir}, executableASegments...)...)
+		executablePathB := filepath.Join(append([]string{resolvedBaseDir}, executableBSegments...)...)
+		targetA, err := daemonUpgradeTargetFromPaths(workingDir, executablePathA)
+		if err != nil {
+			rt.Fatalf("daemonUpgradeTargetFromPaths() error = %v", err)
+		}
+		targetB, err := daemonUpgradeTargetFromPaths(workingDir, executablePathB)
+		if err != nil {
+			rt.Fatalf("daemonUpgradeTargetFromPaths() error = %v", err)
+		}
+
+		wantRepoDir, err := filepath.Abs(filepath.Join(append([]string{resolvedBaseDir}, worktreeSegments...)...))
+		if err != nil {
+			rt.Fatalf("filepath.Abs() error = %v", err)
+		}
+		if targetA.repoDir != wantRepoDir {
+			rt.Fatalf("targetA.repoDir = %q, want %q", targetA.repoDir, wantRepoDir)
+		}
+		if targetB.repoDir != wantRepoDir {
+			rt.Fatalf("targetB.repoDir = %q, want %q", targetB.repoDir, wantRepoDir)
+		}
+		if targetA.repoDir != targetB.repoDir {
+			rt.Fatalf("repoDir depended on executable path: targetA=%q targetB=%q", targetA.repoDir, targetB.repoDir)
+		}
+		if targetA.executablePath != executablePathA {
+			rt.Fatalf("targetA.executablePath = %q, want %q", targetA.executablePath, executablePathA)
+		}
+		if targetB.executablePath != executablePathB {
+			rt.Fatalf("targetB.executablePath = %q, want %q", targetB.executablePath, executablePathB)
+		}
+		if targetA.repoDir == filepath.Dir(filepath.Dir(executablePathA)) {
+			rt.Fatalf("repoDir unexpectedly matched first binary repo: repoDir=%q executablePath=%q", targetA.repoDir, executablePathA)
+		}
+		if targetB.repoDir == filepath.Dir(filepath.Dir(executablePathB)) {
+			rt.Fatalf("repoDir unexpectedly matched second binary repo: repoDir=%q executablePath=%q", targetB.repoDir, executablePathB)
+		}
+	})
+}

--- a/cli/cmd/xylem/upgrade_test.go
+++ b/cli/cmd/xylem/upgrade_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func stubDaemonUpgradeDependencies(
+	t *testing.T,
+	gitPull func(string) error,
+	goBuild func(string, string) error,
+	execFn func(string, []string, []string) error,
+) {
+	t.Helper()
+
+	prevGitPull := daemonGitPull
+	prevGoBuild := daemonGoBuild
+	prevExec := daemonExec
+	daemonGitPull = gitPull
+	daemonGoBuild = goBuild
+	daemonExec = execFn
+	t.Cleanup(func() {
+		daemonGitPull = prevGitPull
+		daemonGoBuild = prevGoBuild
+		daemonExec = prevExec
+	})
+}
+
+func TestResolveDaemonUpgradeTargetUsesWorkingDirectory(t *testing.T) {
+	worktreeDir := filepath.Join(t.TempDir(), ".claude", "worktrees", ".daemon-root")
+	executablePath := filepath.Join(t.TempDir(), "cli", "xylem")
+
+	target, err := resolveDaemonUpgradeTarget(
+		func() (string, error) { return worktreeDir, nil },
+		func() (string, error) { return executablePath, nil },
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, worktreeDir, target.repoDir)
+	assert.Equal(t, executablePath, target.executablePath)
+	assert.NotEqual(t, filepath.Dir(filepath.Dir(executablePath)), target.repoDir)
+}
+
+func TestResolveDaemonUpgradeTargetPropagatesExecutableError(t *testing.T) {
+	wantErr := errors.New("boom")
+
+	_, err := resolveDaemonUpgradeTarget(
+		func() (string, error) { return t.TempDir(), nil },
+		func() (string, error) { return "", wantErr },
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Contains(t, err.Error(), "resolve executable path")
+}
+
+func TestResolveDaemonUpgradeTargetPropagatesWorkingDirectoryError(t *testing.T) {
+	wantErr := errors.New("boom")
+
+	_, err := resolveDaemonUpgradeTarget(
+		func() (string, error) { return "", wantErr },
+		func() (string, error) { return filepath.Join(t.TempDir(), "cli", "xylem"), nil },
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Contains(t, err.Error(), "resolve working directory")
+}
+
+func TestDaemonUpgradeTargetFromPathsNormalizesRelativeWorkingDirectory(t *testing.T) {
+	root := t.TempDir()
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(root))
+	defer func() {
+		require.NoError(t, os.Chdir(oldWd))
+	}()
+
+	target, err := daemonUpgradeTargetFromPaths(
+		filepath.Join(".claude", "worktrees", ".daemon-root"),
+		filepath.Join(root, "cli", "xylem"),
+	)
+	require.NoError(t, err)
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	require.NoError(t, err)
+	wantRepoDir, err := filepath.Abs(filepath.Join(resolvedRoot, ".claude", "worktrees", ".daemon-root"))
+	require.NoError(t, err)
+
+	assert.Equal(t, wantRepoDir, target.repoDir)
+	assert.Equal(t, filepath.Join(root, "cli", "xylem"), target.executablePath)
+}
+
+func TestSmoke_S37_DaemonAutoUpgradeSyncsDaemonWorktreeControlPlaneFiles(t *testing.T) {
+	binaryRepo := t.TempDir()
+	daemonRepo := t.TempDir()
+	executablePath := filepath.Join(binaryRepo, "cli", "xylem")
+	require.NoError(t, os.MkdirAll(filepath.Dir(executablePath), 0o755))
+	require.NoError(t, os.WriteFile(executablePath, []byte("old-binary"), 0o755))
+
+	binaryWorkflowPath := filepath.Join(binaryRepo, ".xylem", "workflows", "merge-pr.yaml")
+	daemonWorkflowPath := filepath.Join(daemonRepo, ".xylem", "workflows", "merge-pr.yaml")
+	binaryPromptPath := filepath.Join(binaryRepo, ".xylem", "prompts", "merge-pr", "check.md")
+	daemonPromptPath := filepath.Join(daemonRepo, ".xylem", "prompts", "merge-pr", "check.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(binaryWorkflowPath), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(daemonWorkflowPath), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(binaryPromptPath), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(daemonPromptPath), 0o755))
+	require.NoError(t, os.WriteFile(binaryWorkflowPath, []byte(`run: "gh pr merge 181 --auto"`), 0o644))
+	require.NoError(t, os.WriteFile(daemonWorkflowPath, []byte(`run: "gh pr merge 181 --admin"`), 0o644))
+	require.NoError(t, os.WriteFile(binaryPromptPath, []byte("use the upgraded merge workflow"), 0o644))
+	require.NoError(t, os.WriteFile(daemonPromptPath, []byte("stale prompt from old worktree"), 0o644))
+
+	var pulledRepo string
+	var builtCLI string
+	var execPath string
+	stubDaemonUpgradeDependencies(
+		t,
+		func(repoDir string) error {
+			pulledRepo = repoDir
+			updated, err := os.ReadFile(binaryWorkflowPath)
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(daemonWorkflowPath, updated, 0o644); err != nil {
+				return err
+			}
+			updatedPrompt, err := os.ReadFile(binaryPromptPath)
+			if err != nil {
+				return err
+			}
+			return os.WriteFile(daemonPromptPath, updatedPrompt, 0o644)
+		},
+		func(cliDir, outPath string) error {
+			builtCLI = cliDir
+			return os.WriteFile(outPath, []byte("new-binary"), 0o755)
+		},
+		func(path string, _ []string, _ []string) error {
+			execPath = path
+			return errors.New("exec blocked in test")
+		},
+	)
+
+	target, err := resolveDaemonUpgradeTarget(
+		func() (string, error) { return daemonRepo, nil },
+		func() (string, error) { return executablePath, nil },
+	)
+	require.NoError(t, err)
+
+	selfUpgrade(target.repoDir, target.executablePath)
+
+	assert.Equal(t, daemonRepo, pulledRepo)
+	assert.Equal(t, filepath.Join(daemonRepo, "cli"), builtCLI)
+	assert.Equal(t, executablePath, execPath)
+
+	got, err := os.ReadFile(filepath.Join(target.repoDir, ".xylem", "workflows", "merge-pr.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "--auto")
+	assert.NotContains(t, string(got), "--admin")
+
+	prompt, err := os.ReadFile(filepath.Join(target.repoDir, ".xylem", "prompts", "merge-pr", "check.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "use the upgraded merge workflow", string(prompt))
+}

--- a/cli/internal/source/scheduled.go
+++ b/cli/internal/source/scheduled.go
@@ -107,6 +107,8 @@ func (s *Scheduled) OnEnqueue(_ context.Context, vessel queue.Vessel) error {
 }
 
 func (s *Scheduled) OnStart(_ context.Context, _ queue.Vessel) error            { return nil }
+func (s *Scheduled) OnWait(_ context.Context, _ queue.Vessel) error             { return nil }
+func (s *Scheduled) OnResume(_ context.Context, _ queue.Vessel) error           { return nil }
 func (s *Scheduled) OnComplete(_ context.Context, _ queue.Vessel) error         { return nil }
 func (s *Scheduled) OnFail(_ context.Context, _ queue.Vessel) error             { return nil }
 func (s *Scheduled) OnTimedOut(_ context.Context, _ queue.Vessel) error         { return nil }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -376,8 +376,12 @@ None. Intervals are configured in `.xylem.yml` under the `daemon` key.
 |--------------|---------|-------------|
 | `daemon.scan_interval` | `"60s"` | How often the daemon scans for new work. |
 | `daemon.drain_interval` | `"30s"` | How often the daemon drains pending vessels. |
+| `daemon.auto_upgrade` | `false` | Periodically `git fetch`/`reset` the daemon's current worktree to `origin/main`, rebuild the binary, and `exec()` into it when the binary changes. |
+| `daemon.upgrade_interval` | `"5m"` | How often the daemon re-checks `auto_upgrade` while it is running. |
 
 The daemon uses the shorter of the two intervals as its tick interval and checks whether enough time has elapsed for each operation on every tick.
+
+Run the daemon from the **root of a dedicated git worktree on branch `main`**. Auto-upgrade syncs the daemon's current working directory before rebuilding, so workflow YAML and prompt changes must be present in that worktree to take effect.
 
 ### Behavior
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -348,6 +348,10 @@ The `daemon` section controls polling intervals when running `xylem daemon`.
 |-------|------|---------|----------|-------------|
 | `daemon.scan_interval` | string | `"60s"` | No | How often the daemon scans sources for new work. Must be a valid Go duration string. |
 | `daemon.drain_interval` | string | `"30s"` | No | How often the daemon drains pending vessels from the queue. Must be a valid Go duration string. |
+| `daemon.auto_upgrade` | bool | `false` | No | When true, periodically syncs the daemon's current worktree to `origin/main`, rebuilds the binary, and `exec()`s into the new binary if it changed. |
+| `daemon.upgrade_interval` | string | `"5m"` | No | How often to rerun the auto-upgrade check while the daemon is running. Must be a valid Go duration string. |
+
+When `daemon.auto_upgrade` is enabled, start the daemon from the **root of a dedicated git worktree on branch `main`**. Xylem upgrades the current working tree in place before rebuilding, so the worktree's `.xylem/workflows/` and prompt files become the authoritative control-plane inputs for the upgraded daemon.
 
 ### Harness settings
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -286,6 +286,8 @@ daemon:
   drain_interval: "30s"
 ```
 
+Start the daemon from the **root of a dedicated git worktree on branch `main`**. When `daemon.auto_upgrade` is enabled, xylem syncs the daemon's current working tree before rebuilding the binary, so the checked-out `.xylem/workflows/` and prompt files in that worktree stay aligned with the upgraded executable.
+
 ## Check status
 
 View the current state of the queue:


### PR DESCRIPTION
## Summary
- Implements https://github.com/nicholls-inc/xylem/issues/202.
- Resolve the daemon auto-upgrade target from the daemon process working directory instead of deriving the repo from the installed binary path, so upgraded runs use the daemon worktree's current `.xylem/workflows/` and prompt files.
- Add regression coverage for workflow/prompt drift and document the dedicated-main-worktree requirement for `daemon.auto_upgrade`.

## Smoke scenarios covered
- S37 — Daemon auto-upgrade syncs daemon worktree control-plane files

## Changes summary
- **Modified** `cli/cmd/xylem/daemon.go` to capture a `daemonUpgradeTarget` via `resolveDaemonUpgradeTarget(os.Getwd, os.Executable)` and reuse it for initial and periodic upgrades.
- **Modified** `cli/cmd/xylem/upgrade.go` to add `daemonUpgradeTarget`, `resolveDaemonUpgradeTarget`, and `daemonUpgradeTargetFromPaths`, plus injectable upgrade helpers used by the regression tests.
- **Added** `cli/cmd/xylem/upgrade_test.go` with executable/working-directory error propagation tests and `TestSmoke_S37_DaemonAutoUpgradeSyncsDaemonWorktreeControlPlaneFiles`.
- **Added** `cli/cmd/xylem/upgrade_prop_test.go` with `TestPropDaemonUpgradeTargetAlwaysUsesWorkingDirectory`.
- **Modified** `cli/internal/source/scheduled.go` to satisfy the source lifecycle with no-op `OnWait` and `OnResume` hooks.
- **Modified** `docs/cli-reference.md`, `docs/configuration.md`, and `docs/getting-started.md` to document `daemon.auto_upgrade`, `daemon.upgrade_interval`, and the dedicated `main` worktree requirement.
- **Modified** `cli/cmd/xylem/drain.go` as part of the staged command-package changes in this branch.

## Test plan
- `cd cli && goimports -w .`
- `cd cli && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #202