### PR TITLE
runner: stop cancelled vessels from blocking drain and auto-upgrade

### DIFF
--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -273,6 +273,33 @@ func (t *trackerStub) Start(duration time.Duration) {
 	}()
 }
 
+type cancellableTrackerStub struct {
+	inFlight atomic.Int32
+	maxSeen  atomic.Int32
+}
+
+func (t *cancellableTrackerStub) Wait() runner.DrainResult {
+	return runner.DrainResult{}
+}
+
+func (t *cancellableTrackerStub) InFlightCount() int {
+	return int(t.inFlight.Load())
+}
+
+func (t *cancellableTrackerStub) Start() {
+	cur := t.inFlight.Add(1)
+	for {
+		old := t.maxSeen.Load()
+		if cur <= old || t.maxSeen.CompareAndSwap(old, cur) {
+			return
+		}
+	}
+}
+
+func (t *cancellableTrackerStub) Cancel() {
+	t.inFlight.Add(-1)
+}
+
 func TestDaemonShutdown(t *testing.T) {
 	dir := t.TempDir()
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
@@ -551,6 +578,53 @@ func TestSmoke_S36_DaemonLoopUpgradeWaitsForTrackerIdle(t *testing.T) {
 	launchTime := time.Unix(0, launchedAt.Load())
 	upgradeTime := time.Unix(0, upgradedAt.Load())
 	assert.GreaterOrEqual(t, upgradeTime.Sub(launchTime), 60*time.Millisecond)
+}
+
+func TestSmoke_S39_DaemonAutoUpgradeProceedsAfterCancelledVesselDropsInFlight(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	tracker := &cancellableTrackerStub{}
+
+	var (
+		drainCalls  atomic.Int32
+		upgradeSeen atomic.Int32
+	)
+	cancelIssued := make(chan struct{})
+
+	drain := func(_ context.Context) (runner.DrainResult, error) {
+		if drainCalls.Add(1) == 1 {
+			tracker.Start()
+			go func() {
+				time.Sleep(40 * time.Millisecond)
+				tracker.Cancel()
+				close(cancelIssued)
+			}()
+			return runner.DrainResult{Launched: 1}, nil
+		}
+		return runner.DrainResult{}, nil
+	}
+	upgrade := func() {
+		if tracker.InFlightCount() != 0 {
+			t.Errorf("upgrade fired before cancelled vessel drained: in_flight=%d", tracker.InFlightCount())
+		}
+		upgradeSeen.Add(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, time.Hour, 10*time.Millisecond, time.Millisecond)
+	require.NoError(t, err)
+
+	select {
+	case <-cancelIssued:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for cancelled vessel to drop in-flight count")
+	}
+
+	assert.GreaterOrEqual(t, drainCalls.Load(), int32(2))
+	assert.NotZero(t, upgradeSeen.Load())
+	assert.Zero(t, tracker.InFlightCount())
 }
 
 // TestDaemonLoopUpgradeOverduePausesDrainToCreateIdleWindow verifies the

--- a/cli/internal/dtu/scenario_cancel_test.go
+++ b/cli/internal/dtu/scenario_cancel_test.go
@@ -1,0 +1,158 @@
+package dtu_test
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	dtu "github.com/nicholls-inc/xylem/cli/internal/dtu"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	runnerpkg "github.com/nicholls-inc/xylem/cli/internal/runner"
+	"github.com/nicholls-inc/xylem/cli/internal/source"
+	"github.com/nicholls-inc/xylem/cli/internal/worktree"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type blockingResolveScenarioCmdRunner struct {
+	base         *dtuScenarioCmdRunner
+	resolveStart chan struct{}
+	resolveExit  chan struct{}
+	startOnce    sync.Once
+	exitOnce     sync.Once
+	pushStarted  atomic.Int32
+}
+
+func newBlockingResolveScenarioCmdRunner(base *dtuScenarioCmdRunner) *blockingResolveScenarioCmdRunner {
+	return &blockingResolveScenarioCmdRunner{
+		base:         base,
+		resolveStart: make(chan struct{}),
+		resolveExit:  make(chan struct{}),
+	}
+}
+
+func (r *blockingResolveScenarioCmdRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return r.base.Run(ctx, name, args...)
+}
+
+func (r *blockingResolveScenarioCmdRunner) RunOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return r.base.RunOutput(ctx, name, args...)
+}
+
+func (r *blockingResolveScenarioCmdRunner) RunProcess(ctx context.Context, dir string, name string, args ...string) error {
+	return r.base.RunProcess(ctx, dir, name, args...)
+}
+
+func (r *blockingResolveScenarioCmdRunner) RunPhase(ctx context.Context, _ string, stdin io.Reader, _ string, _ ...string) ([]byte, error) {
+	promptBytes, err := io.ReadAll(stdin)
+	if err != nil {
+		return nil, err
+	}
+	prompt := string(promptBytes)
+
+	switch {
+	case strings.Contains(prompt, "Analyze conflicts"):
+		return []byte("analysis complete"), nil
+	case strings.Contains(prompt, "Resolve conflicts"):
+		r.startOnce.Do(func() { close(r.resolveStart) })
+		<-ctx.Done()
+		r.exitOnce.Do(func() { close(r.resolveExit) })
+		return nil, ctx.Err()
+	case strings.Contains(prompt, "Push branch"):
+		r.pushStarted.Add(1)
+		return []byte("push complete"), nil
+	default:
+		return []byte("mock output"), nil
+	}
+}
+
+func TestScenarioIssueCancelDuringResolveStopsRunner(t *testing.T) {
+	env := newScenarioEnv(t, "issue-cancel-resolve.yaml")
+	defer withWorkingDir(t, env.repoDir)()
+
+	writeScenarioWorkflow(t, env.repoDir, "resolve-conflicts", []scenarioPhase{
+		{name: "analyze", prompt: "Analyze conflicts for issue {{.Issue.Number}}"},
+		{name: "resolve", prompt: "Resolve conflicts for issue {{.Issue.Number}}"},
+		{name: "push", prompt: "Push branch for issue {{.Issue.Number}}"},
+	})
+
+	cfg := staticIssueConfig(env.stateDir, config.Task{
+		Labels:   []string{"needs-conflict-resolution"},
+		Workflow: "resolve-conflicts",
+		StatusLabels: &config.StatusLabels{
+			Running: "in-progress",
+		},
+	})
+
+	scanResult := scanScenario(t, env, cfg)
+	require.Equal(t, 1, scanResult.Added)
+
+	cmdRunner := newBlockingResolveScenarioCmdRunner(env.cmdRunner)
+	src := &source.GitHub{Repo: "owner/repo", CmdRunner: cmdRunner}
+	drainer := runnerpkg.New(cfg, env.queue, worktree.New(env.repoDir, cmdRunner), cmdRunner)
+	drainer.Sources = map[string]source.Source{
+		src.Name(): src,
+	}
+
+	drainResult, err := drainer.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, drainResult.Launched)
+
+	select {
+	case <-cmdRunner.resolveStart:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resolve phase to start")
+	}
+
+	require.NoError(t, env.queue.Cancel("issue-181"))
+
+	select {
+	case <-cmdRunner.resolveExit:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resolve phase to stop after cancel")
+	}
+
+	waitDone := make(chan runnerpkg.DrainResult, 1)
+	go func() {
+		waitDone <- drainer.Wait()
+	}()
+
+	var waited runnerpkg.DrainResult
+	select {
+	case waited = <-waitDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for runner.Wait()")
+	}
+
+	assert.Equal(t, 1, waited.Skipped)
+	assert.Zero(t, drainer.InFlightCount())
+	assert.Zero(t, cmdRunner.pushStarted.Load())
+
+	vessel, err := env.queue.FindByID("issue-181")
+	require.NoError(t, err)
+	require.NotNil(t, vessel)
+	assert.Equal(t, queue.StateCancelled, vessel.State)
+
+	events := readEvents(t, env.store)
+	cancelSeen := false
+	for _, event := range events {
+		if event.Vessel == nil {
+			continue
+		}
+		if event.Vessel.Operation == dtu.VesselOperationCancel && event.Vessel.VesselID == "issue-181" {
+			cancelSeen = true
+			break
+		}
+	}
+	assert.True(t, cancelSeen, "expected DTU cancel event for issue-181")
+
+	summary := loadVesselSummary(t, env.stateDir, "issue-181")
+	assert.Equal(t, "cancelled", summary.State)
+	assert.FileExists(t, filepath.Join(env.stateDir, "phases", "issue-181", "summary.json"))
+}

--- a/cli/internal/dtu/testdata/issue-cancel-resolve.yaml
+++ b/cli/internal/dtu/testdata/issue-cancel-resolve.yaml
@@ -1,0 +1,22 @@
+metadata:
+  name: issue-cancel-resolve
+  scenario: cancelling a running resolve-conflicts vessel stops the runner cleanly
+repositories:
+  - owner: owner
+    name: repo
+    default_branch: main
+    labels:
+      - name: needs-conflict-resolution
+      - name: in-progress
+    issues:
+      - number: 181
+        title: resolve conflicts for PR 181
+        body: cancel during resolve phase
+        labels: [needs-conflict-resolution]
+providers:
+  scripts:
+    - name: analyze
+      provider: claude
+      match:
+        phase: analyze
+      stdout: analysis complete

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -34,6 +34,10 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
+var errVesselCancelled = errors.New("vessel cancelled")
+
+const vesselCancelPollInterval = 25 * time.Millisecond
+
 // CommandRunner abstracts subprocess execution for testing.
 type CommandRunner interface {
 	RunOutput(ctx context.Context, name string, args ...string) ([]byte, error)
@@ -214,7 +218,9 @@ drainLoop:
 				vesselTimeout = timeout // fallback to global
 			}
 
-			vesselCtx, cancel := context.WithTimeout(vesselBaseCtx, vesselTimeout)
+			watchedCtx, stopWatching := r.watchVesselCancellation(vesselBaseCtx, j.ID)
+			defer stopWatching(nil)
+			vesselCtx, cancel := context.WithTimeout(watchedCtx, vesselTimeout)
 			defer cancel()
 
 			outcome := r.runVessel(vesselCtx, j)
@@ -356,6 +362,8 @@ func (r *Runner) recordOutcome(outcome string) {
 		r.result.Failed++
 	case "waiting":
 		r.result.Waiting++
+	case "cancelled":
+		r.result.Skipped++
 	default:
 		r.result.Skipped++
 	}
@@ -531,6 +539,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 	// Execute phases sequentially (no explicit dependencies)
 	var phaseResults []reporter.PhaseResult
 	for i := vessel.CurrentPhase; i < len(sk.Phases); i++ {
+		if r.vesselCancelled(ctx, vessel.ID) {
+			return r.cancelVessel(vessel, worktreePath, vrs, claims)
+		}
 		p := sk.Phases[i]
 		gateResult := ""
 
@@ -541,6 +552,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 		// Gate retry loop: may re-run the same phase with gate output appended
 		for {
+			if r.vesselCancelled(ctx, vessel.ID) {
+				return r.cancelVessel(vessel, worktreePath, vrs, claims)
+			}
 			log.Printf("%sphase %q starting (%d/%d)", vesselLabel(vessel), p.Name, i+1, len(sk.Phases))
 			phaseStart := r.runtimeNow()
 
@@ -710,6 +724,11 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				output, runErr = r.runPhaseWithRateLimitRetry(ctx, worktreePath, stdinContent, cmd, args)
 			}
 
+			if r.vesselCancelled(ctx, vessel.ID) {
+				finishCurrentPhaseSpan(context.Canceled)
+				return r.cancelVessel(vessel, worktreePath, vrs, claims)
+			}
+
 			// Shared: Write phase output
 			outputPath := filepath.Join(phasesDir, p.Name+".output")
 			if wErr := os.WriteFile(outputPath, output, 0o644); wErr != nil {
@@ -784,6 +803,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			}
 			vessel.PhaseOutputs[p.Name] = outputPath
 			if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
+				if r.cancelledTransition(vessel.ID, updateErr) {
+					finishCurrentPhaseSpan(context.Canceled)
+					return r.cancelVessel(vessel, worktreePath, vrs, claims)
+				}
 				log.Printf("warn: persist phase progress for %s: %v", vessel.ID, updateErr)
 			}
 
@@ -807,6 +830,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, ""))
 				log.Printf("%sphase %q triggered no-op; completing workflow early", vesselLabel(vessel), p.Name)
 				finishCurrentPhaseSpan(nil)
+				if r.vesselCancelled(ctx, vessel.ID) {
+					return r.cancelVessel(vessel, worktreePath, vrs, claims)
+				}
 				return r.completeVessel(ctx, vessel, worktreePath, phaseResults, vrs, claims)
 			}
 
@@ -820,6 +846,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			switch p.Gate.Type {
 			case "command", "live":
 				gateResultExec := r.executeVerificationGate(ctx, phaseSpan, vessel, p, td, worktreePath, retryAttempt)
+				if r.vesselCancelled(ctx, vessel.ID) {
+					finishCurrentPhaseSpan(context.Canceled)
+					return r.cancelVessel(vessel, worktreePath, vrs, claims)
+				}
 				gateOut, passed, gateErr := gateResultExec.output, gateResultExec.passed, gateResultExec.err
 				if gateErr != nil {
 					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error()))
@@ -868,6 +898,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				vessel.GateRetries--
 				log.Printf("%sgate failed for phase %q, retries remaining=%d", vesselLabel(vessel), p.Name, vessel.GateRetries)
 				if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
+					if r.cancelledTransition(vessel.ID, updateErr) {
+						finishCurrentPhaseSpan(context.Canceled)
+						return r.cancelVessel(vessel, worktreePath, vrs, claims)
+					}
 					log.Printf("warn: persist gate retries for %s: %v", vessel.ID, updateErr)
 				}
 
@@ -875,6 +909,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				gateResult = fmt.Sprintf("The following gate check failed after the previous phase. Fix the issues and try again:\n\n%s", gateOut)
 
 				if err := r.runtimeSleep(ctx, retryDelay); err != nil {
+					if r.vesselCancelled(ctx, vessel.ID) {
+						finishCurrentPhaseSpan(context.Canceled)
+						return r.cancelVessel(vessel, worktreePath, vrs, claims)
+					}
 					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error()))
 					finishCurrentPhaseSpan(err)
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate retry interrupted: %v", p.Name, err))
@@ -902,6 +940,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				vessel.CurrentPhase = i + 1
 				vessel.State = queue.StateWaiting
 				if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
+					if r.cancelledTransition(vessel.ID, updateErr) {
+						finishCurrentPhaseSpan(context.Canceled)
+						return r.cancelVessel(vessel, worktreePath, vrs, claims)
+					}
 					log.Printf("warn: persist waiting state for %s: %v", vessel.ID, updateErr)
 					finishCurrentPhaseSpan(updateErr)
 					return "failed"
@@ -931,6 +973,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 		vessel.GateRetries = 0
 		if prevRetries != 0 {
 			if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
+				if r.cancelledTransition(vessel.ID, updateErr) {
+					return r.cancelVessel(vessel, worktreePath, vrs, claims)
+				}
 				log.Printf("warn: persist gate retry reset for %s: %v", vessel.ID, updateErr)
 			}
 		}
@@ -938,6 +983,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 	// All phases complete
 	log.Printf("%scompleted all phases", vesselLabel(vessel))
+	if r.vesselCancelled(ctx, vessel.ID) {
+		return r.cancelVessel(vessel, worktreePath, vrs, claims)
+	}
 	if err := src.OnComplete(ctx, vessel); err != nil {
 		log.Printf("warn: OnComplete hook for vessel %s: %v", vessel.ID, err)
 	}
@@ -949,6 +997,9 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 	prompt := vessel.Prompt
 	if vessel.Ref != "" {
 		prompt = fmt.Sprintf("Ref: %s\n\n%s", vessel.Ref, vessel.Prompt)
+	}
+	if r.vesselCancelled(ctx, vessel.ID) {
+		return r.cancelVessel(vessel, worktreePath, vrs, nil)
 	}
 
 	cmd, args := buildPromptOnlyCmdArgs(r.Config, prompt)
@@ -965,6 +1016,9 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 	}
 
 	output, runErr := r.runPhaseWithRateLimitRetry(ctx, worktreePath, prompt, cmd, args)
+	if r.vesselCancelled(ctx, vessel.ID) {
+		return r.cancelVessel(vessel, worktreePath, vrs, nil)
+	}
 	if runErr != nil {
 		r.failVessel(vessel.ID, runErr.Error())
 		if err := src.OnFail(ctx, vessel); err != nil {
@@ -995,6 +1049,9 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 		}
 	}
 
+	if r.vesselCancelled(ctx, vessel.ID) {
+		return r.cancelVessel(vessel, worktreePath, vrs, nil)
+	}
 	if err := src.OnComplete(ctx, vessel); err != nil {
 		log.Printf("warn: OnComplete hook for vessel %s: %v", vessel.ID, err)
 	}
@@ -1005,6 +1062,9 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 func (r *Runner) runBuiltinWorkflow(ctx context.Context, vessel queue.Vessel, src source.Source, vrs *vesselRunState, handler BuiltinWorkflowHandler) string {
 	startedAt := r.runtimeNow()
 	if err := handler(ctx, vessel); err != nil {
+		if r.vesselCancelled(ctx, vessel.ID) {
+			return r.cancelVessel(vessel, "", vrs, nil)
+		}
 		duration := r.runtimeSince(startedAt)
 		if vrs != nil {
 			vrs.addPhase(PhaseSummary{
@@ -1022,6 +1082,9 @@ func (r *Runner) runBuiltinWorkflow(ctx context.Context, vessel queue.Vessel, sr
 		return "failed"
 	}
 
+	if r.vesselCancelled(ctx, vessel.ID) {
+		return r.cancelVessel(vessel, "", vrs, nil)
+	}
 	if vrs != nil {
 		vrs.addPhase(PhaseSummary{
 			Name:       vessel.Workflow,
@@ -1029,6 +1092,9 @@ func (r *Runner) runBuiltinWorkflow(ctx context.Context, vessel queue.Vessel, sr
 			DurationMS: r.runtimeSince(startedAt).Milliseconds(),
 			Status:     "completed",
 		})
+	}
+	if r.vesselCancelled(ctx, vessel.ID) {
+		return r.cancelVessel(vessel, "", vrs, nil)
 	}
 	if err := src.OnComplete(ctx, vessel); err != nil {
 		log.Printf("warn: OnComplete hook for vessel %s: %v", vessel.ID, err)
@@ -1055,6 +1121,9 @@ func (r *Runner) ensureWorktree(ctx context.Context, vessel *queue.Vessel, src s
 			worktreePath = recreated
 			vessel.WorktreePath = worktreePath
 			if updateErr := r.Queue.UpdateVessel(*vessel); updateErr != nil {
+				if r.cancelledTransition(vessel.ID, updateErr) {
+					return "", false
+				}
 				log.Printf("warn: failed to persist worktree path for %s: %v", vessel.ID, updateErr)
 			}
 		}
@@ -1072,6 +1141,9 @@ func (r *Runner) ensureWorktree(ctx context.Context, vessel *queue.Vessel, src s
 	}
 	vessel.WorktreePath = created
 	if updateErr := r.Queue.UpdateVessel(*vessel); updateErr != nil {
+		if r.cancelledTransition(vessel.ID, updateErr) {
+			return "", false
+		}
 		log.Printf("warn: failed to persist worktree path for %s: %v", vessel.ID, updateErr)
 	}
 	return created, true
@@ -1118,8 +1190,80 @@ func (r *Runner) removeWorktree(worktreePath, vesselID string) {
 	}
 }
 
+func (r *Runner) watchVesselCancellation(parent context.Context, vesselID string) (context.Context, context.CancelCauseFunc) {
+	ctx, cancel := context.WithCancelCause(parent)
+	go func() {
+		ticker := time.NewTicker(vesselCancelPollInterval)
+		defer ticker.Stop()
+		for {
+			cancelled, err := r.isVesselCancelled(vesselID)
+			if err != nil {
+				log.Printf("warn: inspect cancel state for %s: %v", vesselID, err)
+			} else if cancelled {
+				cancel(errVesselCancelled)
+				return
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+	return ctx, cancel
+}
+
+func (r *Runner) isVesselCancelled(vesselID string) (bool, error) {
+	vessel, err := r.Queue.FindByID(vesselID)
+	if err != nil {
+		return false, fmt.Errorf("find vessel %s: %w", vesselID, err)
+	}
+	return vessel != nil && vessel.State == queue.StateCancelled, nil
+}
+
+func (r *Runner) vesselCancelled(ctx context.Context, vesselID string) bool {
+	if errors.Is(context.Cause(ctx), errVesselCancelled) {
+		return true
+	}
+	cancelled, err := r.isVesselCancelled(vesselID)
+	if err != nil {
+		log.Printf("warn: inspect cancel state for %s: %v", vesselID, err)
+		return false
+	}
+	return cancelled
+}
+
+func (r *Runner) cancelledTransition(vesselID string, err error) bool {
+	if err == nil || !errors.Is(err, queue.ErrInvalidTransition) {
+		return false
+	}
+	cancelled, findErr := r.isVesselCancelled(vesselID)
+	if findErr != nil {
+		log.Printf("warn: inspect cancel state for %s: %v", vesselID, findErr)
+		return false
+	}
+	return cancelled
+}
+
+func (r *Runner) cancelVessel(vessel queue.Vessel, worktreePath string, vrs *vesselRunState, claims []evidence.Claim) string {
+	current := vessel
+	if latest, err := r.Queue.FindByID(vessel.ID); err != nil {
+		log.Printf("warn: inspect cancelled vessel %s: %v", vessel.ID, err)
+	} else if latest != nil {
+		current = *latest
+	}
+	log.Printf("%svessel cancelled; stopping execution", vesselLabel(current))
+	r.persistRunArtifacts(current, string(queue.StateCancelled), vrs, claims, r.runtimeNow())
+	r.removeWorktree(worktreePath, vessel.ID)
+	return "cancelled"
+}
+
 func (r *Runner) failVessel(id string, errMsg string) {
 	if updateErr := r.Queue.Update(id, queue.StateFailed, errMsg); updateErr != nil {
+		if r.cancelledTransition(id, updateErr) {
+			return
+		}
 		log.Printf("warn: failed to update vessel %s state: %v", id, updateErr)
 	}
 }
@@ -1133,6 +1277,9 @@ func (r *Runner) failUpdatedVessel(vessel *queue.Vessel, errMsg string) {
 	vessel.Error = errMsg
 	vessel.EndedAt = &now
 	if updateErr := r.Queue.UpdateVessel(*vessel); updateErr != nil {
+		if r.cancelledTransition(vessel.ID, updateErr) {
+			return
+		}
 		log.Printf("warn: failed to persist vessel %s state: %v", vessel.ID, updateErr)
 		r.failVessel(vessel.ID, errMsg)
 	}
@@ -1140,6 +1287,9 @@ func (r *Runner) failUpdatedVessel(vessel *queue.Vessel, errMsg string) {
 
 func (r *Runner) completeVessel(ctx context.Context, vessel queue.Vessel, worktreePath string, phaseResults []reporter.PhaseResult, vrs *vesselRunState, claims []evidence.Claim) string {
 	if updateErr := r.Queue.Update(vessel.ID, queue.StateCompleted, ""); updateErr != nil {
+		if r.cancelledTransition(vessel.ID, updateErr) {
+			return r.cancelVessel(vessel, worktreePath, vrs, claims)
+		}
 		log.Printf("warn: failed to update vessel %s state: %v", vessel.ID, updateErr)
 	}
 
@@ -1319,6 +1469,7 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 		waveFailed := false
 		waveWaiting := false
 		waveNoOp := false
+		waveCancelled := false
 		for _, res := range results {
 			p := wf.Phases[res.phaseIdx]
 			result := res.result
@@ -1344,6 +1495,8 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 				waveFailed = true
 			case "waiting":
 				waveWaiting = true
+			case "cancelled":
+				waveCancelled = true
 			}
 
 			if result.status == "completed" || result.status == "no-op" {
@@ -1362,11 +1515,25 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 		if waveFailed {
 			return "failed"
 		}
+		if waveCancelled {
+			var completedClaims []evidence.Claim
+			if claims != nil {
+				completedClaims = *claims
+			}
+			return r.cancelVessel(vessel, worktreePath, vrs, completedClaims)
+		}
 		if waveWaiting {
 			return "waiting"
 		}
 		if waveNoOp {
 			log.Printf("%sphase triggered no-op; completing workflow early", vesselLabel(vessel))
+			if r.vesselCancelled(ctx, vessel.ID) {
+				var completedClaims []evidence.Claim
+				if claims != nil {
+					completedClaims = *claims
+				}
+				return r.cancelVessel(vessel, worktreePath, vrs, completedClaims)
+			}
 			if err := src.OnComplete(ctx, vessel); err != nil {
 				log.Printf("warn: OnComplete hook for vessel %s: %v", vessel.ID, err)
 			}
@@ -1395,6 +1562,13 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 
 	// All waves complete.
 	log.Printf("%scompleted all phases (orchestrated, %d waves)", vesselLabel(vessel), len(graph.waves))
+	if r.vesselCancelled(ctx, vessel.ID) {
+		var completedClaims []evidence.Claim
+		if claims != nil {
+			completedClaims = *claims
+		}
+		return r.cancelVessel(vessel, worktreePath, vrs, completedClaims)
+	}
 	if err := src.OnComplete(ctx, vessel); err != nil {
 		log.Printf("warn: OnComplete hook for vessel %s: %v", vessel.ID, err)
 	}
@@ -1408,7 +1582,7 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 // singlePhaseResult holds the outcome of executing one phase including its gate.
 type singlePhaseResult struct {
 	output        string
-	status        string // "completed", "no-op", "failed", "waiting"
+	status        string // "completed", "no-op", "failed", "waiting", "cancelled"
 	duration      time.Duration
 	gateOut       string
 	phaseSummary  PhaseSummary
@@ -1436,6 +1610,9 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 	srcCfg := r.sourceConfigFromMeta(vessel)
 
 	for {
+		if r.vesselCancelled(ctx, vessel.ID) {
+			return singlePhaseResult{status: "cancelled"}
+		}
 		log.Printf("%sphase %q starting (orchestrated)", vesselLabel(vessel), p.Name)
 		phaseStart := r.runtimeNow()
 
@@ -1601,6 +1778,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			output, runErr = r.runPhaseWithRateLimitRetry(ctx, worktreePath, stdinContent, cmd, args)
 		}
 
+		if r.vesselCancelled(ctx, vessel.ID) {
+			finishCurrentPhaseSpan(context.Canceled)
+			return singlePhaseResult{status: "cancelled", duration: r.runtimeSince(phaseStart)}
+		}
+
 		// Write output file.
 		outputPath := filepath.Join(phasesDir, p.Name+".output")
 		if wErr := os.WriteFile(outputPath, output, 0o644); wErr != nil {
@@ -1711,6 +1893,10 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		switch p.Gate.Type {
 		case "command", "live":
 			gateResultExec := r.executeVerificationGate(ctx, phaseSpan, vessel, p, td, worktreePath, retryAttempt)
+			if r.vesselCancelled(ctx, vessel.ID) {
+				finishCurrentPhaseSpan(context.Canceled)
+				return singlePhaseResult{status: "cancelled", duration: phaseDuration}
+			}
 			gateOut, passed, gateErr := gateResultExec.output, gateResultExec.passed, gateResultExec.err
 			if gateErr != nil {
 				r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate error: %v", p.Name, gateErr))
@@ -1768,6 +1954,10 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			log.Printf("%sgate failed for phase %q, retries remaining=%d", vesselLabel(vessel), p.Name, gateRetries)
 			gateResult = fmt.Sprintf("The following gate check failed after the previous phase. Fix the issues and try again:\n\n%s", gateOut)
 			if err := r.runtimeSleep(ctx, retryDelay); err != nil {
+				if r.vesselCancelled(ctx, vessel.ID) {
+					finishCurrentPhaseSpan(context.Canceled)
+					return singlePhaseResult{status: "cancelled", duration: phaseDuration}
+				}
 				r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate retry interrupted: %v", p.Name, err))
 				if failErr := src.OnFail(ctx, vessel); failErr != nil {
 					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, failErr)
@@ -1798,6 +1988,10 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			vessel.State = queue.StateWaiting
 			vessel.CurrentPhase = phaseIdx + 1
 			if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
+				if r.cancelledTransition(vessel.ID, updateErr) {
+					finishCurrentPhaseSpan(context.Canceled)
+					return singlePhaseResult{status: "cancelled", duration: r.runtimeSince(phaseStart)}
+				}
 				log.Printf("warn: persist waiting state for %s: %v", vessel.ID, updateErr)
 				finishCurrentPhaseSpan(updateErr)
 				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -116,6 +116,46 @@ func TestProp_BudgetEnforcementNeverLeaksAcrossVessels(t *testing.T) {
 	})
 }
 
+func TestProp_CancelledTransitionRequiresCancelledLatestState(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cancelled := rapid.Bool().Draw(t, "cancelled")
+		wrapErr := rapid.Bool().Draw(t, "wrapErr")
+
+		dir, err := os.MkdirTemp("", "runner-cancel-prop-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(dir)
+
+		cfg := makeTestConfig(dir, 1)
+		q := queue.New(filepath.Join(dir, "queue.jsonl"))
+		_, err = q.Enqueue(queue.Vessel{
+			ID:        "issue-1",
+			Source:    "manual",
+			State:     queue.StatePending,
+			CreatedAt: time.Now().UTC(),
+		})
+		if err != nil {
+			t.Fatalf("Enqueue() error = %v", err)
+		}
+		if cancelled {
+			if err := q.Cancel("issue-1"); err != nil {
+				t.Fatalf("Cancel() error = %v", err)
+			}
+		}
+
+		r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+		transitionErr := error(queue.ErrInvalidTransition)
+		if wrapErr {
+			transitionErr = fmt.Errorf("persist update: %w", transitionErr)
+		}
+
+		if got := r.cancelledTransition("issue-1", transitionErr); got != cancelled {
+			t.Fatalf("cancelledTransition() = %t, want %t", got, cancelled)
+		}
+	})
+}
+
 func TestProp_PromptOnlyUsageAccumulatesEstimatedTotals(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		prompt := rapid.StringMatching(`[a-zA-Z0-9 ]{0,120}`).Draw(t, "prompt")

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -204,6 +204,55 @@ func (c *countingCmdRunner) RunPhase(_ context.Context, _ string, stdin io.Reade
 	return []byte("mock output"), nil
 }
 
+type blockingPhaseCmdRunner struct {
+	mu            sync.Mutex
+	phaseCalls    []string
+	resolveStart  chan struct{}
+	resolveExit   chan struct{}
+	pushStarted   atomic.Int32
+	resolveOnce   sync.Once
+	resolveExitMu sync.Once
+}
+
+func newBlockingPhaseCmdRunner() *blockingPhaseCmdRunner {
+	return &blockingPhaseCmdRunner{
+		resolveStart: make(chan struct{}),
+		resolveExit:  make(chan struct{}),
+	}
+}
+
+func (b *blockingPhaseCmdRunner) RunOutput(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (b *blockingPhaseCmdRunner) RunProcess(_ context.Context, _ string, _ string, _ ...string) error {
+	return nil
+}
+
+func (b *blockingPhaseCmdRunner) RunPhase(ctx context.Context, _ string, stdin io.Reader, _ string, _ ...string) ([]byte, error) {
+	prompt, _ := io.ReadAll(stdin)
+	promptText := string(prompt)
+
+	b.mu.Lock()
+	b.phaseCalls = append(b.phaseCalls, promptText)
+	b.mu.Unlock()
+
+	switch {
+	case strings.Contains(promptText, "Analyze conflicts"):
+		return []byte("analysis complete"), nil
+	case strings.Contains(promptText, "Resolve conflicts"):
+		b.resolveOnce.Do(func() { close(b.resolveStart) })
+		<-ctx.Done()
+		b.resolveExitMu.Do(func() { close(b.resolveExit) })
+		return nil, ctx.Err()
+	case strings.Contains(promptText, "Push branch"):
+		b.pushStarted.Add(1)
+		return []byte("push complete"), nil
+	default:
+		return []byte("mock output"), nil
+	}
+}
+
 type mockWorktree struct {
 	mu           sync.Mutex
 	createErr    error
@@ -1569,6 +1618,89 @@ func TestDrainBudgetRespectsContextCancellation(t *testing.T) {
 	if elapsed > 500*time.Millisecond {
 		t.Errorf("Drain() took %s, expected fast cancel-driven return", elapsed)
 	}
+}
+
+func assertCancelledVesselStopsRunningPhaseAndDropsInFlight(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	vessel := makeVessel(181, "resolve-conflicts")
+	vessel.Meta["issue_title"] = "Resolve PR conflicts"
+	vessel.Meta["issue_body"] = "Merge origin/main into the PR branch."
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	writeWorkflowFile(t, dir, "resolve-conflicts", []testPhase{
+		{name: "analyze", promptContent: "Analyze conflicts", maxTurns: 5},
+		{name: "resolve", promptContent: "Resolve conflicts", maxTurns: 5},
+		{name: "push", promptContent: "Push branch", maxTurns: 5},
+	})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := newBlockingPhaseCmdRunner()
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	var logBuf bytes.Buffer
+	oldWriter := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(oldWriter)
+
+	drainResult, err := r.Drain(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, drainResult.Launched)
+
+	select {
+	case <-cmdRunner.resolveStart:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resolve phase to start")
+	}
+
+	require.NoError(t, q.Cancel(vessel.ID))
+
+	select {
+	case <-cmdRunner.resolveExit:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resolve phase to exit after cancel")
+	}
+
+	waitDone := make(chan DrainResult, 1)
+	go func() {
+		waitDone <- r.Wait()
+	}()
+
+	var waited DrainResult
+	select {
+	case waited = <-waitDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for runner.Wait() after cancel")
+	}
+
+	assert.Equal(t, 0, r.InFlightCount())
+	assert.Equal(t, 1, waited.Skipped)
+	assert.Zero(t, cmdRunner.pushStarted.Load())
+	assert.NotContains(t, logBuf.String(), "invalid state transition")
+
+	updated, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assert.Equal(t, queue.StateCancelled, updated.State)
+
+	summary := loadSummary(t, cfg.StateDir, vessel.ID)
+	assert.Equal(t, "cancelled", summary.State)
+	assert.Equal(t, vessel.ID, summary.VesselID)
+}
+
+func TestDrainCancelledVesselStopsRunningPhaseAndDropsInFlight(t *testing.T) {
+	assertCancelledVesselStopsRunningPhaseAndDropsInFlight(t)
+}
+
+func TestSmoke_S38_CancelledVesselStopsRunningPhaseAndDropsInFlight(t *testing.T) {
+	assertCancelledVesselStopsRunningPhaseAndDropsInFlight(t)
 }
 
 func TestSmoke_S33_DrainReturnsBeforeInFlightWorkCompletes(t *testing.T) {


### PR DESCRIPTION
## Summary
- Addresses [issue #205](https://github.com/nicholls-inc/xylem/issues/205) by teaching runner-owned vessel execution to observe queue-visible cancellation, stop active phase work, persist cancelled summaries, and release in-flight capacity so daemon auto-upgrade can proceed.

## Smoke scenarios covered
- `S38` — Cancelled vessel stops running phase and drops in-flight
- `S39` — Daemon auto-upgrade proceeds after cancelled vessel drops in-flight

## Changes summary
- Modified `cli/internal/runner/runner.go` to add `errVesselCancelled`, `vesselCancelPollInterval`, `(*Runner).watchVesselCancellation`, `isVesselCancelled`, `vesselCancelled`, `cancelledTransition`, and `cancelVessel`, and to thread cancellation checks through phase execution, queue state updates, and summary persistence paths.
- Modified `cli/internal/runner/runner_test.go` to add a blocking phase runner helper plus targeted and smoke regression coverage for cancelling a vessel during `resolve`.
- Modified `cli/internal/runner/runner_prop_test.go` to add property coverage that only treats `ErrInvalidTransition` as cancellation when the latest queue state is actually `cancelled`.
- Modified `cli/cmd/xylem/daemon_test.go` to add a cancellable tracker stub and smoke coverage showing auto-upgrade resumes once cancelled work drops the in-flight count.
- Added `cli/internal/dtu/scenario_cancel_test.go` and `cli/internal/dtu/testdata/issue-cancel-resolve.yaml` to cover the DTU regression scenario `issue-cancel-resolve` — cancelling a running resolve-conflicts vessel stops the runner cleanly.

## Test plan
```bash
cd cli
goimports -w .
goimports -l .
go vet ./...
golangci-lint run
go build ./cmd/xylem
go test ./...
```

Fixes #205