### PR TITLE
Wire run-level observability into CLI execution

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -95,6 +95,14 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	defer cleanupDrainRunner()
 	drainRunner.Reporter = buildReporter(cfg, cmdRunner)
 	drainRunner.DrainBudget = drainInterval
+	commandSpan := startCommandSpan(drainRunner.Tracer, ctx, "daemon", false, cfg.StateDir)
+	var commandErr error
+	defer func() {
+		finishCommandSpan(drainRunner.Tracer, commandSpan, commandErr)
+	}()
+	if spanCtx := commandSpan.Context(); spanCtx != nil {
+		ctx = spanCtx
+	}
 	drain := func(ctx context.Context) (runner.DrainResult, error) {
 		return drainRunner.Drain(ctx)
 	}
@@ -109,7 +117,8 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		}
 	}
 
-	return daemonLoop(ctx, q, drainRunner, scan, drain, check, upgrade, scanInterval, drainInterval, upgradeInterval)
+	commandErr = daemonLoop(ctx, q, drainRunner, scan, drain, check, upgrade, scanInterval, drainInterval, upgradeInterval)
+	return commandErr
 }
 
 // parseUpgradeInterval returns the effective periodic upgrade interval. If
@@ -350,8 +359,17 @@ func runDrain(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *workt
 	r, cleanup := buildDrainRunner(cfg, q, wt, cmdRunner)
 	defer cleanup()
 	r.DrainBudget = budget
+	commandSpan := startCommandSpan(r.Tracer, ctx, "run-drain", false, cfg.StateDir)
+	var commandErr error
+	defer func() {
+		finishCommandSpan(r.Tracer, commandSpan, commandErr)
+	}()
+	if spanCtx := commandSpan.Context(); spanCtx != nil {
+		ctx = spanCtx
+	}
 	builtInResult, err := runBuiltInScheduledVessels(ctx, cfg, q, cmdRunner)
 	if err != nil {
+		commandErr = err
 		return builtInResult, fmt.Errorf("drain built-in audit vessels: %w", err)
 	}
 	result, err := r.DrainAndWait(ctx)
@@ -359,6 +377,7 @@ func runDrain(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *workt
 	if err == nil {
 		maybeAutoGenerateHarnessReview(cfg, result)
 	}
+	commandErr = err
 	return result, err
 }
 

--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -36,28 +36,48 @@ func newDrainCmd() *cobra.Command {
 }
 
 func cmdDrain(cfg *config.Config, q *queue.Queue, wt *worktree.Manager, dryRun bool) error {
-	if dryRun {
-		return dryRunDrain(cfg, q)
-	}
-
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+
+	if dryRun {
+		tracer := buildConfiguredTracer(cfg)
+		defer shutdownConfiguredTracer(tracer)
+
+		commandSpan := startCommandSpan(tracer, ctx, "drain", true, cfg.StateDir)
+		var commandErr error
+		defer func() {
+			finishCommandSpan(tracer, commandSpan, commandErr)
+		}()
+
+		commandErr = dryRunDrain(cfg, q)
+		return commandErr
+	}
 
 	cmdRunner := newCmdRunner(cfg)
 	r, cleanup := buildDrainRunner(cfg, q, wt, cmdRunner)
 	defer cleanup()
 	r.Reporter = buildReporter(cfg, cmdRunner)
+	commandSpan := startCommandSpan(r.Tracer, ctx, "drain", false, cfg.StateDir)
+	var commandErr error
+	defer func() {
+		finishCommandSpan(r.Tracer, commandSpan, commandErr)
+	}()
+	if spanCtx := commandSpan.Context(); spanCtx != nil {
+		ctx = spanCtx
+	}
 
 	// Check waiting vessels before draining pending ones
 	r.CheckWaitingVessels(ctx)
 
 	builtInResult, err := runBuiltInScheduledVessels(ctx, cfg, q, cmdRunner)
 	if err != nil {
+		commandErr = err
 		return &exitError{code: 2, err: fmt.Errorf("drain built-in audit vessels: %w", err)}
 	}
 
 	result, err := r.DrainAndWait(ctx)
 	if err != nil {
+		commandErr = err
 		return &exitError{code: 2, err: fmt.Errorf("drain error: %w", err)}
 	}
 	addDrainResults(&result, builtInResult)
@@ -67,6 +87,27 @@ func cmdDrain(cfg *config.Config, q *queue.Queue, wt *worktree.Manager, dryRun b
 		return &exitError{code: 1}
 	}
 	return nil
+}
+
+func startCommandSpan(tracer *observability.Tracer, ctx context.Context, name string, dryRun bool, stateDir string) observability.SpanContext {
+	if tracer == nil {
+		return observability.SpanContext{}
+	}
+	return tracer.StartSpan(ctx, "command:"+name, observability.CommandSpanAttributes(observability.CommandSpanData{
+		Name:     name,
+		DryRun:   dryRun,
+		StateDir: stateDir,
+	}))
+}
+
+func finishCommandSpan(tracer *observability.Tracer, span observability.SpanContext, err error) {
+	if tracer == nil {
+		return
+	}
+	if err != nil {
+		span.RecordError(err)
+	}
+	span.End()
 }
 
 func buildDrainRunner(cfg *config.Config, q *queue.Queue, wt runner.WorktreeManager, cmdRunner *realCmdRunner) (*runner.Runner, func()) {

--- a/cli/cmd/xylem/drain_test.go
+++ b/cli/cmd/xylem/drain_test.go
@@ -217,6 +217,42 @@ func TestDrainDryRun(t *testing.T) {
 	}
 }
 
+func TestDrainDryRunStartsCommandSpan(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeDrainConfig(dir)
+	cfg.Observability.Endpoint = "localhost:4317"
+	cfg.Observability.Insecure = true
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	wt := worktree.New(dir, newCmdRunner(cfg))
+
+	now := time.Now().UTC()
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "issue-1",
+		Source:    "github-issue",
+		Ref:       "https://github.com/owner/repo/issues/1",
+		Workflow:  "fix-bug",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	})
+	require.NoError(t, err)
+
+	tracer, exporter := newRecordingTracer()
+	stubConfiguredTracerFactory(t, func(observability.TracerConfig) (*observability.Tracer, error) {
+		return tracer, nil
+	})
+
+	out := captureStdout(func() {
+		require.NoError(t, cmdDrain(cfg, q, wt, true))
+	})
+
+	assert.Contains(t, out, "dry-run")
+	span := requireSpanNamed(t, exporter.snapshots(), "command:drain")
+	assert.Equal(t, "drain", span.Attributes["xylem.command.name"])
+	assert.Equal(t, "true", span.Attributes["xylem.command.dry_run"])
+	assert.Equal(t, dir, span.Attributes["xylem.command.state_dir"])
+	assert.Equal(t, 1, exporter.shutdownCount())
+}
+
 func TestDrainDryRunCommandFormat(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeDrainConfig(dir)

--- a/cli/internal/observability/tracer.go
+++ b/cli/internal/observability/tracer.go
@@ -101,6 +101,7 @@ func newExporter(config TracerConfig) (sdktrace.SpanExporter, error) {
 
 // NewTracerFromProvider wraps an existing TracerProvider. Used in tests.
 func NewTracerFromProvider(provider *sdktrace.TracerProvider) *Tracer {
+	otel.SetTracerProvider(provider)
 	return &Tracer{
 		provider: provider,
 		tracer:   provider.Tracer("xylem"),
@@ -140,6 +141,34 @@ func (sc SpanContext) RecordError(err error) {
 // to child spans.
 func (sc SpanContext) Context() context.Context {
 	return sc.ctx
+}
+
+// TraceContextData captures the IDs needed to link an artifact back to a trace.
+type TraceContextData struct {
+	TraceID string `json:"trace_id,omitempty"`
+	SpanID  string `json:"span_id,omitempty"`
+}
+
+// TraceContextFromContext extracts trace and span IDs from a context.
+func TraceContextFromContext(ctx context.Context) TraceContextData {
+	if ctx == nil {
+		return TraceContextData{}
+	}
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if !spanCtx.IsValid() {
+		return TraceContextData{}
+	}
+	return TraceContextData{
+		TraceID: spanCtx.TraceID().String(),
+		SpanID:  spanCtx.SpanID().String(),
+	}
+}
+
+// StartGlobalSpan starts a span from the globally-registered tracer provider.
+func StartGlobalSpan(ctx context.Context, name string, attrs []SpanAttribute) SpanContext {
+	ctx, span := otel.Tracer("xylem").Start(ctx, name)
+	AttachSpanAttributes(span, attrs)
+	return SpanContext{span: span, ctx: ctx}
 }
 
 // AttachSpanAttributes converts a slice of SpanAttribute into OTel

--- a/cli/internal/observability/vessel.go
+++ b/cli/internal/observability/vessel.go
@@ -79,11 +79,14 @@ func DrainHealthAttributes(data DrainHealthData) []SpanAttribute {
 
 // PhaseSpanData holds phase information for attribute extraction.
 type PhaseSpanData struct {
-	Name     string `json:"name"`
-	Index    int    `json:"index"`
-	Type     string `json:"type"`
-	Provider string `json:"provider"`
-	Model    string `json:"model"`
+	Name         string `json:"name"`
+	Index        int    `json:"index"`
+	Type         string `json:"type"`
+	Workflow     string `json:"workflow"`
+	Provider     string `json:"provider"`
+	Model        string `json:"model"`
+	RetryAttempt int    `json:"retry_attempt"`
+	SandboxMode  string `json:"sandbox_mode"`
 }
 
 // PhaseSpanAttributes returns span attributes for a phase span.
@@ -93,17 +96,22 @@ func PhaseSpanAttributes(data PhaseSpanData) []SpanAttribute {
 		{Key: "xylem.phase.name", Value: data.Name},
 		{Key: "xylem.phase.index", Value: fmt.Sprintf("%d", data.Index)},
 		{Key: "xylem.phase.type", Value: data.Type},
+		{Key: "xylem.phase.workflow", Value: data.Workflow},
 		{Key: "xylem.phase.provider", Value: data.Provider},
 		{Key: "xylem.phase.model", Value: data.Model},
+		{Key: "xylem.phase.retry_attempt", Value: fmt.Sprintf("%d", data.RetryAttempt)},
+		{Key: "xylem.phase.sandbox_mode", Value: data.SandboxMode},
 	}
 }
 
 // PhaseResultData holds phase result information for attribute extraction.
 type PhaseResultData struct {
-	InputTokensEst  int     `json:"input_tokens_est"`
-	OutputTokensEst int     `json:"output_tokens_est"`
-	CostUSDEst      float64 `json:"cost_usd_est"`
-	DurationMS      int64   `json:"duration_ms"`
+	InputTokensEst     int     `json:"input_tokens_est"`
+	OutputTokensEst    int     `json:"output_tokens_est"`
+	CostUSDEst         float64 `json:"cost_usd_est"`
+	DurationMS         int64   `json:"duration_ms"`
+	Status             string  `json:"status"`
+	OutputArtifactPath string  `json:"output_artifact_path,omitempty"`
 }
 
 // PhaseResultAttributes returns span attributes added to a phase span
@@ -114,6 +122,8 @@ func PhaseResultAttributes(data PhaseResultData) []SpanAttribute {
 		{Key: "xylem.phase.output_tokens_est", Value: fmt.Sprintf("%d", data.OutputTokensEst)},
 		{Key: "xylem.phase.cost_usd_est", Value: fmt.Sprintf("%.6f", data.CostUSDEst)},
 		{Key: "xylem.phase.duration_ms", Value: fmt.Sprintf("%d", data.DurationMS)},
+		{Key: "xylem.phase.status", Value: data.Status},
+		{Key: "xylem.phase.output_artifact_path", Value: data.OutputArtifactPath},
 	}
 }
 
@@ -147,5 +157,73 @@ func GateStepSpanAttributes(data GateStepSpanData) []SpanAttribute {
 		{Key: "xylem.gate.step.name", Value: data.Name},
 		{Key: "xylem.gate.step.mode", Value: data.Mode},
 		{Key: "xylem.gate.step.passed", Value: fmt.Sprintf("%t", data.Passed)},
+	}
+}
+
+// CommandSpanData holds CLI command attributes.
+type CommandSpanData struct {
+	Name     string `json:"name"`
+	DryRun   bool   `json:"dry_run"`
+	StateDir string `json:"state_dir,omitempty"`
+}
+
+// CommandSpanAttributes returns span attributes for a CLI command.
+func CommandSpanAttributes(data CommandSpanData) []SpanAttribute {
+	return []SpanAttribute{
+		{Key: "xylem.command.name", Value: data.Name},
+		{Key: "xylem.command.dry_run", Value: fmt.Sprintf("%t", data.DryRun)},
+		{Key: "xylem.command.state_dir", Value: data.StateDir},
+	}
+}
+
+// WaitSpanData holds wait/resume timeout transition attributes.
+type WaitSpanData struct {
+	Transition string `json:"transition"`
+	PhaseName  string `json:"phase_name,omitempty"`
+	Label      string `json:"label,omitempty"`
+	WaitedMS   int64  `json:"waited_ms"`
+}
+
+// WaitSpanAttributes returns attributes for wait and resume transitions.
+func WaitSpanAttributes(data WaitSpanData) []SpanAttribute {
+	return []SpanAttribute{
+		{Key: "xylem.wait.transition", Value: data.Transition},
+		{Key: "xylem.wait.phase", Value: data.PhaseName},
+		{Key: "xylem.wait.label", Value: data.Label},
+		{Key: "xylem.wait.waited_ms", Value: fmt.Sprintf("%d", data.WaitedMS)},
+	}
+}
+
+// ReporterSpanData holds GitHub reporter action attributes.
+type ReporterSpanData struct {
+	Action    string `json:"action"`
+	Repo      string `json:"repo,omitempty"`
+	IssueNum  int    `json:"issue_num"`
+	PhaseName string `json:"phase_name,omitempty"`
+}
+
+// ReporterSpanAttributes returns attributes for reporter spans.
+func ReporterSpanAttributes(data ReporterSpanData) []SpanAttribute {
+	return []SpanAttribute{
+		{Key: "xylem.reporter.action", Value: data.Action},
+		{Key: "xylem.reporter.repo", Value: data.Repo},
+		{Key: "xylem.reporter.issue_number", Value: fmt.Sprintf("%d", data.IssueNum)},
+		{Key: "xylem.reporter.phase", Value: data.PhaseName},
+	}
+}
+
+// WorktreeSpanData holds worktree lifecycle attributes.
+type WorktreeSpanData struct {
+	Action string `json:"action"`
+	Branch string `json:"branch,omitempty"`
+	Path   string `json:"path,omitempty"`
+}
+
+// WorktreeSpanAttributes returns attributes for worktree spans.
+func WorktreeSpanAttributes(data WorktreeSpanData) []SpanAttribute {
+	return []SpanAttribute{
+		{Key: "xylem.worktree.action", Value: data.Action},
+		{Key: "xylem.worktree.branch", Value: data.Branch},
+		{Key: "xylem.worktree.path", Value: data.Path},
 	}
 }

--- a/cli/internal/observability/vessel_prop_test.go
+++ b/cli/internal/observability/vessel_prop_test.go
@@ -33,17 +33,22 @@ func combinedAttrs() []SpanAttribute {
 		Ref:      "refs/pull/1/head",
 	})...)
 	attrs = append(attrs, PhaseSpanAttributes(PhaseSpanData{
-		Name:     "analyse",
-		Index:    1,
-		Type:     "prompt",
-		Provider: "anthropic",
-		Model:    "claude-sonnet",
+		Name:         "analyse",
+		Index:        1,
+		Type:         "prompt",
+		Workflow:     "fix-bug",
+		Provider:     "anthropic",
+		Model:        "claude-sonnet",
+		RetryAttempt: 1,
+		SandboxMode:  "default",
 	})...)
 	attrs = append(attrs, PhaseResultAttributes(PhaseResultData{
-		InputTokensEst:  10,
-		OutputTokensEst: 20,
-		CostUSDEst:      1.25,
-		DurationMS:      30,
+		InputTokensEst:     10,
+		OutputTokensEst:    20,
+		CostUSDEst:         1.25,
+		DurationMS:         30,
+		Status:             "completed",
+		OutputArtifactPath: "phases/vessel-1/analyse.output",
 	})...)
 	attrs = append(attrs, GateSpanAttributes(GateSpanData{
 		Type:         "command",
@@ -126,17 +131,20 @@ func TestPropVesselAttrsKeysNamespaced(t *testing.T) {
 	})
 }
 
-func TestPropPhaseAttrsAlwaysFive(t *testing.T) {
+func TestPropPhaseAttrsAlwaysEight(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		attrs := PhaseSpanAttributes(PhaseSpanData{
-			Name:     genVesselString().Draw(t, "name"),
-			Index:    rapid.IntRange(0, 100).Draw(t, "index"),
-			Type:     genPhaseType().Draw(t, "phase_type"),
-			Provider: genVesselString().Draw(t, "provider"),
-			Model:    genVesselString().Draw(t, "model"),
+			Name:         genVesselString().Draw(t, "name"),
+			Index:        rapid.IntRange(0, 100).Draw(t, "index"),
+			Type:         genPhaseType().Draw(t, "phase_type"),
+			Workflow:     genVesselString().Draw(t, "workflow"),
+			Provider:     genVesselString().Draw(t, "provider"),
+			Model:        genVesselString().Draw(t, "model"),
+			RetryAttempt: rapid.IntRange(0, 10).Draw(t, "retry_attempt"),
+			SandboxMode:  genVesselString().Draw(t, "sandbox_mode"),
 		})
-		if len(attrs) != 5 {
-			t.Fatalf("expected 5 attributes, got %d", len(attrs))
+		if len(attrs) != 8 {
+			t.Fatalf("expected 8 attributes, got %d", len(attrs))
 		}
 	})
 }
@@ -145,11 +153,14 @@ func TestPropPhaseAttrsIndexStringified(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		index := rapid.IntRange(0, 10000).Draw(t, "index")
 		attrs := PhaseSpanAttributes(PhaseSpanData{
-			Name:     "phase",
-			Index:    index,
-			Type:     "prompt",
-			Provider: "provider",
-			Model:    "model",
+			Name:         "phase",
+			Index:        index,
+			Type:         "prompt",
+			Workflow:     "workflow",
+			Provider:     "provider",
+			Model:        "model",
+			RetryAttempt: 1,
+			SandboxMode:  "default",
 		})
 		got, ok := attrMap(attrs)["xylem.phase.index"]
 		if !ok {
@@ -165,16 +176,18 @@ func TestPropPhaseAttrsIndexStringified(t *testing.T) {
 	})
 }
 
-func TestPropPhaseResultAttrsAlwaysFour(t *testing.T) {
+func TestPropPhaseResultAttrsAlwaysSix(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		attrs := PhaseResultAttributes(PhaseResultData{
-			InputTokensEst:  rapid.IntRange(0, 1000000).Draw(t, "input_tokens"),
-			OutputTokensEst: rapid.IntRange(0, 1000000).Draw(t, "output_tokens"),
-			CostUSDEst:      rapid.Float64Range(0.0, 100.0).Draw(t, "cost"),
-			DurationMS:      int64(rapid.Int64Range(0, 600000).Draw(t, "duration_ms")),
+			InputTokensEst:     rapid.IntRange(0, 1000000).Draw(t, "input_tokens"),
+			OutputTokensEst:    rapid.IntRange(0, 1000000).Draw(t, "output_tokens"),
+			CostUSDEst:         rapid.Float64Range(0.0, 100.0).Draw(t, "cost"),
+			DurationMS:         int64(rapid.Int64Range(0, 600000).Draw(t, "duration_ms")),
+			Status:             genVesselString().Draw(t, "status"),
+			OutputArtifactPath: genVesselString().Draw(t, "output_artifact_path"),
 		})
-		if len(attrs) != 4 {
-			t.Fatalf("expected 4 attributes, got %d", len(attrs))
+		if len(attrs) != 6 {
+			t.Fatalf("expected 6 attributes, got %d", len(attrs))
 		}
 	})
 }

--- a/cli/internal/observability/vessel_test.go
+++ b/cli/internal/observability/vessel_test.go
@@ -44,26 +44,32 @@ func TestSmoke_S2_VesselSpanAttributesOmitsEmptyRef(t *testing.T) {
 	}
 }
 
-func TestSmoke_S3_PhaseSpanAttributesIncludesAllFive(t *testing.T) {
+func TestSmoke_S3_PhaseSpanAttributesIncludesAllFields(t *testing.T) {
 	attrs := PhaseSpanAttributes(PhaseSpanData{
-		Name:     "analyse",
-		Index:    0,
-		Type:     "prompt",
-		Provider: "anthropic",
-		Model:    "claude-sonnet-4-20250514",
+		Name:         "analyse",
+		Index:        0,
+		Type:         "prompt",
+		Workflow:     "fix-bug",
+		Provider:     "anthropic",
+		Model:        "claude-sonnet-4-20250514",
+		RetryAttempt: 2,
+		SandboxMode:  "dangerously-skip-permissions",
 	})
 	got := attrMap(attrs)
 
-	if len(attrs) != 5 {
-		t.Fatalf("expected 5 attributes, got %d", len(attrs))
+	if len(attrs) != 8 {
+		t.Fatalf("expected 8 attributes, got %d", len(attrs))
 	}
 
 	want := map[string]string{
-		"xylem.phase.name":     "analyse",
-		"xylem.phase.index":    "0",
-		"xylem.phase.type":     "prompt",
-		"xylem.phase.provider": "anthropic",
-		"xylem.phase.model":    "claude-sonnet-4-20250514",
+		"xylem.phase.name":          "analyse",
+		"xylem.phase.index":         "0",
+		"xylem.phase.type":          "prompt",
+		"xylem.phase.workflow":      "fix-bug",
+		"xylem.phase.provider":      "anthropic",
+		"xylem.phase.model":         "claude-sonnet-4-20250514",
+		"xylem.phase.retry_attempt": "2",
+		"xylem.phase.sandbox_mode":  "dangerously-skip-permissions",
 	}
 	for key, value := range want {
 		if got[key] != value {
@@ -74,22 +80,26 @@ func TestSmoke_S3_PhaseSpanAttributesIncludesAllFive(t *testing.T) {
 
 func TestSmoke_S4_PhaseResultAttributesFormatsTokensAndCost(t *testing.T) {
 	attrs := PhaseResultAttributes(PhaseResultData{
-		InputTokensEst:  1200,
-		OutputTokensEst: 300,
-		CostUSDEst:      0.0081,
-		DurationMS:      4500,
+		InputTokensEst:     1200,
+		OutputTokensEst:    300,
+		CostUSDEst:         0.0081,
+		DurationMS:         4500,
+		Status:             "completed",
+		OutputArtifactPath: "phases/vessel-1/analyse.output",
 	})
 	got := attrMap(attrs)
 
-	if len(attrs) != 4 {
-		t.Fatalf("expected 4 attributes, got %d", len(attrs))
+	if len(attrs) != 6 {
+		t.Fatalf("expected 6 attributes, got %d", len(attrs))
 	}
 
 	want := map[string]string{
-		"xylem.phase.input_tokens_est":  "1200",
-		"xylem.phase.output_tokens_est": "300",
-		"xylem.phase.cost_usd_est":      "0.008100",
-		"xylem.phase.duration_ms":       "4500",
+		"xylem.phase.input_tokens_est":     "1200",
+		"xylem.phase.output_tokens_est":    "300",
+		"xylem.phase.cost_usd_est":         "0.008100",
+		"xylem.phase.duration_ms":          "4500",
+		"xylem.phase.status":               "completed",
+		"xylem.phase.output_artifact_path": "phases/vessel-1/analyse.output",
 	}
 	for key, value := range want {
 		if got[key] != value {
@@ -194,6 +204,9 @@ func TestPhaseResultAttributesFormatsNegativeDuration(t *testing.T) {
 	}
 	if got["xylem.phase.cost_usd_est"] != "3.500000" {
 		t.Fatalf("xylem.phase.cost_usd_est = %q, want %q", got["xylem.phase.cost_usd_est"], "3.500000")
+	}
+	if got["xylem.phase.status"] != "" {
+		t.Fatalf("xylem.phase.status = %q, want empty string", got["xylem.phase.status"])
 	}
 }
 

--- a/cli/internal/reporter/reporter.go
+++ b/cli/internal/reporter/reporter.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/observability"
 )
 
 // MaxOutputLen is the maximum length of phase output included in comments.
@@ -33,6 +34,14 @@ type PhaseResult struct {
 
 // PhaseComplete posts a comment on the GitHub issue when a phase completes successfully.
 func (r *Reporter) PhaseComplete(ctx context.Context, issueNum int, phaseName string, duration time.Duration, output string) error {
+	span := observability.StartGlobalSpan(ctx, "reporter:phase_complete", observability.ReporterSpanAttributes(observability.ReporterSpanData{
+		Action:    "phase_complete",
+		Repo:      r.Repo,
+		IssueNum:  issueNum,
+		PhaseName: phaseName,
+	}))
+	defer span.End()
+
 	truncated := truncateOutput(output, MaxOutputLen)
 
 	body := fmt.Sprintf(
@@ -41,6 +50,7 @@ func (r *Reporter) PhaseComplete(ctx context.Context, issueNum int, phaseName st
 	)
 
 	if err := postComment(ctx, r.Runner, r.Repo, issueNum, body); err != nil {
+		span.RecordError(err)
 		log.Printf("warn: failed to post phase-complete comment for issue %d: %v", issueNum, err)
 	}
 	return nil
@@ -48,6 +58,14 @@ func (r *Reporter) PhaseComplete(ctx context.Context, issueNum int, phaseName st
 
 // VesselFailed posts a failure comment on the GitHub issue.
 func (r *Reporter) VesselFailed(ctx context.Context, issueNum int, phaseName string, errMsg string, gateOutput string) error {
+	span := observability.StartGlobalSpan(ctx, "reporter:vessel_failed", observability.ReporterSpanAttributes(observability.ReporterSpanData{
+		Action:    "vessel_failed",
+		Repo:      r.Repo,
+		IssueNum:  issueNum,
+		PhaseName: phaseName,
+	}))
+	defer span.End()
+
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "**xylem — failed at phase `%s`**\n\n**Error:** %s", phaseName, errMsg)
 
@@ -56,6 +74,7 @@ func (r *Reporter) VesselFailed(ctx context.Context, issueNum int, phaseName str
 	}
 
 	if err := postComment(ctx, r.Runner, r.Repo, issueNum, sb.String()); err != nil {
+		span.RecordError(err)
 		log.Printf("warn: failed to post vessel-failed comment for issue %d: %v", issueNum, err)
 	}
 	return nil
@@ -63,6 +82,13 @@ func (r *Reporter) VesselFailed(ctx context.Context, issueNum int, phaseName str
 
 // VesselCompleted posts a summary comment when all phases complete.
 func (r *Reporter) VesselCompleted(ctx context.Context, issueNum int, phases []PhaseResult, manifest *evidence.Manifest) error {
+	span := observability.StartGlobalSpan(ctx, "reporter:vessel_completed", observability.ReporterSpanAttributes(observability.ReporterSpanData{
+		Action:   "vessel_completed",
+		Repo:     r.Repo,
+		IssueNum: issueNum,
+	}))
+	defer span.End()
+
 	var sb strings.Builder
 	if workflowCompletedViaNoOp(phases) {
 		sb.WriteString("**xylem — workflow completed early via no-op**\n\n")
@@ -86,6 +112,7 @@ func (r *Reporter) VesselCompleted(ctx context.Context, issueNum int, phases []P
 	}
 
 	if err := postComment(ctx, r.Runner, r.Repo, issueNum, sb.String()); err != nil {
+		span.RecordError(err)
 		log.Printf("warn: failed to post vessel-completed comment for issue %d: %v", issueNum, err)
 	}
 	return nil
@@ -102,9 +129,18 @@ func workflowCompletedViaNoOp(phases []PhaseResult) bool {
 
 // LabelTimeout posts a timeout comment on the GitHub issue.
 func (r *Reporter) LabelTimeout(ctx context.Context, issueNum int, label string, phaseName string, waited time.Duration) error {
+	span := observability.StartGlobalSpan(ctx, "reporter:label_timeout", observability.ReporterSpanAttributes(observability.ReporterSpanData{
+		Action:    "label_timeout",
+		Repo:      r.Repo,
+		IssueNum:  issueNum,
+		PhaseName: phaseName,
+	}))
+	defer span.End()
+
 	body := fmt.Sprintf("xylem — timed out waiting for label `%s` on phase `%s` after %s", label, phaseName, waited)
 
 	if err := postComment(ctx, r.Runner, r.Repo, issueNum, body); err != nil {
+		span.RecordError(err)
 		log.Printf("warn: failed to post label-timeout comment for issue %d: %v", issueNum, err)
 	}
 	return nil

--- a/cli/internal/reporter/reporter_test.go
+++ b/cli/internal/reporter/reporter_test.go
@@ -10,8 +10,11 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 type mockRunner struct {
@@ -40,6 +43,18 @@ func renderVesselCompletedBody(t *testing.T, phases []PhaseResult, manifest *evi
 	return mock.lastBody
 }
 
+func newReporterTracer(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	_ = observability.NewTracerFromProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+	})
+	return rec
+}
+
 func TestPhaseComplete(t *testing.T) {
 	mock := &mockRunner{}
 	r := &Reporter{Runner: mock, Repo: "owner/repo"}
@@ -61,6 +76,31 @@ func TestPhaseComplete(t *testing.T) {
 	if !strings.Contains(mock.lastBody, "<details>") {
 		t.Errorf("expected details block in comment, got: %s", mock.lastBody)
 	}
+}
+
+func TestPhaseCompleteEmitsReporterSpan(t *testing.T) {
+	rec := newReporterTracer(t)
+	mock := &mockRunner{}
+	r := &Reporter{Runner: mock, Repo: "owner/repo"}
+
+	require.NoError(t, r.PhaseComplete(context.Background(), 42, "analyze", time.Second, "ok"))
+
+	var found bool
+	for _, span := range rec.Ended() {
+		if span.Name() != "reporter:phase_complete" {
+			continue
+		}
+		found = true
+		attrs := make(map[string]string, len(span.Attributes()))
+		for _, attr := range span.Attributes() {
+			attrs[string(attr.Key)] = attr.Value.AsString()
+		}
+		assert.Equal(t, "phase_complete", attrs["xylem.reporter.action"])
+		assert.Equal(t, "owner/repo", attrs["xylem.reporter.repo"])
+		assert.Equal(t, "42", attrs["xylem.reporter.issue_number"])
+		assert.Equal(t, "analyze", attrs["xylem.reporter.phase"])
+	}
+	require.True(t, found, "expected reporter:phase_complete span")
 }
 
 func TestPhaseCompleteGhArgs(t *testing.T) {

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -395,15 +395,22 @@ func (r *Runner) CheckWaitingVessels(ctx context.Context) {
 			}
 			waited := r.runtimeSince(*vessel.WaitingSince)
 			if waited > timeoutDur {
+				timeoutSpan := r.startWaitTransitionSpan(ctx, vessel, "timed_out", waited)
 				if updateErr := r.Queue.Update(vessel.ID, queue.StateTimedOut, "label gate timed out"); updateErr != nil {
+					r.finishWaitTransitionSpan(timeoutSpan, updateErr)
 					log.Printf("warn: failed to update vessel %s to timed_out: %v", vessel.ID, updateErr)
+					continue
 				}
 				src := r.resolveSourceForVessel(vessel)
 				if err := src.OnTimedOut(ctx, vessel); err != nil {
 					log.Printf("warn: OnTimedOut hook for vessel %s: %v", vessel.ID, err)
 				}
+				vrs := newVesselRunState(r.Config, vessel, r.runtimeNow())
+				vrs.setTraceContext(observability.TraceContextFromContext(timeoutSpan.Context()))
+				r.persistRunArtifacts(vessel, string(queue.StateTimedOut), vrs, nil, r.runtimeNow())
+				r.finishWaitTransitionSpan(timeoutSpan, nil)
 				// Clean up worktree (best-effort)
-				r.removeWorktree(vessel.WorktreePath, vessel.ID)
+				r.removeWorktree(ctx, vessel.WorktreePath, vessel.ID)
 				// Post timeout comment
 				issueNum := r.parseIssueNum(vessel)
 				if issueNum > 0 && r.Reporter != nil {
@@ -428,16 +435,19 @@ func (r *Runner) CheckWaitingVessels(ctx context.Context) {
 			continue
 		}
 		if found {
+			resumeSpan := r.startWaitTransitionSpan(ctx, vessel, "resumed", waitedDuration(vessel.WaitingSince, r.runtimeNow()))
 			// Advance past the gated phase — CurrentPhase was already incremented
 			// when the vessel entered waiting state. Resume via pending so Drain can
 			// pick the vessel back up through the normal dequeue flow.
 			if err := r.Queue.Update(vessel.ID, queue.StatePending, ""); err != nil {
+				r.finishWaitTransitionSpan(resumeSpan, err)
 				log.Printf("warn: failed to resume vessel %s: %v", vessel.ID, err)
 				continue
 			}
 			if err := src.OnResume(ctx, vessel); err != nil {
 				log.Printf("warn: OnResume hook for vessel %s: %v", vessel.ID, err)
 			}
+			r.finishWaitTransitionSpan(resumeSpan, nil)
 		}
 	}
 }
@@ -465,6 +475,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 	}()
 
 	vrs := newVesselRunState(r.Config, vessel, r.runtimeNow())
+	vrs.setTraceContext(observability.TraceContextFromContext(ctx))
 	var claims []evidence.Claim
 	defer func() {
 		if outcome != "failed" {
@@ -584,17 +595,22 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			if p.Gate != nil && (p.Gate.Type == "command" || p.Gate.Type == "live") {
 				retryAttempt = providerAttempt(&p, vessel.GateRetries)
 			}
-			phaseSpan := startPhaseSpan(r.Tracer, ctx, r.Config, srcCfg, sk, p, i)
+			phaseSpan := startPhaseSpan(r.Tracer, ctx, r.Config, srcCfg, sk, p, i, retryAttempt)
 			phaseSpanEnded := false
 			var phaseDuration time.Duration
+			phaseSpanStatus := "running"
+			phaseOutputArtifactPath := ""
 			finishCurrentPhaseSpan := func(err error) {
 				if phaseSpanEnded {
 					return
 				}
+				if err != nil && phaseSpanStatus == "running" {
+					phaseSpanStatus = "failed"
+				}
 				if phaseDuration == 0 {
 					phaseDuration = r.runtimeSince(phaseStart)
 				}
-				finishPhaseSpan(r.Tracer, phaseSpan, buildPhaseResultData(r.Config, srcCfg, sk, p, promptForCost, string(output), phaseDuration), err)
+				finishPhaseSpan(r.Tracer, phaseSpan, buildPhaseResultData(r.Config, srcCfg, sk, p, promptForCost, string(output), phaseDuration, phaseSpanStatus, phaseOutputArtifactPath), err)
 				phaseSpanEnded = true
 			}
 
@@ -731,6 +747,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 			// Shared: Write phase output
 			outputPath := filepath.Join(phasesDir, p.Name+".output")
+			phaseOutputArtifactPath = phaseArtifactRelativePath(vessel.ID, p.Name)
 			if wErr := os.WriteFile(outputPath, output, 0o644); wErr != nil {
 				log.Printf("warn: write output file %s: %v", outputPath, wErr)
 			}
@@ -738,6 +755,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			phaseDuration = r.runtimeSince(phaseStart)
 
 			if runErr != nil {
+				phaseSpanStatus = "failed"
 				finishCurrentPhaseSpan(runErr)
 				log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
 				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()))
@@ -756,6 +774,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 			if checkProtectedSurfaces {
 				if err := r.verifyProtectedSurfaces(vessel, p, worktreePath, beforeSnapshot); err != nil {
+					phaseSpanStatus = "failed"
 					finishCurrentPhaseSpan(err)
 					log.Printf("%sphase %q violated protected surfaces: %v", vesselLabel(vessel), p.Name, err)
 					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error()))
@@ -789,6 +808,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					r.logReporterError("post vessel-failed comment", vessel.ID,
 						r.Reporter.VesselFailed(ctx, issueNum, p.Name, errMsg, ""))
 				}
+				phaseSpanStatus = "failed"
 				finishCurrentPhaseSpan(fmt.Errorf("%s", errMsg))
 				return "failed"
 			}
@@ -818,6 +838,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			if phaseMatchedNoOp(&p, string(output)) {
 				phaseStatus = "no-op"
 			}
+			phaseSpanStatus = phaseStatus
 
 			// Report phase completion (non-fatal)
 			phaseResults = append(phaseResults, reporter.PhaseResult{Name: p.Name, Duration: phaseDuration, Status: phaseStatus})
@@ -852,6 +873,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				}
 				gateOut, passed, gateErr := gateResultExec.output, gateResultExec.passed, gateResultExec.err
 				if gateErr != nil {
+					phaseSpanStatus = "failed"
 					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error()))
 					finishCurrentPhaseSpan(nil)
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate error: %v", p.Name, gateErr))
@@ -862,6 +884,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				}
 				if passed {
 					log.Printf("%sgate passed for phase %q", vesselLabel(vessel), p.Name)
+					phaseSpanStatus = phaseStatus
 					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, gatePassedPointer(true), ""))
 					if gateResultExec.evidenceClaim != nil {
 						claims = append(claims, *gateResultExec.evidenceClaim)
@@ -880,6 +903,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 				if vessel.GateRetries <= 0 {
 					log.Printf("%sgate failed for phase %q, retries exhausted", vesselLabel(vessel), p.Name)
+					phaseSpanStatus = "failed"
 					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted"))
 					finishCurrentPhaseSpan(nil)
 					vessel.FailedPhase = p.Name
@@ -914,6 +938,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 						return r.cancelVessel(vessel, worktreePath, vrs, claims)
 					}
 					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error()))
+					phaseSpanStatus = "failed"
 					finishCurrentPhaseSpan(err)
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate retry interrupted: %v", p.Name, err))
 					if failErr := src.OnFail(ctx, vessel); failErr != nil {
@@ -921,6 +946,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					}
 					return "failed"
 				}
+				phaseSpanStatus = "retrying"
 				finishCurrentPhaseSpan(nil)
 				continue // re-run same phase
 
@@ -951,6 +977,9 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if err := src.OnWait(ctx, vessel); err != nil {
 					log.Printf("warn: OnWait hook for vessel %s: %v", vessel.ID, err)
 				}
+				waitSpan := r.startWaitTransitionSpan(ctx, vessel, "waiting", 0)
+				r.finishWaitTransitionSpan(waitSpan, nil)
+				phaseSpanStatus = "waiting"
 				finishCurrentPhaseSpan(nil)
 				return "waiting"
 			}
@@ -1181,13 +1210,51 @@ func buildCommand(cfg *config.Config, vessel *queue.Vessel) (string, []string, e
 	return cmd, args, nil
 }
 
-func (r *Runner) removeWorktree(worktreePath, vesselID string) {
+func (r *Runner) removeWorktree(ctx context.Context, worktreePath, vesselID string) {
 	if worktreePath == "" {
 		return
 	}
-	if removeErr := r.Worktree.Remove(context.Background(), worktreePath); removeErr != nil {
+	if removeErr := r.Worktree.Remove(ctx, worktreePath); removeErr != nil {
 		log.Printf("warn: failed to remove worktree for %s: %v", vesselID, removeErr)
 	}
+}
+
+func (r *Runner) startWaitTransitionSpan(ctx context.Context, vessel queue.Vessel, transition string, waited time.Duration) observability.SpanContext {
+	if r.Tracer == nil {
+		return observability.SpanContext{}
+	}
+	attrs := append(
+		observability.VesselSpanAttributes(observability.VesselSpanData{
+			ID:       vessel.ID,
+			Source:   vessel.Source,
+			Workflow: vessel.Workflow,
+			Ref:      vessel.Ref,
+		}),
+		observability.WaitSpanAttributes(observability.WaitSpanData{
+			Transition: transition,
+			PhaseName:  vessel.FailedPhase,
+			Label:      vessel.WaitingFor,
+			WaitedMS:   waited.Milliseconds(),
+		})...,
+	)
+	return r.Tracer.StartSpan(ctx, "wait_transition:"+transition, attrs)
+}
+
+func (r *Runner) finishWaitTransitionSpan(span observability.SpanContext, err error) {
+	if r.Tracer == nil {
+		return
+	}
+	if err != nil {
+		span.RecordError(err)
+	}
+	span.End()
+}
+
+func waitedDuration(since *time.Time, now time.Time) time.Duration {
+	if since == nil {
+		return 0
+	}
+	return now.Sub(*since)
 }
 
 func (r *Runner) watchVesselCancellation(parent context.Context, vesselID string) (context.Context, context.CancelCauseFunc) {
@@ -1255,7 +1322,7 @@ func (r *Runner) cancelVessel(vessel queue.Vessel, worktreePath string, vrs *ves
 	}
 	log.Printf("%svessel cancelled; stopping execution", vesselLabel(current))
 	r.persistRunArtifacts(current, string(queue.StateCancelled), vrs, claims, r.runtimeNow())
-	r.removeWorktree(worktreePath, vessel.ID)
+	r.removeWorktree(context.Background(), worktreePath, vessel.ID)
 	return "cancelled"
 }
 
@@ -1296,7 +1363,7 @@ func (r *Runner) completeVessel(ctx context.Context, vessel queue.Vessel, worktr
 	manifest := r.persistRunArtifacts(vessel, string(queue.StateCompleted), vrs, claims, r.runtimeNow())
 
 	// Clean up worktree (best-effort)
-	r.removeWorktree(worktreePath, vessel.ID)
+	r.removeWorktree(ctx, worktreePath, vessel.ID)
 
 	// Report completion
 	issueNum := r.parseIssueNum(vessel)
@@ -1641,17 +1708,22 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		if p.Gate != nil && (p.Gate.Type == "command" || p.Gate.Type == "live") {
 			retryAttempt = providerAttempt(&p, gateRetries)
 		}
-		phaseSpan := startPhaseSpan(r.Tracer, ctx, r.Config, srcCfg, wf, p, phaseIdx)
+		phaseSpan := startPhaseSpan(r.Tracer, ctx, r.Config, srcCfg, wf, p, phaseIdx, retryAttempt)
 		phaseSpanEnded := false
 		var phaseDuration time.Duration
+		phaseSpanStatus := "running"
+		phaseOutputArtifactPath := ""
 		finishCurrentPhaseSpan := func(err error) {
 			if phaseSpanEnded {
 				return
 			}
+			if err != nil && phaseSpanStatus == "running" {
+				phaseSpanStatus = "failed"
+			}
 			if phaseDuration == 0 {
 				phaseDuration = r.runtimeSince(phaseStart)
 			}
-			finishPhaseSpan(r.Tracer, phaseSpan, buildPhaseResultData(r.Config, srcCfg, wf, p, promptForCost, string(output), phaseDuration), err)
+			finishPhaseSpan(r.Tracer, phaseSpan, buildPhaseResultData(r.Config, srcCfg, wf, p, promptForCost, string(output), phaseDuration, phaseSpanStatus, phaseOutputArtifactPath), err)
 			phaseSpanEnded = true
 		}
 
@@ -1785,6 +1857,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 
 		// Write output file.
 		outputPath := filepath.Join(phasesDir, p.Name+".output")
+		phaseOutputArtifactPath = phaseArtifactRelativePath(vessel.ID, p.Name)
 		if wErr := os.WriteFile(outputPath, output, 0o644); wErr != nil {
 			log.Printf("warn: write output file %s: %v", outputPath, wErr)
 		}
@@ -1792,6 +1865,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		phaseDuration = r.runtimeSince(phaseStart)
 
 		if runErr != nil {
+			phaseSpanStatus = "failed"
 			finishCurrentPhaseSpan(runErr)
 			log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
 			vessel.FailedPhase = p.Name
@@ -1813,6 +1887,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 
 		if checkProtectedSurfaces {
 			if err := r.verifyProtectedSurfaces(vessel, p, worktreePath, beforeSnapshot); err != nil {
+				phaseSpanStatus = "failed"
 				finishCurrentPhaseSpan(err)
 				log.Printf("%sphase %q violated protected surfaces: %v", vesselLabel(vessel), p.Name, err)
 				vessel.FailedPhase = p.Name
@@ -1848,6 +1923,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				r.logReporterError("post vessel-failed comment", vessel.ID,
 					r.Reporter.VesselFailed(ctx, issueNum, p.Name, errMsg, ""))
 			}
+			phaseSpanStatus = "failed"
 			finishCurrentPhaseSpan(fmt.Errorf("%s", errMsg))
 			return singlePhaseResult{
 				status:       "failed",
@@ -1863,6 +1939,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				r.logReporterError("post phase-complete comment", vessel.ID,
 					r.Reporter.PhaseComplete(ctx, issueNum, p.Name, phaseDuration, string(output)))
 			}
+			phaseSpanStatus = "no-op"
 			finishCurrentPhaseSpan(nil)
 			return singlePhaseResult{
 				output:        string(output),
@@ -1880,6 +1957,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 
 		// Handle gate.
 		if p.Gate == nil {
+			phaseSpanStatus = "completed"
 			finishCurrentPhaseSpan(nil)
 			return singlePhaseResult{
 				output:        string(output),
@@ -1903,6 +1981,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				if err := src.OnFail(ctx, vessel); err != nil {
 					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
 				}
+				phaseSpanStatus = "failed"
 				finishCurrentPhaseSpan(nil)
 				return singlePhaseResult{
 					status:       "failed",
@@ -1913,6 +1992,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			}
 			if passed {
 				log.Printf("%sgate passed for phase %q", vesselLabel(vessel), p.Name)
+				phaseSpanStatus = "completed"
 				finishCurrentPhaseSpan(nil)
 				return singlePhaseResult{
 					output:        string(output),
@@ -1942,6 +2022,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					r.logReporterError("post vessel-failed comment", vessel.ID,
 						r.Reporter.VesselFailed(ctx, issueNum, p.Name, "gate failed, retries exhausted", gateOut))
 				}
+				phaseSpanStatus = "failed"
 				finishCurrentPhaseSpan(nil)
 				return singlePhaseResult{
 					status:       "failed",
@@ -1962,6 +2043,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				if failErr := src.OnFail(ctx, vessel); failErr != nil {
 					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, failErr)
 				}
+				phaseSpanStatus = "failed"
 				finishCurrentPhaseSpan(err)
 				return singlePhaseResult{
 					status:       "failed",
@@ -1970,6 +2052,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error()),
 				}
 			}
+			phaseSpanStatus = "retrying"
 			finishCurrentPhaseSpan(nil)
 			continue // re-run phase
 
@@ -1999,11 +2082,15 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if err := src.OnWait(ctx, vessel); err != nil {
 				log.Printf("warn: OnWait hook for vessel %s: %v", vessel.ID, err)
 			}
+			waitSpan := r.startWaitTransitionSpan(ctx, vessel, "waiting", 0)
+			r.finishWaitTransitionSpan(waitSpan, nil)
+			phaseSpanStatus = "waiting"
 			finishCurrentPhaseSpan(nil)
 			return singlePhaseResult{output: string(output), status: "waiting", duration: r.runtimeSince(phaseStart)}
 		}
 
 		// Unknown gate type: treat as passed.
+		phaseSpanStatus = "completed"
 		finishCurrentPhaseSpan(nil)
 		return singlePhaseResult{
 			output:        string(output),
@@ -2015,7 +2102,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 	}
 }
 
-func startPhaseSpan(tracer *observability.Tracer, ctx context.Context, cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p workflow.Phase, phaseIdx int) observability.SpanContext {
+func startPhaseSpan(tracer *observability.Tracer, ctx context.Context, cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p workflow.Phase, phaseIdx int, retryAttempt int) observability.SpanContext {
 	if tracer == nil {
 		return observability.SpanContext{}
 	}
@@ -2024,11 +2111,14 @@ func startPhaseSpan(tracer *observability.Tracer, ctx context.Context, cfg *conf
 	model := resolveModel(cfg, srcCfg, wf, &p, provider)
 
 	return tracer.StartSpan(ctx, "phase:"+p.Name, observability.PhaseSpanAttributes(observability.PhaseSpanData{
-		Name:     p.Name,
-		Index:    phaseIdx,
-		Type:     phaseTypeLabel(p),
-		Provider: provider,
-		Model:    model,
+		Name:         p.Name,
+		Index:        phaseIdx,
+		Type:         phaseTypeLabel(p),
+		Workflow:     workflowName(wf),
+		Provider:     provider,
+		Model:        model,
+		RetryAttempt: retryAttempt,
+		SandboxMode:  sandboxModeFromFlags(cfg),
 	}))
 }
 
@@ -2174,9 +2264,11 @@ func (r *Runner) executeVerificationGate(ctx context.Context, phaseSpan observab
 	}
 }
 
-func buildPhaseResultData(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p workflow.Phase, renderedPrompt, output string, duration time.Duration) observability.PhaseResultData {
+func buildPhaseResultData(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p workflow.Phase, renderedPrompt, output string, duration time.Duration, status string, outputArtifactPath string) observability.PhaseResultData {
 	data := observability.PhaseResultData{
-		DurationMS: duration.Milliseconds(),
+		DurationMS:         duration.Milliseconds(),
+		Status:             status,
+		OutputArtifactPath: outputArtifactPath,
 	}
 	if phaseTypeLabel(p) != "prompt" {
 		return data
@@ -2188,6 +2280,35 @@ func buildPhaseResultData(cfg *config.Config, srcCfg *config.SourceConfig, wf *w
 	data.OutputTokensEst = cost.EstimateTokens(output)
 	data.CostUSDEst = cost.EstimateCost(data.InputTokensEst, data.OutputTokensEst, cost.LookupPricing(model))
 	return data
+}
+
+func workflowName(wf *workflow.Workflow) string {
+	if wf == nil {
+		return ""
+	}
+	return wf.Name
+}
+
+func sandboxModeFromFlags(cfg *config.Config) string {
+	if cfg == nil {
+		return "default"
+	}
+	fields := strings.Fields(cfg.Claude.Flags)
+	for i, field := range fields {
+		switch {
+		case field == "--dangerously-skip-permissions":
+			return "dangerously-skip-permissions"
+		case field == "--permission-mode" || field == "--sandbox":
+			if i+1 < len(fields) && strings.TrimSpace(fields[i+1]) != "" {
+				return fields[i+1]
+			}
+		case strings.HasPrefix(field, "--permission-mode="):
+			return strings.TrimPrefix(field, "--permission-mode=")
+		case strings.HasPrefix(field, "--sandbox="):
+			return strings.TrimPrefix(field, "--sandbox=")
+		}
+	}
+	return "default"
 }
 
 func phaseMatchedNoOp(p *workflow.Phase, output string) bool {
@@ -3273,8 +3394,14 @@ func (r *Runner) CheckHungVessels(ctx context.Context) {
 			continue
 		}
 
+		timeoutSpan := r.startWaitTransitionSpan(ctx, vessel, "timed_out", elapsed)
+		vrs := newVesselRunState(r.Config, vessel, r.runtimeNow())
+		vrs.setTraceContext(observability.TraceContextFromContext(timeoutSpan.Context()))
+		r.persistRunArtifacts(vessel, string(queue.StateTimedOut), vrs, nil, r.runtimeNow())
+		r.finishWaitTransitionSpan(timeoutSpan, nil)
+
 		// Clean up worktree (best-effort)
-		r.removeWorktree(vessel.WorktreePath, vessel.ID)
+		r.removeWorktree(ctx, vessel.WorktreePath, vessel.ID)
 	}
 }
 

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -3182,6 +3182,84 @@ func TestCheckWaitingVesselsTimeoutAppliesTimedOutLabels(t *testing.T) {
 	}
 }
 
+func TestCheckWaitingVesselsResumeEmitsTraceSpan(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fix-bug"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{{
+		name: "plan", promptContent: "Create plan", maxTurns: 5,
+		gate: "      type: label\n      wait_for: \"plan-approved\"\n      timeout: \"24h\"",
+	}, {
+		name: "implement", promptContent: "Implement after approval", maxTurns: 10,
+	}})
+	withTestWorkingDir(t, dir)
+
+	tracer, rec := newTestTracer(t)
+	cmdRunner := &mockCmdRunner{}
+	r := New(cfg, q, &mockWorktree{}, cmdRunner)
+	r.Tracer = tracer
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	first, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, first.Waiting)
+
+	cmdRunner.outputData = []byte(`{"labels":[{"name":"plan-approved"}]}`)
+	r.CheckWaitingVessels(context.Background())
+
+	waitSpan := endedSpanByName(t, rec, "wait_transition:waiting")
+	waitAttrs := spanAttrMap(waitSpan)
+	assert.Equal(t, "waiting", waitAttrs["xylem.wait.transition"])
+	assert.Equal(t, "plan-approved", waitAttrs["xylem.wait.label"])
+	assert.Equal(t, "plan", waitAttrs["xylem.wait.phase"])
+
+	resumeSpan := endedSpanByName(t, rec, "wait_transition:resumed")
+	resumeAttrs := spanAttrMap(resumeSpan)
+	assert.Equal(t, "resumed", resumeAttrs["xylem.wait.transition"])
+	assert.Equal(t, "plan-approved", resumeAttrs["xylem.wait.label"])
+	assert.Equal(t, "plan", resumeAttrs["xylem.wait.phase"])
+}
+
+func TestCheckWaitingVesselsTimeoutWritesTraceableSummary(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	waitingSince := time.Now().UTC().Add(-48 * time.Hour)
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:           "issue-1",
+		Source:       "github-issue",
+		Ref:          "https://github.com/owner/repo/issues/1",
+		Workflow:     "fix-bug",
+		Meta:         map[string]string{"issue_num": "1"},
+		State:        queue.StateWaiting,
+		CreatedAt:    time.Now().UTC(),
+		FailedPhase:  "plan",
+		WaitingFor:   "plan-approved",
+		WaitingSince: &waitingSince,
+	})
+	withTestWorkingDir(t, dir)
+
+	tracer, rec := newTestTracer(t)
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	r.Tracer = tracer
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	r.CheckWaitingVessels(context.Background())
+
+	summary, err := LoadVesselSummary(cfg.StateDir, "issue-1")
+	require.NoError(t, err)
+	require.NotNil(t, summary.Trace)
+	assert.Equal(t, "timed_out", summary.State)
+
+	timeoutSpan := endedSpanByName(t, rec, "wait_transition:timed_out")
+	assert.Equal(t, timeoutSpan.SpanContext().TraceID().String(), summary.Trace.TraceID)
+	assert.Equal(t, timeoutSpan.SpanContext().SpanID().String(), summary.Trace.SpanID)
+}
+
 func TestDrainVesselFails(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 2)
@@ -7089,6 +7167,43 @@ func TestCheckHungVessels_CleansUpWorktree(t *testing.T) {
 	}
 }
 
+func TestCheckHungVesselsWritesTraceableSummary(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Timeout = "1s"
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:        "hung-1",
+		Source:    "manual",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	})
+	vessel, _ := q.Dequeue()
+	require.NotNil(t, vessel)
+
+	old := now.Add(-5 * time.Minute)
+	vessel.StartedAt = &old
+	require.NoError(t, q.UpdateVessel(*vessel))
+
+	tracer, rec := newTestTracer(t)
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	r.Tracer = tracer
+
+	r.CheckHungVessels(context.Background())
+
+	summary, err := LoadVesselSummary(cfg.StateDir, "hung-1")
+	require.NoError(t, err)
+	require.NotNil(t, summary.Trace)
+	assert.Equal(t, "timed_out", summary.State)
+
+	timeoutSpan := endedSpanByName(t, rec, "wait_transition:timed_out")
+	assert.Equal(t, timeoutSpan.SpanContext().TraceID().String(), summary.Trace.TraceID)
+	assert.Equal(t, timeoutSpan.SpanContext().SpanID().String(), summary.Trace.SpanID)
+}
+
 func TestSmoke_S9_NilTracerSkipsAllSpanCreationWithoutPanicking(t *testing.T) {
 	cmdRunner := &mockCmdRunner{
 		phaseOutputs: map[string][]byte{
@@ -7284,6 +7399,70 @@ func TestSmoke_S16_PhaseSpanAlwaysEndsEvenWhenPhaseFails(t *testing.T) {
 		require.Len(t, spans, 1)
 		assert.False(t, spans[0].EndTime().IsZero())
 	}
+}
+
+func TestSmoke_S16b_PhaseSpanStatusIsFailedForEarlyPhaseErrors(t *testing.T) {
+	tracer, rec := newTestTracer(t)
+	cmdRunner := &mockCmdRunner{}
+	r := newWorkflowRunner(t, "trace-early-fail", []testPhase{
+		{name: "analyze", promptContent: "{{", maxTurns: 5},
+	}, cmdRunner, tracer)
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+
+	phaseSpan := endedSpanByName(t, rec, "phase:analyze")
+	attrs := spanAttrMap(phaseSpan)
+	assert.Equal(t, "failed", attrs["xylem.phase.status"])
+	assert.Equal(t, codes.Error, phaseSpan.Status().Code)
+}
+
+func TestSmoke_VesselSummaryLinksToTraceOnCompletion(t *testing.T) {
+	tracer, rec := newTestTracer(t)
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Analyze": []byte("analysis complete"),
+		},
+	}
+	r := newWorkflowRunner(t, "trace-basic", []testPhase{
+		{name: "analyze", promptContent: "Analyze", maxTurns: 5},
+	}, cmdRunner, tracer)
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Completed)
+
+	summary, err := LoadVesselSummary(r.Config.StateDir, "issue-1")
+	require.NoError(t, err)
+	require.NotNil(t, summary.Trace)
+
+	vesselSpan := endedSpanByName(t, rec, "vessel:issue-1")
+	assert.Equal(t, vesselSpan.SpanContext().TraceID().String(), summary.Trace.TraceID)
+	assert.Equal(t, vesselSpan.SpanContext().SpanID().String(), summary.Trace.SpanID)
+}
+
+func TestSmoke_VesselSummaryLinksToTraceOnFailure(t *testing.T) {
+	tracer, rec := newTestTracer(t)
+	cmdRunner := &mockCmdRunner{
+		phaseErr: errors.New("provider crashed"),
+	}
+	r := newWorkflowRunner(t, "trace-fail", []testPhase{
+		{name: "analyze", promptContent: "Analyze", maxTurns: 5},
+	}, cmdRunner, tracer)
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Failed)
+
+	summary, err := LoadVesselSummary(r.Config.StateDir, "issue-1")
+	require.NoError(t, err)
+	require.NotNil(t, summary.Trace)
+	assert.Equal(t, "failed", summary.State)
+
+	vesselSpan := endedSpanByName(t, rec, "vessel:issue-1")
+	assert.Equal(t, vesselSpan.SpanContext().TraceID().String(), summary.Trace.TraceID)
+	assert.Equal(t, vesselSpan.SpanContext().SpanID().String(), summary.Trace.SpanID)
 }
 
 func TestSmoke_S10_PhaseSpanIsAlwaysEndedEvenOnFailureDuringOrchestratedExecution(t *testing.T) {

--- a/cli/internal/runner/summary.go
+++ b/cli/internal/runner/summary.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
+	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 )
@@ -51,9 +52,15 @@ type VesselSummary struct {
 	CostReportPath       string           `json:"cost_report_path,omitempty"`
 	BudgetAlertsPath     string           `json:"budget_alerts_path,omitempty"`
 	EvalReportPath       string           `json:"eval_report_path,omitempty"`
+	Trace                *TraceArtifacts  `json:"trace,omitempty"`
 	ReviewArtifacts      *ReviewArtifacts `json:"review_artifacts,omitempty"`
 
 	Note string `json:"note"`
+}
+
+type TraceArtifacts struct {
+	TraceID string `json:"trace_id,omitempty"`
+	SpanID  string `json:"span_id,omitempty"`
 }
 
 type ReviewArtifacts struct {
@@ -95,6 +102,7 @@ type vesselRunState struct {
 	extraInputTokensEst  int
 	extraOutputTokensEst int
 	extraCostUSDEst      float64
+	trace                *TraceArtifacts
 }
 
 func newVesselRunState(cfg *config.Config, vessel queue.Vessel, startedAt time.Time) *vesselRunState {
@@ -126,6 +134,16 @@ func newVesselRunState(cfg *config.Config, vessel queue.Vessel, startedAt time.T
 	return s
 }
 
+func (s *vesselRunState) setTraceContext(data observability.TraceContextData) {
+	if data.TraceID == "" && data.SpanID == "" {
+		return
+	}
+	s.trace = &TraceArtifacts{
+		TraceID: data.TraceID,
+		SpanID:  data.SpanID,
+	}
+}
+
 func (s *vesselRunState) addPhase(ps PhaseSummary) {
 	s.phases = append(s.phases, ps)
 }
@@ -152,6 +170,7 @@ func (s *vesselRunState) buildSummary(state string, endedAt time.Time) *VesselSu
 		Phases:           phases,
 		BudgetMaxCostUSD: s.budgetMaxCostUSD,
 		BudgetMaxTokens:  s.budgetMaxTokens,
+		Trace:            s.trace,
 		Note:             summaryDisclaimer,
 	}
 

--- a/cli/internal/worktree/worktree.go
+++ b/cli/internal/worktree/worktree.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/dtu"
+	"github.com/nicholls-inc/xylem/cli/internal/observability"
 )
 
 // CommandRunner abstracts shell command execution for testing.
@@ -123,8 +124,15 @@ func (m *Manager) DetectDefaultBranch(ctx context.Context) (string, error) {
 // Create creates a git worktree at .claude/worktrees/<branchName> branched from origin/<defaultBranch>.
 // It also copies .claude/ config files (settings.json, settings.local.json, rules/) into the worktree.
 func (m *Manager) Create(ctx context.Context, branchName string) (string, error) {
+	span := observability.StartGlobalSpan(ctx, "worktree:create", observability.WorktreeSpanAttributes(observability.WorktreeSpanData{
+		Action: "create",
+		Branch: branchName,
+	}))
+	defer span.End()
+
 	defaultBranch, err := m.DetectDefaultBranch(ctx)
 	if err != nil {
+		span.RecordError(err)
 		return "", fmt.Errorf("create worktree: %w", err)
 	}
 
@@ -134,6 +142,7 @@ func (m *Manager) Create(ctx context.Context, branchName string) (string, error)
 	// Fetch the default branch (only if origin exists)
 	if hasOrigin {
 		if _, err := retryGitCmd(ctx, m.Runner, 3, "fetch", "origin", defaultBranch); err != nil {
+			span.RecordError(err)
 			return "", fmt.Errorf("git fetch origin %s: %w", defaultBranch, err)
 		}
 	}
@@ -150,11 +159,13 @@ func (m *Manager) Create(ctx context.Context, branchName string) (string, error)
 	// if the worktree PATH is already registered or exists on disk.
 	if m.branchForWorktree(ctx, worktreePath) != "" {
 		if _, removeErr := m.Runner.Run(ctx, "git", "worktree", "remove", worktreePath, "--force"); removeErr != nil {
+			span.RecordError(removeErr)
 			return "", fmt.Errorf("remove stale worktree %s: %w", worktreePath, removeErr)
 		}
 	} else if _, err := os.Stat(worktreePath); err == nil {
 		// Directory exists on disk but isn't registered as a git worktree (orphaned).
 		if removeErr := os.RemoveAll(worktreePath); removeErr != nil {
+			span.RecordError(removeErr)
 			return "", fmt.Errorf("remove orphaned worktree dir %s: %w", worktreePath, removeErr)
 		}
 	}
@@ -169,12 +180,14 @@ func (m *Manager) Create(ctx context.Context, branchName string) (string, error)
 		if _, removeErr := m.Runner.Run(ctx, "git", "worktree", "remove", existingPath, "--force"); removeErr != nil {
 			// Prune may succeed even when remove fails (e.g., path already deleted).
 			if _, pruneErr := m.Runner.Run(ctx, "git", "worktree", "prune"); pruneErr != nil {
+				span.RecordError(removeErr)
 				return "", fmt.Errorf("remove cross-path worktree %s for branch %s: %w", existingPath, branchName, removeErr)
 			}
 		}
 	}
 
 	if _, err := retryGitCmd(ctx, m.Runner, 3, "worktree", "add", worktreePath, "-B", branchName, startPoint); err != nil {
+		span.RecordError(err)
 		return "", fmt.Errorf("git worktree add: %w", err)
 	}
 
@@ -188,6 +201,11 @@ func (m *Manager) Create(ctx context.Context, branchName string) (string, error)
 	if err := protectXylemSurfaces(worktreePath, m.protectedSurfacePatterns()); err != nil {
 		fmt.Fprintf(os.Stderr, "warn: protect .xylem/ surfaces: %v\n", err)
 	}
+	span.AddAttributes(observability.WorktreeSpanAttributes(observability.WorktreeSpanData{
+		Action: "create",
+		Branch: branchName,
+		Path:   worktreePath,
+	}))
 
 	return worktreePath, nil
 }
@@ -327,17 +345,29 @@ func protectXylemSurfaces(worktreePath string, patterns []string) error {
 // It looks up the branch name from `git worktree list --porcelain` before removal
 // to correctly handle branch names containing path separators (e.g., "fix/issue-42").
 func (m *Manager) Remove(ctx context.Context, worktreePath string) error {
+	span := observability.StartGlobalSpan(ctx, "worktree:remove", observability.WorktreeSpanAttributes(observability.WorktreeSpanData{
+		Action: "remove",
+		Path:   worktreePath,
+	}))
+	defer span.End()
+
 	// Look up the branch name before removing the worktree, because
 	// filepath.Base() would incorrectly truncate "fix/issue-42" to "issue-42".
 	branchName := m.branchForWorktree(ctx, worktreePath)
 
 	if _, err := m.Runner.Run(ctx, "git", "worktree", "remove", worktreePath, "--force"); err != nil {
+		span.RecordError(err)
 		return fmt.Errorf("git worktree remove: %w", err)
 	}
 	// Best-effort branch deletion using the real branch name
 	if branchName != "" {
 		m.Runner.Run(ctx, "git", "branch", "-d", branchName) //nolint:errcheck
 	}
+	span.AddAttributes(observability.WorktreeSpanAttributes(observability.WorktreeSpanData{
+		Action: "remove",
+		Branch: branchName,
+		Path:   worktreePath,
+	}))
 	return nil
 }
 

--- a/cli/internal/worktree/worktree_test.go
+++ b/cli/internal/worktree/worktree_test.go
@@ -9,6 +9,12 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/observability"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // mockRunner captures calls for verification.
@@ -23,6 +29,18 @@ func newMock() *mockRunner {
 		outputs: make(map[string][]byte),
 		errs:    make(map[string]error),
 	}
+}
+
+func newWorktreeTracer(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	_ = observability.NewTracerFromProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+	})
+	return rec
 }
 
 func (m *mockRunner) setOutput(key string, out []byte) { m.outputs[key] = out }
@@ -105,6 +123,32 @@ func TestCreateIssuesCorrectCommands(t *testing.T) {
 	if !r.called("git", "worktree", "add", ".claude/worktrees/fix/issue-42-null-response", "-B", "fix/issue-42-null-response", "origin/main") {
 		t.Errorf("expected 'git worktree add' to be called, calls were: %v", r.calls)
 	}
+}
+
+func TestCreateEmitsWorktreeSpan(t *testing.T) {
+	rec := newWorktreeTracer(t)
+	r := newMock()
+	r.setOutput("gh repo view --json defaultBranchRef", []byte(`{"defaultBranchRef":{"name":"main"}}`))
+
+	m := New("/repo", r)
+	_, err := m.Create(context.Background(), "fix/issue-42-null-response")
+	require.NoError(t, err)
+
+	var found bool
+	for _, span := range rec.Ended() {
+		if span.Name() != "worktree:create" {
+			continue
+		}
+		found = true
+		attrs := make(map[string]string, len(span.Attributes()))
+		for _, attr := range span.Attributes() {
+			attrs[string(attr.Key)] = attr.Value.AsString()
+		}
+		assert.Equal(t, "create", attrs["xylem.worktree.action"])
+		assert.Equal(t, "fix/issue-42-null-response", attrs["xylem.worktree.branch"])
+		assert.Equal(t, ".claude/worktrees/fix/issue-42-null-response", attrs["xylem.worktree.path"])
+	}
+	require.True(t, found, "expected worktree:create span")
 }
 
 func TestCreateFetchFailure(t *testing.T) {


### PR DESCRIPTION
## Summary
- initialize and shut down tracing from the drain and daemon CLI paths, including command-level spans
- add runner, wait/resume, reporter, and worktree span coverage with consistent xylem attributes
- persist per-vessel summary artifacts that link traces to evidence/cost surfaces and extend tests for completed, failed, waiting, and timed-out runs

Closes https://github.com/nicholls-inc/xylem/issues/52