### PR TITLE
feat: add daemon stall monitor and idle backlog health reporting

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -87,19 +87,25 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	scan := func(ctx context.Context) (scanner.ScanResult, error) {
-		return runScan(ctx, cfg, q)
-	}
 	cmdRunner := newCmdRunner(cfg)
 	drainRunner, cleanupDrainRunner := buildDrainRunner(cfg, q, wt, cmdRunner)
 	defer cleanupDrainRunner()
 	drainRunner.Reporter = buildReporter(cfg, cmdRunner)
 	drainRunner.DrainBudget = drainInterval
+	backlogMonitor := newDaemonBacklogMonitor(cfg, cmdRunner)
+	scan := func(ctx context.Context) (scanner.ScanResult, error) {
+		result, err := runScan(ctx, cfg, q)
+		if err == nil {
+			backlogMonitor.ObserveScan(ctx, daemonNow(), result, drainRunner, q)
+		}
+		return result, err
+	}
 	drain := func(ctx context.Context) (runner.DrainResult, error) {
 		return drainRunner.Drain(ctx)
 	}
-	check := func(ctx context.Context) {
+	check := func(ctx context.Context) []daemonStatusAlert {
 		drainRunner.CheckWaitingVessels(ctx)
+		stallAlerts := drainRunner.CheckStalledVessels(ctx)
 		drainRunner.CheckHungVessels(ctx)
 		// Auto-merge: best-effort request copilot review on merge-ready
 		// harness PRs, then enable GitHub auto-merge once checks are green
@@ -107,9 +113,20 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		if cfg.Daemon.AutoMerge {
 			autoMergeXylemPRs(ctx, cfg.Daemon.AutoMergeRepo)
 		}
+		alerts := make([]daemonStatusAlert, 0, len(stallAlerts)+len(backlogMonitor.CurrentAlerts(drainRunner, q)))
+		for _, alert := range stallAlerts {
+			alerts = append(alerts, daemonStatusAlert{
+				Code:     alert.Code,
+				Severity: alert.Severity,
+				Message:  alert.Message,
+			})
+		}
+		alerts = append(alerts, backlogMonitor.CurrentAlerts(drainRunner, q)...)
+		return alerts
 	}
 
-	return daemonLoop(ctx, q, drainRunner, scan, drain, check, upgrade, scanInterval, drainInterval, upgradeInterval)
+	health := newDaemonHealthRecorder(cfg, daemonNow(), upgrade != nil)
+	return daemonLoop(ctx, q, drainRunner, scan, drain, check, upgrade, health, scanInterval, drainInterval, upgradeInterval)
 }
 
 // parseUpgradeInterval returns the effective periodic upgrade interval. If
@@ -155,8 +172,9 @@ type inFlightTracker interface {
 }
 
 // checkFunc runs periodic vessel health checks (waiting vessel label checks,
-// hung vessel timeouts). May be nil if no checks are needed.
-type checkFunc func(ctx context.Context)
+// hung vessel timeouts) and returns daemon health alerts for status reporting.
+// May be nil if no checks are needed.
+type checkFunc func(ctx context.Context) []daemonStatusAlert
 
 // upgradeFunc runs a self-upgrade attempt. If it succeeds with a binary
 // change, it calls exec() and never returns. If it returns, either the
@@ -203,7 +221,7 @@ const upgradeOverdueMultiplier = 3
 //     Once in_flight reaches zero, the normal path fires.
 //
 // Pass nil/zero upgrade/upgradeInterval to disable.
-func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, scan scanFunc, drain drainFunc, check checkFunc, upgrade upgradeFunc, scanInterval, drainInterval, upgradeInterval time.Duration) error {
+func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, scan scanFunc, drain drainFunc, check checkFunc, upgrade upgradeFunc, health *daemonHealthRecorder, scanInterval, drainInterval, upgradeInterval time.Duration) error {
 	tickInterval := scanInterval
 	if drainInterval < tickInterval {
 		tickInterval = drainInterval
@@ -217,6 +235,9 @@ func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, sc
 	// upgradeInterval — not immediately, since cmdDaemon already ran the
 	// startup upgrade.
 	lastUpgrade = daemonNow()
+	if health != nil {
+		health.Update(lastUpgrade, nil, lastUpgrade)
+	}
 
 	slog.Info("daemon started",
 		"scan_interval", scanInterval,
@@ -258,8 +279,9 @@ func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, sc
 		}
 
 		// Run vessel health checks (waiting label gates, hung vessel timeouts)
+		var healthAlerts []daemonStatusAlert
 		if check != nil {
-			check(ctx)
+			healthAlerts = check(ctx)
 		}
 
 		// Compute upgrade state once per tick so both the upgrade check and
@@ -314,6 +336,9 @@ func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, sc
 			}
 		}
 
+		if health != nil {
+			health.Update(now, healthAlerts, lastUpgrade)
+		}
 		logTickSummary(q)
 
 		select {

--- a/cli/cmd/xylem/daemon_health.go
+++ b/cli/cmd/xylem/daemon_health.go
@@ -248,15 +248,35 @@ func daemonHealthPath(cfg *config.Config) string {
 }
 
 func saveDaemonStatusSnapshot(path string, snapshot daemonStatusSnapshot) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create daemon health dir: %w", err)
 	}
 	data, err := json.MarshalIndent(snapshot, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal daemon health snapshot: %w", err)
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		return fmt.Errorf("write daemon health snapshot: %w", err)
+	tmp, err := os.CreateTemp(dir, daemonHealthFileName+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp daemon health snapshot: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp daemon health snapshot: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp daemon health snapshot: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp daemon health snapshot: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename temp daemon health snapshot: %w", err)
 	}
 	return nil
 }

--- a/cli/cmd/xylem/daemon_health.go
+++ b/cli/cmd/xylem/daemon_health.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/scanner"
+	"github.com/nicholls-inc/xylem/cli/internal/source"
+)
+
+const daemonHealthFileName = "daemon-health.json"
+
+type daemonStatusAlert struct {
+	Code     string `json:"code"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+}
+
+type daemonStatusSnapshot struct {
+	PID           int                 `json:"pid"`
+	StartedAt     time.Time           `json:"started_at"`
+	HeartbeatAt   time.Time           `json:"heartbeat_at"`
+	Build         string              `json:"build,omitempty"`
+	AutoUpgrade   bool                `json:"auto_upgrade"`
+	LastUpgradeAt *time.Time          `json:"last_upgrade_at,omitempty"`
+	Alerts        []daemonStatusAlert `json:"alerts,omitempty"`
+}
+
+type daemonHealthRecorder struct {
+	cfg      *config.Config
+	snapshot daemonStatusSnapshot
+}
+
+type daemonBacklogMonitor struct {
+	cfg        *config.Config
+	cmdRunner  source.CommandRunner
+	idleSince  time.Time
+	lastAlerts []daemonStatusAlert
+}
+
+type ghIssueBacklogItem struct {
+	Number int `json:"number"`
+	Labels []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+}
+
+type ghPRBacklogItem struct {
+	Number    int    `json:"number"`
+	Mergeable string `json:"mergeable"`
+	Labels    []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+}
+
+func newDaemonHealthRecorder(cfg *config.Config, startedAt time.Time, autoUpgradeActive bool) *daemonHealthRecorder {
+	return &daemonHealthRecorder{
+		cfg: cfg,
+		snapshot: daemonStatusSnapshot{
+			PID:         os.Getpid(),
+			StartedAt:   startedAt.UTC(),
+			HeartbeatAt: startedAt.UTC(),
+			Build:       buildInfo(),
+			AutoUpgrade: autoUpgradeActive,
+		},
+	}
+}
+
+func (r *daemonHealthRecorder) Update(now time.Time, alerts []daemonStatusAlert, lastUpgrade time.Time) {
+	if r == nil || r.cfg == nil {
+		return
+	}
+	r.snapshot.HeartbeatAt = now.UTC()
+	r.snapshot.Alerts = cloneDaemonAlerts(alerts)
+	if r.snapshot.AutoUpgrade && !lastUpgrade.IsZero() {
+		upgradeAt := lastUpgrade.UTC()
+		r.snapshot.LastUpgradeAt = &upgradeAt
+	}
+	if err := saveDaemonStatusSnapshot(daemonHealthPath(r.cfg), r.snapshot); err != nil {
+		slog.Warn("persist daemon health snapshot", "error", err)
+	}
+}
+
+func newDaemonBacklogMonitor(cfg *config.Config, cmdRunner source.CommandRunner) *daemonBacklogMonitor {
+	return &daemonBacklogMonitor{cfg: cfg, cmdRunner: cmdRunner}
+}
+
+func (m *daemonBacklogMonitor) ObserveScan(ctx context.Context, now time.Time, result scanner.ScanResult, tracker inFlightTracker, q *queue.Queue) []daemonStatusAlert {
+	if m == nil {
+		return nil
+	}
+	if result.Added > 0 || !daemonQueueIdle(q, tracker) {
+		m.idleSince = time.Time{}
+		m.lastAlerts = nil
+		return nil
+	}
+
+	threshold, err := time.ParseDuration(m.cfg.Daemon.StallMonitor.ScannerIdleThreshold)
+	if err != nil {
+		slog.Warn("parse scanner idle threshold", "error", err)
+		return nil
+	}
+	if m.idleSince.IsZero() {
+		m.idleSince = now.UTC()
+		m.lastAlerts = nil
+		return nil
+	}
+	if now.Sub(m.idleSince) < threshold {
+		m.lastAlerts = nil
+		return nil
+	}
+
+	backlogCount, err := countEligibleGitHubBacklog(ctx, m.cfg, m.cmdRunner)
+	if err != nil {
+		slog.Warn("query daemon backlog", "error", err)
+		m.lastAlerts = nil
+		return nil
+	}
+	if backlogCount <= 0 {
+		m.lastAlerts = nil
+		return nil
+	}
+
+	m.lastAlerts = []daemonStatusAlert{{
+		Code:     "idle_with_backlog",
+		Severity: "warning",
+		Message:  fmt.Sprintf("Daemon idle with %d backlog items on GitHub", backlogCount),
+	}}
+	slog.Warn("daemon idle with backlog", "count", backlogCount)
+	return cloneDaemonAlerts(m.lastAlerts)
+}
+
+func (m *daemonBacklogMonitor) CurrentAlerts(tracker inFlightTracker, q *queue.Queue) []daemonStatusAlert {
+	if m == nil {
+		return nil
+	}
+	if !daemonQueueIdle(q, tracker) {
+		m.lastAlerts = nil
+		return nil
+	}
+	return cloneDaemonAlerts(m.lastAlerts)
+}
+
+func countEligibleGitHubBacklog(ctx context.Context, cfg *config.Config, cmdRunner source.CommandRunner) (int, error) {
+	if cfg == nil || cmdRunner == nil {
+		return 0, nil
+	}
+
+	seenIssues := map[string]struct{}{}
+	seenPRs := map[string]struct{}{}
+	for _, srcCfg := range cfg.Sources {
+		switch srcCfg.Type {
+		case "github":
+			excluded := make(map[string]struct{}, len(srcCfg.Exclude))
+			for _, label := range srcCfg.Exclude {
+				excluded[label] = struct{}{}
+			}
+			for _, task := range srcCfg.Tasks {
+				for _, label := range task.Labels {
+					out, err := cmdRunner.Run(ctx, "gh", "search", "issues", "--repo", srcCfg.Repo, "--state", "open", "--json", "number,labels", "--limit", "100", "--label", label)
+					if err != nil {
+						return 0, fmt.Errorf("gh search issues: %w", err)
+					}
+					var issues []ghIssueBacklogItem
+					if err := json.Unmarshal(out, &issues); err != nil {
+						return 0, fmt.Errorf("parse gh search output: %w", err)
+					}
+					for _, issue := range issues {
+						if hasExcludedBacklogLabel(issue.Labels, excluded) {
+							continue
+						}
+						seenIssues[fmt.Sprintf("%s#%d", srcCfg.Repo, issue.Number)] = struct{}{}
+					}
+				}
+			}
+		case "github-pr":
+			excluded := make(map[string]struct{}, len(srcCfg.Exclude))
+			for _, label := range srcCfg.Exclude {
+				excluded[label] = struct{}{}
+			}
+			for _, task := range srcCfg.Tasks {
+				if task.Workflow != "resolve-conflicts" {
+					continue
+				}
+				for _, label := range task.Labels {
+					out, err := cmdRunner.Run(ctx, "gh", "pr", "list", "--repo", srcCfg.Repo, "--state", "open", "--label", label, "--json", "number,labels,mergeable", "--limit", "100")
+					if err != nil {
+						return 0, fmt.Errorf("gh pr list: %w", err)
+					}
+					var prs []ghPRBacklogItem
+					if err := json.Unmarshal(out, &prs); err != nil {
+						return 0, fmt.Errorf("parse gh pr list output: %w", err)
+					}
+					for _, pr := range prs {
+						if pr.Mergeable != "CONFLICTING" || hasExcludedBacklogLabel(pr.Labels, excluded) {
+							continue
+						}
+						seenPRs[fmt.Sprintf("%s#%d", srcCfg.Repo, pr.Number)] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+
+	return len(seenIssues) + len(seenPRs), nil
+}
+
+func hasExcludedBacklogLabel(labels []struct {
+	Name string `json:"name"`
+}, excluded map[string]struct{}) bool {
+	for _, label := range labels {
+		if _, ok := excluded[label.Name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func daemonQueueIdle(q *queue.Queue, tracker inFlightTracker) bool {
+	if trackerInFlightCount(tracker) > 0 {
+		return false
+	}
+	if q == nil {
+		return true
+	}
+	vessels, err := q.List()
+	if err != nil {
+		return false
+	}
+	for _, vessel := range vessels {
+		switch vessel.State {
+		case queue.StatePending, queue.StateRunning, queue.StateWaiting:
+			return false
+		}
+	}
+	return true
+}
+
+func daemonHealthPath(cfg *config.Config) string {
+	return filepath.Join(cfg.StateDir, daemonHealthFileName)
+}
+
+func saveDaemonStatusSnapshot(path string, snapshot daemonStatusSnapshot) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create daemon health dir: %w", err)
+	}
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal daemon health snapshot: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write daemon health snapshot: %w", err)
+	}
+	return nil
+}
+
+func loadDaemonStatusSnapshot(path string) (*daemonStatusSnapshot, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var snapshot daemonStatusSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return nil, fmt.Errorf("parse daemon health snapshot: %w", err)
+	}
+	return &snapshot, nil
+}
+
+func daemonHeartbeatFreshness(cfg *config.Config) time.Duration {
+	scanInterval, drainInterval := parseDaemonIntervals(cfg.Daemon)
+	freshness := scanInterval
+	if drainInterval > freshness {
+		freshness = drainInterval
+	}
+	return freshness*2 + 5*time.Second
+}
+
+func cloneDaemonAlerts(alerts []daemonStatusAlert) []daemonStatusAlert {
+	if len(alerts) == 0 {
+		return nil
+	}
+	out := make([]daemonStatusAlert, len(alerts))
+	copy(out, alerts)
+	return out
+}

--- a/cli/cmd/xylem/daemon_health_test.go
+++ b/cli/cmd/xylem/daemon_health_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/scanner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type backlogCmdRunnerStub struct {
+	responses map[string][]byte
+}
+
+func (b backlogCmdRunnerStub) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	key := strings.Join(append([]string{name}, args...), "\x00")
+	if out, ok := b.responses[key]; ok {
+		return out, nil
+	}
+	return []byte("[]"), nil
+}
+
+func TestSmoke_S2_IdleWithBacklogWarnsWhenQueueIdle(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		StateDir: filepath.Join(dir, ".xylem"),
+		Daemon: config.DaemonConfig{
+			StallMonitor: config.StallMonitorConfig{
+				ScannerIdleThreshold: "5m",
+			},
+		},
+		Sources: map[string]config.SourceConfig{
+			"issues": {
+				Type: "github",
+				Repo: "owner/repo",
+				Tasks: map[string]config.Task{
+					"bugs": {Labels: []string{"bug"}, Workflow: "fix-bug"},
+				},
+			},
+		},
+	}
+	require.NoError(t, os.MkdirAll(cfg.StateDir, 0o755))
+	q := queue.New(filepath.Join(cfg.StateDir, "queue.jsonl"))
+	runner := backlogCmdRunnerStub{
+		responses: map[string][]byte{
+			strings.Join([]string{"gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,labels", "--limit", "100", "--label", "bug"}, "\x00"): []byte(`[
+				{"number":1,"labels":[{"name":"bug"}]},
+				{"number":2,"labels":[{"name":"bug"}]},
+				{"number":3,"labels":[{"name":"bug"}]}
+			]`),
+		},
+	}
+	monitor := newDaemonBacklogMonitor(cfg, runner)
+	logBuf := withBufferedDefaultLogger(t)
+
+	now := time.Now().UTC()
+	require.Empty(t, monitor.ObserveScan(context.Background(), now, scanner.ScanResult{}, nil, q))
+
+	alerts := monitor.ObserveScan(context.Background(), now.Add(6*time.Minute), scanner.ScanResult{}, nil, q)
+	require.Len(t, alerts, 1)
+	assert.Equal(t, "idle_with_backlog", alerts[0].Code)
+	assert.Contains(t, alerts[0].Message, "3 backlog items")
+	assert.Contains(t, logBuf.String(), "daemon idle with backlog")
+}
+
+func TestSmoke_S5_StatusShowsDaemonHealthAlerts(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testStatusConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	snapshot := daemonStatusSnapshot{
+		PID:         os.Getpid(),
+		StartedAt:   time.Now().UTC().Add(-2 * time.Hour),
+		HeartbeatAt: time.Now().UTC(),
+		Build:       "abcdef123456",
+		AutoUpgrade: true,
+		Alerts: []daemonStatusAlert{
+			{Code: "idle_with_backlog", Severity: "warning", Message: "Daemon idle with 3 backlog items on GitHub"},
+			{Code: "phase_stalled", Severity: "critical", Message: "Vessel issue-158 phase-stalled (10m12s no output on analyze)"},
+		},
+	}
+	lastUpgrade := time.Now().UTC().Add(-30 * time.Minute)
+	snapshot.LastUpgradeAt = &lastUpgrade
+	require.NoError(t, saveDaemonStatusSnapshot(daemonHealthPath(cfg), snapshot))
+
+	var err error
+	out := captureStdout(func() { err = cmdStatus(cfg, q, false, "") })
+	require.NoError(t, err)
+	require.Contains(t, out, "No vessels in queue.")
+	for _, want := range []string{
+		"Daemon health:",
+		"OK Daemon alive",
+		"OK Auto-upgrade current",
+		"WARN Daemon idle with 3 backlog items on GitHub",
+		"FAIL Vessel issue-158 phase-stalled",
+	} {
+		assert.Contains(t, out, want)
+	}
+}
+
+func TestNewDaemonHealthRecorderOnlyMarksActiveAutoUpgradeWhenWired(t *testing.T) {
+	cfg := &config.Config{
+		Daemon: config.DaemonConfig{
+			AutoUpgrade: true,
+		},
+	}
+
+	recorder := newDaemonHealthRecorder(cfg, time.Now().UTC(), false)
+	if recorder.snapshot.AutoUpgrade {
+		t.Fatal("snapshot.AutoUpgrade = true, want false when upgrade path is unavailable")
+	}
+
+	recorder = newDaemonHealthRecorder(cfg, time.Now().UTC(), true)
+	if !recorder.snapshot.AutoUpgrade {
+		t.Fatal("snapshot.AutoUpgrade = false, want true when upgrade path is active")
+	}
+}

--- a/cli/cmd/xylem/daemon_health_test.go
+++ b/cli/cmd/xylem/daemon_health_test.go
@@ -104,6 +104,30 @@ func TestSmoke_S5_StatusShowsDaemonHealthAlerts(t *testing.T) {
 	}
 }
 
+func TestSaveDaemonStatusSnapshotReplacesFileAtomically(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, daemonHealthFileName)
+	require.NoError(t, os.WriteFile(path, []byte(`{"pid":1,"heartbeat_at":"2026-01-01T00:00:00Z"}`), 0o644))
+
+	snapshot := daemonStatusSnapshot{
+		PID:         2,
+		StartedAt:   time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC),
+		HeartbeatAt: time.Date(2026, time.January, 2, 3, 5, 5, 0, time.UTC),
+		Build:       "abcdef123456",
+	}
+	require.NoError(t, saveDaemonStatusSnapshot(path, snapshot))
+
+	got, err := loadDaemonStatusSnapshot(path)
+	require.NoError(t, err)
+	assert.Equal(t, snapshot.PID, got.PID)
+	assert.Equal(t, snapshot.StartedAt, got.StartedAt)
+	assert.Equal(t, snapshot.HeartbeatAt, got.HeartbeatAt)
+
+	matches, err := filepath.Glob(filepath.Join(dir, daemonHealthFileName+".*.tmp"))
+	require.NoError(t, err)
+	assert.Empty(t, matches)
+}
+
 func TestNewDaemonHealthRecorderOnlyMarksActiveAutoUpgradeWhenWired(t *testing.T) {
 	cfg := &config.Config{
 		Daemon: config.DaemonConfig{

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -229,7 +229,7 @@ func TestDaemonLoopScheduledSourceRunsSingleTick(t *testing.T) {
 		return runner.DrainResult{Launched: 1, Completed: 1}, nil
 	}
 
-	if err := daemonLoop(ctx, q, tracker, scan, drain, nil, nil, 10*time.Millisecond, 10*time.Millisecond, 0); err != nil {
+	if err := daemonLoop(ctx, q, tracker, scan, drain, nil, nil, nil, 10*time.Millisecond, 10*time.Millisecond, 0); err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
 
@@ -307,7 +307,7 @@ func TestDaemonShutdown(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, nil, time.Hour, time.Hour, 0)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, nil, nil, time.Hour, time.Hour, 0)
 	if err != nil {
 		t.Fatalf("expected nil error on shutdown, got: %v", err)
 	}
@@ -354,7 +354,7 @@ func TestSmoke_S3_DaemonTickDrainsScheduledVessel(t *testing.T) {
 
 	err := daemonLoop(ctx, q, nil, func(ctx context.Context) (scanner.ScanResult, error) {
 		return runScan(ctx, cfg, q)
-	}, drain, nil, nil, time.Millisecond, time.Millisecond, 0)
+	}, drain, nil, nil, nil, time.Millisecond, time.Millisecond, 0)
 	require.NoError(t, err)
 
 	vessels, err := q.List()
@@ -428,7 +428,7 @@ func TestDaemonLoopPeriodicUpgradeFiresAtDrainEnd(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, upgrade, time.Hour, 2*time.Millisecond, time.Millisecond)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, upgrade, nil, time.Hour, 2*time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -450,7 +450,7 @@ func TestDaemonLoopPeriodicUpgradeRespectsInterval(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, upgrade, time.Hour, 2*time.Millisecond, 10*time.Second)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, upgrade, nil, time.Hour, 2*time.Millisecond, 10*time.Second)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -470,7 +470,7 @@ func TestDaemonLoopPeriodicUpgradeNilDisables(t *testing.T) {
 	defer cancel()
 
 	// Passing nil upgrade should not panic even with a non-zero interval.
-	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, nil, time.Hour, 2*time.Millisecond, 10*time.Millisecond)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, nil, nil, time.Hour, 2*time.Millisecond, 10*time.Millisecond)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -509,7 +509,7 @@ func TestDaemonLoopUpgradeWaitsForDrainCompletion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, nil, noopScan, slowDrain, nil, upgrade, time.Hour, time.Millisecond, time.Millisecond)
+	err := daemonLoop(ctx, q, nil, noopScan, slowDrain, nil, upgrade, nil, time.Hour, time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -537,7 +537,7 @@ func TestSmoke_S35_DaemonLoopAllowsNewDrainTicksWhileVesselsRemainInFlight(t *te
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, nil, time.Hour, 10*time.Millisecond, 0)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, nil, nil, time.Hour, 10*time.Millisecond, 0)
 	require.NoError(t, err)
 
 	assert.GreaterOrEqual(t, drainCalls.Load(), int32(2))
@@ -571,7 +571,7 @@ func TestSmoke_S36_DaemonLoopUpgradeWaitsForTrackerIdle(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, time.Hour, 10*time.Millisecond, time.Millisecond)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, time.Hour, 10*time.Millisecond, time.Millisecond)
 	require.NoError(t, err)
 
 	assert.NotZero(t, upgradeSeen.Load())
@@ -613,7 +613,7 @@ func TestSmoke_S39_DaemonAutoUpgradeProceedsAfterCancelledVesselDropsInFlight(t 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, time.Hour, 10*time.Millisecond, time.Millisecond)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, time.Hour, 10*time.Millisecond, time.Millisecond)
 	require.NoError(t, err)
 
 	select {
@@ -671,7 +671,7 @@ func TestDaemonLoopUpgradeOverduePausesDrainToCreateIdleWindow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, time.Hour, 5*time.Millisecond, 5*time.Millisecond)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, time.Hour, 5*time.Millisecond, 5*time.Millisecond)
 	require.NoError(t, err)
 
 	// Upgrade MUST have fired at least once despite the continuously saturating drain.
@@ -708,7 +708,7 @@ func TestDaemonLoopUpgradeOverdueDoesNotFireUnderNormalConditions(t *testing.T) 
 	defer cancel()
 
 	// upgradeInterval=2ms; over 100ms, normal path should fire many times.
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, time.Hour, 2*time.Millisecond, 2*time.Millisecond)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, time.Hour, 2*time.Millisecond, 2*time.Millisecond)
 	require.NoError(t, err)
 
 	assert.GreaterOrEqual(t, upgradeSeen.Load(), int32(5),
@@ -794,7 +794,7 @@ func TestDaemonNonBlockingDrain(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	err := daemonLoop(ctx, q, nil, noopScan, slowDrain, nil, nil, time.Hour, time.Millisecond, 0)
+	err := daemonLoop(ctx, q, nil, noopScan, slowDrain, nil, nil, nil, time.Hour, time.Millisecond, 0)
 	elapsed := time.Since(start)
 
 	if err != nil {
@@ -1178,5 +1178,21 @@ func TestAcquireDaemonLock(t *testing.T) {
 			t.Fatalf("expected no error, got: %v", err)
 		}
 		defer unlock()
+
+		info, err := os.Stat(filepath.Dir(pidPath))
+		if err != nil {
+			t.Fatalf("Stat(%q): %v", filepath.Dir(pidPath), err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("parent path %q is not a directory", filepath.Dir(pidPath))
+		}
+
+		data, err := os.ReadFile(pidPath)
+		if err != nil {
+			t.Fatalf("ReadFile(%q): %v", pidPath, err)
+		}
+		if len(data) == 0 {
+			t.Fatalf("PID file %q is empty", pidPath)
+		}
 	})
 }

--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -78,6 +78,9 @@ func buildDrainRunner(cfg *config.Config, q *queue.Queue, wt runner.WorktreeMana
 	r := runner.New(cfg, q, wt, cmdRunner)
 	r.Sources = buildSourceMap(cfg, q, cmdRunner)
 	r.BuiltinWorkflows = buildBuiltinWorkflowHandlers(cfg, wt, cmdRunner)
+	if tracker, ok := interface{}(cmdRunner).(runner.ProcessTracker); ok {
+		r.ProcessTracker = tracker
+	}
 	wireRunnerScaffolding(cfg, r, tracer)
 
 	return r, func() {

--- a/cli/cmd/xylem/exec.go
+++ b/cli/cmd/xylem/exec.go
@@ -3,13 +3,17 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"sync"
+	"syscall"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	xrunner "github.com/nicholls-inc/xylem/cli/internal/runner"
 )
 
 // maxStderrBytes is the maximum amount of stderr captured from a phase subprocess.
@@ -73,6 +77,14 @@ type realCmdRunner struct {
 	// extraEnv holds additional KEY=VALUE pairs merged into the subprocess
 	// environment. Populated from claude.env and copilot.env in config.
 	extraEnv []string
+	mu       sync.Mutex
+	tracked  map[string]*trackedProcess
+}
+
+type trackedProcess struct {
+	cmd       *exec.Cmd
+	phase     string
+	startedAt time.Time
 }
 
 // newCmdRunner creates a realCmdRunner with extra env vars merged from
@@ -113,7 +125,7 @@ func newCmdRunner(cfg *config.Config) *realCmdRunner {
 	for k, v := range cfg.Copilot.Env {
 		addEnv(k, v)
 	}
-	return &realCmdRunner{extraEnv: env}
+	return &realCmdRunner{extraEnv: env, tracked: make(map[string]*trackedProcess)}
 }
 
 // cmdEnv returns the environment to use for a subprocess: the daemon's
@@ -140,7 +152,11 @@ func (r *realCmdRunner) Run(ctx context.Context, name string, args ...string) ([
 func (r *realCmdRunner) RunOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Env = r.cmdEnv()
-	return cmd.CombinedOutput()
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stdout
+	err := r.runTrackedCommand(ctx, cmd)
+	return stdout.Bytes(), err
 }
 
 func (r *realCmdRunner) RunProcess(ctx context.Context, dir string, name string, args ...string) error {
@@ -175,9 +191,96 @@ func (r *realCmdRunner) RunPhase(ctx context.Context, dir string, stdin io.Reade
 	cmd.Stdout = &stdout
 	cmd.Stderr = stderr
 
-	err := cmd.Run()
+	err := r.runTrackedCommand(ctx, cmd)
 	if err != nil && stderr.Len() > 0 {
 		return stdout.Bytes(), fmt.Errorf("%w\nstderr: %s", err, stderr.String())
 	}
 	return stdout.Bytes(), err
+}
+
+func (r *realCmdRunner) ProcessInfo(vesselID string) (xrunner.ProcessInfo, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	proc, ok := r.tracked[vesselID]
+	if !ok || proc.cmd == nil || proc.cmd.Process == nil {
+		return xrunner.ProcessInfo{}, false
+	}
+	return xrunner.ProcessInfo{
+		PID:       proc.cmd.Process.Pid,
+		Phase:     proc.phase,
+		StartedAt: proc.startedAt,
+		Live:      true,
+	}, true
+}
+
+func (r *realCmdRunner) TerminateProcess(vesselID string, gracePeriod time.Duration) error {
+	info, ok := r.ProcessInfo(vesselID)
+	if !ok {
+		return fmt.Errorf("terminate process for vessel %s: not tracked", vesselID)
+	}
+
+	r.mu.Lock()
+	proc := r.tracked[vesselID]
+	r.mu.Unlock()
+	if proc == nil || proc.cmd == nil || proc.cmd.Process == nil {
+		return fmt.Errorf("terminate process for vessel %s: no process", vesselID)
+	}
+
+	if err := proc.cmd.Process.Signal(syscall.SIGTERM); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("sigterm pid %d: %w", info.PID, err)
+	}
+	if r.waitForExit(vesselID, gracePeriod) {
+		return nil
+	}
+	if err := proc.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("sigkill pid %d: %w", info.PID, err)
+	}
+	r.waitForExit(vesselID, time.Second)
+	return nil
+}
+
+func (r *realCmdRunner) waitForExit(vesselID string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if _, ok := r.ProcessInfo(vesselID); !ok {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func (r *realCmdRunner) runTrackedCommand(ctx context.Context, cmd *exec.Cmd) error {
+	meta, ok := xrunner.PhaseExecutionMetadataFromContext(ctx)
+	if !ok || meta.VesselID == "" {
+		return cmd.Run()
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	r.trackProcess(meta, cmd)
+	defer r.untrackProcess(meta.VesselID)
+	return cmd.Wait()
+}
+
+func (r *realCmdRunner) trackProcess(meta xrunner.PhaseExecutionMetadata, cmd *exec.Cmd) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.tracked == nil {
+		r.tracked = make(map[string]*trackedProcess)
+	}
+	r.tracked[meta.VesselID] = &trackedProcess{
+		cmd:       cmd,
+		phase:     meta.PhaseName,
+		startedAt: time.Now().UTC(),
+	}
+}
+
+func (r *realCmdRunner) untrackProcess(vesselID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.tracked, vesselID)
 }

--- a/cli/cmd/xylem/status.go
+++ b/cli/cmd/xylem/status.go
@@ -78,8 +78,14 @@ func cmdStatus(cfg *config.Config, q *queue.Queue, jsonMode bool, stateFilter st
 		return nil
 	}
 
+	var daemonStatus *daemonStatusSnapshot
+	if cfg != nil && cfg.StateDir != "" {
+		daemonStatus, _ = loadDaemonStatusSnapshot(daemonHealthPath(cfg))
+	}
+
 	if len(vessels) == 0 {
 		fmt.Println("No vessels in queue.")
+		printDaemonHealth(cfg, daemonStatus)
 		return nil
 	}
 
@@ -120,6 +126,7 @@ func cmdStatus(cfg *config.Config, q *queue.Queue, jsonMode bool, stateFilter st
 	if len(fleet.Patterns) > 0 {
 		fmt.Printf("Patterns: %s\n", runner.FormatFleetPatterns(fleet.Patterns))
 	}
+	printDaemonHealth(cfg, daemonStatus)
 	return nil
 }
 
@@ -149,4 +156,28 @@ func pauseMarkerPath(cfg *config.Config) string {
 func isPaused(cfg *config.Config) bool {
 	_, err := os.Stat(pauseMarkerPath(cfg))
 	return err == nil
+}
+
+func printDaemonHealth(cfg *config.Config, snapshot *daemonStatusSnapshot) {
+	if cfg == nil || snapshot == nil {
+		return
+	}
+
+	fmt.Println("Daemon health:")
+	now := time.Now().UTC()
+	if now.Sub(snapshot.HeartbeatAt) <= daemonHeartbeatFreshness(cfg) {
+		fmt.Printf("  OK Daemon alive (pid=%d, uptime=%s)\n", snapshot.PID, now.Sub(snapshot.StartedAt).Round(time.Second))
+	} else {
+		fmt.Printf("  WARN Daemon heartbeat stale (pid=%d, last=%s)\n", snapshot.PID, snapshot.HeartbeatAt.UTC().Format(time.RFC3339))
+	}
+	if snapshot.AutoUpgrade && snapshot.LastUpgradeAt != nil {
+		fmt.Printf("  OK Auto-upgrade current (binary=%s, last=%s)\n", snapshot.Build, snapshot.LastUpgradeAt.UTC().Format("15:04:05"))
+	}
+	for _, alert := range snapshot.Alerts {
+		prefix := "  WARN"
+		if alert.Severity == "critical" {
+			prefix = "  FAIL"
+		}
+		fmt.Printf("%s %s\n", prefix, alert.Message)
+	}
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -149,9 +149,10 @@ type CopilotConfig struct {
 }
 
 type DaemonConfig struct {
-	ScanInterval  string `yaml:"scan_interval,omitempty"`
-	DrainInterval string `yaml:"drain_interval,omitempty"`
-	AutoUpgrade   bool   `yaml:"auto_upgrade,omitempty"`
+	ScanInterval  string             `yaml:"scan_interval,omitempty"`
+	DrainInterval string             `yaml:"drain_interval,omitempty"`
+	StallMonitor  StallMonitorConfig `yaml:"stall_monitor,omitempty"`
+	AutoUpgrade   bool               `yaml:"auto_upgrade,omitempty"`
 	// UpgradeInterval controls how often the daemon re-runs the
 	// auto_upgrade check while the loop is running. Only meaningful when
 	// AutoUpgrade is true. Defaults to 5m. Accepts any Go duration string.
@@ -164,6 +165,12 @@ type DaemonConfig struct {
 	// AutoMergeRepo is the GitHub repo slug (owner/name) for auto-merge.
 	// If empty, gh CLI uses the current directory's origin remote.
 	AutoMergeRepo string `yaml:"auto_merge_repo,omitempty"`
+}
+
+type StallMonitorConfig struct {
+	PhaseStallThreshold  string `yaml:"phase_stall_threshold,omitempty"`
+	ScannerIdleThreshold string `yaml:"scanner_idle_threshold,omitempty"`
+	OrphanCheckEnabled   bool   `yaml:"orphan_check_enabled,omitempty"`
 }
 
 type HarnessConfig struct {
@@ -234,6 +241,11 @@ func Load(path string) (*Config, error) {
 		Daemon: DaemonConfig{
 			ScanInterval:  "60s",
 			DrainInterval: "30s",
+			StallMonitor: StallMonitorConfig{
+				PhaseStallThreshold:  "10m",
+				ScannerIdleThreshold: "5m",
+				OrphanCheckEnabled:   true,
+			},
 		},
 	}
 
@@ -322,6 +334,16 @@ func (c *Config) Validate() error {
 	if c.Daemon.DrainInterval != "" {
 		if _, err := time.ParseDuration(c.Daemon.DrainInterval); err != nil {
 			return fmt.Errorf("daemon.drain_interval must be a valid duration: %w", err)
+		}
+	}
+	if c.Daemon.StallMonitor.PhaseStallThreshold != "" {
+		if _, err := time.ParseDuration(c.Daemon.StallMonitor.PhaseStallThreshold); err != nil {
+			return fmt.Errorf("daemon.stall_monitor.phase_stall_threshold must be a valid duration: %w", err)
+		}
+	}
+	if c.Daemon.StallMonitor.ScannerIdleThreshold != "" {
+		if _, err := time.ParseDuration(c.Daemon.StallMonitor.ScannerIdleThreshold); err != nil {
+			return fmt.Errorf("daemon.stall_monitor.scanner_idle_threshold must be a valid duration: %w", err)
 		}
 	}
 

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -497,6 +497,77 @@ func TestValidateDaemonDrainIntervalInvalid(t *testing.T) {
 	requireErrorContains(t, err, "daemon.drain_interval must be a valid duration")
 }
 
+func TestValidateDaemonStallMonitorInvalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  func(*Config)
+		wantErr string
+	}{
+		{
+			name: "phase stall threshold",
+			config: func(cfg *Config) {
+				cfg.Daemon.StallMonitor.PhaseStallThreshold = "bad"
+			},
+			wantErr: "daemon.stall_monitor.phase_stall_threshold must be a valid duration",
+		},
+		{
+			name: "scanner idle threshold",
+			config: func(cfg *Config) {
+				cfg.Daemon.StallMonitor.ScannerIdleThreshold = "bad"
+			},
+			wantErr: "daemon.stall_monitor.scanner_idle_threshold must be a valid duration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			tt.config(cfg)
+
+			err := cfg.Validate()
+			requireErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestLoadDaemonStallMonitorConfig(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+daemon:
+  stall_monitor:
+    phase_stall_threshold: "11m"
+    scanner_idle_threshold: "7m"
+    orphan_check_enabled: false
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	if cfg.Daemon.StallMonitor.PhaseStallThreshold != "11m" {
+		t.Fatalf("Daemon.StallMonitor.PhaseStallThreshold = %q, want 11m", cfg.Daemon.StallMonitor.PhaseStallThreshold)
+	}
+	if cfg.Daemon.StallMonitor.ScannerIdleThreshold != "7m" {
+		t.Fatalf("Daemon.StallMonitor.ScannerIdleThreshold = %q, want 7m", cfg.Daemon.StallMonitor.ScannerIdleThreshold)
+	}
+	if cfg.Daemon.StallMonitor.OrphanCheckEnabled {
+		t.Fatal("Daemon.StallMonitor.OrphanCheckEnabled = true, want false")
+	}
+}
+
 func TestLoadWithFlagsAndEnv(t *testing.T) {
 	path := writeConfigFile(t, `sources:
   github:

--- a/cli/internal/dtu/scenario_daemon_stall_test.go
+++ b/cli/internal/dtu/scenario_daemon_stall_test.go
@@ -1,0 +1,139 @@
+package dtu_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	dtu "github.com/nicholls-inc/xylem/cli/internal/dtu"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+	"github.com/nicholls-inc/xylem/cli/internal/scanner"
+	"github.com/nicholls-inc/xylem/cli/internal/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stallScenarioCmdRunner struct{}
+
+func (stallScenarioCmdRunner) RunOutput(context.Context, string, ...string) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (stallScenarioCmdRunner) RunProcess(context.Context, string, string, ...string) error {
+	return nil
+}
+
+func (stallScenarioCmdRunner) RunPhase(context.Context, string, io.Reader, string, ...string) ([]byte, error) {
+	return []byte("ok"), nil
+}
+
+type stallScenarioWorktree struct {
+	removedPath string
+}
+
+func (s *stallScenarioWorktree) Create(context.Context, string) (string, error) {
+	return ".claude/worktrees/stall", nil
+}
+
+func (s *stallScenarioWorktree) Remove(_ context.Context, worktreePath string) error {
+	s.removedPath = worktreePath
+	return nil
+}
+
+type stallScenarioTracker struct {
+	info       map[string]runner.ProcessInfo
+	terminated []string
+}
+
+func (s *stallScenarioTracker) ProcessInfo(vesselID string) (runner.ProcessInfo, bool) {
+	info, ok := s.info[vesselID]
+	return info, ok
+}
+
+func (s *stallScenarioTracker) TerminateProcess(vesselID string, _ time.Duration) error {
+	s.terminated = append(s.terminated, vesselID)
+	delete(s.info, vesselID)
+	return nil
+}
+
+func TestSmoke_S4_DaemonPhaseStallRecovery(t *testing.T) {
+	env := newScenarioEnv(t, "issue-daemon-stall.yaml")
+	defer withWorkingDir(t, env.repoDir)()
+
+	cfg := baseScenarioConfig(env.stateDir)
+	cfg.Sources = map[string]config.SourceConfig{
+		"issues": {
+			Type: "github",
+			Repo: "owner/repo",
+			Tasks: map[string]config.Task{
+				"bugs": {
+					Labels:   []string{"bug"},
+					Workflow: "fix-bug",
+					StatusLabels: &config.StatusLabels{
+						Queued:   "queued",
+						Running:  "in-progress",
+						TimedOut: "timed-out",
+					},
+				},
+			},
+		},
+	}
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "10m"
+
+	scan := scanner.New(cfg, env.queue, env.cmdRunner)
+	result, err := scan.Scan(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Added)
+
+	src := &source.GitHub{Repo: "owner/repo", CmdRunner: env.cmdRunner}
+	vessel, err := env.queue.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, vessel)
+	vessel.WorktreePath = ".claude/worktrees/issue-4"
+	require.NoError(t, env.queue.UpdateVessel(*vessel))
+	require.NoError(t, src.OnStart(context.Background(), *vessel))
+
+	phaseDir := filepath.Join(env.stateDir, "phases", vessel.ID)
+	require.NoError(t, os.MkdirAll(phaseDir, 0o755))
+	outputPath := filepath.Join(phaseDir, "analyze.output")
+	require.NoError(t, os.WriteFile(outputPath, []byte("stalled"), 0o644))
+	now, err := dtu.RuntimeNow()
+	require.NoError(t, err)
+	staleAt := now.Add(-11 * time.Minute)
+	require.NoError(t, os.Chtimes(outputPath, staleAt, staleAt))
+
+	wt := &stallScenarioWorktree{}
+	r := runner.New(cfg, env.queue, wt, stallScenarioCmdRunner{})
+	r.Sources = map[string]source.Source{"issues": src, "github-issue": src}
+	tracker := &stallScenarioTracker{
+		info: map[string]runner.ProcessInfo{
+			vessel.ID: {
+				PID:       1234,
+				Phase:     "analyze",
+				StartedAt: staleAt,
+				Live:      true,
+			},
+		},
+	}
+	r.ProcessTracker = tracker
+
+	alerts := r.CheckStalledVessels(context.Background())
+	require.Len(t, alerts, 1)
+	assert.Equal(t, "phase_stalled", alerts[0].Code)
+	assert.Equal(t, "analyze", alerts[0].Phase)
+
+	updated, err := env.queue.FindByID(vessel.ID)
+	require.NoError(t, err)
+	require.Equal(t, queue.StateTimedOut, updated.State)
+	assert.Equal(t, vessel.WorktreePath, wt.removedPath)
+	assert.Equal(t, []string{vessel.ID}, tracker.terminated)
+	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 4), []string{"bug", "timed-out"})
+
+	events := readEvents(t, env.store)
+	assert.NotEmpty(t, events)
+}

--- a/cli/internal/dtu/testdata/issue-daemon-stall.yaml
+++ b/cli/internal/dtu/testdata/issue-daemon-stall.yaml
@@ -1,0 +1,24 @@
+metadata:
+  name: issue-daemon-stall
+  scenario: daemon stall monitor recovers stalled running vessel
+repositories:
+  - owner: owner
+    name: repo
+    default_branch: main
+    labels:
+      - name: bug
+      - name: queued
+      - name: in-progress
+      - name: timed-out
+    issues:
+      - number: 4
+        title: stalled vessel
+        body: phase output stopped changing
+        labels: [bug]
+providers:
+  scripts:
+    - name: implement
+      provider: claude
+      match:
+        phase: implement
+      stdout: implementation complete

--- a/cli/internal/runner/monitor.go
+++ b/cli/internal/runner/monitor.go
@@ -75,6 +75,14 @@ func (r *Runner) CheckStalledVessels(ctx context.Context) []StallAlert {
 			if !r.Config.Daemon.StallMonitor.OrphanCheckEnabled {
 				continue
 			}
+			activityAt, err := phaseActivityAt(r.Config.StateDir, vessel, time.Time{})
+			if err != nil {
+				log.Printf("warn: inspect phase activity for orphan check for %s: %v", vessel.ID, err)
+				continue
+			}
+			if activityAt.IsZero() || r.runtimeSince(activityAt) <= threshold {
+				continue
+			}
 			errMsg := "vessel orphaned (no live subprocess)"
 			log.Printf("warn: %s for vessel %s", errMsg, vessel.ID)
 			if r.timeoutRunningVessel(ctx, vessel, errMsg) {
@@ -88,17 +96,10 @@ func (r *Runner) CheckStalledVessels(ctx context.Context) []StallAlert {
 			continue
 		}
 
-		activityAt, err := latestPhaseActivityAt(r.Config.StateDir, vessel.ID)
+		activityAt, err := phaseActivityAt(r.Config.StateDir, vessel, info.StartedAt)
 		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				activityAt = info.StartedAt
-			} else {
-				log.Printf("warn: inspect phase activity for %s: %v", vessel.ID, err)
-				continue
-			}
-		}
-		if activityAt.IsZero() && vessel.StartedAt != nil {
-			activityAt = *vessel.StartedAt
+			log.Printf("warn: inspect phase activity for %s: %v", vessel.ID, err)
+			continue
 		}
 		if activityAt.IsZero() {
 			continue
@@ -139,6 +140,20 @@ func (r *Runner) timeoutRunningVessel(ctx context.Context, vessel queue.Vessel, 
 	}
 	r.removeWorktree(vessel.WorktreePath, vessel.ID)
 	return true
+}
+
+func phaseActivityAt(stateDir string, vessel queue.Vessel, fallback time.Time) (time.Time, error) {
+	activityAt, err := latestPhaseActivityAt(stateDir, vessel.ID)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return time.Time{}, err
+		}
+		activityAt = fallback
+	}
+	if activityAt.IsZero() && vessel.StartedAt != nil {
+		activityAt = *vessel.StartedAt
+	}
+	return activityAt, nil
 }
 
 func latestPhaseActivityAt(stateDir, vesselID string) (time.Time, error) {

--- a/cli/internal/runner/monitor.go
+++ b/cli/internal/runner/monitor.go
@@ -1,0 +1,172 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+const phaseStallTerminationGracePeriod = 30 * time.Second
+
+type phaseExecutionContextKey struct{}
+
+type PhaseExecutionMetadata struct {
+	VesselID  string
+	PhaseName string
+}
+
+type ProcessInfo struct {
+	PID       int
+	Phase     string
+	StartedAt time.Time
+	Live      bool
+}
+
+type ProcessTracker interface {
+	ProcessInfo(vesselID string) (ProcessInfo, bool)
+	TerminateProcess(vesselID string, gracePeriod time.Duration) error
+}
+
+type StallAlert struct {
+	Code     string
+	Severity string
+	VesselID string
+	Phase    string
+	Message  string
+}
+
+func WithPhaseExecutionMetadata(ctx context.Context, meta PhaseExecutionMetadata) context.Context {
+	return context.WithValue(ctx, phaseExecutionContextKey{}, meta)
+}
+
+func PhaseExecutionMetadataFromContext(ctx context.Context) (PhaseExecutionMetadata, bool) {
+	meta, ok := ctx.Value(phaseExecutionContextKey{}).(PhaseExecutionMetadata)
+	return meta, ok
+}
+
+func (r *Runner) CheckStalledVessels(ctx context.Context) []StallAlert {
+	if r == nil || r.Config == nil || r.ProcessTracker == nil {
+		return nil
+	}
+
+	threshold, err := time.ParseDuration(r.Config.Daemon.StallMonitor.PhaseStallThreshold)
+	if err != nil {
+		log.Printf("warn: parse phase stall threshold: %v", err)
+		return nil
+	}
+
+	running, err := r.Queue.ListByState(queue.StateRunning)
+	if err != nil {
+		log.Printf("warn: list running vessels for stall check: %v", err)
+		return nil
+	}
+
+	alerts := make([]StallAlert, 0)
+	for _, vessel := range running {
+		info, ok := r.ProcessTracker.ProcessInfo(vessel.ID)
+		if !ok || !info.Live || info.PID <= 0 {
+			if !r.Config.Daemon.StallMonitor.OrphanCheckEnabled {
+				continue
+			}
+			errMsg := "vessel orphaned (no live subprocess)"
+			log.Printf("warn: %s for vessel %s", errMsg, vessel.ID)
+			if r.timeoutRunningVessel(ctx, vessel, errMsg) {
+				alerts = append(alerts, StallAlert{
+					Code:     "orphaned_subprocess",
+					Severity: "critical",
+					VesselID: vessel.ID,
+					Message:  fmt.Sprintf("Vessel %s orphaned (no live subprocess)", vessel.ID),
+				})
+			}
+			continue
+		}
+
+		activityAt, err := latestPhaseActivityAt(r.Config.StateDir, vessel.ID)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				activityAt = info.StartedAt
+			} else {
+				log.Printf("warn: inspect phase activity for %s: %v", vessel.ID, err)
+				continue
+			}
+		}
+		if activityAt.IsZero() && vessel.StartedAt != nil {
+			activityAt = *vessel.StartedAt
+		}
+		if activityAt.IsZero() {
+			continue
+		}
+
+		staleFor := r.runtimeSince(activityAt)
+		if staleFor <= threshold {
+			continue
+		}
+
+		errMsg := fmt.Sprintf("phase stalled: no output for %s", staleFor.Round(time.Second))
+		log.Printf("warn: %s for vessel %s phase=%q pid=%d", errMsg, vessel.ID, info.Phase, info.PID)
+		if err := r.ProcessTracker.TerminateProcess(vessel.ID, phaseStallTerminationGracePeriod); err != nil {
+			log.Printf("warn: terminate stalled vessel %s: %v", vessel.ID, err)
+		}
+		if r.timeoutRunningVessel(ctx, vessel, errMsg) {
+			alerts = append(alerts, StallAlert{
+				Code:     "phase_stalled",
+				Severity: "critical",
+				VesselID: vessel.ID,
+				Phase:    info.Phase,
+				Message:  fmt.Sprintf("Vessel %s phase-stalled (%s no output on %s)", vessel.ID, staleFor.Round(time.Second), info.Phase),
+			})
+		}
+	}
+
+	return alerts
+}
+
+func (r *Runner) timeoutRunningVessel(ctx context.Context, vessel queue.Vessel, errMsg string) bool {
+	if updateErr := r.Queue.Update(vessel.ID, queue.StateTimedOut, errMsg); updateErr != nil {
+		log.Printf("warn: failed to update vessel %s to timed_out: %v", vessel.ID, updateErr)
+		return false
+	}
+	src := r.resolveSourceForVessel(vessel)
+	if err := src.OnTimedOut(ctx, vessel); err != nil {
+		log.Printf("warn: OnTimedOut hook for vessel %s: %v", vessel.ID, err)
+	}
+	r.removeWorktree(vessel.WorktreePath, vessel.ID)
+	return true
+}
+
+func latestPhaseActivityAt(stateDir, vesselID string) (time.Time, error) {
+	phaseDir := filepath.Join(stateDir, "phases", vesselID)
+	var latest time.Time
+	var found bool
+	err := filepath.WalkDir(phaseDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !found || info.ModTime().After(latest) {
+			latest = info.ModTime()
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		return time.Time{}, err
+	}
+	if !found {
+		return time.Time{}, os.ErrNotExist
+	}
+	return latest, nil
+}

--- a/cli/internal/runner/monitor_prop_test.go
+++ b/cli/internal/runner/monitor_prop_test.go
@@ -1,0 +1,51 @@
+package runner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+)
+
+func TestProp_LatestPhaseActivityAtReturnsNewestMTime(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		dir, err := os.MkdirTemp("", "runner-monitor-prop-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(dir)
+		vesselID := rapid.StringMatching(`[A-Za-z0-9_-]{1,16}`).Draw(t, "vesselID")
+		phaseDir := filepath.Join(dir, "phases", vesselID)
+		if err := os.MkdirAll(phaseDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", phaseDir, err)
+		}
+
+		count := rapid.IntRange(1, 8).Draw(t, "count")
+		base := time.Now().UTC().Add(-1 * time.Hour)
+		var want time.Time
+		for i := 0; i < count; i++ {
+			path := filepath.Join(phaseDir, fmt.Sprintf("%d-%s", i, rapid.StringMatching(`[a-z]{1,8}\.(output|prompt|command)`).Draw(t, "name")))
+			if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+				t.Fatalf("WriteFile(%q): %v", path, err)
+			}
+			modTime := base.Add(time.Duration(rapid.IntRange(0, 3_600).Draw(t, "seconds")) * time.Second)
+			if err := os.Chtimes(path, modTime, modTime); err != nil {
+				t.Fatalf("Chtimes(%q): %v", path, err)
+			}
+			if modTime.After(want) {
+				want = modTime
+			}
+		}
+
+		got, err := latestPhaseActivityAt(dir, vesselID)
+		if err != nil {
+			t.Fatalf("latestPhaseActivityAt() error = %v", err)
+		}
+		if !got.Equal(want) {
+			t.Fatalf("latestPhaseActivityAt() = %s, want %s", got, want)
+		}
+	})
+}

--- a/cli/internal/runner/monitor_test.go
+++ b/cli/internal/runner/monitor_test.go
@@ -1,0 +1,170 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeProcessTracker struct {
+	info           map[string]ProcessInfo
+	terminated     []string
+	gracePeriods   []time.Duration
+	terminateError error
+}
+
+func (f *fakeProcessTracker) ProcessInfo(vesselID string) (ProcessInfo, bool) {
+	info, ok := f.info[vesselID]
+	return info, ok
+}
+
+func (f *fakeProcessTracker) TerminateProcess(vesselID string, gracePeriod time.Duration) error {
+	f.terminated = append(f.terminated, vesselID)
+	f.gracePeriods = append(f.gracePeriods, gracePeriod)
+	if f.info != nil {
+		delete(f.info, vesselID)
+	}
+	return f.terminateError
+}
+
+func TestSmoke_S1_PhaseLevelStallTimesOutVessel(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "10m"
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	started := now.Add(-11 * time.Minute)
+	vessel := queue.Vessel{
+		ID:           "issue-1",
+		Source:       "manual",
+		Workflow:     "fix-bug",
+		State:        queue.StateRunning,
+		CreatedAt:    now.Add(-12 * time.Minute),
+		StartedAt:    &started,
+		WorktreePath: "/tmp/worktree-1",
+	}
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	phaseDir := filepath.Join(dir, "phases", vessel.ID)
+	require.NoError(t, os.MkdirAll(phaseDir, 0o755))
+	outputPath := filepath.Join(phaseDir, "analyze.output")
+	require.NoError(t, os.WriteFile(outputPath, []byte("stale"), 0o644))
+	staleAt := now.Add(-11 * time.Minute)
+	require.NoError(t, os.Chtimes(outputPath, staleAt, staleAt))
+
+	wt := &mockWorktree{}
+	tracker := &fakeProcessTracker{
+		info: map[string]ProcessInfo{
+			vessel.ID: {PID: 4242, Phase: "analyze", StartedAt: started, Live: true},
+		},
+	}
+	r := New(cfg, q, wt, &mockCmdRunner{})
+	r.ProcessTracker = tracker
+
+	alerts := r.CheckStalledVessels(context.Background())
+	require.Len(t, alerts, 1)
+	assert.Equal(t, "phase_stalled", alerts[0].Code)
+	assert.Equal(t, "analyze", alerts[0].Phase)
+	require.Equal(t, []string{vessel.ID}, tracker.terminated)
+	require.Equal(t, []time.Duration{phaseStallTerminationGracePeriod}, tracker.gracePeriods)
+
+	updated, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	require.Equal(t, queue.StateTimedOut, updated.State)
+	assert.Contains(t, updated.Error, "phase stalled: no output for")
+	assert.True(t, wt.removeCalled)
+	assert.Equal(t, vessel.WorktreePath, wt.removePath)
+}
+
+func TestSmoke_S3_OrphanedSubprocessTimesOutVessel(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "10m"
+	cfg.Daemon.StallMonitor.OrphanCheckEnabled = true
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	started := now.Add(-2 * time.Minute)
+	vessel := queue.Vessel{
+		ID:           "issue-2",
+		Source:       "manual",
+		Workflow:     "fix-bug",
+		State:        queue.StateRunning,
+		CreatedAt:    now.Add(-3 * time.Minute),
+		StartedAt:    &started,
+		WorktreePath: "/tmp/worktree-2",
+	}
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, &mockCmdRunner{})
+	r.ProcessTracker = &fakeProcessTracker{info: map[string]ProcessInfo{}}
+
+	alerts := r.CheckStalledVessels(context.Background())
+	require.Len(t, alerts, 1)
+	assert.Equal(t, "orphaned_subprocess", alerts[0].Code)
+
+	updated, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	require.Equal(t, queue.StateTimedOut, updated.State)
+	assert.Equal(t, "vessel orphaned (no live subprocess)", updated.Error)
+	assert.True(t, wt.removeCalled)
+	assert.Equal(t, vessel.WorktreePath, wt.removePath)
+}
+
+func TestCheckStalledVesselsSkipsRecentActivity(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "10m"
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	started := now.Add(-2 * time.Minute)
+	vessel := queue.Vessel{
+		ID:        "issue-3",
+		Source:    "manual",
+		Workflow:  "fix-bug",
+		State:     queue.StateRunning,
+		CreatedAt: now.Add(-3 * time.Minute),
+		StartedAt: &started,
+	}
+	if _, err := q.Enqueue(vessel); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+
+	phaseDir := filepath.Join(dir, "phases", vessel.ID)
+	if err := os.MkdirAll(phaseDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", phaseDir, err)
+	}
+	outputPath := filepath.Join(phaseDir, "analyze.output")
+	if err := os.WriteFile(outputPath, []byte("fresh"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", outputPath, err)
+	}
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	r.ProcessTracker = &fakeProcessTracker{
+		info: map[string]ProcessInfo{
+			vessel.ID: {PID: 7, Phase: "analyze", StartedAt: started, Live: true},
+		},
+	}
+
+	if alerts := r.CheckStalledVessels(context.Background()); len(alerts) != 0 {
+		t.Fatalf("len(alerts) = %d, want 0", len(alerts))
+	}
+	updated, err := q.FindByID(vessel.ID)
+	if err != nil {
+		t.Fatalf("FindByID(%q): %v", vessel.ID, err)
+	}
+	if updated.State != queue.StateRunning {
+		t.Fatalf("updated.State = %q, want %q", updated.State, queue.StateRunning)
+	}
+}

--- a/cli/internal/runner/monitor_test.go
+++ b/cli/internal/runner/monitor_test.go
@@ -92,7 +92,7 @@ func TestSmoke_S3_OrphanedSubprocessTimesOutVessel(t *testing.T) {
 
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
 	now := time.Now().UTC()
-	started := now.Add(-2 * time.Minute)
+	started := now.Add(-11 * time.Minute)
 	vessel := queue.Vessel{
 		ID:           "issue-2",
 		Source:       "manual",
@@ -119,6 +119,37 @@ func TestSmoke_S3_OrphanedSubprocessTimesOutVessel(t *testing.T) {
 	assert.Equal(t, "vessel orphaned (no live subprocess)", updated.Error)
 	assert.True(t, wt.removeCalled)
 	assert.Equal(t, vessel.WorktreePath, wt.removePath)
+}
+
+func TestCheckStalledVesselsSkipsRecentOrphanActivity(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "10m"
+	cfg.Daemon.StallMonitor.OrphanCheckEnabled = true
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	started := now.Add(-2 * time.Minute)
+	vessel := queue.Vessel{
+		ID:        "issue-2b",
+		Source:    "manual",
+		Workflow:  "fix-bug",
+		State:     queue.StateRunning,
+		CreatedAt: now.Add(-3 * time.Minute),
+		StartedAt: &started,
+	}
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	r.ProcessTracker = &fakeProcessTracker{info: map[string]ProcessInfo{}}
+
+	alerts := r.CheckStalledVessels(context.Background())
+	require.Empty(t, alerts)
+
+	updated, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	require.Equal(t, queue.StateRunning, updated.State)
 }
 
 func TestCheckStalledVesselsSkipsRecentActivity(t *testing.T) {

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -76,6 +76,7 @@ type Runner struct {
 	// instead of loading .xylem/workflows/<name>.yaml.
 	BuiltinWorkflows map[string]BuiltinWorkflowHandler
 	Reporter         *reporter.Reporter // may be nil for non-github vessels
+	ProcessTracker   ProcessTracker
 	// Shared harness scaffolding for phase policy enforcement, audit logging,
 	// protected-surface verification, and tracing.
 	Intermediary *intermediary.Intermediary // nil = no policy enforcement
@@ -653,7 +654,8 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					}
 					return "failed"
 				}
-				cmdOut, cmdErr := gate.RunCommand(ctx, r.Runner, worktreePath, rendered)
+				phaseCtx := WithPhaseExecutionMetadata(ctx, PhaseExecutionMetadata{VesselID: vessel.ID, PhaseName: p.Name})
+				cmdOut, cmdErr := gate.RunCommand(phaseCtx, r.Runner, worktreePath, rendered)
 				output = []byte(cmdOut)
 				runErr = cmdErr
 			} else {
@@ -721,7 +723,8 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if phaseStdin != nil {
 					stdinContent = rendered
 				}
-				output, runErr = r.runPhaseWithRateLimitRetry(ctx, worktreePath, stdinContent, cmd, args)
+				phaseCtx := WithPhaseExecutionMetadata(ctx, PhaseExecutionMetadata{VesselID: vessel.ID, PhaseName: p.Name})
+				output, runErr = r.runPhaseWithRateLimitRetry(phaseCtx, worktreePath, stdinContent, cmd, args)
 			}
 
 			if r.vesselCancelled(ctx, vessel.ID) {
@@ -1015,7 +1018,8 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 		return "failed"
 	}
 
-	output, runErr := r.runPhaseWithRateLimitRetry(ctx, worktreePath, prompt, cmd, args)
+	phaseCtx := WithPhaseExecutionMetadata(ctx, PhaseExecutionMetadata{VesselID: vessel.ID, PhaseName: "prompt-only"})
+	output, runErr := r.runPhaseWithRateLimitRetry(phaseCtx, worktreePath, prompt, cmd, args)
 	if r.vesselCancelled(ctx, vessel.ID) {
 		return r.cancelVessel(vessel, worktreePath, vrs, nil)
 	}
@@ -1708,7 +1712,8 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				}
 				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
 			}
-			cmdOut, cmdErr := gate.RunCommand(ctx, r.Runner, worktreePath, rendered)
+			phaseCtx := WithPhaseExecutionMetadata(ctx, PhaseExecutionMetadata{VesselID: vessel.ID, PhaseName: p.Name})
+			cmdOut, cmdErr := gate.RunCommand(phaseCtx, r.Runner, worktreePath, rendered)
 			output = []byte(cmdOut)
 			runErr = cmdErr
 		} else {
@@ -1775,7 +1780,8 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if phaseStdin != nil {
 				stdinContent = rendered
 			}
-			output, runErr = r.runPhaseWithRateLimitRetry(ctx, worktreePath, stdinContent, cmd, args)
+			phaseCtx := WithPhaseExecutionMetadata(ctx, PhaseExecutionMetadata{VesselID: vessel.ID, PhaseName: p.Name})
+			output, runErr = r.runPhaseWithRateLimitRetry(phaseCtx, worktreePath, stdinContent, cmd, args)
 		}
 
 		if r.vesselCancelled(ctx, vessel.ID) {
@@ -3268,13 +3274,7 @@ func (r *Runner) CheckHungVessels(ctx context.Context) {
 		errMsg := fmt.Sprintf("vessel timed out after %s", elapsed.Truncate(time.Second))
 		log.Printf("warn: %s for vessel %s", errMsg, vessel.ID)
 
-		if updateErr := r.Queue.Update(vessel.ID, queue.StateTimedOut, errMsg); updateErr != nil {
-			log.Printf("warn: failed to update vessel %s to timed_out: %v", vessel.ID, updateErr)
-			continue
-		}
-
-		// Clean up worktree (best-effort)
-		r.removeWorktree(vessel.WorktreePath, vessel.ID)
+		r.timeoutRunningVessel(ctx, vessel, errMsg)
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,6 +103,10 @@ copilot:
 daemon:
   scan_interval: "60s"   # how often the daemon scans for new work
   drain_interval: "30s"  # how often the daemon drains pending vessels
+  stall_monitor:
+    phase_stall_threshold: "10m"   # max age of the newest phase artifact before a running vessel is declared stalled
+    scanner_idle_threshold: "5m"   # idle time before xylem checks GitHub for backlog the scanner missed
+    orphan_check_enabled: true      # mark running vessels timed_out when no subprocess is tracked
 ```
 
 ## Field reference
@@ -126,6 +130,26 @@ daemon:
 | `harness` | object | see below | No | Agent safety guardrails: protected file surfaces, policy rules, and audit logging. |
 | `observability` | object | see below | No | OpenTelemetry instrumentation settings. |
 | `cost` | object | see below | No | Token budget enforcement settings. |
+
+### `daemon`
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `scan_interval` | string | `"60s"` | No | How often the daemon scans configured sources for new work. Must be a valid Go duration string. |
+| `drain_interval` | string | `"30s"` | No | How often the daemon starts a drain tick. Must be a valid Go duration string. |
+| `stall_monitor` | object | see below | No | Deterministic self-monitoring for stalled vessels and idle-with-backlog detection. |
+| `auto_upgrade` | boolean | `false` | No | Rebuild and exec a fresh daemon binary when `main` advances. |
+| `upgrade_interval` | string | `"5m"` | No | How often the daemon re-checks whether auto-upgrade should run while the loop is active. |
+| `auto_merge` | boolean | `false` | No | Enable automatic review and GitHub auto-merge for ready harness PRs. |
+| `auto_merge_repo` | string | current repo | No | Explicit `owner/name` target for daemon auto-merge operations. |
+
+### `daemon.stall_monitor`
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `phase_stall_threshold` | string | `"10m"` | No | If the newest artifact under `<state_dir>/phases/<vessel>/` is older than this threshold for a running vessel, the daemon terminates the subprocess and marks the vessel `timed_out`. |
+| `scanner_idle_threshold` | string | `"5m"` | No | If the daemon stays idle after a zero-add scan for this long, it queries GitHub for eligible backlog and records a warning when matches exist. |
+| `orphan_check_enabled` | boolean | `true` | No | When enabled, running vessels with no tracked subprocess are marked `timed_out` immediately instead of waiting for a daemon restart. |
 
 ### Sources
 


### PR DESCRIPTION
## Summary

Implements [issue #207](https://github.com/nicholls-inc/xylem/issues/207) by adding deterministic daemon self-monitoring for stalled running vessels, orphaned subprocesses, and idle-with-backlog detection, and by surfacing those signals in `xylem status`.

## Smoke scenarios covered

- `S1` — `PhaseLevelStallTimesOutVessel`
- `S2` — `IdleWithBacklogWarnsWhenQueueIdle`
- `S3` — `OrphanedSubprocessTimesOutVessel`
- `S4` — `DaemonPhaseStallRecovery`
- `S5` — `StatusShowsDaemonHealthAlerts`

## Changes summary

### Files added

- `cli/cmd/xylem/daemon_health.go`
- `cli/cmd/xylem/daemon_health_test.go`
- `cli/internal/runner/monitor.go`
- `cli/internal/runner/monitor_test.go`
- `cli/internal/runner/monitor_prop_test.go`
- `cli/internal/dtu/scenario_daemon_stall_test.go`
- `cli/internal/dtu/testdata/issue-daemon-stall.yaml`

### Files modified

- `cli/cmd/xylem/daemon.go`
- `cli/cmd/xylem/daemon_test.go`
- `cli/cmd/xylem/drain.go`
- `cli/cmd/xylem/exec.go`
- `cli/cmd/xylem/status.go`
- `cli/internal/config/config.go`
- `cli/internal/config/config_test.go`
- `cli/internal/runner/runner.go`
- `docs/configuration.md`

### Key types and functions

- Added `daemonHealthRecorder`, `daemonStatusSnapshot`, and `daemonBacklogMonitor` to persist daemon heartbeat/alert state and detect idle-with-backlog conditions.
- Added `countEligibleGitHubBacklog`, `printDaemonHealth`, and daemon-loop wiring so every tick records health alerts and `xylem status` renders them.
- Added `runner.ProcessTracker`, `runner.ProcessInfo`, `runner.PhaseExecutionMetadata`, and `Runner.CheckStalledVessels()` to detect phase stalls and orphaned subprocesses and mark affected vessels `timed_out`.
- Extended `realCmdRunner` with tracked phase subprocess registration plus `ProcessInfo` / `TerminateProcess` so the stall monitor can terminate hung sessions deterministically.
- Added `config.StallMonitorConfig` defaults and validation for `phase_stall_threshold`, `scanner_idle_threshold`, and `orphan_check_enabled`.
- Updated the DTU scenario fixture and daemon/config tests to cover phase stall recovery, idle backlog warnings, orphan recovery, health rendering, and newest-artifact detection.

## Test plan

- `cd cli && goimports -w .`
- `cd cli && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #207