### PR TITLE
Add failure-recovery routing, persisted review artifacts, and recovery observability

### DIFF
--- a/cli/cmd/xylem/retry.go
+++ b/cli/cmd/xylem/retry.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 )
 
 func newRetryCmd() *cobra.Command {
@@ -82,6 +83,9 @@ func cmdRetry(q *queue.Queue, cfg *config.Config, id string, fromScratch bool) e
 
 	if _, err := q.Enqueue(newVessel); err != nil {
 		return fmt.Errorf("enqueue retry: %w", err)
+	}
+	if err := recovery.UpdateRetryOutcome(cfg.StateDir, vessel.ID, "enqueued"); err != nil {
+		return fmt.Errorf("record retry outcome: %w", err)
 	}
 	fmt.Printf("Created retry vessel %s (retrying %s)\n", newVessel.ID, vessel.ID)
 	return nil

--- a/cli/cmd/xylem/retry_test.go
+++ b/cli/cmd/xylem/retry_test.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newRetryTestQueue(t *testing.T) *queue.Queue {
@@ -19,6 +22,43 @@ func newRetryTestQueue(t *testing.T) *queue.Queue {
 func newRetryTestConfig(t *testing.T) *config.Config {
 	t.Helper()
 	return &config.Config{StateDir: t.TempDir()}
+}
+
+func TestSmoke_S1_RetryCommandMarksRecoveryArtifactEnqueued(t *testing.T) {
+	q := newRetryTestQueue(t)
+	cfg := newRetryTestConfig(t)
+	now := time.Now().UTC()
+	v := queue.Vessel{
+		ID:        "issue-42",
+		Source:    "github-issue",
+		Workflow:  "fix-bug",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	}
+	_, err := q.Enqueue(v)
+	require.NoError(t, err)
+	require.NoError(t, q.Update("issue-42", queue.StateRunning, ""))
+	require.NoError(t, q.Update("issue-42", queue.StateFailed, "temporary failure from upstream 503"))
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID:  "issue-42",
+		Source:    "github-issue",
+		Workflow:  "fix-bug",
+		State:     queue.StateFailed,
+		Error:     "temporary failure from upstream 503",
+		CreatedAt: now.Add(time.Minute),
+	})
+	require.NoError(t, recovery.Save(cfg.StateDir, artifact))
+
+	require.NoError(t, cmdRetry(q, cfg, "issue-42", false))
+
+	loaded, err := recovery.Load(filepath.Join(cfg.StateDir, recovery.RelativePath("issue-42")))
+	require.NoError(t, err)
+	assert.Equal(t, "enqueued", loaded.RetryOutcome)
+
+	retry, err := q.FindByID("issue-42-retry-1")
+	require.NoError(t, err)
+	assert.Equal(t, queue.StatePending, retry.State)
 }
 
 func TestRetryCreatesNewVessel(t *testing.T) {

--- a/cli/internal/lessons/lessons.go
+++ b/cli/internal/lessons/lessons.go
@@ -84,6 +84,9 @@ type Lesson struct {
 	Phase              string        `json:"phase"`
 	SignalKind         string        `json:"signal_kind"`
 	Signal             string        `json:"signal"`
+	RecoveryClass      string        `json:"recovery_class,omitempty"`
+	RecoveryAction     string        `json:"recovery_action,omitempty"`
+	FollowUpRoute      string        `json:"follow_up_route,omitempty"`
 	Samples            int           `json:"samples"`
 	NegativeConstraint string        `json:"negative_constraint"`
 	Rationale          string        `json:"rationale"`
@@ -118,25 +121,31 @@ type SkippedLesson struct {
 }
 
 type observation struct {
-	theme        string
-	source       string
-	workflow     string
-	phase        string
-	signalKind   string
-	signal       string
-	example      string
-	artifactPath string
-	vesselID     string
-	endedAt      time.Time
+	theme          string
+	source         string
+	workflow       string
+	phase          string
+	signalKind     string
+	signal         string
+	recoveryClass  string
+	recoveryAction string
+	followUpRoute  string
+	example        string
+	artifactPath   string
+	vesselID       string
+	endedAt        time.Time
 }
 
 type clusterKey struct {
-	theme      string
-	source     string
-	workflow   string
-	phase      string
-	signalKind string
-	signal     string
+	theme          string
+	source         string
+	workflow       string
+	phase          string
+	signalKind     string
+	signal         string
+	recoveryClass  string
+	recoveryAction string
+	followUpRoute  string
 }
 
 type cluster struct {
@@ -272,12 +281,15 @@ func buildClusters(runs []review.LoadedRun) map[clusterKey]*cluster {
 	for _, run := range runs {
 		for _, obs := range extractObservations(run) {
 			key := clusterKey{
-				theme:      obs.theme,
-				source:     obs.source,
-				workflow:   obs.workflow,
-				phase:      obs.phase,
-				signalKind: obs.signalKind,
-				signal:     obs.signal,
+				theme:          obs.theme,
+				source:         obs.source,
+				workflow:       obs.workflow,
+				phase:          obs.phase,
+				signalKind:     obs.signalKind,
+				signal:         obs.signal,
+				recoveryClass:  obs.recoveryClass,
+				recoveryAction: obs.recoveryAction,
+				followUpRoute:  obs.followUpRoute,
 			}
 			group, ok := clusters[key]
 			if !ok {
@@ -352,6 +364,9 @@ func lessonFromCluster(group *cluster, maxEvidence int) Lesson {
 		Phase:              obs.phase,
 		SignalKind:         obs.signalKind,
 		Signal:             obs.signal,
+		RecoveryClass:      obs.recoveryClass,
+		RecoveryAction:     obs.recoveryAction,
+		FollowUpRoute:      obs.followUpRoute,
 		Samples:            len(group.items),
 		NegativeConstraint: rule,
 		Rationale:          rationale,
@@ -425,16 +440,19 @@ func extractObservations(run review.LoadedRun) []observation {
 		}
 		seen[seenKey] = true
 		observations = append(observations, observation{
-			theme:        themeFor(run.Summary.Workflow, phase),
-			source:       run.Summary.Source,
-			workflow:     run.Summary.Workflow,
-			phase:        phase,
-			signalKind:   kind,
-			signal:       normalized,
-			example:      truncate(example, 180),
-			artifactPath: artifactPath,
-			vesselID:     run.Summary.VesselID,
-			endedAt:      run.Summary.EndedAt,
+			theme:          themeFor(run.Summary.Workflow, phase),
+			source:         run.Summary.Source,
+			workflow:       run.Summary.Workflow,
+			phase:          phase,
+			signalKind:     kind,
+			signal:         normalized,
+			recoveryClass:  recoveryClass(run),
+			recoveryAction: recoveryAction(run),
+			followUpRoute:  recoveryFollowUpRoute(run),
+			example:        truncate(example, 180),
+			artifactPath:   artifactPath,
+			vesselID:       run.Summary.VesselID,
+			endedAt:        run.Summary.EndedAt,
 		})
 	}
 
@@ -528,7 +546,11 @@ func renderProposalBody(theme string, lessons []Lesson) string {
 	fmt.Fprintf(&b, "## Institutional memory updates for %s\n\n", theme)
 	b.WriteString("This PR proposes evidence-backed `Do Not` guidance derived from recurring failed vessels.\n\n")
 	for _, lesson := range lessons {
-		fmt.Fprintf(&b, "- `%s` (%d samples)\n", lesson.Fingerprint, lesson.Samples)
+		fmt.Fprintf(&b, "- `%s` (%d samples", lesson.Fingerprint, lesson.Samples)
+		if lesson.RecoveryClass != "" || lesson.RecoveryAction != "" {
+			fmt.Fprintf(&b, ", class=%s, action=%s", lesson.RecoveryClass, lesson.RecoveryAction)
+		}
+		b.WriteString(")\n")
 	}
 	b.WriteString("\n### Proposed HARNESS.md additions\n\n")
 	for _, lesson := range lessons {
@@ -558,7 +580,14 @@ func renderMarkdown(report *Report) string {
 	}
 	b.WriteString("## Lessons\n\n")
 	for _, lesson := range report.Lessons {
-		fmt.Fprintf(&b, "- `%s` — %s\n", lesson.Fingerprint, lesson.NegativeConstraint)
+		fmt.Fprintf(&b, "- `%s` — %s", lesson.Fingerprint, lesson.NegativeConstraint)
+		if lesson.RecoveryClass != "" || lesson.RecoveryAction != "" {
+			fmt.Fprintf(&b, " _(class=%s, action=%s)_", lesson.RecoveryClass, lesson.RecoveryAction)
+		}
+		if lesson.FollowUpRoute != "" {
+			fmt.Fprintf(&b, " _(route=%s)_", lesson.FollowUpRoute)
+		}
+		b.WriteString("\n")
 	}
 	if len(report.Proposals) > 0 {
 		b.WriteString("\n## Proposal slices\n\n")
@@ -651,4 +680,25 @@ func min(a, b int) int {
 
 func sha256Sum(data []byte) [32]byte {
 	return sha256.Sum256(data)
+}
+
+func recoveryClass(run review.LoadedRun) string {
+	if run.Recovery == nil {
+		return ""
+	}
+	return string(run.Recovery.RecoveryClass)
+}
+
+func recoveryAction(run review.LoadedRun) string {
+	if run.Recovery == nil {
+		return ""
+	}
+	return string(run.Recovery.RecoveryAction)
+}
+
+func recoveryFollowUpRoute(run review.LoadedRun) string {
+	if run.Recovery == nil {
+		return ""
+	}
+	return run.Recovery.FollowUpRoute
 }

--- a/cli/internal/lessons/lessons_test.go
+++ b/cli/internal/lessons/lessons_test.go
@@ -9,7 +9,11 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type prClientStub struct {
@@ -98,6 +102,31 @@ func TestGenerateSkipsLessonWhenEquivalentOpenPRExists(t *testing.T) {
 	}
 }
 
+func TestSmoke_S1_LessonsClusterCarriesRecoveryDecision(t *testing.T) {
+	stateDir := t.TempDir()
+	harnessPath := filepath.Join(stateDir, "HARNESS.md")
+	require.NoError(t, os.WriteFile(harnessPath, []byte("# Harness\n"), 0o644))
+
+	base := time.Date(2026, time.April, 9, 6, 0, 0, 0, time.UTC)
+	writeFailedRunWithRecovery(t, stateDir, "failed-a", base, "missing requirement: acceptance criteria are ambiguous")
+	writeFailedRunWithRecovery(t, stateDir, "failed-b", base.Add(time.Hour), "missing requirement: acceptance criteria are ambiguous")
+
+	result, err := Generate(context.Background(), stateDir, Options{
+		Repo:           "owner/repo",
+		HarnessPath:    harnessPath,
+		LookbackWindow: 30 * 24 * time.Hour,
+		MinSamples:     2,
+		Now:            base.Add(2 * time.Hour),
+	}, &prClientStub{})
+	require.NoError(t, err)
+	require.Len(t, result.Report.Lessons, 1)
+
+	lesson := result.Report.Lessons[0]
+	assert.Equal(t, string(recovery.ClassSpecGap), lesson.RecoveryClass)
+	assert.Equal(t, string(recovery.ActionRefine), lesson.RecoveryAction)
+	assert.Equal(t, "needs-refinement", lesson.FollowUpRoute)
+}
+
 func writeFailedRun(t *testing.T, stateDir, vesselID string, endedAt time.Time, claim string) {
 	t.Helper()
 	startedAt := endedAt.Add(-2 * time.Minute)
@@ -137,5 +166,42 @@ func writeFailedRun(t *testing.T, stateDir, vesselID string, endedAt time.Time, 
 	}
 	if err := runner.SaveVesselSummary(stateDir, summary); err != nil {
 		t.Fatalf("SaveVesselSummary() error = %v", err)
+	}
+}
+
+func writeFailedRunWithRecovery(t *testing.T, stateDir, vesselID string, endedAt time.Time, claim string) {
+	t.Helper()
+	writeFailedRun(t, stateDir, vesselID, endedAt, claim)
+	artifact := recovery.Build(recovery.Input{
+		VesselID:    vesselID,
+		Source:      "schedule",
+		Workflow:    "lessons",
+		State:       queue.StateFailed,
+		FailedPhase: "verify",
+		Error:       claim,
+		CreatedAt:   endedAt,
+	})
+	if err := recovery.Save(stateDir, artifact); err != nil {
+		t.Fatalf("Save() recovery artifact error = %v", err)
+	}
+
+	summary, err := runner.LoadVesselSummary(stateDir, vesselID)
+	if err != nil {
+		t.Fatalf("LoadVesselSummary() error = %v", err)
+	}
+	summary.FailureReviewPath = filepath.ToSlash(filepath.Join("phases", vesselID, "failure-review.json"))
+	if summary.ReviewArtifacts == nil {
+		summary.ReviewArtifacts = &runner.ReviewArtifacts{}
+	}
+	summary.ReviewArtifacts.FailureReview = summary.FailureReviewPath
+	summary.Recovery = &runner.RecoverySummary{
+		Class:           string(artifact.RecoveryClass),
+		Action:          string(artifact.RecoveryAction),
+		FollowUpRoute:   artifact.FollowUpRoute,
+		RetrySuppressed: artifact.RetrySuppressed,
+		RetryOutcome:    artifact.RetryOutcome,
+	}
+	if err := runner.SaveVesselSummary(stateDir, summary); err != nil {
+		t.Fatalf("SaveVesselSummary() updated error = %v", err)
 	}
 }

--- a/cli/internal/observability/vessel.go
+++ b/cli/internal/observability/vessel.go
@@ -227,3 +227,26 @@ func WorktreeSpanAttributes(data WorktreeSpanData) []SpanAttribute {
 		{Key: "xylem.worktree.path", Value: data.Path},
 	}
 }
+
+// RecoveryData holds recovery classification attributes for failed or timed out vessels.
+type RecoveryData struct {
+	Class           string `json:"class,omitempty"`
+	Action          string `json:"action,omitempty"`
+	RetrySuppressed string `json:"retry_suppressed,omitempty"`
+	RetryOutcome    string `json:"retry_outcome,omitempty"`
+	UnlockDimension string `json:"unlock_dimension,omitempty"`
+}
+
+// RecoveryAttributes returns span attributes for recovery classification and routing.
+func RecoveryAttributes(data RecoveryData) []SpanAttribute {
+	if data.Class == "" && data.Action == "" && data.RetrySuppressed == "" && data.RetryOutcome == "" && data.UnlockDimension == "" {
+		return nil
+	}
+	return []SpanAttribute{
+		{Key: "xylem.recovery.class", Value: data.Class},
+		{Key: "xylem.recovery.action", Value: data.Action},
+		{Key: "xylem.recovery.retry_suppressed", Value: data.RetrySuppressed},
+		{Key: "xylem.recovery.retry_outcome", Value: data.RetryOutcome},
+		{Key: "xylem.recovery.unlock_dimension", Value: data.UnlockDimension},
+	}
+}

--- a/cli/internal/observability/vessel_test.go
+++ b/cli/internal/observability/vessel_test.go
@@ -1,6 +1,12 @@
 package observability
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestSmoke_S1_VesselSpanAttributesIncludesIDSourceWorkflowRef(t *testing.T) {
 	attrs := VesselSpanAttributes(VesselSpanData{
@@ -210,33 +216,35 @@ func TestPhaseResultAttributesFormatsNegativeDuration(t *testing.T) {
 	}
 }
 
-func TestDrainSpanAttributes_Keys(t *testing.T) {
-	attrs := DrainSpanAttributes(DrainSpanData{
-		Concurrency: 4,
-		Timeout:     "30m",
-	})
-	got := attrMap(attrs)
-
-	if len(attrs) != 2 {
-		t.Fatalf("expected 2 attributes, got %d", len(attrs))
+func TestDrainSpanAttributes_FormatAllFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		concurrency int
+		timeout     string
+	}{
+		{name: "typical values", concurrency: 4, timeout: "30m"},
+		{name: "two digit concurrency", concurrency: 17, timeout: "90s"},
 	}
-	if got["xylem.drain.concurrency"] != "4" {
-		t.Fatalf("xylem.drain.concurrency = %q, want %q", got["xylem.drain.concurrency"], "4")
-	}
-	if got["xylem.drain.timeout"] != "30m" {
-		t.Fatalf("xylem.drain.timeout = %q, want %q", got["xylem.drain.timeout"], "30m")
-	}
-}
 
-func TestDrainSpanAttributes_ConcurrencyFormatted(t *testing.T) {
-	attrs := DrainSpanAttributes(DrainSpanData{
-		Concurrency: 17,
-		Timeout:     "90s",
-	})
-	got := attrMap(attrs)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrs := DrainSpanAttributes(DrainSpanData{
+				Concurrency: tt.concurrency,
+				Timeout:     tt.timeout,
+			})
+			got := attrMap(attrs)
 
-	if got["xylem.drain.concurrency"] != "17" {
-		t.Fatalf("xylem.drain.concurrency = %q, want %q", got["xylem.drain.concurrency"], "17")
+			if len(attrs) != 2 {
+				t.Fatalf("expected 2 attributes, got %d", len(attrs))
+			}
+			wantConcurrency := strconv.Itoa(tt.concurrency)
+			if got["xylem.drain.concurrency"] != wantConcurrency {
+				t.Fatalf("xylem.drain.concurrency = %q, want %q", got["xylem.drain.concurrency"], wantConcurrency)
+			}
+			if got["xylem.drain.timeout"] != tt.timeout {
+				t.Fatalf("xylem.drain.timeout = %q, want %q", got["xylem.drain.timeout"], tt.timeout)
+			}
+		})
 	}
 }
 
@@ -261,4 +269,27 @@ func TestDrainHealthAttributesIncludePatterns(t *testing.T) {
 	if got["xylem.drain.unhealthy_patterns"] != "budget_exceeded=2, run_failed=1" {
 		t.Fatalf("xylem.drain.unhealthy_patterns = %q, want joined patterns", got["xylem.drain.unhealthy_patterns"])
 	}
+}
+
+func TestSmoke_S6_RecoveryAttributesIncludeDecisionFields(t *testing.T) {
+	attrs := RecoveryAttributes(RecoveryData{
+		Class:           "spec_gap",
+		Action:          "refine",
+		RetrySuppressed: "true",
+		RetryOutcome:    "suppressed",
+		UnlockDimension: "decision",
+	})
+	got := attrMap(attrs)
+
+	require.Len(t, attrs, 5)
+	assert.Equal(t, "spec_gap", got["xylem.recovery.class"])
+	assert.Equal(t, "refine", got["xylem.recovery.action"])
+	assert.Equal(t, "true", got["xylem.recovery.retry_suppressed"])
+	assert.Equal(t, "suppressed", got["xylem.recovery.retry_outcome"])
+	assert.Equal(t, "decision", got["xylem.recovery.unlock_dimension"])
+}
+
+func TestSmoke_S7_RecoveryAttributesOmitEmptyRecoveryData(t *testing.T) {
+	attrs := RecoveryAttributes(RecoveryData{})
+	assert.Nil(t, attrs)
 }

--- a/cli/internal/recovery/recovery.go
+++ b/cli/internal/recovery/recovery.go
@@ -1,0 +1,286 @@
+package recovery
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/observability"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+const (
+	artifactFileName = "failure-review.json"
+	schemaVersion    = "v1"
+
+	MetaClass           = "recovery_class"
+	MetaAction          = "recovery_action"
+	MetaRationale       = "recovery_rationale"
+	MetaFollowUpRoute   = "recovery_followup_route"
+	MetaRetrySuppressed = "recovery_retry_suppressed"
+	MetaRetryOutcome    = "recovery_retry_outcome"
+	MetaUnlockDimension = "recovery_unlock_dimension"
+)
+
+var safePathComponent = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+type Class string
+
+const (
+	ClassTransient  Class = "transient"
+	ClassHarnessGap Class = "harness_gap"
+	ClassSpecGap    Class = "spec_gap"
+	ClassScopeGap   Class = "scope_gap"
+	ClassUnknown    Class = "unknown"
+)
+
+type Action string
+
+const (
+	ActionRetry     Action = "retry"
+	ActionLessons   Action = "lessons"
+	ActionRefine    Action = "refine"
+	ActionSplitTask Action = "split_task"
+	ActionDiagnose  Action = "diagnose"
+)
+
+type Artifact struct {
+	SchemaVersion   string                          `json:"schema_version"`
+	VesselID        string                          `json:"vessel_id"`
+	Source          string                          `json:"source,omitempty"`
+	Workflow        string                          `json:"workflow,omitempty"`
+	Ref             string                          `json:"ref,omitempty"`
+	State           string                          `json:"state"`
+	FailedPhase     string                          `json:"failed_phase,omitempty"`
+	Error           string                          `json:"error,omitempty"`
+	GateOutput      string                          `json:"gate_output,omitempty"`
+	RecoveryClass   Class                           `json:"recovery_class"`
+	RecoveryAction  Action                          `json:"recovery_action"`
+	Rationale       string                          `json:"rationale"`
+	FollowUpRoute   string                          `json:"follow_up_route,omitempty"`
+	RetrySuppressed bool                            `json:"retry_suppressed"`
+	RetryOutcome    string                          `json:"retry_outcome,omitempty"`
+	UnlockDimension string                          `json:"unlock_dimension,omitempty"`
+	RetryOf         string                          `json:"retry_of,omitempty"`
+	Trace           *observability.TraceContextData `json:"trace,omitempty"`
+	CreatedAt       time.Time                       `json:"created_at"`
+}
+
+type Input struct {
+	VesselID    string
+	Source      string
+	Workflow    string
+	Ref         string
+	State       queue.VesselState
+	FailedPhase string
+	Error       string
+	GateOutput  string
+	RetryOf     string
+	Meta        map[string]string
+	Trace       *observability.TraceContextData
+	CreatedAt   time.Time
+}
+
+func Build(input Input) *Artifact {
+	createdAt := input.CreatedAt.UTC()
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+
+	class, action, rationale := classify(input)
+	followUpRoute := followUpRouteFor(action)
+	retrySuppressed := action != ActionRetry
+	retryOutcome := strings.TrimSpace(metaValue(input.Meta, MetaRetryOutcome))
+	if retryOutcome == "" {
+		if retrySuppressed {
+			retryOutcome = "suppressed"
+		} else {
+			retryOutcome = "not_attempted"
+		}
+	}
+
+	unlockDimension := strings.TrimSpace(metaValue(input.Meta, MetaUnlockDimension))
+	trace := input.Trace
+	if trace != nil && trace.TraceID == "" && trace.SpanID == "" {
+		trace = nil
+	}
+
+	return &Artifact{
+		SchemaVersion:   schemaVersion,
+		VesselID:        input.VesselID,
+		Source:          input.Source,
+		Workflow:        input.Workflow,
+		Ref:             input.Ref,
+		State:           string(input.State),
+		FailedPhase:     input.FailedPhase,
+		Error:           input.Error,
+		GateOutput:      input.GateOutput,
+		RecoveryClass:   class,
+		RecoveryAction:  action,
+		Rationale:       rationale,
+		FollowUpRoute:   followUpRoute,
+		RetrySuppressed: retrySuppressed,
+		RetryOutcome:    retryOutcome,
+		UnlockDimension: unlockDimension,
+		RetryOf:         input.RetryOf,
+		Trace:           trace,
+		CreatedAt:       createdAt,
+	}
+}
+
+func ApplyToMeta(meta map[string]string, artifact *Artifact) map[string]string {
+	if artifact == nil {
+		return meta
+	}
+	if meta == nil {
+		meta = make(map[string]string)
+	}
+	meta[MetaClass] = string(artifact.RecoveryClass)
+	meta[MetaAction] = string(artifact.RecoveryAction)
+	meta[MetaRationale] = artifact.Rationale
+	if artifact.FollowUpRoute != "" {
+		meta[MetaFollowUpRoute] = artifact.FollowUpRoute
+	} else {
+		delete(meta, MetaFollowUpRoute)
+	}
+	meta[MetaRetrySuppressed] = strconv.FormatBool(artifact.RetrySuppressed)
+	if artifact.RetryOutcome != "" {
+		meta[MetaRetryOutcome] = artifact.RetryOutcome
+	} else {
+		delete(meta, MetaRetryOutcome)
+	}
+	if artifact.UnlockDimension != "" {
+		meta[MetaUnlockDimension] = artifact.UnlockDimension
+	} else {
+		delete(meta, MetaUnlockDimension)
+	}
+	return meta
+}
+
+func Path(stateDir, vesselID string) string {
+	return filepath.Join(stateDir, "phases", vesselID, artifactFileName)
+}
+
+func RelativePath(vesselID string) string {
+	return filepath.ToSlash(filepath.Join("phases", vesselID, artifactFileName))
+}
+
+func Save(stateDir string, artifact *Artifact) error {
+	if artifact == nil {
+		return fmt.Errorf("save recovery artifact: artifact must not be nil")
+	}
+	if err := validatePathComponent(artifact.VesselID); err != nil {
+		return fmt.Errorf("save recovery artifact: invalid vessel ID: %w", err)
+	}
+	path := Path(stateDir, artifact.VesselID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("save recovery artifact: create dir: %w", err)
+	}
+	data, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		return fmt.Errorf("save recovery artifact: marshal: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("save recovery artifact: write: %w", err)
+	}
+	return nil
+}
+
+func Load(path string) (*Artifact, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("load recovery artifact: read: %w", err)
+	}
+	var artifact Artifact
+	if err := json.Unmarshal(data, &artifact); err != nil {
+		return nil, fmt.Errorf("load recovery artifact: unmarshal: %w", err)
+	}
+	return &artifact, nil
+}
+
+func classify(input Input) (Class, Action, string) {
+	combined := strings.ToLower(strings.TrimSpace(strings.Join([]string{
+		input.Error,
+		input.GateOutput,
+	}, "\n")))
+
+	switch {
+	case input.State == queue.StateTimedOut ||
+		containsAny(combined, "timeout", "timed out", "deadline exceeded", "connection reset", "connection refused",
+			"temporarily unavailable", "temporary failure", "rate limit", "429", "502", "503", "504"):
+		return ClassTransient, ActionRetry, "The failure looks transient, so retry remains the preferred recovery path."
+	case containsAny(combined, "harness", "agents.md", "protected surface", "policy blocked", "instruction", "prompt template"):
+		return ClassHarnessGap, ActionLessons, "The failure points at missing or incorrect harness guidance and should feed institutional memory instead of repeating the same run."
+	case containsAny(combined, "acceptance criteria", "unclear requirement", "missing requirement", "spec gap", "requirements gap",
+		"underspecified", "need clarification", "needs clarification", "ambiguous requirement", "ambiguous spec"):
+		return ClassSpecGap, ActionRefine, "The task is underspecified, so it should route back through refinement instead of retrying unchanged."
+	case containsAny(combined, "too broad", "split task", "split into", "scope gap", "out of scope", "multiple tasks", "too much work",
+		"larger than one change", "separate issue"):
+		return ClassScopeGap, ActionSplitTask, "The task exceeds the current execution scope and should be refined or split before another attempt."
+	default:
+		return ClassUnknown, ActionDiagnose, "The failure needs diagnosis before xylem can safely decide whether to retry or route follow-up work."
+	}
+}
+
+func followUpRouteFor(action Action) string {
+	switch action {
+	case ActionRefine, ActionSplitTask:
+		return "needs-refinement"
+	default:
+		return ""
+	}
+}
+
+func UpdateRetryOutcome(stateDir, vesselID, outcome string) error {
+	if strings.TrimSpace(outcome) == "" {
+		return nil
+	}
+	if err := validatePathComponent(vesselID); err != nil {
+		return fmt.Errorf("update retry outcome: invalid vessel ID: %w", err)
+	}
+	path := Path(stateDir, vesselID)
+	artifact, err := Load(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	artifact.RetryOutcome = outcome
+	return Save(stateDir, artifact)
+}
+
+func metaValue(meta map[string]string, key string) string {
+	if meta == nil {
+		return ""
+	}
+	return meta[key]
+}
+
+func containsAny(text string, substrings ...string) bool {
+	for _, substring := range substrings {
+		if strings.Contains(text, substring) {
+			return true
+		}
+	}
+	return false
+}
+
+func validatePathComponent(component string) error {
+	if component == "" {
+		return fmt.Errorf("path component must not be empty")
+	}
+	if strings.Contains(component, "..") {
+		return fmt.Errorf("path component must not contain %q", "..")
+	}
+	if !safePathComponent.MatchString(component) {
+		return fmt.Errorf("path component %q contains invalid characters (allowed: a-zA-Z0-9._-)", component)
+	}
+	return nil
+}

--- a/cli/internal/recovery/recovery_prop_test.go
+++ b/cli/internal/recovery/recovery_prop_test.go
@@ -1,0 +1,57 @@
+package recovery
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"pgregory.net/rapid"
+)
+
+func TestPropApplyToMetaPreservesRecoveryFields(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		vesselID := rapid.StringMatching(`[a-z0-9-]{1,24}`).Draw(t, "vesselID")
+		retryOutcome := rapid.SampledFrom([]string{"suppressed", "not_attempted", "enqueued"}).Draw(t, "retryOutcome")
+		unlockDimension := rapid.SampledFrom([]string{"", "source", "workflow", "decision"}).Draw(t, "unlockDimension")
+
+		artifact := &Artifact{
+			VesselID:        vesselID,
+			RecoveryClass:   ClassSpecGap,
+			RecoveryAction:  ActionRefine,
+			Rationale:       "needs clarification",
+			FollowUpRoute:   "needs-refinement",
+			RetrySuppressed: true,
+			RetryOutcome:    retryOutcome,
+			UnlockDimension: unlockDimension,
+			State:           string(queue.StateFailed),
+			CreatedAt:       time.Unix(0, 0).UTC(),
+		}
+
+		meta := ApplyToMeta(map[string]string{"keep": "me"}, artifact)
+		if meta["keep"] != "me" {
+			t.Fatalf("expected unrelated metadata to be preserved")
+		}
+		if meta[MetaClass] != string(artifact.RecoveryClass) {
+			t.Fatalf("MetaClass = %q, want %q", meta[MetaClass], artifact.RecoveryClass)
+		}
+		if meta[MetaAction] != string(artifact.RecoveryAction) {
+			t.Fatalf("MetaAction = %q, want %q", meta[MetaAction], artifact.RecoveryAction)
+		}
+		if meta[MetaRetrySuppressed] != strconv.FormatBool(artifact.RetrySuppressed) {
+			t.Fatalf("MetaRetrySuppressed = %q, want %q", meta[MetaRetrySuppressed], strconv.FormatBool(artifact.RetrySuppressed))
+		}
+		if meta[MetaRetryOutcome] != retryOutcome {
+			t.Fatalf("MetaRetryOutcome = %q, want %q", meta[MetaRetryOutcome], retryOutcome)
+		}
+		if unlockDimension == "" {
+			if _, ok := meta[MetaUnlockDimension]; ok {
+				t.Fatalf("MetaUnlockDimension should be absent when empty, got %q", meta[MetaUnlockDimension])
+			}
+			return
+		}
+		if meta[MetaUnlockDimension] != unlockDimension {
+			t.Fatalf("MetaUnlockDimension = %q, want %q", meta[MetaUnlockDimension], unlockDimension)
+		}
+	})
+}

--- a/cli/internal/recovery/recovery_test.go
+++ b/cli/internal/recovery/recovery_test.go
@@ -1,0 +1,155 @@
+package recovery
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/observability"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSmoke_S1_TransientTimeoutClassifiesToRetry(t *testing.T) {
+	artifact := Build(Input{
+		VesselID:  "issue-99",
+		Workflow:  "fix-bug",
+		State:     queue.StateTimedOut,
+		Error:     "context deadline exceeded",
+		CreatedAt: time.Date(2026, time.April, 9, 18, 5, 0, 0, time.UTC),
+		Trace: &observability.TraceContextData{
+			TraceID: "trace",
+			SpanID:  "span",
+		},
+	})
+
+	require.NotNil(t, artifact)
+	assert.Equal(t, ClassTransient, artifact.RecoveryClass)
+	assert.Equal(t, ActionRetry, artifact.RecoveryAction)
+	assert.False(t, artifact.RetrySuppressed)
+	assert.Equal(t, "not_attempted", artifact.RetryOutcome)
+	require.NotNil(t, artifact.Trace)
+	assert.Equal(t, "trace", artifact.Trace.TraceID)
+}
+
+func TestSmoke_S2_HarnessGapPreservesUnlockDimensionForLessonsRouting(t *testing.T) {
+	artifact := Build(Input{
+		VesselID:  "issue-214-harness",
+		Workflow:  "implement-harness",
+		State:     queue.StateFailed,
+		Error:     "policy blocked write to .xylem/HARNESS.md",
+		CreatedAt: time.Date(2026, time.April, 9, 18, 7, 0, 0, time.UTC),
+		Meta: map[string]string{
+			MetaUnlockDimension: "workflow",
+		},
+	})
+
+	require.NotNil(t, artifact)
+	assert.Equal(t, ClassHarnessGap, artifact.RecoveryClass)
+	assert.Equal(t, ActionLessons, artifact.RecoveryAction)
+	assert.Equal(t, "workflow", artifact.UnlockDimension)
+	assert.True(t, artifact.RetrySuppressed)
+	assert.Equal(t, "suppressed", artifact.RetryOutcome)
+	assert.Empty(t, artifact.FollowUpRoute)
+}
+
+func TestSmoke_S3_SpecGapRoutesToNeedsRefinement(t *testing.T) {
+	artifact := Build(Input{
+		VesselID:    "issue-214",
+		Source:      "github-issue",
+		Workflow:    "implement-harness",
+		State:       queue.StateFailed,
+		FailedPhase: "analyze",
+		Error:       "missing requirement: acceptance criteria are ambiguous",
+		CreatedAt:   time.Date(2026, time.April, 9, 18, 0, 0, 0, time.UTC),
+	})
+
+	require.NotNil(t, artifact)
+	assert.Equal(t, ClassSpecGap, artifact.RecoveryClass)
+	assert.Equal(t, ActionRefine, artifact.RecoveryAction)
+	assert.Equal(t, "needs-refinement", artifact.FollowUpRoute)
+	assert.True(t, artifact.RetrySuppressed)
+	assert.Equal(t, "suppressed", artifact.RetryOutcome)
+}
+
+func TestSmoke_S4_ScopeGapRoutesToSplitTaskNeedsRefinement(t *testing.T) {
+	artifact := Build(Input{
+		VesselID:  "issue-214-scope",
+		Workflow:  "implement-harness",
+		State:     queue.StateFailed,
+		Error:     "too broad for one change; split into separate issue",
+		CreatedAt: time.Date(2026, time.April, 9, 18, 8, 0, 0, time.UTC),
+	})
+
+	require.NotNil(t, artifact)
+	assert.Equal(t, ClassScopeGap, artifact.RecoveryClass)
+	assert.Equal(t, ActionSplitTask, artifact.RecoveryAction)
+	assert.Equal(t, "needs-refinement", artifact.FollowUpRoute)
+	assert.True(t, artifact.RetrySuppressed)
+	assert.Equal(t, "suppressed", artifact.RetryOutcome)
+}
+
+func TestSmoke_S5_AmbiguousFailureRoutesToDiagnose(t *testing.T) {
+	artifact := Build(Input{
+		VesselID:  "issue-214-ambiguous",
+		Workflow:  "implement-harness",
+		State:     queue.StateFailed,
+		Error:     "panic: invariant violated during phase execution",
+		CreatedAt: time.Date(2026, time.April, 9, 18, 9, 0, 0, time.UTC),
+	})
+
+	require.NotNil(t, artifact)
+	assert.Equal(t, ClassUnknown, artifact.RecoveryClass)
+	assert.Equal(t, ActionDiagnose, artifact.RecoveryAction)
+	assert.Empty(t, artifact.FollowUpRoute)
+	assert.True(t, artifact.RetrySuppressed)
+	assert.Equal(t, "suppressed", artifact.RetryOutcome)
+}
+
+func TestSmoke_S6_SaveLoadAndUpdateRetryOutcomePersistsEnqueuedState(t *testing.T) {
+	stateDir := t.TempDir()
+	artifact := Build(Input{
+		VesselID:  "issue-101",
+		Workflow:  "fix-bug",
+		State:     queue.StateFailed,
+		Error:     "temporary failure from upstream 503",
+		CreatedAt: time.Date(2026, time.April, 9, 18, 10, 0, 0, time.UTC),
+	})
+
+	require.NoError(t, Save(stateDir, artifact))
+	require.NoError(t, UpdateRetryOutcome(stateDir, artifact.VesselID, "enqueued"))
+
+	loaded, err := Load(filepath.Join(stateDir, RelativePath(artifact.VesselID)))
+	require.NoError(t, err)
+	assert.Equal(t, "enqueued", loaded.RetryOutcome)
+}
+
+func TestSaveRejectsUnsafeVesselID(t *testing.T) {
+	artifact := Build(Input{
+		VesselID:  "../escape",
+		Workflow:  "fix-bug",
+		State:     queue.StateFailed,
+		Error:     "temporary failure from upstream 503",
+		CreatedAt: time.Date(2026, time.April, 9, 18, 10, 0, 0, time.UTC),
+	})
+
+	err := Save(t.TempDir(), artifact)
+	if err == nil {
+		t.Fatal("Save() error = nil, want invalid vessel ID error")
+	}
+	if got := err.Error(); got == "" || !strings.Contains(got, "invalid vessel ID") {
+		t.Fatalf("Save() error = %q, want invalid vessel ID", got)
+	}
+}
+
+func TestUpdateRetryOutcomeRejectsUnsafeVesselID(t *testing.T) {
+	err := UpdateRetryOutcome(t.TempDir(), "../escape", "enqueued")
+	if err == nil {
+		t.Fatal("UpdateRetryOutcome() error = nil, want invalid vessel ID error")
+	}
+	if got := err.Error(); got == "" || !strings.Contains(got, "invalid vessel ID") {
+		t.Fatalf("UpdateRetryOutcome() error = %q, want invalid vessel ID", got)
+	}
+}

--- a/cli/internal/review/load.go
+++ b/cli/internal/review/load.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
 )
 
@@ -21,6 +22,7 @@ type LoadedRun struct {
 	CostReport   *cost.CostReport
 	BudgetAlerts []cost.BudgetAlert
 	EvalReport   *evaluator.LoopResult
+	Recovery     *recovery.Artifact
 }
 
 func LoadRuns(stateDir string, lookbackRuns int) ([]LoadedRun, int, []string, error) {
@@ -111,6 +113,16 @@ func LoadRuns(stateDir string, lookbackRuns int) ([]LoadedRun, int, []string, er
 			}
 		}
 
+		if recoveryPath := resolveArtifactPath(stateDir, record.summary.FailureReviewPath, reviewArtifactValue(record.summary.ReviewArtifacts, func(a *runner.ReviewArtifacts) string {
+			return a.FailureReview
+		})); recoveryPath != "" {
+			artifact, warning := loadOptionalRecoveryArtifact(recoveryPath)
+			run.Recovery = artifact
+			if warning != "" {
+				warnings = append(warnings, warning)
+			}
+		}
+
 		runs = append(runs, run)
 	}
 
@@ -196,6 +208,14 @@ func loadOptionalEvalReport(path string) (*evaluator.LoopResult, string) {
 	report, err := evaluator.LoadReport(filepath.Dir(path))
 	if err == nil || errors.Is(err, os.ErrNotExist) {
 		return report, ""
+	}
+	return nil, fmt.Sprintf("%s: %v", filepath.Base(path), err)
+}
+
+func loadOptionalRecoveryArtifact(path string) (*recovery.Artifact, string) {
+	artifact, err := recovery.Load(path)
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return artifact, ""
 	}
 	return nil, fmt.Sprintf("%s: %v", filepath.Base(path), err)
 }

--- a/cli/internal/review/review_test.go
+++ b/cli/internal/review/review_test.go
@@ -10,7 +10,11 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateAggregatesReviewRecommendations(t *testing.T) {
@@ -194,21 +198,55 @@ func TestGenerateToleratesMissingOptionalArtifacts(t *testing.T) {
 	}
 }
 
+func TestSmoke_S1_LoadRunsIncludesRecoveryArtifactWhenPresent(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 8, 13, 30, 0, 0, time.UTC)
+
+	writeRunArtifacts(t, stateDir, runFixture{
+		vesselID:  "failed-with-recovery",
+		source:    "github-issue",
+		workflow:  "implement-harness",
+		state:     "failed",
+		startedAt: now,
+		endedAt:   now.Add(time.Minute),
+		recoveryArtifact: recovery.Build(recovery.Input{
+			VesselID:    "failed-with-recovery",
+			Source:      "github-issue",
+			Workflow:    "implement-harness",
+			State:       queue.StateFailed,
+			FailedPhase: "analyze",
+			Error:       "missing requirement: acceptance criteria are ambiguous",
+			CreatedAt:   now.Add(time.Minute),
+		}),
+	})
+
+	runs, _, _, err := LoadRuns(stateDir, 10)
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+	require.NotNil(t, runs[0].Recovery)
+	assert.Equal(t, recovery.ClassSpecGap, runs[0].Recovery.RecoveryClass)
+	assert.Equal(t, recovery.ActionRefine, runs[0].Recovery.RecoveryAction)
+	assert.Equal(t, "needs-refinement", runs[0].Recovery.FollowUpRoute)
+	assert.True(t, runs[0].Recovery.RetrySuppressed)
+	assert.Equal(t, "suppressed", runs[0].Recovery.RetryOutcome)
+}
+
 type runFixture struct {
-	vesselID     string
-	source       string
-	workflow     string
-	state        string
-	startedAt    time.Time
-	endedAt      time.Time
-	phases       []runner.PhaseSummary
-	totalInput   int
-	totalOutput  int
-	totalCost    float64
-	manifest     *evidence.Manifest
-	costReport   *cost.CostReport
-	budgetAlerts []cost.BudgetAlert
-	evalReport   *evaluator.LoopResult
+	vesselID         string
+	source           string
+	workflow         string
+	state            string
+	startedAt        time.Time
+	endedAt          time.Time
+	phases           []runner.PhaseSummary
+	totalInput       int
+	totalOutput      int
+	totalCost        float64
+	manifest         *evidence.Manifest
+	costReport       *cost.CostReport
+	budgetAlerts     []cost.BudgetAlert
+	evalReport       *evaluator.LoopResult
+	recoveryArtifact *recovery.Artifact
 }
 
 func writeRunArtifacts(t *testing.T, stateDir string, fixture runFixture) {
@@ -281,7 +319,22 @@ func writeRunArtifacts(t *testing.T, stateDir string, fixture runFixture) {
 		summary.BudgetAlertsPath = filepath.ToSlash(filepath.Join("phases", fixture.vesselID, "budget-alerts.json"))
 		artifacts.BudgetAlerts = summary.BudgetAlertsPath
 	}
-	if artifacts.EvidenceManifest != "" || artifacts.CostReport != "" || artifacts.BudgetAlerts != "" || artifacts.EvalReport != "" {
+	if fixture.recoveryArtifact != nil {
+		if err := recovery.Save(stateDir, fixture.recoveryArtifact); err != nil {
+			t.Fatalf("recovery.Save() error = %v", err)
+		}
+		summary.FailureReviewPath = filepath.ToSlash(filepath.Join("phases", fixture.vesselID, "failure-review.json"))
+		summary.Recovery = &runner.RecoverySummary{
+			Class:           string(fixture.recoveryArtifact.RecoveryClass),
+			Action:          string(fixture.recoveryArtifact.RecoveryAction),
+			FollowUpRoute:   fixture.recoveryArtifact.FollowUpRoute,
+			RetrySuppressed: fixture.recoveryArtifact.RetrySuppressed,
+			RetryOutcome:    fixture.recoveryArtifact.RetryOutcome,
+			UnlockDimension: fixture.recoveryArtifact.UnlockDimension,
+		}
+		artifacts.FailureReview = summary.FailureReviewPath
+	}
+	if artifacts.EvidenceManifest != "" || artifacts.CostReport != "" || artifacts.BudgetAlerts != "" || artifacts.EvalReport != "" || artifacts.FailureReview != "" {
 		summary.ReviewArtifacts = artifacts
 	}
 	requireSummaryOnly(t, stateDir, summary)

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/orchestrator"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/surface"
@@ -238,6 +239,7 @@ drainLoop:
 					AnomalyCount: len(status.Anomalies),
 					Anomalies:    AnomalyCodes(status.Anomalies),
 				}))
+				vesselSpan.AddAttributes(observability.RecoveryAttributes(recoveryAttributesFromMeta(finalVessel.Meta)))
 			}
 
 			drainStatsMu.Lock()
@@ -401,13 +403,19 @@ func (r *Runner) CheckWaitingVessels(ctx context.Context) {
 					log.Printf("warn: failed to update vessel %s to timed_out: %v", vessel.ID, updateErr)
 					continue
 				}
+				vrs := newVesselRunState(r.Config, vessel, r.runtimeNow())
+				vrs.setTraceContext(observability.TraceContextFromContext(timeoutSpan.Context()))
+				r.annotateRecoveryMetadata(vessel.ID, queue.StateTimedOut, "label gate timed out", traceContextPointer(vrs.trace))
 				src := r.resolveSourceForVessel(vessel)
 				if err := src.OnTimedOut(ctx, vessel); err != nil {
 					log.Printf("warn: OnTimedOut hook for vessel %s: %v", vessel.ID, err)
 				}
-				vrs := newVesselRunState(r.Config, vessel, r.runtimeNow())
-				vrs.setTraceContext(observability.TraceContextFromContext(timeoutSpan.Context()))
 				r.persistRunArtifacts(vessel, string(queue.StateTimedOut), vrs, nil, r.runtimeNow())
+				if r.Tracer != nil {
+					if current, findErr := r.Queue.FindByID(vessel.ID); findErr == nil && current != nil {
+						timeoutSpan.AddAttributes(observability.RecoveryAttributes(recoveryAttributesFromMeta(current.Meta)))
+					}
+				}
 				r.finishWaitTransitionSpan(timeoutSpan, nil)
 				// Clean up worktree (best-effort)
 				r.removeWorktree(ctx, vessel.WorktreePath, vessel.ID)
@@ -1332,7 +1340,9 @@ func (r *Runner) failVessel(id string, errMsg string) {
 			return
 		}
 		log.Printf("warn: failed to update vessel %s state: %v", id, updateErr)
+		return
 	}
+	r.annotateRecoveryMetadata(id, queue.StateFailed, errMsg, nil)
 }
 
 func (r *Runner) failUpdatedVessel(vessel *queue.Vessel, errMsg string) {
@@ -1343,12 +1353,52 @@ func (r *Runner) failUpdatedVessel(vessel *queue.Vessel, errMsg string) {
 	vessel.State = queue.StateFailed
 	vessel.Error = errMsg
 	vessel.EndedAt = &now
+	vessel.Meta = recovery.ApplyToMeta(vessel.Meta, recovery.Build(recovery.Input{
+		VesselID:    vessel.ID,
+		Source:      vessel.Source,
+		Workflow:    vessel.Workflow,
+		Ref:         vessel.Ref,
+		State:       queue.StateFailed,
+		FailedPhase: vessel.FailedPhase,
+		Error:       errMsg,
+		GateOutput:  vessel.GateOutput,
+		RetryOf:     vessel.RetryOf,
+		Meta:        vessel.Meta,
+		CreatedAt:   now,
+	}))
 	if updateErr := r.Queue.UpdateVessel(*vessel); updateErr != nil {
 		if r.cancelledTransition(vessel.ID, updateErr) {
 			return
 		}
 		log.Printf("warn: failed to persist vessel %s state: %v", vessel.ID, updateErr)
 		r.failVessel(vessel.ID, errMsg)
+	}
+}
+
+func (r *Runner) annotateRecoveryMetadata(id string, state queue.VesselState, errMsg string, trace *observability.TraceContextData) {
+	if r.Queue == nil {
+		return
+	}
+	current, err := r.Queue.FindByID(id)
+	if err != nil || current == nil {
+		return
+	}
+	current.Meta = recovery.ApplyToMeta(current.Meta, recovery.Build(recovery.Input{
+		VesselID:    current.ID,
+		Source:      current.Source,
+		Workflow:    current.Workflow,
+		Ref:         current.Ref,
+		State:       state,
+		FailedPhase: current.FailedPhase,
+		Error:       errMsg,
+		GateOutput:  current.GateOutput,
+		RetryOf:     current.RetryOf,
+		Meta:        current.Meta,
+		Trace:       trace,
+		CreatedAt:   r.runtimeNow(),
+	}))
+	if updateErr := r.Queue.UpdateVessel(*current); updateErr != nil {
+		log.Printf("warn: annotate recovery metadata for vessel %s: %v", id, updateErr)
 	}
 }
 
@@ -1382,6 +1432,10 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 
 	summary := vrs.buildSummary(state, now)
 	reviewArtifacts := &ReviewArtifacts{}
+	artifactVessel := vessel
+	if latest, err := r.Queue.FindByID(vessel.ID); err == nil && latest != nil {
+		artifactVessel = *latest
+	}
 	var manifest *evidence.Manifest
 	if len(claims) > 0 {
 		manifest = &evidence.Manifest{
@@ -1424,8 +1478,32 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 		reviewArtifacts.EvalReport = summary.EvalReportPath
 	}
 
+	if state == string(queue.StateFailed) || state == string(queue.StateTimedOut) {
+		reviewArtifact := recovery.Build(recovery.Input{
+			VesselID:    artifactVessel.ID,
+			Source:      artifactVessel.Source,
+			Workflow:    artifactVessel.Workflow,
+			Ref:         artifactVessel.Ref,
+			State:       artifactVessel.State,
+			FailedPhase: artifactVessel.FailedPhase,
+			Error:       artifactVessel.Error,
+			GateOutput:  artifactVessel.GateOutput,
+			RetryOf:     artifactVessel.RetryOf,
+			Meta:        artifactVessel.Meta,
+			Trace:       traceContextPointer(vrs.trace),
+			CreatedAt:   now,
+		})
+		if err := recovery.Save(r.Config.StateDir, reviewArtifact); err != nil {
+			log.Printf("warn: save recovery artifact: %v", err)
+		} else {
+			summary.FailureReviewPath = failureReviewRelativePath(vessel.ID)
+			reviewArtifacts.FailureReview = summary.FailureReviewPath
+			summary.Recovery = recoverySummaryFromArtifact(reviewArtifact)
+		}
+	}
+
 	if reviewArtifacts.EvidenceManifest != "" || reviewArtifacts.CostReport != "" ||
-		reviewArtifacts.BudgetAlerts != "" || reviewArtifacts.EvalReport != "" {
+		reviewArtifacts.BudgetAlerts != "" || reviewArtifacts.EvalReport != "" || reviewArtifacts.FailureReview != "" {
 		summary.ReviewArtifacts = reviewArtifacts
 	}
 
@@ -1448,6 +1526,29 @@ func saveJSONArtifact(path string, value any) error {
 		return fmt.Errorf("write: %w", err)
 	}
 	return nil
+}
+
+func recoveryAttributesFromMeta(meta map[string]string) observability.RecoveryData {
+	if meta == nil {
+		return observability.RecoveryData{}
+	}
+	return observability.RecoveryData{
+		Class:           meta[recovery.MetaClass],
+		Action:          meta[recovery.MetaAction],
+		RetrySuppressed: meta[recovery.MetaRetrySuppressed],
+		RetryOutcome:    meta[recovery.MetaRetryOutcome],
+		UnlockDimension: meta[recovery.MetaUnlockDimension],
+	}
+}
+
+func traceContextPointer(data *TraceArtifacts) *observability.TraceContextData {
+	if data == nil {
+		return nil
+	}
+	return &observability.TraceContextData{
+		TraceID: data.TraceID,
+		SpanID:  data.SpanID,
+	}
 }
 
 // runVesselOrchestrated executes a workflow with explicit phase dependencies
@@ -3397,7 +3498,17 @@ func (r *Runner) CheckHungVessels(ctx context.Context) {
 		timeoutSpan := r.startWaitTransitionSpan(ctx, vessel, "timed_out", elapsed)
 		vrs := newVesselRunState(r.Config, vessel, r.runtimeNow())
 		vrs.setTraceContext(observability.TraceContextFromContext(timeoutSpan.Context()))
+		r.annotateRecoveryMetadata(vessel.ID, queue.StateTimedOut, errMsg, traceContextPointer(vrs.trace))
+		src := r.resolveSourceForVessel(vessel)
+		if err := src.OnTimedOut(ctx, vessel); err != nil {
+			log.Printf("warn: OnTimedOut hook for vessel %s: %v", vessel.ID, err)
+		}
 		r.persistRunArtifacts(vessel, string(queue.StateTimedOut), vrs, nil, r.runtimeNow())
+		if r.Tracer != nil {
+			if current, findErr := r.Queue.FindByID(vessel.ID); findErr == nil && current != nil {
+				timeoutSpan.AddAttributes(observability.RecoveryAttributes(recoveryAttributesFromMeta(current.Meta)))
+			}
+		}
 		r.finishWaitTransitionSpan(timeoutSpan, nil)
 
 		// Clean up worktree (best-effort)

--- a/cli/internal/runner/summary.go
+++ b/cli/internal/runner/summary.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 )
 
@@ -52,8 +53,10 @@ type VesselSummary struct {
 	CostReportPath       string           `json:"cost_report_path,omitempty"`
 	BudgetAlertsPath     string           `json:"budget_alerts_path,omitempty"`
 	EvalReportPath       string           `json:"eval_report_path,omitempty"`
+	FailureReviewPath    string           `json:"failure_review_path,omitempty"`
 	Trace                *TraceArtifacts  `json:"trace,omitempty"`
 	ReviewArtifacts      *ReviewArtifacts `json:"review_artifacts,omitempty"`
+	Recovery             *RecoverySummary `json:"recovery,omitempty"`
 
 	Note string `json:"note"`
 }
@@ -68,6 +71,16 @@ type ReviewArtifacts struct {
 	CostReport       string `json:"cost_report,omitempty"`
 	BudgetAlerts     string `json:"budget_alerts,omitempty"`
 	EvalReport       string `json:"eval_report,omitempty"`
+	FailureReview    string `json:"failure_review,omitempty"`
+}
+
+type RecoverySummary struct {
+	Class           string `json:"class,omitempty"`
+	Action          string `json:"action,omitempty"`
+	FollowUpRoute   string `json:"follow_up_route,omitempty"`
+	RetrySuppressed bool   `json:"retry_suppressed"`
+	RetryOutcome    string `json:"retry_outcome,omitempty"`
+	UnlockDimension string `json:"unlock_dimension,omitempty"`
 }
 
 // PhaseSummary records the outcome of a single phase.
@@ -290,8 +303,26 @@ func evalReportRelativePath(vesselID string) string {
 	return filepath.ToSlash(filepath.Join("phases", vesselID, evalReportFileName))
 }
 
+func failureReviewRelativePath(vesselID string) string {
+	return recovery.RelativePath(vesselID)
+}
+
 func phaseArtifactRelativePath(vesselID, phaseName string) string {
 	return filepath.ToSlash(filepath.Join("phases", vesselID, phaseName+".output"))
+}
+
+func recoverySummaryFromArtifact(artifact *recovery.Artifact) *RecoverySummary {
+	if artifact == nil {
+		return nil
+	}
+	return &RecoverySummary{
+		Class:           string(artifact.RecoveryClass),
+		Action:          string(artifact.RecoveryAction),
+		FollowUpRoute:   artifact.FollowUpRoute,
+		RetrySuppressed: artifact.RetrySuppressed,
+		RetryOutcome:    artifact.RetryOutcome,
+		UnlockDimension: artifact.UnlockDimension,
+	}
 }
 
 // SaveVesselSummary writes a summary to <stateDir>/phases/<vesselID>/summary.json.

--- a/cli/internal/runner/summary_test.go
+++ b/cli/internal/runner/summary_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
@@ -111,69 +112,10 @@ func TestSmoke_S4_SummaryJSONIsPrettyPrinted(t *testing.T) {
 	assert.Contains(t, string(data), "\n  \"")
 	assert.Equal(t, "{", lines[0])
 	assert.True(t, strings.HasPrefix(lines[1], "  \""))
-}
 
-func TestSmoke_S5_PhaseSummaryRecordsCompletedStatusForASuccessfulPhase(t *testing.T) {
-	vrs := newVesselRunState(nil, queue.Vessel{
-		ID:       "vessel-phase-complete",
-		Source:   "manual",
-		Workflow: "fix-bug",
-	}, time.Now().UTC())
-	vrs.addPhase(PhaseSummary{Name: "implement", Status: "completed"})
-
-	summary := vrs.buildSummary("completed", time.Now().UTC())
-	require.Len(t, summary.Phases, 1)
-
-	assert.Equal(t, "completed", summary.Phases[0].Status)
-	assert.Empty(t, summary.Phases[0].Error)
-}
-
-func TestSmoke_S6_PhaseSummaryRecordsFailedStatusForAFailedPhase(t *testing.T) {
-	vrs := newVesselRunState(nil, queue.Vessel{
-		ID:       "vessel-phase-failed",
-		Source:   "manual",
-		Workflow: "fix-bug",
-	}, time.Now().UTC())
-	vrs.addPhase(PhaseSummary{Name: "test", Status: "failed", Error: "exit status 1"})
-
-	summary := vrs.buildSummary("failed", time.Now().UTC())
-	require.Len(t, summary.Phases, 1)
-
-	assert.Equal(t, "failed", summary.Phases[0].Status)
-	assert.Equal(t, "exit status 1", summary.Phases[0].Error)
-}
-
-func TestSmoke_S7_PhaseSummaryRecordsNoOpStatusForAnEarlyCompletionPhase(t *testing.T) {
-	vrs := newVesselRunState(nil, queue.Vessel{
-		ID:       "vessel-phase-noop",
-		Source:   "manual",
-		Workflow: "fix-bug",
-	}, time.Now().UTC())
-	vrs.addPhase(PhaseSummary{Name: "test", Status: "no-op"})
-
-	summary := vrs.buildSummary("completed", time.Now().UTC())
-	require.Len(t, summary.Phases, 1)
-
-	assert.Equal(t, "no-op", summary.Phases[0].Status)
-	assert.Zero(t, summary.Phases[0].InputTokensEst)
-	assert.Zero(t, summary.Phases[0].CostUSDEst)
-}
-
-func TestSmoke_S8_VesselRunStateAddPhaseAccumulatesPhasesInInsertionOrder(t *testing.T) {
-	vrs := newVesselRunState(nil, queue.Vessel{
-		ID:       "vessel-order",
-		Source:   "manual",
-		Workflow: "fix-bug",
-	}, time.Now().UTC())
-
-	vrs.addPhase(PhaseSummary{Name: "plan"})
-	vrs.addPhase(PhaseSummary{Name: "implement"})
-	vrs.addPhase(PhaseSummary{Name: "test"})
-
-	require.Len(t, vrs.phases, 3)
-	assert.Equal(t, "plan", vrs.phases[0].Name)
-	assert.Equal(t, "implement", vrs.phases[1].Name)
-	assert.Equal(t, "test", vrs.phases[2].Name)
+	var summary VesselSummary
+	require.NoError(t, json.Unmarshal(data, &summary))
+	assert.Equal(t, summaryDisclaimer, summary.Note)
 }
 
 func TestSmoke_S9_BuildSummaryComputesTotalTokensEstAsSumOfPhaseTokenFields(t *testing.T) {
@@ -314,55 +256,6 @@ func TestSmoke_S14_SaveVesselSummaryFailureIsNonFatalCallerContinues(t *testing.
 	assert.Equal(t, 1, result.Failed)
 	assert.Contains(t, buf.String(), "warn: save vessel summary:")
 	assert.Equal(t, queue.StateFailed, queueVesselByID(t, q, vessel.ID).State)
-}
-
-func TestSmoke_S15_CompleteVesselUpdatedSignatureAcceptsVesselRunState(t *testing.T) {
-	dir := t.TempDir()
-	cfg := makeTestConfig(dir, 1)
-	cfg.StateDir = filepath.Join(dir, ".xylem-state")
-
-	startedAt := time.Date(2026, time.April, 8, 20, 29, 0, 0, time.UTC)
-	vessel := runningSmokeVessel("vessel-complete-state", "github", "fix-bug", startedAt)
-
-	q := queue.New(filepath.Join(dir, "queue.jsonl"))
-	_, err := q.Enqueue(vessel)
-	require.NoError(t, err)
-
-	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
-	vrs := newVesselRunState(cfg, vessel, startedAt)
-	vrs.addPhase(PhaseSummary{Name: "plan", Status: "completed"})
-	vrs.addPhase(PhaseSummary{Name: "implement", Status: "completed"})
-
-	outcome := r.completeVessel(context.Background(), vessel, "", nil, vrs, nil)
-	assert.Equal(t, "completed", outcome)
-
-	_, err = os.Stat(filepath.Join(cfg.StateDir, "phases", vessel.ID, summaryFileName))
-	require.NoError(t, err)
-}
-
-func TestSmoke_S16_CompleteVesselSavesSummaryAfterExistingCompletionLogic(t *testing.T) {
-	dir := t.TempDir()
-	cfg := makeTestConfig(dir, 1)
-	cfg.StateDir = filepath.Join(dir, ".xylem-state")
-
-	startedAt := time.Date(2026, time.April, 8, 20, 30, 0, 0, time.UTC)
-	vessel := runningSmokeVessel("vessel-complete-order", "github", "fix-bug", startedAt)
-
-	q := queue.New(filepath.Join(dir, "queue.jsonl"))
-	_, err := q.Enqueue(vessel)
-	require.NoError(t, err)
-
-	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
-	vrs := newVesselRunState(cfg, vessel, startedAt)
-	vrs.addPhase(PhaseSummary{Name: "plan", Status: "completed"})
-	vrs.addPhase(PhaseSummary{Name: "implement", Status: "completed"})
-
-	outcome := r.completeVessel(context.Background(), vessel, "", nil, vrs, nil)
-	assert.Equal(t, "completed", outcome)
-	assert.Equal(t, queue.StateCompleted, queueVesselByID(t, q, vessel.ID).State)
-
-	summary := loadSummary(t, cfg.StateDir, vessel.ID)
-	assert.Equal(t, "completed", summary.State)
 }
 
 func TestSmoke_S17_CompleteVesselSavesEvidenceManifestWhenClaimsArePresent(t *testing.T) {
@@ -554,6 +447,18 @@ func TestSmoke_S19_FailurePathBuildsSummaryWithStateFailedAndCallsSaveVesselSumm
 	assert.Len(t, summary.Phases, 2)
 	assert.Equal(t, "completed", summary.Phases[0].Status)
 	assert.Equal(t, "failed", summary.Phases[1].Status)
+	require.NotEmpty(t, summary.FailureReviewPath)
+	require.NotNil(t, summary.Recovery)
+	artifact, err := recovery.Load(filepath.Join(cfg.StateDir, summary.FailureReviewPath))
+	require.NoError(t, err)
+	assert.Equal(t, summary.Recovery.Class, string(artifact.RecoveryClass))
+	assert.Equal(t, summary.Recovery.Action, string(artifact.RecoveryAction))
+	assert.Equal(t, summary.Recovery.FollowUpRoute, artifact.FollowUpRoute)
+	assert.Equal(t, summary.Recovery.RetrySuppressed, artifact.RetrySuppressed)
+	assert.Equal(t, summary.Recovery.RetryOutcome, artifact.RetryOutcome)
+	assert.Equal(t, summary.Recovery.UnlockDimension, artifact.UnlockDimension)
+	require.NotNil(t, summary.ReviewArtifacts)
+	assert.Equal(t, summary.FailureReviewPath, summary.ReviewArtifacts.FailureReview)
 }
 
 func TestSmoke_S20_BudgetMaxCostUSDAndBudgetMaxTokensAppearInSummaryWhenBudgetIsConfigured(t *testing.T) {
@@ -584,37 +489,6 @@ func TestSmoke_S20_BudgetMaxCostUSDAndBudgetMaxTokensAppearInSummaryWhenBudgetIs
 	require.NotNil(t, summary.BudgetMaxTokens)
 	assert.Equal(t, 1.0, *summary.BudgetMaxCostUSD)
 	assert.Equal(t, 50000, *summary.BudgetMaxTokens)
-}
-
-func TestSaveVesselSummaryWritesPrettyPrintedJSON(t *testing.T) {
-	stateDir := t.TempDir()
-	summary := &VesselSummary{
-		VesselID: "vessel-abc123",
-		Source:   "manual",
-		State:    "completed",
-		Phases:   []PhaseSummary{},
-	}
-
-	if err := SaveVesselSummary(stateDir, summary); err != nil {
-		t.Fatalf("SaveVesselSummary() error = %v", err)
-	}
-
-	path := filepath.Join(stateDir, "phases", "vessel-abc123", summaryFileName)
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read summary file: %v", err)
-	}
-	if !strings.Contains(string(data), "\n  \"") {
-		t.Fatalf("summary.json is not pretty printed: %s", string(data))
-	}
-
-	var got VesselSummary
-	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatalf("unmarshal summary.json: %v", err)
-	}
-	if got.Note != summaryDisclaimer {
-		t.Fatalf("Note = %q, want %q", got.Note, summaryDisclaimer)
-	}
 }
 
 func TestSaveVesselSummaryWritesEmptyPhasesArray(t *testing.T) {
@@ -791,39 +665,6 @@ func TestVesselRunStateBuildSummaryAggregatesTotalsAndStatus(t *testing.T) {
 	}
 	if got := summary.Phases[1].Error; got != "exit status 1" {
 		t.Fatalf("Phases[1].Error = %q, want exit status 1", got)
-	}
-}
-
-func TestVesselRunStateBuildSummaryReflectsBudgetExceeded(t *testing.T) {
-	cfg := makeTestConfig(t.TempDir(), 1)
-	setPricedModel(cfg)
-	setBudget(cfg, 0.0001, 10)
-
-	startedAt := time.Now().Add(-time.Second).UTC()
-	vrs := newVesselRunState(cfg, queue.Vessel{
-		ID:       "vessel-budget-exceeded",
-		Source:   "manual",
-		Workflow: "fix-bug",
-	}, startedAt)
-
-	inputTokens, outputTokens, costUSDEst := vrs.recordPhaseTokens(
-		workflow.Phase{Name: "implement"},
-		"claude-sonnet-4",
-		"Implement the requested changes",
-		strings.Repeat("output ", 40),
-		startedAt.Add(500*time.Millisecond),
-	)
-	vrs.addPhase(PhaseSummary{
-		Name:            "implement",
-		Status:          "failed",
-		InputTokensEst:  inputTokens,
-		OutputTokensEst: outputTokens,
-		CostUSDEst:      costUSDEst,
-	})
-
-	summary := vrs.buildSummary("failed", startedAt.Add(2*time.Second))
-	if !summary.BudgetExceeded {
-		t.Fatal("BudgetExceeded = false, want true")
 	}
 }
 

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/dtu"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 )
 
 // GitHubTask defines a label-based task for the GitHub source.
@@ -185,16 +186,32 @@ func (g *GitHub) OnComplete(ctx context.Context, vessel queue.Vessel) error {
 }
 
 func (g *GitHub) OnFail(ctx context.Context, vessel queue.Vessel) error {
-	g.applyIssueLabels(ctx, vessel.Meta["issue_num"],
-		[]string{vessel.Meta["status_label_failed"]},
+	latest := g.recoveryAwareVessel(vessel)
+	g.applyIssueLabels(ctx, latest.Meta["issue_num"],
+		[]string{latest.Meta["status_label_failed"]},
 		[]string{ResolveRunningLabel(vessel), resolveWaitingLabel(vessel), resolveReadyLabel(vessel)})
+	if shouldRouteToRefinement(latest) {
+		remove := []string{}
+		if trig := latest.Meta["trigger_label"]; trig != "" {
+			remove = append(remove, trig)
+		}
+		g.applyIssueLabels(ctx, latest.Meta["issue_num"], []string{"needs-refinement"}, remove)
+	}
 	return nil
 }
 
 func (g *GitHub) OnTimedOut(ctx context.Context, vessel queue.Vessel) error {
-	g.applyIssueLabels(ctx, vessel.Meta["issue_num"],
-		[]string{vessel.Meta["status_label_timed_out"]},
+	latest := g.recoveryAwareVessel(vessel)
+	g.applyIssueLabels(ctx, latest.Meta["issue_num"],
+		[]string{latest.Meta["status_label_timed_out"]},
 		[]string{ResolveRunningLabel(vessel), resolveWaitingLabel(vessel), resolveReadyLabel(vessel)})
+	if shouldRouteToRefinement(latest) {
+		remove := []string{}
+		if trig := latest.Meta["trigger_label"]; trig != "" {
+			remove = append(remove, trig)
+		}
+		g.applyIssueLabels(ctx, latest.Meta["issue_num"], []string{"needs-refinement"}, remove)
+	}
 	return nil
 }
 
@@ -258,6 +275,26 @@ func (g *GitHub) hasMatchingFailedFingerprint(ref, fingerprint string) bool {
 	}
 	isTerminalFailure := latest.State == queue.StateFailed || latest.State == queue.StateTimedOut
 	return isTerminalFailure && latest.Meta["source_input_fingerprint"] == fingerprint
+}
+
+func (g *GitHub) recoveryAwareVessel(vessel queue.Vessel) queue.Vessel {
+	if g == nil || g.Queue == nil {
+		return vessel
+	}
+	latest, err := g.Queue.FindByID(vessel.ID)
+	if err != nil || latest == nil {
+		return vessel
+	}
+	return *latest
+}
+
+func shouldRouteToRefinement(vessel queue.Vessel) bool {
+	action := vessel.Meta[recovery.MetaAction]
+	class := vessel.Meta[recovery.MetaClass]
+	return action == string(recovery.ActionRefine) ||
+		action == string(recovery.ActionSplitTask) ||
+		class == string(recovery.ClassSpecGap) ||
+		class == string(recovery.ClassScopeGap)
 }
 
 func issueLabelNames(labels []struct {

--- a/cli/internal/source/github_test.go
+++ b/cli/internal/source/github_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHasMergedPRTrue(t *testing.T) {
@@ -218,6 +221,39 @@ func TestOnFailAppliesLabel(t *testing.T) {
 	if !strings.Contains(joined, "--remove-label in-progress") {
 		t.Errorf("expected --remove-label in-progress in call, got %q", joined)
 	}
+}
+
+func TestSmoke_S1_OnFailRoutesSpecGapToNeedsRefinement(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	vessel := queue.Vessel{
+		ID:     "issue-214",
+		Source: "github-issue",
+		Meta: map[string]string{
+			"issue_num":            "214",
+			"status_label_failed":  "xylem-failed",
+			"status_label_running": "in-progress",
+			"trigger_label":        "ready-for-work",
+			recovery.MetaAction:    string(recovery.ActionRefine),
+		},
+		State: queue.StateFailed,
+	}
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	r := newMock()
+	g := &GitHub{
+		Repo:      "owner/repo",
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	require.NoError(t, g.OnFail(context.Background(), queue.Vessel{ID: vessel.ID, Meta: map[string]string{"issue_num": "214"}}))
+	require.Len(t, r.calls, 2)
+
+	refine := strings.Join(r.calls[1], " ")
+	assert.Contains(t, refine, "--add-label needs-refinement")
+	assert.Contains(t, refine, "--remove-label ready-for-work")
 }
 
 func TestOnFailNoLabelsConfigured(t *testing.T) {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -339,7 +339,7 @@ None.
 ### Behavior
 
 1. Scans historical vessel summaries under `<state_dir>/phases/`.
-2. Loads any linked evidence manifests, cost reports, budget alerts, and eval reports when present.
+2. Loads any linked evidence manifests, cost reports, budget alerts, eval reports, and failure-review artifacts when present.
 3. Rolls those artifacts up by source, workflow, and phase into deterministic recommendations: `keep`, `investigate`, `prune-candidate`, or `insufficient-data`.
 4. Writes:
    - `<state_dir>/<harness.review.output_dir>/harness-review.json`
@@ -375,7 +375,7 @@ None.
 
 1. Scans historical vessel summaries under `<state_dir>/phases/`.
 2. Filters to failed and timed-out runs inside the last 30 days by default.
-3. Clusters recurring failures using structured artifacts first: evidence manifests, phase failures, and evaluator reports.
+3. Clusters recurring failures using structured artifacts first: evidence manifests, phase failures, evaluator reports, and persisted recovery decisions.
 4. Skips lessons already present in `.xylem/HARNESS.md` or already represented by an equivalent open PR.
 5. Writes:
    - `<state_dir>/reviews/lessons.json`
@@ -392,7 +392,7 @@ None.
 
 `<state_dir>/reviews/lessons.json` contains:
 
-- `lessons[]`: evidence-backed negative constraints with `fingerprint`, `negative_constraint`, `rationale`, `example`, and `evidence[]`
+- `lessons[]`: evidence-backed negative constraints with `fingerprint`, `negative_constraint`, `rationale`, `example`, `evidence[]`, and any recovery decision context (`recovery_class`, `recovery_action`, `follow_up_route`) that shaped the cluster
 - `proposals[]`: narrow PR slices with `branch`, `title`, `body`, `harness_path`, `harness_patch`, `lesson_fingerprints`, `status`, and optional `pr_number` / `pr_url`
 - `skipped[]`: deduplicated lessons omitted because the harness or an open PR already covers them
 
@@ -569,7 +569,7 @@ xylem retry <vessel-id> [flags]
 ### Behavior
 
 1. Looks up the vessel by ID. Returns an error if not found.
-2. Validates the vessel is in the `failed` state. Returns an error if the vessel is in any other state.
+2. Validates the vessel is in the `failed` or `timed_out` state. Returns an error if the vessel is in any other state.
 3. Creates a new vessel with ID `<original-id>-retry-<N>`, where `N` is auto-incremented based on existing retries in the queue.
 4. Copies all configuration from the original vessel (source, ref, workflow, prompt, metadata).
 5. Adds failure context to the new vessel's metadata:
@@ -580,6 +580,7 @@ xylem retry <vessel-id> [flags]
 6. Sets the new vessel to `pending` state.
 7. By default, if the failed vessel has a saved worktree path, retry resumes from the failed phase and copies phase outputs into the new retry vessel's phase directory.
 8. If `--from-scratch` is set, xylem does not reuse the saved worktree path or copied phase outputs.
+9. If `<state_dir>/phases/<vessel-id>/failure-review.json` exists, xylem records the prior run's `retry_outcome` as `enqueued` so operators can inspect that the failed run was explicitly retried.
 
 This failure context is available to prompt templates so the retried session can avoid repeating the same mistakes.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -427,7 +427,7 @@ harness:
     output_dir: "reviews"
 ```
 
-`xylem review` writes `harness-review.json` and `harness-review.md` under `<state_dir>/<output_dir>/`. Automatic reviews are best-effort: failed review generation never fails `drain` or `daemon`. Built-in context-weight audits also write `context-weight-audit.json`, `context-weight-audit.md`, and a durable issue-dedup state file in the same directory when a scheduled `context-weight-audit` vessel runs.
+`xylem review` writes `harness-review.json` and `harness-review.md` under `<state_dir>/<output_dir>/`. Automatic reviews are best-effort: failed review generation never fails `drain` or `daemon`. Built-in context-weight audits also write `context-weight-audit.json`, `context-weight-audit.md`, and a durable issue-dedup state file in the same directory when a scheduled `context-weight-audit` vessel runs. When failed or timed-out runs also have `<state_dir>/phases/<vessel-id>/failure-review.json`, the review loader reconstructs those recovery decisions alongside the existing evidence/cost/eval artifacts.
 
 ### Observability settings
 
@@ -639,7 +639,7 @@ sources:
 - `schedule_fired_at`
 - `schedule_next_due_at`
 
-The built-in `lessons` workflow is designed for this source type: it synthesizes recurring failures into `.xylem/HARNESS.md` proposals, records them under `<state_dir>/reviews/lessons.{json,md}`, and opens reviewable PRs instead of editing the default branch directly.
+The built-in `lessons` workflow is designed for this source type: it synthesizes recurring failures into `.xylem/HARNESS.md` proposals, records them under `<state_dir>/reviews/lessons.{json,md}`, and opens reviewable PRs instead of editing the default branch directly. When recovery artifacts are present, the lessons report also carries forward the persisted `recovery_class`, `recovery_action`, and `follow_up_route` fields so operators can inspect why a failure clustered the way it did.
 
 ## Legacy config format
 


### PR DESCRIPTION
## Summary

Implements [issue #214](https://github.com/nicholls-inc/xylem/issues/214) by adding persisted failure-recovery artifacts, routing spec/scope-gap failures back to refinement, carrying recovery context into lessons/review flows, and emitting recovery decision data in vessel observability artifacts.

## Smoke scenarios covered

- `cli/internal/recovery/recovery_test.go` — `S1` TransientTimeoutClassifiesToRetry
- `cli/internal/recovery/recovery_test.go` — `S2` HarnessGapPreservesUnlockDimensionForLessonsRouting
- `cli/internal/recovery/recovery_test.go` — `S3` SpecGapRoutesToNeedsRefinement
- `cli/internal/recovery/recovery_test.go` — `S4` ScopeGapRoutesToSplitTaskNeedsRefinement
- `cli/internal/recovery/recovery_test.go` — `S5` AmbiguousFailureRoutesToDiagnose
- `cli/internal/recovery/recovery_test.go` — `S6` SaveLoadAndUpdateRetryOutcomePersistsEnqueuedState
- `cli/cmd/xylem/retry_test.go` — `S1` RetryCommandMarksRecoveryArtifactEnqueued
- `cli/internal/source/github_test.go` — `S1` OnFailRoutesSpecGapToNeedsRefinement
- `cli/internal/lessons/lessons_test.go` — `S1` LessonsClusterCarriesRecoveryDecision
- `cli/internal/review/review_test.go` — `S1` LoadRunsIncludesRecoveryArtifactWhenPresent
- `cli/internal/observability/vessel_test.go` — `S6` RecoveryAttributesIncludeDecisionFields
- `cli/internal/observability/vessel_test.go` — `S7` RecoveryAttributesOmitEmptyRecoveryData
- `cli/internal/runner/summary_test.go` — `S19` FailurePathBuildsSummaryWithStateFailedAndCallsSaveVesselSummary

## Changes summary

### Files added

- `cli/internal/recovery/recovery.go`
- `cli/internal/recovery/recovery_test.go`
- `cli/internal/recovery/recovery_prop_test.go`

### Files modified

- `cli/cmd/xylem/retry.go`
- `cli/cmd/xylem/retry_test.go`
- `cli/internal/lessons/lessons.go`
- `cli/internal/lessons/lessons_test.go`
- `cli/internal/observability/vessel.go`
- `cli/internal/observability/vessel_test.go`
- `cli/internal/review/load.go`
- `cli/internal/review/review_test.go`
- `cli/internal/runner/runner.go`
- `cli/internal/runner/summary.go`
- `cli/internal/runner/summary_test.go`
- `cli/internal/source/github.go`
- `cli/internal/source/github_test.go`
- `docs/cli-reference.md`
- `docs/configuration.md`

### Key types and functions

- Added `recovery.Artifact`, `recovery.Input`, `recovery.Build`, `recovery.ApplyToMeta`, `recovery.Save`, `recovery.Load`, `recovery.UpdateRetryOutcome`, `recovery.Path`, and `recovery.RelativePath` to classify failed/timed-out vessels and persist `failure-review.json` safely under `<state_dir>/phases/<vessel-id>/`.
- Updated `runner.failUpdatedVessel`, `runner.annotateRecoveryMetadata`, and `runner.persistRunArtifacts` to stamp recovery metadata onto failed/timed-out vessels, write recovery review artifacts, and expose `FailureReviewPath` plus `RecoverySummary` through `runner.VesselSummary` / `runner.ReviewArtifacts`.
- Added `observability.RecoveryData` and `observability.RecoveryAttributes`, then wired `runner.recoveryAttributesFromMeta` into vessel and timeout spans so traces show recovery class/action/retry outcome/unlock dimension.
- Updated `source.GitHub.OnFail` / `OnTimedOut` to use persisted recovery metadata and route refinement-worthy failures onto `needs-refinement`, removing the trigger label when appropriate.
- Updated `cmdRetry` to mark the original failure review artifact as `retry_outcome = enqueued` when a retry vessel is created.
- Updated `review.LoadRuns` and `lessons.Generate` / clustering to load persisted recovery artifacts and carry `recovery_class`, `recovery_action`, and `follow_up_route` into review and lessons outputs.
- Refreshed `docs/cli-reference.md` and `docs/configuration.md` to document recovery-context fields in lessons outputs.

## Test plan

Run from `cli/`:

- `goimports -w .`
- `goimports -l .`
- `go vet ./...`
- `golangci-lint run`
- `go build ./cmd/xylem`
- `go test ./...`

Fixes #214