### PR TITLE
feat: scanner: remediation-aware gating for failed-vessel re-enqueue

### DIFF
--- a/cli/internal/recovery/recovery.go
+++ b/cli/internal/recovery/recovery.go
@@ -1,0 +1,398 @@
+package recovery
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+const FailureReviewFileName = "failure-review.json"
+
+type UnlockFingerprint struct {
+	SourceInputFingerprint string `json:"source_input_fingerprint,omitempty"`
+	HarnessDigest          string `json:"harness_digest,omitempty"`
+	WorkflowDigest         string `json:"workflow_digest,omitempty"`
+	DecisionDigest         string `json:"decision_digest,omitempty"`
+}
+
+type FailureReview struct {
+	VesselID                string            `json:"vessel_id"`
+	FailureFingerprint      string            `json:"failure_fingerprint,omitempty"`
+	SourceRef               string            `json:"source_ref,omitempty"`
+	Workflow                string            `json:"workflow,omitempty"`
+	FailedPhase             string            `json:"failed_phase,omitempty"`
+	Class                   string            `json:"class,omitempty"`
+	Confidence              float64           `json:"confidence,omitempty"`
+	RecommendedAction       string            `json:"recommended_action,omitempty"`
+	RetryCount              int               `json:"retry_count,omitempty"`
+	RetryCap                int               `json:"retry_cap,omitempty"`
+	RetryAfter              *time.Time        `json:"retry_after,omitempty"`
+	RequiresHarnessChange   bool              `json:"requires_harness_change,omitempty"`
+	RequiresSourceChange    bool              `json:"requires_source_change,omitempty"`
+	RequiresDecisionRefresh bool              `json:"requires_decision_refresh,omitempty"`
+	EvidencePaths           []string          `json:"evidence_paths,omitempty"`
+	Hypothesis              string            `json:"hypothesis,omitempty"`
+	Unlock                  UnlockFingerprint `json:"unlock,omitempty"`
+	RemediationEpoch        string            `json:"remediation_epoch,omitempty"`
+	RemediationFingerprint  string            `json:"remediation_fingerprint,omitempty"`
+}
+
+type RetryGateResult struct {
+	Allowed            bool
+	CurrentFingerprint string
+	UnlockedBy         string
+	FailureFingerprint string
+	RecoveryClass      string
+	RecoveryAction     string
+}
+
+func FailureReviewPath(stateDir, vesselID string) string {
+	return filepath.Join(stateDir, "phases", vesselID, FailureReviewFileName)
+}
+
+func FailureReviewRelativePath(vesselID string) string {
+	return filepath.ToSlash(filepath.Join("phases", vesselID, FailureReviewFileName))
+}
+
+func SaveFailureReview(stateDir string, review *FailureReview) error {
+	if review == nil {
+		return fmt.Errorf("save failure review: review must not be nil")
+	}
+	if err := validatePathComponent(review.VesselID); err != nil {
+		return fmt.Errorf("save failure review: invalid vessel ID: %w", err)
+	}
+
+	normalized := *review
+	normalized.EvidencePaths = normalizePaths(review.EvidencePaths)
+	decisionDigest := DecisionDigest(&normalized)
+	if normalized.Unlock.DecisionDigest == "" {
+		normalized.Unlock.DecisionDigest = decisionDigest
+	}
+	if normalized.RemediationFingerprint == "" {
+		normalized.RemediationFingerprint = RemediationFingerprint(
+			normalized.Unlock.SourceInputFingerprint,
+			normalized.Unlock.HarnessDigest,
+			normalized.Unlock.WorkflowDigest,
+			normalized.Unlock.DecisionDigest,
+			normalized.RemediationEpoch,
+		)
+	}
+
+	path := FailureReviewPath(stateDir, normalized.VesselID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("save failure review: create dir: %w", err)
+	}
+	data, err := json.MarshalIndent(&normalized, "", "  ")
+	if err != nil {
+		return fmt.Errorf("save failure review: marshal: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("save failure review: write: %w", err)
+	}
+	return nil
+}
+
+func LoadFailureReview(stateDir, vesselID string) (*FailureReview, error) {
+	data, err := os.ReadFile(FailureReviewPath(stateDir, vesselID))
+	if err != nil {
+		return nil, fmt.Errorf("load failure review: read: %w", err)
+	}
+	var review FailureReview
+	if err := json.Unmarshal(data, &review); err != nil {
+		return nil, fmt.Errorf("load failure review: unmarshal: %w", err)
+	}
+	return &review, nil
+}
+
+func DecisionDigest(review *FailureReview) string {
+	if review == nil {
+		return ""
+	}
+	evidencePaths := normalizePaths(review.EvidencePaths)
+	payload := struct {
+		Class                   string   `json:"class,omitempty"`
+		Confidence              float64  `json:"confidence,omitempty"`
+		RecommendedAction       string   `json:"recommended_action,omitempty"`
+		RetryCount              int      `json:"retry_count,omitempty"`
+		RetryCap                int      `json:"retry_cap,omitempty"`
+		RetryAfter              string   `json:"retry_after,omitempty"`
+		RequiresHarnessChange   bool     `json:"requires_harness_change,omitempty"`
+		RequiresSourceChange    bool     `json:"requires_source_change,omitempty"`
+		RequiresDecisionRefresh bool     `json:"requires_decision_refresh,omitempty"`
+		FailedPhase             string   `json:"failed_phase,omitempty"`
+		EvidencePaths           []string `json:"evidence_paths,omitempty"`
+		Hypothesis              string   `json:"hypothesis,omitempty"`
+	}{
+		Class:                   strings.TrimSpace(review.Class),
+		Confidence:              review.Confidence,
+		RecommendedAction:       strings.TrimSpace(review.RecommendedAction),
+		RetryCount:              review.RetryCount,
+		RetryCap:                review.RetryCap,
+		RequiresHarnessChange:   review.RequiresHarnessChange,
+		RequiresSourceChange:    review.RequiresSourceChange,
+		RequiresDecisionRefresh: review.RequiresDecisionRefresh,
+		FailedPhase:             strings.TrimSpace(review.FailedPhase),
+		EvidencePaths:           evidencePaths,
+		Hypothesis:              strings.TrimSpace(review.Hypothesis),
+	}
+	if review.RetryAfter != nil && !review.RetryAfter.IsZero() {
+		payload.RetryAfter = review.RetryAfter.UTC().Format(time.RFC3339Nano)
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	return hashBytes(data)
+}
+
+func RemediationFingerprint(sourceFingerprint, harnessDigest, workflowDigest, decisionDigest, remediationEpoch string) string {
+	return hashStrings(
+		strings.TrimSpace(sourceFingerprint),
+		strings.TrimSpace(harnessDigest),
+		strings.TrimSpace(workflowDigest),
+		strings.TrimSpace(decisionDigest),
+		strings.TrimSpace(remediationEpoch),
+	)
+}
+
+func EvaluateRetry(review *FailureReview, currentSourceFingerprint, currentHarnessDigest, currentWorkflowDigest string, now time.Time) RetryGateResult {
+	if review == nil {
+		return RetryGateResult{}
+	}
+
+	currentDecisionDigest := DecisionDigest(review)
+	previousDecisionDigest := strings.TrimSpace(review.Unlock.DecisionDigest)
+	if previousDecisionDigest == "" {
+		previousDecisionDigest = currentDecisionDigest
+	}
+
+	currentEpoch := strings.TrimSpace(review.RemediationEpoch)
+	if isCooldownSatisfied(review, now) {
+		currentEpoch = cooldownEpoch(review.RetryAfter.UTC())
+	}
+
+	result := RetryGateResult{
+		CurrentFingerprint: RemediationFingerprint(
+			currentSourceFingerprint,
+			currentHarnessDigest,
+			currentWorkflowDigest,
+			currentDecisionDigest,
+			currentEpoch,
+		),
+		FailureFingerprint: strings.TrimSpace(review.FailureFingerprint),
+		RecoveryClass:      strings.TrimSpace(review.Class),
+		RecoveryAction:     strings.TrimSpace(review.RecommendedAction),
+	}
+
+	if !strings.EqualFold(strings.TrimSpace(review.RecommendedAction), "retry") {
+		return result
+	}
+	if review.RetryCap > 0 && review.RetryCount >= review.RetryCap {
+		return result
+	}
+	if review.RetryAfter != nil && !review.RetryAfter.IsZero() && now.Before(review.RetryAfter.UTC()) {
+		return result
+	}
+	if review.RequiresSourceChange && currentSourceFingerprint == strings.TrimSpace(review.Unlock.SourceInputFingerprint) {
+		return result
+	}
+	if review.RequiresHarnessChange && currentHarnessDigest == strings.TrimSpace(review.Unlock.HarnessDigest) {
+		return result
+	}
+	if review.RequiresDecisionRefresh && currentDecisionDigest == previousDecisionDigest {
+		return result
+	}
+
+	previousFingerprint := strings.TrimSpace(review.RemediationFingerprint)
+	if previousFingerprint == "" {
+		previousFingerprint = RemediationFingerprint(
+			review.Unlock.SourceInputFingerprint,
+			review.Unlock.HarnessDigest,
+			review.Unlock.WorkflowDigest,
+			previousDecisionDigest,
+			review.RemediationEpoch,
+		)
+	}
+	if result.CurrentFingerprint == previousFingerprint {
+		return result
+	}
+
+	result.UnlockedBy = firstUnlockDimension(
+		currentSourceFingerprint != strings.TrimSpace(review.Unlock.SourceInputFingerprint),
+		currentHarnessDigest != strings.TrimSpace(review.Unlock.HarnessDigest),
+		currentWorkflowDigest != strings.TrimSpace(review.Unlock.WorkflowDigest),
+		currentDecisionDigest != previousDecisionDigest,
+		currentEpoch != strings.TrimSpace(review.RemediationEpoch),
+	)
+	result.Allowed = result.UnlockedBy != ""
+	return result
+}
+
+func CurrentHarnessDigest() string {
+	return FileDigest(filepath.Join(".xylem", "HARNESS.md"))
+}
+
+func CurrentWorkflowDigest(workflowName string) string {
+	if strings.TrimSpace(workflowName) == "" {
+		return ""
+	}
+	return FileDigest(filepath.Join(".xylem", "workflows", workflowName+".yaml"))
+}
+
+func FileDigest(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return hashBytes(data)
+}
+
+func FailureFingerprint(vessel queue.Vessel) string {
+	return hashStrings(
+		string(vessel.State),
+		strings.TrimSpace(vessel.FailedPhase),
+		strings.TrimSpace(vessel.Error),
+		strings.TrimSpace(vessel.GateOutput),
+	)
+}
+
+func RetryID(originalID string, q *queue.Queue) string {
+	vessels, err := q.List()
+	if err != nil {
+		return originalID + "-retry-1"
+	}
+	maxRetry := 0
+	prefix := originalID + "-retry-"
+	for _, vessel := range vessels {
+		if !strings.HasPrefix(vessel.ID, prefix) {
+			continue
+		}
+		numStr := strings.TrimPrefix(vessel.ID, prefix)
+		n, err := strconv.Atoi(numStr)
+		if err == nil && n > maxRetry {
+			maxRetry = n
+		}
+	}
+	return fmt.Sprintf("%s-retry-%d", originalID, maxRetry+1)
+}
+
+func RetryRootID(vessel queue.Vessel) string {
+	if vessel.Meta != nil {
+		if root := strings.TrimSpace(vessel.Meta["retry_of"]); root != "" {
+			return root
+		}
+	}
+	if root := strings.TrimSpace(vessel.RetryOf); root != "" {
+		return root
+	}
+	return strings.TrimSpace(baseRetryID(vessel.ID))
+}
+
+func RetryCountFromVessel(vessel queue.Vessel) int {
+	if vessel.Meta != nil {
+		if raw := strings.TrimSpace(vessel.Meta["retry_count"]); raw != "" {
+			if count, err := strconv.Atoi(raw); err == nil && count >= 0 {
+				return count
+			}
+		}
+	}
+	return retrySuffixCount(vessel.ID)
+}
+
+func retrySuffixCount(id string) int {
+	base := baseRetryID(id)
+	if base == id {
+		return 0
+	}
+	count, err := strconv.Atoi(id[len(base)+len("-retry-"):])
+	if err != nil || count < 0 {
+		return 0
+	}
+	return count
+}
+
+func baseRetryID(id string) string {
+	idx := strings.LastIndex(id, "-retry-")
+	if idx < 0 {
+		return id
+	}
+	base := id[:idx]
+	if _, err := strconv.Atoi(id[idx+len("-retry-"):]); err != nil {
+		return id
+	}
+	return base
+}
+
+func normalizePaths(paths []string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+	normalized := make([]string, 0, len(paths))
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		normalized = append(normalized, filepath.ToSlash(path))
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func hashStrings(parts ...string) string {
+	return hashBytes([]byte(strings.Join(parts, "\n")))
+}
+
+func hashBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum)
+}
+
+func isCooldownSatisfied(review *FailureReview, now time.Time) bool {
+	if review == nil || review.RetryAfter == nil || review.RetryAfter.IsZero() {
+		return false
+	}
+	return !now.Before(review.RetryAfter.UTC())
+}
+
+func cooldownEpoch(retryAfter time.Time) string {
+	return "cooldown:" + retryAfter.UTC().Format(time.RFC3339Nano)
+}
+
+func firstUnlockDimension(sourceChanged, harnessChanged, workflowChanged, decisionChanged, cooldownChanged bool) string {
+	switch {
+	case sourceChanged:
+		return "source"
+	case harnessChanged:
+		return "harness"
+	case workflowChanged:
+		return "workflow"
+	case decisionChanged:
+		return "decision"
+	case cooldownChanged:
+		return "cooldown"
+	default:
+		return ""
+	}
+}
+
+func validatePathComponent(component string) error {
+	if component == "" {
+		return fmt.Errorf("path component must not be empty")
+	}
+	if strings.Contains(component, "..") {
+		return fmt.Errorf("path component must not contain %q", "..")
+	}
+	if strings.ContainsAny(component, `/\`) {
+		return fmt.Errorf("path component %q contains invalid separators", component)
+	}
+	return nil
+}

--- a/cli/internal/recovery/recovery_prop_test.go
+++ b/cli/internal/recovery/recovery_prop_test.go
@@ -1,0 +1,25 @@
+package recovery
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropRemediationFingerprintStable(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		source := rapid.String().Draw(t, "source")
+		harness := rapid.String().Draw(t, "harness")
+		workflow := rapid.String().Draw(t, "workflow")
+		decision := rapid.String().Draw(t, "decision")
+		epoch := rapid.String().Draw(t, "epoch")
+
+		got := RemediationFingerprint(source, harness, workflow, decision, epoch)
+		if got == "" {
+			t.Fatal("RemediationFingerprint() = empty, want digest")
+		}
+		if again := RemediationFingerprint(source, harness, workflow, decision, epoch); again != got {
+			t.Fatalf("RemediationFingerprint() unstable: first=%q second=%q", got, again)
+		}
+	})
+}

--- a/cli/internal/recovery/recovery_test.go
+++ b/cli/internal/recovery/recovery_test.go
@@ -1,0 +1,290 @@
+package recovery
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+func TestEvaluateRetryUnlocksByDimension(t *testing.T) {
+	now := time.Date(2026, time.April, 9, 18, 0, 0, 0, time.UTC)
+	past := now.Add(-time.Hour)
+
+	tests := []struct {
+		name       string
+		review     *FailureReview
+		source     string
+		harness    string
+		workflow   string
+		wantAllow  bool
+		wantUnlock string
+	}{
+		{
+			name: "source",
+			review: &FailureReview{
+				RecommendedAction: "retry",
+				RetryCap:          2,
+				Unlock: UnlockFingerprint{
+					SourceInputFingerprint: "source-a",
+					HarnessDigest:          "harness-a",
+					WorkflowDigest:         "workflow-a",
+				},
+			},
+			source:     "source-b",
+			harness:    "harness-a",
+			workflow:   "workflow-a",
+			wantAllow:  true,
+			wantUnlock: "source",
+		},
+		{
+			name: "harness",
+			review: &FailureReview{
+				RecommendedAction: "retry",
+				RetryCap:          2,
+				Unlock: UnlockFingerprint{
+					SourceInputFingerprint: "source-a",
+					HarnessDigest:          "harness-a",
+					WorkflowDigest:         "workflow-a",
+				},
+			},
+			source:     "source-a",
+			harness:    "harness-b",
+			workflow:   "workflow-a",
+			wantAllow:  true,
+			wantUnlock: "harness",
+		},
+		{
+			name: "workflow",
+			review: &FailureReview{
+				RecommendedAction: "retry",
+				RetryCap:          2,
+				Unlock: UnlockFingerprint{
+					SourceInputFingerprint: "source-a",
+					HarnessDigest:          "harness-a",
+					WorkflowDigest:         "workflow-a",
+				},
+			},
+			source:     "source-a",
+			harness:    "harness-a",
+			workflow:   "workflow-b",
+			wantAllow:  true,
+			wantUnlock: "workflow",
+		},
+		{
+			name: "decision",
+			review: &FailureReview{
+				RecommendedAction: "retry",
+				RetryCap:          2,
+				Hypothesis:        "new hypothesis",
+				Unlock: UnlockFingerprint{
+					SourceInputFingerprint: "source-a",
+					HarnessDigest:          "harness-a",
+					WorkflowDigest:         "workflow-a",
+					DecisionDigest:         "old-decision",
+				},
+			},
+			source:     "source-a",
+			harness:    "harness-a",
+			workflow:   "workflow-a",
+			wantAllow:  true,
+			wantUnlock: "decision",
+		},
+		{
+			name: "cooldown",
+			review: &FailureReview{
+				RecommendedAction: "retry",
+				RetryCap:          2,
+				RetryAfter:        &past,
+				Unlock: UnlockFingerprint{
+					SourceInputFingerprint: "source-a",
+					HarnessDigest:          "harness-a",
+					WorkflowDigest:         "workflow-a",
+				},
+			},
+			source:     "source-a",
+			harness:    "harness-a",
+			workflow:   "workflow-a",
+			wantAllow:  true,
+			wantUnlock: "cooldown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previousDecisionDigest := tt.review.Unlock.DecisionDigest
+			if previousDecisionDigest == "" {
+				previousDecisionDigest = DecisionDigest(tt.review)
+				tt.review.Unlock.DecisionDigest = previousDecisionDigest
+			}
+			tt.review.RemediationFingerprint = RemediationFingerprint(
+				tt.review.Unlock.SourceInputFingerprint,
+				tt.review.Unlock.HarnessDigest,
+				tt.review.Unlock.WorkflowDigest,
+				previousDecisionDigest,
+				tt.review.RemediationEpoch,
+			)
+
+			got := EvaluateRetry(tt.review, tt.source, tt.harness, tt.workflow, now)
+			if got.Allowed != tt.wantAllow {
+				t.Fatalf("Allowed = %v, want %v", got.Allowed, tt.wantAllow)
+			}
+			if got.UnlockedBy != tt.wantUnlock {
+				t.Fatalf("UnlockedBy = %q, want %q", got.UnlockedBy, tt.wantUnlock)
+			}
+		})
+	}
+}
+
+func TestEvaluateRetryBlocksPendingCooldownAndExhaustedCap(t *testing.T) {
+	now := time.Date(2026, time.April, 9, 18, 0, 0, 0, time.UTC)
+	future := now.Add(time.Hour)
+
+	tests := []struct {
+		name   string
+		review *FailureReview
+	}{
+		{
+			name: "cooldown pending",
+			review: &FailureReview{
+				RecommendedAction: "retry",
+				RetryCap:          2,
+				RetryAfter:        &future,
+				Unlock: UnlockFingerprint{
+					SourceInputFingerprint: "source-a",
+					HarnessDigest:          "harness-a",
+					WorkflowDigest:         "workflow-a",
+				},
+			},
+		},
+		{
+			name: "retry cap exhausted",
+			review: &FailureReview{
+				RecommendedAction: "retry",
+				RetryCap:          1,
+				RetryCount:        1,
+				Unlock: UnlockFingerprint{
+					SourceInputFingerprint: "source-a",
+					HarnessDigest:          "harness-a",
+					WorkflowDigest:         "workflow-a",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.review.Unlock.DecisionDigest = DecisionDigest(tt.review)
+			tt.review.RemediationFingerprint = RemediationFingerprint(
+				tt.review.Unlock.SourceInputFingerprint,
+				tt.review.Unlock.HarnessDigest,
+				tt.review.Unlock.WorkflowDigest,
+				tt.review.Unlock.DecisionDigest,
+				tt.review.RemediationEpoch,
+			)
+
+			got := EvaluateRetry(tt.review, "source-b", "harness-b", "workflow-b", now)
+			if got.Allowed {
+				t.Fatal("Allowed = true, want blocked")
+			}
+			if got.UnlockedBy != "" {
+				t.Fatalf("UnlockedBy = %q, want empty when blocked", got.UnlockedBy)
+			}
+			if got.CurrentFingerprint == "" {
+				t.Fatal("CurrentFingerprint = empty, want computed fingerprint even when blocked")
+			}
+		})
+	}
+}
+
+func TestEvaluateRetryReturnsZeroValueForNilReview(t *testing.T) {
+	got := EvaluateRetry(nil, "source-a", "harness-a", "workflow-a", time.Now().UTC())
+	if got != (RetryGateResult{}) {
+		t.Fatalf("EvaluateRetry(nil) = %#v, want zero value", got)
+	}
+}
+
+func TestSaveFailureReviewPopulatesDerivedFields(t *testing.T) {
+	stateDir := t.TempDir()
+	review := &FailureReview{
+		VesselID:           "issue-42",
+		RecommendedAction:  "retry",
+		RetryCap:           2,
+		EvidencePaths:      []string{filepath.Join("phases", "issue-42", "summary.json"), " phases/issue-42/log.txt "},
+		FailureFingerprint: "fail-123",
+		Unlock: UnlockFingerprint{
+			SourceInputFingerprint: "source-a",
+			HarnessDigest:          "harness-a",
+			WorkflowDigest:         "workflow-a",
+		},
+	}
+
+	if err := SaveFailureReview(stateDir, review); err != nil {
+		t.Fatalf("SaveFailureReview() error = %v", err)
+	}
+
+	loaded, err := LoadFailureReview(stateDir, "issue-42")
+	if err != nil {
+		t.Fatalf("LoadFailureReview() error = %v", err)
+	}
+	if loaded.Unlock.DecisionDigest == "" {
+		t.Fatal("DecisionDigest = empty, want populated")
+	}
+	if loaded.RemediationFingerprint == "" {
+		t.Fatal("RemediationFingerprint = empty, want populated")
+	}
+	if got, want := loaded.EvidencePaths, []string{"phases/issue-42/log.txt", "phases/issue-42/summary.json"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("EvidencePaths = %#v, want %#v", got, want)
+	}
+	if got, want := FailureReviewPath(stateDir, "issue-42"), filepath.Join(stateDir, "phases", "issue-42", FailureReviewFileName); got != want {
+		t.Fatalf("FailureReviewPath() = %q, want %q", got, want)
+	}
+}
+
+func TestRetryHelpersUseOriginalRootSequence(t *testing.T) {
+	stateDir := t.TempDir()
+	q := queue.New(filepath.Join(stateDir, "queue.jsonl"))
+	if _, err := q.Enqueue(queue.Vessel{ID: "issue-42", Ref: "ref", State: queue.StateFailed}); err != nil {
+		t.Fatalf("Enqueue(root) error = %v", err)
+	}
+	if _, err := q.Enqueue(queue.Vessel{ID: "issue-42-retry-1", Ref: "ref", State: queue.StateFailed}); err != nil {
+		t.Fatalf("Enqueue(retry) error = %v", err)
+	}
+	if got := RetryID("issue-42", q); got != "issue-42-retry-2" {
+		t.Fatalf("RetryID() = %q, want issue-42-retry-2", got)
+	}
+	if got := RetryRootID(queue.Vessel{
+		ID:      "issue-42-retry-1",
+		RetryOf: "issue-42",
+		Meta:    map[string]string{"retry_of": "issue-42"},
+	}); got != "issue-42" {
+		t.Fatalf("RetryRootID() = %q, want issue-42", got)
+	}
+	if got := RetryCountFromVessel(queue.Vessel{ID: "issue-42-retry-3"}); got != 3 {
+		t.Fatalf("RetryCountFromVessel() = %d, want 3", got)
+	}
+}
+
+func TestRetryIDContinuesRootSequenceForNestedRetries(t *testing.T) {
+	stateDir := t.TempDir()
+	q := queue.New(filepath.Join(stateDir, "queue.jsonl"))
+
+	_, _ = q.Enqueue(queue.Vessel{ID: "issue-42", Ref: "ref", State: queue.StateFailed})
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:      "issue-42-retry-1",
+		Ref:     "ref",
+		State:   queue.StateFailed,
+		RetryOf: "issue-42",
+		Meta:    map[string]string{"retry_of": "issue-42", "retry_count": "1"},
+	})
+
+	prior := queue.Vessel{
+		ID:      "issue-42-retry-1",
+		RetryOf: "issue-42",
+		Meta:    map[string]string{"retry_of": "issue-42", "retry_count": "1"},
+	}
+	if got := RetryID(RetryRootID(prior), q); got != "issue-42-retry-2" {
+		t.Fatalf("RetryID(RetryRootID(prior)) = %q, want issue-42-retry-2", got)
+	}
+}

--- a/cli/internal/review/load.go
+++ b/cli/internal/review/load.go
@@ -12,15 +12,17 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
 )
 
 type LoadedRun struct {
-	Summary      runner.VesselSummary
-	Evidence     *evidence.Manifest
-	CostReport   *cost.CostReport
-	BudgetAlerts []cost.BudgetAlert
-	EvalReport   *evaluator.LoopResult
+	Summary       runner.VesselSummary
+	Evidence      *evidence.Manifest
+	CostReport    *cost.CostReport
+	BudgetAlerts  []cost.BudgetAlert
+	EvalReport    *evaluator.LoopResult
+	FailureReview *recovery.FailureReview
 }
 
 func LoadRuns(stateDir string, lookbackRuns int) ([]LoadedRun, int, []string, error) {
@@ -106,6 +108,16 @@ func LoadRuns(stateDir string, lookbackRuns int) ([]LoadedRun, int, []string, er
 		})); evalPath != "" {
 			report, warning := loadOptionalEvalReport(evalPath)
 			run.EvalReport = report
+			if warning != "" {
+				warnings = append(warnings, warning)
+			}
+		}
+
+		if failureReviewPath := resolveArtifactPath(stateDir, record.summary.FailureReviewPath, reviewArtifactValue(record.summary.ReviewArtifacts, func(a *runner.ReviewArtifacts) string {
+			return a.FailureReview
+		})); failureReviewPath != "" {
+			reviewArtifact, warning := loadOptionalFailureReview(failureReviewPath)
+			run.FailureReview = reviewArtifact
 			if warning != "" {
 				warnings = append(warnings, warning)
 			}
@@ -198,4 +210,19 @@ func loadOptionalEvalReport(path string) (*evaluator.LoopResult, string) {
 		return report, ""
 	}
 	return nil, fmt.Sprintf("%s: %v", filepath.Base(path), err)
+}
+
+func loadOptionalFailureReview(path string) (*recovery.FailureReview, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ""
+		}
+		return nil, fmt.Sprintf("%s: %v", filepath.Base(path), err)
+	}
+	var review recovery.FailureReview
+	if err := json.Unmarshal(data, &review); err != nil {
+		return nil, fmt.Sprintf("%s: unmarshal failure review: %v", filepath.Base(path), err)
+	}
+	return &review, ""
 }

--- a/cli/internal/review/review_test.go
+++ b/cli/internal/review/review_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
 )
 
@@ -194,21 +195,63 @@ func TestGenerateToleratesMissingOptionalArtifacts(t *testing.T) {
 	}
 }
 
+func TestLoadRunsLoadsFailureReviewArtifact(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 8, 14, 0, 0, 0, time.UTC)
+	retryAfter := now.Add(15 * time.Minute)
+
+	writeRunArtifacts(t, stateDir, runFixture{
+		vesselID:  "failed-run",
+		source:    "github-issue",
+		workflow:  "fix-bug",
+		state:     "failed",
+		startedAt: now,
+		endedAt:   now.Add(time.Minute),
+		failureReview: &recovery.FailureReview{
+			VesselID:           "failed-run",
+			Workflow:           "fix-bug",
+			Class:              "unknown",
+			RecommendedAction:  "retry",
+			RetryCap:           2,
+			RetryAfter:         &retryAfter,
+			FailureFingerprint: "fail-123",
+		},
+	})
+
+	runs, total, warnings, err := LoadRuns(stateDir, 10)
+	if err != nil {
+		t.Fatalf("LoadRuns() error = %v", err)
+	}
+	if total != 1 {
+		t.Fatalf("total = %d, want 1", total)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if len(runs) != 1 || runs[0].FailureReview == nil {
+		t.Fatalf("runs = %#v, want one run with failure review", runs)
+	}
+	if runs[0].FailureReview.FailureFingerprint != "fail-123" {
+		t.Fatalf("FailureFingerprint = %q, want fail-123", runs[0].FailureReview.FailureFingerprint)
+	}
+}
+
 type runFixture struct {
-	vesselID     string
-	source       string
-	workflow     string
-	state        string
-	startedAt    time.Time
-	endedAt      time.Time
-	phases       []runner.PhaseSummary
-	totalInput   int
-	totalOutput  int
-	totalCost    float64
-	manifest     *evidence.Manifest
-	costReport   *cost.CostReport
-	budgetAlerts []cost.BudgetAlert
-	evalReport   *evaluator.LoopResult
+	vesselID      string
+	source        string
+	workflow      string
+	state         string
+	startedAt     time.Time
+	endedAt       time.Time
+	phases        []runner.PhaseSummary
+	totalInput    int
+	totalOutput   int
+	totalCost     float64
+	manifest      *evidence.Manifest
+	costReport    *cost.CostReport
+	budgetAlerts  []cost.BudgetAlert
+	evalReport    *evaluator.LoopResult
+	failureReview *recovery.FailureReview
 }
 
 func writeRunArtifacts(t *testing.T, stateDir string, fixture runFixture) {
@@ -281,7 +324,16 @@ func writeRunArtifacts(t *testing.T, stateDir string, fixture runFixture) {
 		summary.BudgetAlertsPath = filepath.ToSlash(filepath.Join("phases", fixture.vesselID, "budget-alerts.json"))
 		artifacts.BudgetAlerts = summary.BudgetAlertsPath
 	}
-	if artifacts.EvidenceManifest != "" || artifacts.CostReport != "" || artifacts.BudgetAlerts != "" || artifacts.EvalReport != "" {
+	if fixture.failureReview != nil {
+		reviewDoc := *fixture.failureReview
+		reviewDoc.VesselID = fixture.vesselID
+		if err := recovery.SaveFailureReview(stateDir, &reviewDoc); err != nil {
+			t.Fatalf("SaveFailureReview() error = %v", err)
+		}
+		summary.FailureReviewPath = filepath.ToSlash(filepath.Join("phases", fixture.vesselID, recovery.FailureReviewFileName))
+		artifacts.FailureReview = summary.FailureReviewPath
+	}
+	if artifacts.EvidenceManifest != "" || artifacts.CostReport != "" || artifacts.BudgetAlerts != "" || artifacts.EvalReport != "" || artifacts.FailureReview != "" {
 		summary.ReviewArtifacts = artifacts
 	}
 	requireSummaryOnly(t, stateDir, summary)

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/orchestrator"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/surface"
@@ -1424,8 +1425,19 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 		reviewArtifacts.EvalReport = summary.EvalReportPath
 	}
 
+	if state == string(queue.StateFailed) || state == string(queue.StateTimedOut) {
+		failureReview := r.buildFailureReview(vessel, summary, now)
+		if err := recovery.SaveFailureReview(r.Config.StateDir, failureReview); err != nil {
+			log.Printf("warn: save failure review: %v", err)
+		} else {
+			summary.FailureReviewPath = recovery.FailureReviewRelativePath(vessel.ID)
+			reviewArtifacts.FailureReview = summary.FailureReviewPath
+		}
+	}
+
 	if reviewArtifacts.EvidenceManifest != "" || reviewArtifacts.CostReport != "" ||
-		reviewArtifacts.BudgetAlerts != "" || reviewArtifacts.EvalReport != "" {
+		reviewArtifacts.BudgetAlerts != "" || reviewArtifacts.EvalReport != "" ||
+		reviewArtifacts.FailureReview != "" {
 		summary.ReviewArtifacts = reviewArtifacts
 	}
 
@@ -1434,6 +1446,45 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 	}
 
 	return manifest
+}
+
+func (r *Runner) buildFailureReview(vessel queue.Vessel, summary *VesselSummary, now time.Time) *recovery.FailureReview {
+	evidencePaths := []string{filepath.ToSlash(filepath.Join("phases", vessel.ID, summaryFileName))}
+	for _, path := range []string{
+		summary.EvidenceManifestPath,
+		summary.CostReportPath,
+		summary.BudgetAlertsPath,
+		summary.EvalReportPath,
+	} {
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		evidencePaths = append(evidencePaths, path)
+	}
+
+	hypothesis := strings.TrimSpace(vessel.Error)
+	if hypothesis == "" {
+		hypothesis = strings.TrimSpace(vessel.GateOutput)
+	}
+
+	return &recovery.FailureReview{
+		VesselID:           vessel.ID,
+		FailureFingerprint: recovery.FailureFingerprint(vessel),
+		SourceRef:          vessel.Ref,
+		Workflow:           vessel.Workflow,
+		FailedPhase:        vessel.FailedPhase,
+		Class:              "unknown",
+		RecommendedAction:  "retry",
+		RetryCount:         recovery.RetryCountFromVessel(vessel),
+		RetryCap:           2,
+		EvidencePaths:      evidencePaths,
+		Hypothesis:         hypothesis,
+		Unlock: recovery.UnlockFingerprint{
+			SourceInputFingerprint: vessel.Meta["source_input_fingerprint"],
+			HarnessDigest:          recovery.CurrentHarnessDigest(),
+			WorkflowDigest:         recovery.CurrentWorkflowDigest(vessel.Workflow),
+		},
+	}
 }
 
 func saveJSONArtifact(path string, value any) error {

--- a/cli/internal/runner/summary.go
+++ b/cli/internal/runner/summary.go
@@ -52,6 +52,7 @@ type VesselSummary struct {
 	CostReportPath       string           `json:"cost_report_path,omitempty"`
 	BudgetAlertsPath     string           `json:"budget_alerts_path,omitempty"`
 	EvalReportPath       string           `json:"eval_report_path,omitempty"`
+	FailureReviewPath    string           `json:"failure_review_path,omitempty"`
 	Trace                *TraceArtifacts  `json:"trace,omitempty"`
 	ReviewArtifacts      *ReviewArtifacts `json:"review_artifacts,omitempty"`
 
@@ -68,6 +69,7 @@ type ReviewArtifacts struct {
 	CostReport       string `json:"cost_report,omitempty"`
 	BudgetAlerts     string `json:"budget_alerts,omitempty"`
 	EvalReport       string `json:"eval_report,omitempty"`
+	FailureReview    string `json:"failure_review,omitempty"`
 }
 
 // PhaseSummary records the outcome of a single phase.
@@ -288,6 +290,10 @@ func budgetAlertsRelativePath(vesselID string) string {
 
 func evalReportRelativePath(vesselID string) string {
 	return filepath.ToSlash(filepath.Join("phases", vesselID, evalReportFileName))
+}
+
+func failureReviewRelativePath(vesselID string) string {
+	return filepath.ToSlash(filepath.Join("phases", vesselID, "failure-review.json"))
 }
 
 func phaseArtifactRelativePath(vesselID, phaseName string) string {

--- a/cli/internal/runner/summary_test.go
+++ b/cli/internal/runner/summary_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
@@ -497,6 +498,38 @@ func TestSmoke_S18b_PersistRunArtifactsLinksExistingEvalReport(t *testing.T) {
 	assert.Equal(t, evalReportRelativePath(vessel.ID), summary.EvalReportPath)
 	require.NotNil(t, summary.ReviewArtifacts)
 	assert.Equal(t, summary.EvalReportPath, summary.ReviewArtifacts.EvalReport)
+}
+
+func TestSmoke_S18c_PersistRunArtifactsWritesFailureReviewForFailedRuns(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem-state")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".xylem", "workflows"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem", "HARNESS.md"), []byte("follow the harness"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem", "workflows", "fix-bug.yaml"), []byte("name: fix-bug\nphases:\n  - name: implement\n    prompt_file: .xylem/prompts/fix-bug/implement.md\n    max_turns: 5\n"), 0o644))
+
+	startedAt := time.Date(2026, time.April, 8, 20, 33, 0, 0, time.UTC)
+	vessel := runningSmokeVessel("vessel-failure-review", "github", "fix-bug", startedAt)
+	vessel.Error = "network timeout"
+	vessel.FailedPhase = "implement"
+	vessel.Meta = map[string]string{"source_input_fingerprint": "src-123"}
+
+	r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{}, &mockCmdRunner{})
+	r.persistRunArtifacts(vessel, string(queue.StateFailed), newVesselRunState(cfg, vessel, startedAt), nil, startedAt.Add(time.Second))
+
+	summary := loadSummary(t, cfg.StateDir, vessel.ID)
+	assert.Equal(t, failureReviewRelativePath(vessel.ID), summary.FailureReviewPath)
+	require.NotNil(t, summary.ReviewArtifacts)
+	assert.Equal(t, summary.FailureReviewPath, summary.ReviewArtifacts.FailureReview)
+
+	reviewDoc, err := recovery.LoadFailureReview(cfg.StateDir, vessel.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "retry", reviewDoc.RecommendedAction)
+	assert.Equal(t, 2, reviewDoc.RetryCap)
+	assert.Equal(t, "src-123", reviewDoc.Unlock.SourceInputFingerprint)
+	assert.NotEmpty(t, reviewDoc.RemediationFingerprint)
 }
 
 func TestSmoke_S19_FailurePathBuildsSummaryWithStateFailedAndCallsSaveVesselSummary(t *testing.T) {

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -95,6 +95,7 @@ func (s *Scanner) buildSources() []sourceEntry {
 			entries = append(entries, sourceEntry{
 				src: &source.GitHub{
 					Repo:      srcCfg.Repo,
+					StateDir:  s.Config.StateDir,
 					Tasks:     tasks,
 					Exclude:   srcCfg.Exclude,
 					Queue:     s.Queue,
@@ -107,6 +108,7 @@ func (s *Scanner) buildSources() []sourceEntry {
 			entries = append(entries, sourceEntry{
 				src: &source.GitHubPR{
 					Repo:      srcCfg.Repo,
+					StateDir:  s.Config.StateDir,
 					Tasks:     tasks,
 					Exclude:   srcCfg.Exclude,
 					Queue:     s.Queue,

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -26,6 +26,7 @@ type GitHubTask struct {
 // GitHub scans GitHub issues and produces vessels.
 type GitHub struct {
 	Repo      string
+	StateDir  string
 	Tasks     map[string]GitHubTask
 	Exclude   []string
 	Queue     *queue.Queue
@@ -79,9 +80,17 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					continue
 				}
 				fingerprint := githubSourceFingerprint(issue.Title, issue.Body, issueLabelNames(issue.Labels))
+				prior, err := g.latestVesselForRef(issue.URL)
+				if err != nil {
+					return vessels, err
+				}
+				decision, err := g.reenqueueDecision(prior, fingerprint)
+				if err != nil {
+					return vessels, err
+				}
 				if g.hasExcludedLabel(issue, excludeSet) ||
 					g.Queue.HasRef(issue.URL) ||
-					g.hasMatchingFailedFingerprint(issue.URL, fingerprint) ||
+					decision.Block ||
 					g.hasBranch(ctx, issue.Number) ||
 					g.hasOpenPR(ctx, issue.Number) ||
 					g.hasMergedPR(ctx, issue.Number) {
@@ -103,6 +112,7 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					// consistent with its workflow state.
 					"trigger_label": label,
 				}
+				applyRecoveryMeta(meta, decision)
 				sl := task.StatusLabels
 				if sl != nil {
 					meta["status_label_queued"] = sl.Queued
@@ -116,14 +126,21 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					meta["label_gate_label_waiting"] = lgl.Waiting
 					meta["label_gate_label_ready"] = lgl.Ready
 				}
+				vesselID := fmt.Sprintf("issue-%d", issue.Number)
+				retryOf := ""
+				if decision.Parent != nil {
+					vesselID = decision.NextID
+					retryOf = decision.Parent.ID
+				}
 				vessels = append(vessels, queue.Vessel{
-					ID:        fmt.Sprintf("issue-%d", issue.Number),
+					ID:        vesselID,
 					Source:    "github-issue",
 					Ref:       issue.URL,
 					Workflow:  task.Workflow,
 					Meta:      meta,
 					State:     queue.StatePending,
 					CreatedAt: sourceNow(),
+					RetryOf:   retryOf,
 				})
 			}
 		}
@@ -251,13 +268,15 @@ func sourceNow() time.Time {
 	return now.UTC()
 }
 
-func (g *GitHub) hasMatchingFailedFingerprint(ref, fingerprint string) bool {
+func (g *GitHub) latestVesselForRef(ref string) (*queue.Vessel, error) {
 	latest, err := g.Queue.FindLatestByRef(ref)
-	if err != nil || latest == nil {
-		return false
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("find latest vessel for ref %s: %w", ref, err)
 	}
-	isTerminalFailure := latest.State == queue.StateFailed || latest.State == queue.StateTimedOut
-	return isTerminalFailure && latest.Meta["source_input_fingerprint"] == fingerprint
+	return latest, nil
 }
 
 func issueLabelNames(labels []struct {

--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -13,6 +13,7 @@ import (
 // GitHubPR scans GitHub pull requests and produces vessels.
 type GitHubPR struct {
 	Repo      string
+	StateDir  string
 	Tasks     map[string]GitHubTask
 	Exclude   []string
 	Queue     *queue.Queue
@@ -104,8 +105,16 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					continue
 				}
 				fingerprint := githubSourceFingerprint(pr.Title, pr.Body, issueLabelNames(pr.Labels))
+				prior, err := g.latestVesselForWorkflowRef(pr.URL, task.Workflow)
+				if err != nil {
+					return vessels, err
+				}
+				decision, err := g.reenqueueDecision(prior, fingerprint)
+				if err != nil {
+					return vessels, err
+				}
 				if g.hasExcludedLabel(pr, excludeSet) ||
-					g.isBlockedByPriorVessel(pr.URL, fingerprint, task.Workflow) ||
+					decision.Block ||
 					g.hasBranch(ctx, pr.Number) {
 					continue
 				}
@@ -132,6 +141,7 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					"pr_labels":                strings.Join(issueLabelNames(pr.Labels), ","),
 					"source_input_fingerprint": fingerprint,
 				}
+				applyRecoveryMeta(meta, decision)
 				sl := task.StatusLabels
 				if sl != nil {
 					meta["status_label_queued"] = sl.Queued
@@ -145,14 +155,21 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					meta["label_gate_label_waiting"] = lgl.Waiting
 					meta["label_gate_label_ready"] = lgl.Ready
 				}
+				vesselID := fmt.Sprintf("pr-%d-%s", pr.Number, task.Workflow)
+				retryOf := ""
+				if decision.Parent != nil {
+					vesselID = decision.NextID
+					retryOf = decision.Parent.ID
+				}
 				vessels = append(vessels, queue.Vessel{
-					ID:        fmt.Sprintf("pr-%d-%s", pr.Number, task.Workflow),
+					ID:        vesselID,
 					Source:    "github-pr",
 					Ref:       prWorkflowRef(pr.URL, task.Workflow),
 					Workflow:  task.Workflow,
 					Meta:      meta,
 					State:     queue.StatePending,
 					CreatedAt: sourceNow(),
+					RetryOf:   retryOf,
 				})
 			}
 		}
@@ -295,59 +312,32 @@ func priorVesselBlocksReenqueue(v *queue.Vessel, fingerprint string) bool {
 	switch v.State {
 	case queue.StatePending, queue.StateRunning, queue.StateWaiting:
 		return true
-	case queue.StateFailed:
+	case queue.StateFailed, queue.StateTimedOut:
 		return v.Meta["source_input_fingerprint"] == fingerprint
 	default:
 		return false
 	}
 }
 
-// isBlockedByPriorVessel reports whether a prior vessel already occupies
-// the dedup slot for this (PR URL, workflow) pair and so the scanner
-// should not enqueue a new vessel. It checks the new workflow-qualified
-// ref (`<url>#workflow=<name>`) first; then for backward-compat with
-// queue entries written before refs were qualified, it falls back to
-// the legacy bare-URL ref and only treats a legacy vessel as blocking
-// when it belongs to the SAME workflow as the current task.
-//
-// Blocking conditions:
-//   - A pending/running/waiting vessel at the qualified ref.
-//   - A failed vessel at the qualified ref whose fingerprint equals the
-//     current PR input fingerprint.
-//   - If no qualified vessel exists yet, a legacy bare-URL vessel whose
-//     Workflow matches and is either active (pending/running/waiting)
-//     or terminally failed with a matching fingerprint.
-//
-// Completed/cancelled/timed_out vessels do not block. This is important
-// for resolve-conflicts retries: if a prior vessel completed without
-// actually changing the PR branch and GitHub still reports CONFLICTING,
-// the scanner must be able to enqueue a fresh vessel.
-//
-// Once a qualified-ref vessel exists, it is always newer than any
-// legacy bare-URL vessel for the same PR/workflow and therefore solely
-// determines whether the dedup slot is occupied. Falling back to an
-// older legacy vessel in that case would let stale pre-upgrade state
-// incorrectly block a newer completed/cancelled run.
-//
-// This preserves the dedup guarantees of the pre-qualification scheme for
-// in-flight workflows while allowing distinct workflows over the same PR
-// (e.g., merge-pr and resolve-conflicts) to coexist.
-func (g *GitHubPR) isBlockedByPriorVessel(prURL, fingerprint, workflow string) bool {
+func (g *GitHubPR) latestVesselForWorkflowRef(prURL, workflow string) (*queue.Vessel, error) {
 	qualifiedRef := prWorkflowRef(prURL, workflow)
 	latest, err := g.Queue.FindLatestByRef(qualifiedRef)
 	if err == nil {
-		return priorVesselBlocksReenqueue(latest, fingerprint)
+		return latest, nil
 	}
 	// Backward-compat: legacy queue entries were written with ref = prURL.
 	latest, err = g.Queue.FindLatestByRef(prURL)
 	if err != nil || latest == nil {
-		return false
+		if err != nil && !strings.Contains(err.Error(), "not found") {
+			return nil, fmt.Errorf("find latest vessel for ref %s: %w", prURL, err)
+		}
+		return nil, nil
 	}
 	// Only a legacy vessel belonging to the SAME workflow is blocking.
 	// Otherwise a failed merge-pr vessel would block resolve-conflicts
 	// enqueue for the same PR — the exact regression this fix addresses.
 	if latest.Workflow != workflow {
-		return false
+		return nil, nil
 	}
-	return priorVesselBlocksReenqueue(latest, fingerprint)
+	return latest, nil
 }

--- a/cli/internal/source/github_pr_prop_test.go
+++ b/cli/internal/source/github_pr_prop_test.go
@@ -40,7 +40,7 @@ func TestPropPriorVesselBlocksReenqueueMatchesStateMachine(t *testing.T) {
 		switch state {
 		case queue.StatePending, queue.StateRunning, queue.StateWaiting:
 			want = true
-		case queue.StateFailed:
+		case queue.StateFailed, queue.StateTimedOut:
 			want = match
 		}
 

--- a/cli/internal/source/github_pr_test.go
+++ b/cli/internal/source/github_pr_test.go
@@ -402,7 +402,12 @@ func TestPriorVesselBlocksReenqueue(t *testing.T) {
 		},
 		{name: "completed", vessel: &queue.Vessel{State: queue.StateCompleted}, fingerprint: fingerprint, want: false},
 		{name: "cancelled", vessel: &queue.Vessel{State: queue.StateCancelled}, fingerprint: fingerprint, want: false},
-		{name: "timed out", vessel: &queue.Vessel{State: queue.StateTimedOut}, fingerprint: fingerprint, want: false},
+		{
+			name:        "timed out fingerprint match",
+			vessel:      &queue.Vessel{State: queue.StateTimedOut, Meta: map[string]string{"source_input_fingerprint": fingerprint}},
+			fingerprint: fingerprint,
+			want:        true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cli/internal/source/recovery_gate.go
+++ b/cli/internal/source/recovery_gate.go
@@ -1,0 +1,106 @@
+package source
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
+)
+
+type reenqueueDecision struct {
+	Block  bool
+	Parent *queue.Vessel
+	NextID string
+	Meta   map[string]string
+}
+
+func (g *GitHub) reenqueueDecision(prior *queue.Vessel, fingerprint string) (reenqueueDecision, error) {
+	return evaluateReenqueue(g.Queue, g.StateDir, prior, fingerprint)
+}
+
+func (g *GitHubPR) reenqueueDecision(prior *queue.Vessel, fingerprint string) (reenqueueDecision, error) {
+	return evaluateReenqueue(g.Queue, g.StateDir, prior, fingerprint)
+}
+
+func evaluateReenqueue(q *queue.Queue, stateDir string, prior *queue.Vessel, fingerprint string) (reenqueueDecision, error) {
+	if prior == nil {
+		return reenqueueDecision{}, nil
+	}
+
+	switch prior.State {
+	case queue.StatePending, queue.StateRunning, queue.StateWaiting:
+		return reenqueueDecision{Block: true}, nil
+	case queue.StateFailed, queue.StateTimedOut:
+	default:
+		return reenqueueDecision{}, nil
+	}
+
+	review, err := recovery.LoadFailureReview(stateDir, prior.ID)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return reenqueueDecision{}, fmt.Errorf("load failure review for %s: %w", prior.ID, err)
+		}
+		if prior.Meta["source_input_fingerprint"] == fingerprint {
+			return reenqueueDecision{Block: true}, nil
+		}
+		return newRetryDecision(q, prior, map[string]string{
+			"recovery_unlocked_by": "source",
+		}), nil
+	}
+
+	gate := recovery.EvaluateRetry(
+		review,
+		fingerprint,
+		recovery.CurrentHarnessDigest(),
+		recovery.CurrentWorkflowDigest(prior.Workflow),
+		sourceNow(),
+	)
+	if !gate.Allowed {
+		return reenqueueDecision{Block: true}, nil
+	}
+
+	meta := map[string]string{
+		"recovery_class":          gate.RecoveryClass,
+		"recovery_action":         gate.RecoveryAction,
+		"recovery_unlocked_by":    gate.UnlockedBy,
+		"remediation_fingerprint": gate.CurrentFingerprint,
+		"failure_fingerprint":     gate.FailureFingerprint,
+	}
+	return newRetryDecision(q, prior, meta), nil
+}
+
+func newRetryDecision(q *queue.Queue, prior *queue.Vessel, meta map[string]string) reenqueueDecision {
+	rootID := recovery.RetryRootID(*prior)
+	copied := make(map[string]string, len(meta))
+	for key, value := range meta {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		copied[key] = value
+	}
+	copied["retry_of"] = rootID
+	if _, ok := copied["retry_count"]; !ok {
+		copied["retry_count"] = strconv.Itoa(recovery.RetryCountFromVessel(*prior) + 1)
+	}
+	return reenqueueDecision{
+		Parent: prior,
+		NextID: recovery.RetryID(rootID, q),
+		Meta:   copied,
+	}
+}
+
+func applyRecoveryMeta(meta map[string]string, decision reenqueueDecision) {
+	if len(decision.Meta) == 0 {
+		return
+	}
+	for key, value := range decision.Meta {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		meta[key] = value
+	}
+}

--- a/cli/internal/source/recovery_gate_test.go
+++ b/cli/internal/source/recovery_gate_test.go
@@ -1,0 +1,816 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvaluateReenqueueBackwardCompatibleWithoutFailureReview(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	prior := seedTerminalVessel(t, q, queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      "https://github.com/owner/repo/issues/42",
+		Workflow: "fix-bug",
+		Meta:     map[string]string{"source_input_fingerprint": "source-a"},
+	}, queue.StateFailed)
+
+	blocked, err := evaluateReenqueue(q, filepath.Join(dir, ".xylem-state"), prior, "source-a")
+	if err != nil {
+		t.Fatalf("evaluateReenqueue() error = %v", err)
+	}
+	if !blocked.Block {
+		t.Fatal("Block = false, want true for unchanged legacy failure")
+	}
+
+	allowed, err := evaluateReenqueue(q, filepath.Join(dir, ".xylem-state"), prior, "source-b")
+	if err != nil {
+		t.Fatalf("evaluateReenqueue() error = %v", err)
+	}
+	if allowed.Block {
+		t.Fatal("Block = true, want source unlock")
+	}
+	if allowed.Meta["recovery_unlocked_by"] != "source" {
+		t.Fatalf("recovery_unlocked_by = %q, want source", allowed.Meta["recovery_unlocked_by"])
+	}
+	if allowed.Meta["retry_of"] != prior.ID {
+		t.Fatalf("retry_of = %q, want %q", allowed.Meta["retry_of"], prior.ID)
+	}
+	if allowed.Meta["retry_count"] != "1" {
+		t.Fatalf("retry_count = %q, want 1", allowed.Meta["retry_count"])
+	}
+}
+
+func TestEvaluateReenqueueUnlockDimensions(t *testing.T) {
+	now := time.Date(2026, time.April, 9, 18, 0, 0, 0, time.UTC)
+	past := now.Add(-time.Hour)
+
+	tests := []struct {
+		name         string
+		mutate       func(t *testing.T, controlPlane controlPlanePaths, stateDir, vesselID string)
+		retryAfter   *time.Time
+		wantUnlockBy string
+		wantBlock    bool
+	}{
+		{
+			name: "harness",
+			mutate: func(t *testing.T, paths controlPlanePaths, _ string, _ string) {
+				t.Helper()
+				if err := os.WriteFile(paths.harness, []byte("updated harness"), 0o644); err != nil {
+					t.Fatalf("WriteFile(harness) error = %v", err)
+				}
+			},
+			wantUnlockBy: "harness",
+		},
+		{
+			name: "workflow",
+			mutate: func(t *testing.T, paths controlPlanePaths, _ string, _ string) {
+				t.Helper()
+				if err := os.WriteFile(paths.workflow, []byte("name: fix-bug\nupdated: true\n"), 0o644); err != nil {
+					t.Fatalf("WriteFile(workflow) error = %v", err)
+				}
+			},
+			wantUnlockBy: "workflow",
+		},
+		{
+			name: "decision",
+			mutate: func(t *testing.T, _ controlPlanePaths, stateDir, vesselID string) {
+				t.Helper()
+				path := recovery.FailureReviewPath(stateDir, vesselID)
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("ReadFile(failure-review) error = %v", err)
+				}
+				var reviewDoc recovery.FailureReview
+				if err := json.Unmarshal(data, &reviewDoc); err != nil {
+					t.Fatalf("Unmarshal(failure-review) error = %v", err)
+				}
+				reviewDoc.Hypothesis = "decision changed"
+				updated, err := json.MarshalIndent(&reviewDoc, "", "  ")
+				if err != nil {
+					t.Fatalf("MarshalIndent(failure-review) error = %v", err)
+				}
+				if err := os.WriteFile(path, updated, 0o644); err != nil {
+					t.Fatalf("WriteFile(failure-review) error = %v", err)
+				}
+			},
+			wantUnlockBy: "decision",
+		},
+		{
+			name:         "cooldown",
+			retryAfter:   &past,
+			wantUnlockBy: "cooldown",
+		},
+		{
+			name: "cooldown pending",
+			retryAfter: func() *time.Time {
+				future := now.Add(time.Hour)
+				return &future
+			}(),
+			wantBlock: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Chdir(dir)
+			stateDir := filepath.Join(dir, ".xylem-state")
+			paths := writeControlPlane(t, dir, "fix-bug", "base harness", "name: fix-bug\n")
+			q := queue.New(filepath.Join(dir, "queue.jsonl"))
+			prior := seedTerminalVessel(t, q, queue.Vessel{
+				ID:       "issue-42",
+				Source:   "github-issue",
+				Ref:      "https://github.com/owner/repo/issues/42",
+				Workflow: "fix-bug",
+				Meta:     map[string]string{"source_input_fingerprint": "source-a"},
+			}, queue.StateFailed)
+			reviewDoc := &recovery.FailureReview{
+				VesselID:           prior.ID,
+				SourceRef:          prior.Ref,
+				Workflow:           prior.Workflow,
+				Class:              "unknown",
+				RecommendedAction:  "retry",
+				FailureFingerprint: "fail-123",
+				RetryCap:           2,
+				RetryAfter:         tt.retryAfter,
+				Unlock: recovery.UnlockFingerprint{
+					SourceInputFingerprint: "source-a",
+					HarnessDigest:          recovery.FileDigest(paths.harness),
+					WorkflowDigest:         recovery.FileDigest(paths.workflow),
+				},
+			}
+			if err := recovery.SaveFailureReview(stateDir, reviewDoc); err != nil {
+				t.Fatalf("SaveFailureReview() error = %v", err)
+			}
+			if tt.mutate != nil {
+				tt.mutate(t, paths, stateDir, prior.ID)
+			}
+
+			decision, err := evaluateReenqueue(q, stateDir, prior, "source-a")
+			if err != nil {
+				t.Fatalf("evaluateReenqueue() error = %v", err)
+			}
+			if decision.Block != tt.wantBlock {
+				t.Fatalf("Block = %v, want %v", decision.Block, tt.wantBlock)
+			}
+			if !tt.wantBlock {
+				if decision.Meta["recovery_unlocked_by"] != tt.wantUnlockBy {
+					t.Fatalf("recovery_unlocked_by = %q, want %q", decision.Meta["recovery_unlocked_by"], tt.wantUnlockBy)
+				}
+				if decision.Meta["recovery_action"] != "retry" {
+					t.Fatalf("recovery_action = %q, want retry", decision.Meta["recovery_action"])
+				}
+				if decision.Meta["recovery_class"] != "unknown" {
+					t.Fatalf("recovery_class = %q, want unknown", decision.Meta["recovery_class"])
+				}
+				if decision.Meta["failure_fingerprint"] != "fail-123" {
+					t.Fatalf("failure_fingerprint = %q, want fail-123", decision.Meta["failure_fingerprint"])
+				}
+				if decision.Meta["remediation_fingerprint"] == "" {
+					t.Fatal("remediation_fingerprint = empty, want propagated fingerprint")
+				}
+				if decision.Meta["retry_of"] != prior.ID {
+					t.Fatalf("retry_of = %q, want %q", decision.Meta["retry_of"], prior.ID)
+				}
+				if decision.Meta["retry_count"] != "1" {
+					t.Fatalf("retry_count = %q, want 1", decision.Meta["retry_count"])
+				}
+				if decision.Parent == nil || decision.Parent.ID != prior.ID {
+					t.Fatalf("Parent = %#v, want %s", decision.Parent, prior.ID)
+				}
+				if decision.NextID != "issue-42-retry-1" {
+					t.Fatalf("NextID = %q, want issue-42-retry-1", decision.NextID)
+				}
+			}
+		})
+	}
+}
+
+func TestGitHubScanCreatesRetryVesselWithRecoveryLineage(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	stateDir := filepath.Join(dir, ".xylem-state")
+	paths := writeControlPlane(t, dir, "fix-bug", "base harness", "name: fix-bug\n")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{{
+		Number: 42,
+		Title:  "retry me",
+		Body:   "body",
+		URL:    "https://github.com/owner/repo/issues/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}},
+	}}
+	issueBytes, err := json.Marshal(issues)
+	if err != nil {
+		t.Fatalf("Marshal(issues) error = %v", err)
+	}
+	r.set(issueBytes, "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+
+	prior := seedTerminalVessel(t, q, queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      issues[0].URL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": githubSourceFingerprint("retry me", "body", []string{"bug"}),
+		},
+	}, queue.StateFailed)
+	reviewDoc := &recovery.FailureReview{
+		VesselID:           prior.ID,
+		SourceRef:          prior.Ref,
+		Workflow:           prior.Workflow,
+		Class:              "unknown",
+		RecommendedAction:  "retry",
+		FailureFingerprint: "fail-123",
+		RetryCap:           2,
+		Unlock: recovery.UnlockFingerprint{
+			SourceInputFingerprint: prior.Meta["source_input_fingerprint"],
+			HarnessDigest:          recovery.FileDigest(paths.harness),
+			WorkflowDigest:         recovery.FileDigest(paths.workflow),
+		},
+	}
+	if err := recovery.SaveFailureReview(stateDir, reviewDoc); err != nil {
+		t.Fatalf("SaveFailureReview() error = %v", err)
+	}
+	if err := os.WriteFile(paths.harness, []byte("updated harness"), 0o644); err != nil {
+		t.Fatalf("WriteFile(harness) error = %v", err)
+	}
+
+	src := &GitHub{
+		Repo:      "owner/repo",
+		StateDir:  stateDir,
+		Tasks:     map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("len(vessels) = %d, want 1", len(vessels))
+	}
+	if vessels[0].RetryOf != "issue-42" {
+		t.Fatalf("RetryOf = %q, want issue-42", vessels[0].RetryOf)
+	}
+	if vessels[0].Meta["retry_of"] != "issue-42" {
+		t.Fatalf("retry_of = %q, want issue-42", vessels[0].Meta["retry_of"])
+	}
+	if vessels[0].Meta["retry_count"] != "1" {
+		t.Fatalf("retry_count = %q, want 1", vessels[0].Meta["retry_count"])
+	}
+	if vessels[0].Meta["recovery_unlocked_by"] != "harness" {
+		t.Fatalf("recovery_unlocked_by = %q, want harness", vessels[0].Meta["recovery_unlocked_by"])
+	}
+	if vessels[0].Meta["recovery_action"] != "retry" {
+		t.Fatalf("recovery_action = %q, want retry", vessels[0].Meta["recovery_action"])
+	}
+	if vessels[0].Meta["recovery_class"] != "unknown" {
+		t.Fatalf("recovery_class = %q, want unknown", vessels[0].Meta["recovery_class"])
+	}
+	if vessels[0].Meta["failure_fingerprint"] != "fail-123" {
+		t.Fatalf("failure_fingerprint = %q, want fail-123", vessels[0].Meta["failure_fingerprint"])
+	}
+	if vessels[0].Meta["remediation_fingerprint"] == "" {
+		t.Fatal("remediation_fingerprint = empty, want populated")
+	}
+}
+
+func TestGitHubPRScanCreatesRetryVesselWithRecoveryLineage(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	stateDir := filepath.Join(dir, ".xylem-state")
+	paths := writeControlPlane(t, dir, "review-pr", "base harness", "name: review-pr\n")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{{
+		Number: 42,
+		Title:  "review me",
+		Body:   "body",
+		URL:    "https://github.com/owner/repo/pull/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "review-me"}},
+	}}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+
+	prior := seedTerminalVessel(t, q, queue.Vessel{
+		ID:       "pr-42-review-pr",
+		Source:   "github-pr",
+		Ref:      prWorkflowRef(prs[0].URL, "review-pr"),
+		Workflow: "review-pr",
+		Meta: map[string]string{
+			"pr_num":                   "42",
+			"source_input_fingerprint": githubSourceFingerprint("review me", "body", []string{"review-me"}),
+		},
+	}, queue.StateFailed)
+	reviewDoc := &recovery.FailureReview{
+		VesselID:           prior.ID,
+		SourceRef:          prior.Ref,
+		Workflow:           prior.Workflow,
+		Class:              "unknown",
+		RecommendedAction:  "retry",
+		FailureFingerprint: "fail-123",
+		RetryCap:           2,
+		Unlock: recovery.UnlockFingerprint{
+			SourceInputFingerprint: prior.Meta["source_input_fingerprint"],
+			HarnessDigest:          recovery.FileDigest(paths.harness),
+			WorkflowDigest:         recovery.FileDigest(paths.workflow),
+		},
+	}
+	if err := recovery.SaveFailureReview(stateDir, reviewDoc); err != nil {
+		t.Fatalf("SaveFailureReview() error = %v", err)
+	}
+	if err := os.WriteFile(paths.harness, []byte("updated harness"), 0o644); err != nil {
+		t.Fatalf("WriteFile(harness) error = %v", err)
+	}
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		StateDir:  stateDir,
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("len(vessels) = %d, want 1", len(vessels))
+	}
+	if vessels[0].RetryOf != "pr-42-review-pr" {
+		t.Fatalf("RetryOf = %q, want pr-42-review-pr", vessels[0].RetryOf)
+	}
+	if vessels[0].Meta["retry_of"] != "pr-42-review-pr" {
+		t.Fatalf("retry_of = %q, want pr-42-review-pr", vessels[0].Meta["retry_of"])
+	}
+	if vessels[0].Meta["retry_count"] != "1" {
+		t.Fatalf("retry_count = %q, want 1", vessels[0].Meta["retry_count"])
+	}
+	if vessels[0].Meta["recovery_unlocked_by"] != "harness" {
+		t.Fatalf("recovery_unlocked_by = %q, want harness", vessels[0].Meta["recovery_unlocked_by"])
+	}
+	if vessels[0].Meta["recovery_action"] != "retry" {
+		t.Fatalf("recovery_action = %q, want retry", vessels[0].Meta["recovery_action"])
+	}
+	if vessels[0].Meta["recovery_class"] != "unknown" {
+		t.Fatalf("recovery_class = %q, want unknown", vessels[0].Meta["recovery_class"])
+	}
+	if vessels[0].Meta["failure_fingerprint"] != "fail-123" {
+		t.Fatalf("failure_fingerprint = %q, want fail-123", vessels[0].Meta["failure_fingerprint"])
+	}
+	if vessels[0].Meta["remediation_fingerprint"] == "" {
+		t.Fatal("remediation_fingerprint = empty, want populated")
+	}
+}
+
+func TestEvaluateReenqueueContinuesRetrySequenceFromOriginalRoot(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	prior := seedTerminalVessel(t, q, queue.Vessel{
+		ID:       "issue-42-retry-1",
+		Source:   "github-issue",
+		Ref:      "https://github.com/owner/repo/issues/42",
+		Workflow: "fix-bug",
+		RetryOf:  "issue-42",
+		Meta: map[string]string{
+			"retry_of":                 "issue-42",
+			"retry_count":              "1",
+			"source_input_fingerprint": "source-a",
+		},
+	}, queue.StateFailed)
+
+	decision, err := evaluateReenqueue(q, filepath.Join(dir, ".xylem-state"), prior, "source-b")
+	if err != nil {
+		t.Fatalf("evaluateReenqueue() error = %v", err)
+	}
+	if decision.NextID != "issue-42-retry-2" {
+		t.Fatalf("NextID = %q, want issue-42-retry-2", decision.NextID)
+	}
+	if decision.Meta["retry_of"] != "issue-42" {
+		t.Fatalf("retry_of = %q, want issue-42", decision.Meta["retry_of"])
+	}
+	if decision.Meta["retry_count"] != "2" {
+		t.Fatalf("retry_count = %q, want 2", decision.Meta["retry_count"])
+	}
+}
+
+func TestSmoke_S1_TransientFailureRetriesOnceCooldownExpires(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	stateDir := filepath.Join(dir, ".xylem-state")
+	paths := writeControlPlane(t, dir, "fix-bug", "base harness", "name: fix-bug\n")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	prior := seedTerminalVessel(t, q, queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      "https://github.com/owner/repo/issues/42",
+		Workflow: "fix-bug",
+		Meta:     map[string]string{"source_input_fingerprint": "source-a"},
+	}, queue.StateFailed)
+
+	retryAfter := time.Now().UTC().Add(-time.Hour)
+	reviewDoc := &recovery.FailureReview{
+		VesselID:           prior.ID,
+		SourceRef:          prior.Ref,
+		Workflow:           prior.Workflow,
+		Class:              "transient",
+		RecommendedAction:  "retry",
+		FailureFingerprint: "fail-123",
+		RetryCap:           2,
+		RetryAfter:         &retryAfter,
+		Unlock: recovery.UnlockFingerprint{
+			SourceInputFingerprint: "source-a",
+			HarnessDigest:          recovery.FileDigest(paths.harness),
+			WorkflowDigest:         recovery.FileDigest(paths.workflow),
+		},
+	}
+	require.NoError(t, recovery.SaveFailureReview(stateDir, reviewDoc))
+
+	decision, err := evaluateReenqueue(q, stateDir, prior, "source-a")
+	require.NoError(t, err)
+
+	assert.False(t, decision.Block)
+	require.NotNil(t, decision.Parent)
+	assert.Equal(t, prior.ID, decision.Parent.ID)
+	assert.Equal(t, "issue-42-retry-1", decision.NextID)
+	assert.Equal(t, "retry", decision.Meta["recovery_action"])
+	assert.Equal(t, "transient", decision.Meta["recovery_class"])
+	assert.Equal(t, "cooldown", decision.Meta["recovery_unlocked_by"])
+	assert.Equal(t, "fail-123", decision.Meta["failure_fingerprint"])
+	assert.Equal(t, prior.ID, decision.Meta["retry_of"])
+	assert.Equal(t, "1", decision.Meta["retry_count"])
+	assert.NotEmpty(t, decision.Meta["remediation_fingerprint"])
+}
+
+func TestSmoke_S2_HarnessChangeUnlocksRetryWithoutSourceEdit(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	stateDir := filepath.Join(dir, ".xylem-state")
+	paths := writeControlPlane(t, dir, "fix-bug", "base harness", "name: fix-bug\n")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{{
+		Number: 42,
+		Title:  "retry me",
+		Body:   "body",
+		URL:    "https://github.com/owner/repo/issues/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}},
+	}}
+	issueBytes, err := json.Marshal(issues)
+	require.NoError(t, err)
+	r.set(issueBytes, "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+
+	sourceFingerprint := githubSourceFingerprint("retry me", "body", []string{"bug"})
+	prior := seedTerminalVessel(t, q, queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      issues[0].URL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": sourceFingerprint,
+		},
+	}, queue.StateFailed)
+	reviewDoc := &recovery.FailureReview{
+		VesselID:           prior.ID,
+		SourceRef:          prior.Ref,
+		Workflow:           prior.Workflow,
+		Class:              "harness_gap",
+		RecommendedAction:  "retry",
+		FailureFingerprint: "fail-123",
+		RetryCap:           2,
+		Unlock: recovery.UnlockFingerprint{
+			SourceInputFingerprint: sourceFingerprint,
+			HarnessDigest:          recovery.FileDigest(paths.harness),
+			WorkflowDigest:         recovery.FileDigest(paths.workflow),
+		},
+	}
+	require.NoError(t, recovery.SaveFailureReview(stateDir, reviewDoc))
+	require.NoError(t, os.WriteFile(paths.harness, []byte("updated harness"), 0o644))
+
+	src := &GitHub{
+		Repo:      "owner/repo",
+		StateDir:  stateDir,
+		Tasks:     map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+
+	assert.Equal(t, "issue-42-retry-1", vessels[0].ID)
+	assert.Equal(t, queue.StatePending, vessels[0].State)
+	assert.Equal(t, prior.ID, vessels[0].RetryOf)
+	assert.Equal(t, sourceFingerprint, vessels[0].Meta["source_input_fingerprint"])
+	assert.Equal(t, "retry", vessels[0].Meta["recovery_action"])
+	assert.Equal(t, "harness_gap", vessels[0].Meta["recovery_class"])
+	assert.Equal(t, "harness", vessels[0].Meta["recovery_unlocked_by"])
+	assert.Equal(t, "fail-123", vessels[0].Meta["failure_fingerprint"])
+	assert.Equal(t, prior.ID, vessels[0].Meta["retry_of"])
+	assert.Equal(t, "1", vessels[0].Meta["retry_count"])
+	assert.NotEmpty(t, vessels[0].Meta["remediation_fingerprint"])
+}
+
+func TestSmoke_S3_WorkflowChangeUnlocksRetryWithoutSourceEdit(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	stateDir := filepath.Join(dir, ".xylem-state")
+	paths := writeControlPlane(t, dir, "fix-bug", "base harness", "name: fix-bug\n")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{{
+		Number: 42,
+		Title:  "retry me",
+		Body:   "body",
+		URL:    "https://github.com/owner/repo/issues/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}},
+	}}
+	issueBytes, err := json.Marshal(issues)
+	require.NoError(t, err)
+	r.set(issueBytes, "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+
+	sourceFingerprint := githubSourceFingerprint("retry me", "body", []string{"bug"})
+	prior := seedTerminalVessel(t, q, queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      issues[0].URL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": sourceFingerprint,
+		},
+	}, queue.StateFailed)
+	reviewDoc := &recovery.FailureReview{
+		VesselID:           prior.ID,
+		SourceRef:          prior.Ref,
+		Workflow:           prior.Workflow,
+		Class:              "workflow_gap",
+		RecommendedAction:  "retry",
+		FailureFingerprint: "fail-123",
+		RetryCap:           2,
+		Unlock: recovery.UnlockFingerprint{
+			SourceInputFingerprint: sourceFingerprint,
+			HarnessDigest:          recovery.FileDigest(paths.harness),
+			WorkflowDigest:         recovery.FileDigest(paths.workflow),
+		},
+	}
+	require.NoError(t, recovery.SaveFailureReview(stateDir, reviewDoc))
+	require.NoError(t, os.WriteFile(paths.workflow, []byte("name: fix-bug\nupdated: true\n"), 0o644))
+
+	src := &GitHub{
+		Repo:      "owner/repo",
+		StateDir:  stateDir,
+		Tasks:     map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+
+	assert.Equal(t, "issue-42-retry-1", vessels[0].ID)
+	assert.Equal(t, prior.ID, vessels[0].RetryOf)
+	assert.Equal(t, sourceFingerprint, vessels[0].Meta["source_input_fingerprint"])
+	assert.Equal(t, "retry", vessels[0].Meta["recovery_action"])
+	assert.Equal(t, "workflow_gap", vessels[0].Meta["recovery_class"])
+	assert.Equal(t, "workflow", vessels[0].Meta["recovery_unlocked_by"])
+	assert.Equal(t, "fail-123", vessels[0].Meta["failure_fingerprint"])
+	assert.Equal(t, prior.ID, vessels[0].Meta["retry_of"])
+	assert.Equal(t, "1", vessels[0].Meta["retry_count"])
+	assert.NotEmpty(t, vessels[0].Meta["remediation_fingerprint"])
+}
+
+func TestSmoke_S4_AmbiguousRepeatedFailureStaysBlockedUntilDecisionChange(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	stateDir := filepath.Join(dir, ".xylem-state")
+	paths := writeControlPlane(t, dir, "fix-bug", "base harness", "name: fix-bug\n")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{{
+		Number: 42,
+		Title:  "retry me",
+		Body:   "body",
+		URL:    "https://github.com/owner/repo/issues/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}},
+	}}
+	issueBytes, err := json.Marshal(issues)
+	require.NoError(t, err)
+	r.set(issueBytes, "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+
+	sourceFingerprint := githubSourceFingerprint("retry me", "body", []string{"bug"})
+	prior := seedTerminalVessel(t, q, queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      issues[0].URL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": sourceFingerprint,
+		},
+	}, queue.StateFailed)
+	reviewDoc := &recovery.FailureReview{
+		VesselID:                prior.ID,
+		SourceRef:               prior.Ref,
+		Workflow:                prior.Workflow,
+		Class:                   "unknown",
+		RecommendedAction:       "retry",
+		FailureFingerprint:      "fail-123",
+		RetryCap:                2,
+		RequiresDecisionRefresh: true,
+		Hypothesis:              "initial hypothesis",
+		Unlock: recovery.UnlockFingerprint{
+			SourceInputFingerprint: sourceFingerprint,
+			HarnessDigest:          recovery.FileDigest(paths.harness),
+			WorkflowDigest:         recovery.FileDigest(paths.workflow),
+		},
+	}
+	require.NoError(t, recovery.SaveFailureReview(stateDir, reviewDoc))
+
+	src := &GitHub{
+		Repo:      "owner/repo",
+		StateDir:  stateDir,
+		Tasks:     map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, vessels)
+
+	reviewPath := recovery.FailureReviewPath(stateDir, prior.ID)
+	data, err := os.ReadFile(reviewPath)
+	require.NoError(t, err)
+
+	var updated recovery.FailureReview
+	require.NoError(t, json.Unmarshal(data, &updated))
+	updated.Hypothesis = "refined hypothesis"
+
+	rewritten, err := json.MarshalIndent(&updated, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(reviewPath, rewritten, 0o644))
+
+	vessels, err = src.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+
+	assert.Equal(t, "issue-42-retry-1", vessels[0].ID)
+	assert.Equal(t, prior.ID, vessels[0].RetryOf)
+	assert.Equal(t, "decision", vessels[0].Meta["recovery_unlocked_by"])
+	assert.Equal(t, "retry", vessels[0].Meta["recovery_action"])
+	assert.Equal(t, "unknown", vessels[0].Meta["recovery_class"])
+	assert.Equal(t, prior.ID, vessels[0].Meta["retry_of"])
+	assert.Equal(t, "1", vessels[0].Meta["retry_count"])
+	assert.NotEmpty(t, vessels[0].Meta["remediation_fingerprint"])
+}
+
+func TestSmoke_S5_PRScannerAppliesRemediationAwareRetryUnlocks(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	stateDir := filepath.Join(dir, ".xylem-state")
+	paths := writeControlPlane(t, dir, "review-pr", "base harness", "name: review-pr\n")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{{
+		Number: 42,
+		Title:  "review me",
+		Body:   "body",
+		URL:    "https://github.com/owner/repo/pull/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "review-me"}},
+	}}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+
+	sourceFingerprint := githubSourceFingerprint("review me", "body", []string{"review-me"})
+	prior := seedTerminalVessel(t, q, queue.Vessel{
+		ID:       "pr-42-review-pr",
+		Source:   "github-pr",
+		Ref:      prWorkflowRef(prs[0].URL, "review-pr"),
+		Workflow: "review-pr",
+		Meta: map[string]string{
+			"pr_num":                   "42",
+			"source_input_fingerprint": sourceFingerprint,
+		},
+	}, queue.StateFailed)
+	reviewDoc := &recovery.FailureReview{
+		VesselID:           prior.ID,
+		SourceRef:          prior.Ref,
+		Workflow:           prior.Workflow,
+		Class:              "harness_gap",
+		RecommendedAction:  "retry",
+		FailureFingerprint: "fail-123",
+		RetryCap:           2,
+		Unlock: recovery.UnlockFingerprint{
+			SourceInputFingerprint: sourceFingerprint,
+			HarnessDigest:          recovery.FileDigest(paths.harness),
+			WorkflowDigest:         recovery.FileDigest(paths.workflow),
+		},
+	}
+	require.NoError(t, recovery.SaveFailureReview(stateDir, reviewDoc))
+	require.NoError(t, os.WriteFile(paths.harness, []byte("updated harness"), 0o644))
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		StateDir:  stateDir,
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+
+	assert.Equal(t, "pr-42-review-pr-retry-1", vessels[0].ID)
+	assert.Equal(t, queue.StatePending, vessels[0].State)
+	assert.Equal(t, prior.ID, vessels[0].RetryOf)
+	assert.Equal(t, sourceFingerprint, vessels[0].Meta["source_input_fingerprint"])
+	assert.Equal(t, "retry", vessels[0].Meta["recovery_action"])
+	assert.Equal(t, "harness_gap", vessels[0].Meta["recovery_class"])
+	assert.Equal(t, "harness", vessels[0].Meta["recovery_unlocked_by"])
+	assert.Equal(t, "fail-123", vessels[0].Meta["failure_fingerprint"])
+	assert.Equal(t, prior.ID, vessels[0].Meta["retry_of"])
+	assert.Equal(t, "1", vessels[0].Meta["retry_count"])
+	assert.NotEmpty(t, vessels[0].Meta["remediation_fingerprint"])
+}
+
+type controlPlanePaths struct {
+	harness  string
+	workflow string
+}
+
+func writeControlPlane(t *testing.T, dir, workflowName, harnessContent, workflowContent string) controlPlanePaths {
+	t.Helper()
+	harnessPath := filepath.Join(dir, ".xylem", "HARNESS.md")
+	workflowPath := filepath.Join(dir, ".xylem", "workflows", workflowName+".yaml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(workflow) error = %v", err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(harnessContent), 0o644); err != nil {
+		t.Fatalf("WriteFile(harness) error = %v", err)
+	}
+	if err := os.WriteFile(workflowPath, []byte(workflowContent), 0o644); err != nil {
+		t.Fatalf("WriteFile(workflow) error = %v", err)
+	}
+	return controlPlanePaths{harness: harnessPath, workflow: workflowPath}
+}
+
+func seedTerminalVessel(t *testing.T, q *queue.Queue, vessel queue.Vessel, state queue.VesselState) *queue.Vessel {
+	t.Helper()
+	vessel.State = queue.StatePending
+	vessel.CreatedAt = time.Now().UTC()
+	if _, err := q.Enqueue(vessel); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	if _, err := q.Dequeue(); err != nil {
+		t.Fatalf("Dequeue() error = %v", err)
+	}
+	if err := q.Update(vessel.ID, state, "boom"); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	found, err := q.FindByID(vessel.ID)
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	return found
+}


### PR DESCRIPTION
## Summary

Implements [issue #213](https://github.com/nicholls-inc/xylem/issues/213) by making scanner re-enqueue of failed and timed-out vessels remediation-aware instead of source-diff-only. Failed runs now persist a failure-review artifact with remediation fingerprints, and GitHub issue/PR sources only mint retry vessels when source, harness, workflow, decision, or cooldown state has actually unlocked a retry.

## Smoke scenarios covered

- S2 — Harness change unlocks retry without source edit
- S3 — Workflow change unlocks retry without source edit
- S5 — PR scanner applies remediation-aware retry unlocks
- S18c — Persist run artifacts writes failure review for failed runs

## Changes summary

- **Added** `cli/internal/recovery/recovery.go`, `cli/internal/recovery/recovery_test.go`, `cli/internal/recovery/recovery_prop_test.go` with `FailureReview`, `UnlockFingerprint`, `RetryGateResult`, `EvaluateRetry`, remediation fingerprint helpers, and retry lineage helpers.
- **Added** `cli/internal/source/recovery_gate.go`, `cli/internal/source/recovery_gate_test.go` to evaluate prior failed vessels, load failure reviews, compute retry metadata, and issue remediation-aware retry IDs for both GitHub issue and PR sources.
- **Modified** `cli/internal/source/github.go` and `cli/internal/source/github_pr.go` to stamp `source_input_fingerprint`, qualify PR refs by workflow, propagate recovery metadata onto retry vessels, and preserve retry lineage through `RetryOf` and `retry_count` metadata.
- **Modified** `cli/internal/scanner/scanner.go` so GitHub and GitHub PR sources receive `StateDir`, allowing scanners to consult persisted failure-review artifacts during re-enqueue decisions.
- **Modified** `cli/internal/runner/runner.go` and `cli/internal/runner/summary.go` so failed/timed-out runs write `failure-review.json`, expose `FailureReviewPath`, and include the artifact in `ReviewArtifacts` and persisted vessel summaries.
- **Modified** `cli/internal/review/load.go` and `cli/internal/review/review_test.go` so retrospective review loading resolves and deserializes the new failure-review artifact alongside existing evidence, cost, budget, and eval artifacts.
- **Modified** `cli/internal/runner/summary_test.go`, `cli/internal/source/github_pr_test.go`, `cli/internal/source/github_pr_prop_test.go`, and related scanner/source tests to cover unchanged-failure blocking, remediation unlock paths, retry sequencing, and summary artifact persistence.

## Test plan

- `cd cli && goimports -w .`
- `cd cli && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #213