### PR TITLE
Add review-loader smoke coverage for failure-review artifacts

### DIFF
--- a/cli/internal/review/review_test.go
+++ b/cli/internal/review/review_test.go
@@ -231,6 +231,29 @@ func TestSmoke_S1_LoadRunsIncludesRecoveryArtifactWhenPresent(t *testing.T) {
 	assert.Equal(t, "suppressed", runs[0].Recovery.RetryOutcome)
 }
 
+func TestSmoke_S2_LoadRunsLeavesRecoveryNilWhenArtifactAbsent(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 8, 13, 31, 0, 0, time.UTC)
+
+	writeRunArtifacts(t, stateDir, runFixture{
+		vesselID:  "legacy-run-without-recovery",
+		source:    "github-issue",
+		workflow:  "implement-harness",
+		state:     "failed",
+		startedAt: now,
+		endedAt:   now.Add(time.Minute),
+	})
+
+	runs, total, warnings, err := LoadRuns(stateDir, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, runs, 1)
+	assert.Nil(t, runs[0].Recovery)
+	assert.Equal(t, "legacy-run-without-recovery", runs[0].Summary.VesselID)
+	assert.Equal(t, "failed", runs[0].Summary.State)
+	assert.Empty(t, warnings)
+}
+
 type runFixture struct {
 	vesselID         string
 	source           string


### PR DESCRIPTION
## Summary
- Adds regression coverage around the review substrate that loads persisted `failure-review.json` artifacts for `xylem review`.
- Confirms legacy failed runs without a persisted recovery artifact still load cleanly.
- Related issue: https://github.com/nicholls-inc/xylem/issues/210

## Smoke scenarios covered
- `S1` — `LoadRunsIncludesRecoveryArtifactWhenPresent`
- `S2` — `LoadRunsLeavesRecoveryNilWhenArtifactAbsent`

## Changes summary
- **Modified:** `cli/internal/review/review_test.go`
- Extends the `LoadRuns` smoke coverage to assert recovery metadata is surfaced when `failure-review.json` exists.
- Adds a backward-compatibility smoke test that keeps `Run.Recovery` nil for legacy failed runs with no recovery artifact while preserving the loaded vessel summary and empty warning set.
- Exercises the `LoadRuns` review substrate through the existing `runFixture` artifact writer rather than adding new production paths.

## Test plan
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && goimports -w .`
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && goimports -l .`
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && go vet ./...`
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && golangci-lint run`
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && go build ./cmd/xylem`
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && go test ./...`

Fixes #210