### PR TITLE
Add deterministic failure classification and cooldown retry policy

### DIFF
--- a/cli/cmd/xylem/retry.go
+++ b/cli/cmd/xylem/retry.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -39,44 +39,27 @@ func cmdRetry(q *queue.Queue, cfg *config.Config, id string, fromScratch bool) e
 		return fmt.Errorf("error: vessel %s is not in a retryable state (current: %s)", id, vessel.State)
 	}
 
-	newID := retryID(vessel.ID, q)
-
-	meta := make(map[string]string)
-	for k, v := range vessel.Meta {
-		meta[k] = v
-	}
-	meta["retry_of"] = vessel.ID
-	if vessel.Error != "" {
-		meta["retry_error"] = vessel.Error
-	}
-	if vessel.FailedPhase != "" {
-		meta["failed_phase"] = vessel.FailedPhase
-	}
-	if vessel.GateOutput != "" {
-		meta["gate_output"] = vessel.GateOutput
+	var artifact *recovery.Artifact
+	if cfg != nil && cfg.StateDir != "" {
+		loaded, loadErr := recovery.LoadForVessel(cfg.StateDir, vessel.ID)
+		if loadErr != nil && !errors.Is(loadErr, os.ErrNotExist) {
+			return fmt.Errorf("load recovery artifact: %w", loadErr)
+		}
+		if loadErr == nil {
+			artifact = loaded
+		}
 	}
 
-	newVessel := queue.Vessel{
-		ID:          newID,
-		Source:      vessel.Source,
-		Ref:         vessel.Ref,
-		Workflow:    vessel.Workflow,
-		Prompt:      vessel.Prompt,
-		Meta:        meta,
-		State:       queue.StatePending,
-		CreatedAt:   commandNow(),
-		RetryOf:     vessel.ID,
-		FailedPhase: vessel.FailedPhase,
-		GateOutput:  vessel.GateOutput,
-	}
+	now := commandNow()
+	newVessel := recovery.NextRetryVessel(*vessel, *vessel, artifact, q, now, "decision")
 
 	// Resume from failed phase unless --from-scratch or no worktree exists
 	if !fromScratch && vessel.WorktreePath != "" {
 		newVessel.CurrentPhase = vessel.CurrentPhase
 		newVessel.WorktreePath = vessel.WorktreePath
-		newVessel.PhaseOutputs = rewritePhaseOutputs(vessel.PhaseOutputs, vessel.ID, newID)
+		newVessel.PhaseOutputs = rewritePhaseOutputs(vessel.PhaseOutputs, vessel.ID, newVessel.ID)
 
-		if err := copyPhaseOutputFiles(cfg.StateDir, vessel.ID, newID); err != nil {
+		if err := copyPhaseOutputFiles(cfg.StateDir, vessel.ID, newVessel.ID); err != nil {
 			return fmt.Errorf("copy phase outputs: %w", err)
 		}
 	}
@@ -157,17 +140,4 @@ func copyFile(src, dst string) error {
 	return out.Close()
 }
 
-func retryID(originalID string, q *queue.Queue) string {
-	vessels, _ := q.List()
-	maxRetry := 0
-	prefix := originalID + "-retry-"
-	for _, v := range vessels {
-		if strings.HasPrefix(v.ID, prefix) {
-			numStr := strings.TrimPrefix(v.ID, prefix)
-			if n, err := strconv.Atoi(numStr); err == nil && n > maxRetry {
-				maxRetry = n
-			}
-		}
-	}
-	return fmt.Sprintf("%s-retry-%d", originalID, maxRetry+1)
-}
+func retryID(originalID string, q *queue.Queue) string { return recovery.RetryID(originalID, q) }

--- a/cli/cmd/xylem/retry_test.go
+++ b/cli/cmd/xylem/retry_test.go
@@ -59,6 +59,9 @@ func TestSmoke_S1_RetryCommandMarksRecoveryArtifactEnqueued(t *testing.T) {
 	retry, err := q.FindByID("issue-42-retry-1")
 	require.NoError(t, err)
 	assert.Equal(t, queue.StatePending, retry.State)
+	assert.Equal(t, "decision", retry.Meta[recovery.MetaUnlockedBy])
+	assert.Equal(t, "1", retry.Meta[recovery.MetaRetryCount])
+	assert.Equal(t, string(recovery.ClassTransient), retry.Meta[recovery.MetaClass])
 }
 
 func TestRetryCreatesNewVessel(t *testing.T) {
@@ -514,8 +517,12 @@ func TestRewritePhaseOutputsNil(t *testing.T) {
 
 func TestCopyPhaseOutputFilesMissingSrcDir(t *testing.T) {
 	stateDir := t.TempDir()
+	dstDir := filepath.Join(stateDir, "phases", "new")
 	// Source directory does not exist — should be a no-op
 	if err := copyPhaseOutputFiles(stateDir, "nonexistent", "new"); err != nil {
 		t.Fatalf("expected no error for missing src dir, got: %v", err)
+	}
+	if _, err := os.Stat(dstDir); !os.IsNotExist(err) {
+		t.Fatalf("expected missing source dir to avoid creating %s, got err=%v", dstDir, err)
 	}
 }

--- a/cli/internal/recovery/recovery.go
+++ b/cli/internal/recovery/recovery.go
@@ -1,6 +1,7 @@
 package recovery
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,13 +20,21 @@ const (
 	artifactFileName = "failure-review.json"
 	schemaVersion    = "v1"
 
-	MetaClass           = "recovery_class"
-	MetaAction          = "recovery_action"
-	MetaRationale       = "recovery_rationale"
-	MetaFollowUpRoute   = "recovery_followup_route"
-	MetaRetrySuppressed = "recovery_retry_suppressed"
-	MetaRetryOutcome    = "recovery_retry_outcome"
-	MetaUnlockDimension = "recovery_unlock_dimension"
+	DefaultRetryCap            = 2
+	DefaultRetryCooldown       = 5 * time.Minute
+	MetaClass                  = "recovery_class"
+	MetaAction                 = "recovery_action"
+	MetaRationale              = "recovery_rationale"
+	MetaFollowUpRoute          = "recovery_followup_route"
+	MetaRetrySuppressed        = "recovery_retry_suppressed"
+	MetaRetryOutcome           = "recovery_retry_outcome"
+	MetaRetryCount             = "recovery_retry_count"
+	MetaRetryCap               = "recovery_retry_cap"
+	MetaRetryAfter             = "recovery_retry_after"
+	MetaFailureFingerprint     = "failure_fingerprint"
+	MetaRemediationFingerprint = "remediation_fingerprint"
+	MetaUnlockedBy             = "recovery_unlocked_by"
+	MetaUnlockDimension        = "recovery_unlock_dimension"
 )
 
 var safePathComponent = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
@@ -51,25 +60,29 @@ const (
 )
 
 type Artifact struct {
-	SchemaVersion   string                          `json:"schema_version"`
-	VesselID        string                          `json:"vessel_id"`
-	Source          string                          `json:"source,omitempty"`
-	Workflow        string                          `json:"workflow,omitempty"`
-	Ref             string                          `json:"ref,omitempty"`
-	State           string                          `json:"state"`
-	FailedPhase     string                          `json:"failed_phase,omitempty"`
-	Error           string                          `json:"error,omitempty"`
-	GateOutput      string                          `json:"gate_output,omitempty"`
-	RecoveryClass   Class                           `json:"recovery_class"`
-	RecoveryAction  Action                          `json:"recovery_action"`
-	Rationale       string                          `json:"rationale"`
-	FollowUpRoute   string                          `json:"follow_up_route,omitempty"`
-	RetrySuppressed bool                            `json:"retry_suppressed"`
-	RetryOutcome    string                          `json:"retry_outcome,omitempty"`
-	UnlockDimension string                          `json:"unlock_dimension,omitempty"`
-	RetryOf         string                          `json:"retry_of,omitempty"`
-	Trace           *observability.TraceContextData `json:"trace,omitempty"`
-	CreatedAt       time.Time                       `json:"created_at"`
+	SchemaVersion      string                          `json:"schema_version"`
+	VesselID           string                          `json:"vessel_id"`
+	Source             string                          `json:"source,omitempty"`
+	Workflow           string                          `json:"workflow,omitempty"`
+	Ref                string                          `json:"ref,omitempty"`
+	State              string                          `json:"state"`
+	FailedPhase        string                          `json:"failed_phase,omitempty"`
+	Error              string                          `json:"error,omitempty"`
+	GateOutput         string                          `json:"gate_output,omitempty"`
+	FailureFingerprint string                          `json:"failure_fingerprint,omitempty"`
+	RecoveryClass      Class                           `json:"recovery_class"`
+	RecoveryAction     Action                          `json:"recovery_action"`
+	Rationale          string                          `json:"rationale"`
+	FollowUpRoute      string                          `json:"follow_up_route,omitempty"`
+	RetrySuppressed    bool                            `json:"retry_suppressed"`
+	RetryCount         int                             `json:"retry_count"`
+	RetryCap           int                             `json:"retry_cap"`
+	RetryAfter         *time.Time                      `json:"retry_after,omitempty"`
+	RetryOutcome       string                          `json:"retry_outcome,omitempty"`
+	UnlockDimension    string                          `json:"unlock_dimension,omitempty"`
+	RetryOf            string                          `json:"retry_of,omitempty"`
+	Trace              *observability.TraceContextData `json:"trace,omitempty"`
+	CreatedAt          time.Time                       `json:"created_at"`
 }
 
 type Input struct {
@@ -96,6 +109,16 @@ func Build(input Input) *Artifact {
 	class, action, rationale := classify(input)
 	followUpRoute := followUpRouteFor(action)
 	retrySuppressed := action != ActionRetry
+	retryCount := metaInt(input.Meta, MetaRetryCount)
+	retryCap := metaInt(input.Meta, MetaRetryCap)
+	if retryCap <= 0 && action == ActionRetry {
+		retryCap = DefaultRetryCap
+	}
+	var retryAfter *time.Time
+	if action == ActionRetry {
+		next := retryAfterFor(createdAt, retryCount)
+		retryAfter = &next
+	}
 	retryOutcome := strings.TrimSpace(metaValue(input.Meta, MetaRetryOutcome))
 	if retryOutcome == "" {
 		if retrySuppressed {
@@ -105,32 +128,43 @@ func Build(input Input) *Artifact {
 		}
 	}
 
-	unlockDimension := strings.TrimSpace(metaValue(input.Meta, MetaUnlockDimension))
+	unlockDimension := strings.TrimSpace(firstNonEmpty(
+		metaValue(input.Meta, MetaUnlockedBy),
+		metaValue(input.Meta, MetaUnlockDimension),
+	))
+	failureFingerprint := strings.TrimSpace(metaValue(input.Meta, MetaFailureFingerprint))
+	if failureFingerprint == "" {
+		failureFingerprint = computeFailureFingerprint(input)
+	}
 	trace := input.Trace
 	if trace != nil && trace.TraceID == "" && trace.SpanID == "" {
 		trace = nil
 	}
 
 	return &Artifact{
-		SchemaVersion:   schemaVersion,
-		VesselID:        input.VesselID,
-		Source:          input.Source,
-		Workflow:        input.Workflow,
-		Ref:             input.Ref,
-		State:           string(input.State),
-		FailedPhase:     input.FailedPhase,
-		Error:           input.Error,
-		GateOutput:      input.GateOutput,
-		RecoveryClass:   class,
-		RecoveryAction:  action,
-		Rationale:       rationale,
-		FollowUpRoute:   followUpRoute,
-		RetrySuppressed: retrySuppressed,
-		RetryOutcome:    retryOutcome,
-		UnlockDimension: unlockDimension,
-		RetryOf:         input.RetryOf,
-		Trace:           trace,
-		CreatedAt:       createdAt,
+		SchemaVersion:      schemaVersion,
+		VesselID:           input.VesselID,
+		Source:             input.Source,
+		Workflow:           input.Workflow,
+		Ref:                input.Ref,
+		State:              string(input.State),
+		FailedPhase:        input.FailedPhase,
+		Error:              input.Error,
+		GateOutput:         input.GateOutput,
+		FailureFingerprint: failureFingerprint,
+		RecoveryClass:      class,
+		RecoveryAction:     action,
+		Rationale:          rationale,
+		FollowUpRoute:      followUpRoute,
+		RetrySuppressed:    retrySuppressed,
+		RetryCount:         retryCount,
+		RetryCap:           retryCap,
+		RetryAfter:         retryAfter,
+		RetryOutcome:       retryOutcome,
+		UnlockDimension:    unlockDimension,
+		RetryOf:            input.RetryOf,
+		Trace:              trace,
+		CreatedAt:          createdAt,
 	}
 }
 
@@ -150,14 +184,27 @@ func ApplyToMeta(meta map[string]string, artifact *Artifact) map[string]string {
 		delete(meta, MetaFollowUpRoute)
 	}
 	meta[MetaRetrySuppressed] = strconv.FormatBool(artifact.RetrySuppressed)
+	meta[MetaRetryCount] = strconv.Itoa(artifact.RetryCount)
+	meta[MetaRetryCap] = strconv.Itoa(artifact.RetryCap)
+	meta[MetaFailureFingerprint] = artifact.FailureFingerprint
 	if artifact.RetryOutcome != "" {
 		meta[MetaRetryOutcome] = artifact.RetryOutcome
 	} else {
 		delete(meta, MetaRetryOutcome)
 	}
+	if artifact.RetryAfter != nil && !artifact.RetryAfter.IsZero() {
+		meta[MetaRetryAfter] = artifact.RetryAfter.UTC().Format(time.RFC3339)
+	} else {
+		delete(meta, MetaRetryAfter)
+	}
+	if artifact.FailureFingerprint == "" {
+		delete(meta, MetaFailureFingerprint)
+	}
 	if artifact.UnlockDimension != "" {
+		meta[MetaUnlockedBy] = artifact.UnlockDimension
 		meta[MetaUnlockDimension] = artifact.UnlockDimension
 	} else {
+		delete(meta, MetaUnlockedBy)
 		delete(meta, MetaUnlockDimension)
 	}
 	return meta
@@ -202,6 +249,114 @@ func Load(path string) (*Artifact, error) {
 		return nil, fmt.Errorf("load recovery artifact: unmarshal: %w", err)
 	}
 	return &artifact, nil
+}
+
+type RetryDecision struct {
+	Eligible        bool
+	UnlockDimension string
+}
+
+func RetryReady(artifact *Artifact, now time.Time) RetryDecision {
+	if artifact == nil || artifact.RecoveryAction != ActionRetry {
+		return RetryDecision{}
+	}
+	if artifact.RetryCap > 0 && artifact.RetryCount >= artifact.RetryCap {
+		return RetryDecision{}
+	}
+	if artifact.RetryAfter != nil && now.UTC().Before(artifact.RetryAfter.UTC()) {
+		return RetryDecision{}
+	}
+	return RetryDecision{
+		Eligible:        true,
+		UnlockDimension: "cooldown",
+	}
+}
+
+func LoadForVessel(stateDir, vesselID string) (*Artifact, error) {
+	if err := validatePathComponent(vesselID); err != nil {
+		return nil, fmt.Errorf("load recovery artifact: invalid vessel ID: %w", err)
+	}
+	return Load(Path(stateDir, vesselID))
+}
+
+func NextRetryVessel(base, parent queue.Vessel, artifact *Artifact, q *queue.Queue, createdAt time.Time, unlockDimension string) queue.Vessel {
+	meta := copyMeta(parent.Meta)
+	for key, value := range base.Meta {
+		meta[key] = value
+	}
+	meta["retry_of"] = parent.ID
+	if parent.Error != "" {
+		meta["retry_error"] = parent.Error
+	}
+	if parent.FailedPhase != "" {
+		meta["failed_phase"] = parent.FailedPhase
+	}
+	if parent.GateOutput != "" {
+		meta["gate_output"] = parent.GateOutput
+	}
+
+	retryCount := 1
+	if artifact != nil {
+		retryCount = artifact.RetryCount + 1
+		meta = ApplyToMeta(meta, artifact)
+		meta[MetaRetryOutcome] = "enqueued"
+		if artifact.FollowUpRoute == "" {
+			delete(meta, MetaFollowUpRoute)
+		}
+		if artifact.Rationale == "" {
+			delete(meta, MetaRationale)
+		}
+	}
+	meta[MetaRetryCount] = strconv.Itoa(retryCount)
+	if unlockDimension != "" {
+		meta[MetaUnlockedBy] = unlockDimension
+		meta[MetaUnlockDimension] = unlockDimension
+	}
+	failureFingerprint := firstNonEmpty(meta[MetaFailureFingerprint], computeFailureFingerprint(Input{
+		State:       parent.State,
+		FailedPhase: parent.FailedPhase,
+		Error:       parent.Error,
+		GateOutput:  parent.GateOutput,
+	}))
+	if failureFingerprint != "" {
+		meta[MetaFailureFingerprint] = failureFingerprint
+	}
+	if sourceFingerprint := strings.TrimSpace(meta["source_input_fingerprint"]); sourceFingerprint != "" {
+		meta[MetaRemediationFingerprint] = remediationFingerprint(sourceFingerprint, unlockDimension, retryCount)
+	}
+
+	retry := queue.Vessel{
+		ID:        RetryID(parent.ID, q),
+		Source:    firstNonEmpty(base.Source, parent.Source),
+		Ref:       firstNonEmpty(base.Ref, parent.Ref),
+		Workflow:  firstNonEmpty(base.Workflow, parent.Workflow),
+		Prompt:    firstNonEmpty(base.Prompt, parent.Prompt),
+		Meta:      meta,
+		State:     queue.StatePending,
+		CreatedAt: createdAt.UTC(),
+		RetryOf:   parent.ID,
+	}
+	retry.FailedPhase = parent.FailedPhase
+	retry.GateOutput = parent.GateOutput
+	return retry
+}
+
+func RetryID(originalID string, q *queue.Queue) string {
+	if q == nil {
+		return originalID + "-retry-1"
+	}
+	vessels, _ := q.List()
+	maxRetry := 0
+	prefix := originalID + "-retry-"
+	for _, vessel := range vessels {
+		if strings.HasPrefix(vessel.ID, prefix) {
+			numStr := strings.TrimPrefix(vessel.ID, prefix)
+			if n, err := strconv.Atoi(numStr); err == nil && n > maxRetry {
+				maxRetry = n
+			}
+		}
+	}
+	return fmt.Sprintf("%s-retry-%d", originalID, maxRetry+1)
 }
 
 func classify(input Input) (Class, Action, string) {
@@ -263,6 +418,18 @@ func metaValue(meta map[string]string, key string) string {
 	return meta[key]
 }
 
+func metaInt(meta map[string]string, key string) int {
+	value := strings.TrimSpace(metaValue(meta, key))
+	if value == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
 func containsAny(text string, substrings ...string) bool {
 	for _, substring := range substrings {
 		if strings.Contains(text, substring) {
@@ -270,6 +437,54 @@ func containsAny(text string, substrings ...string) bool {
 		}
 	}
 	return false
+}
+
+func retryAfterFor(createdAt time.Time, retryCount int) time.Time {
+	backoffMultiplier := 1 << max(retryCount, 0)
+	return createdAt.Add(time.Duration(backoffMultiplier) * DefaultRetryCooldown).UTC()
+}
+
+func computeFailureFingerprint(input Input) string {
+	sum := sha256.Sum256([]byte(strings.ToLower(strings.TrimSpace(strings.Join([]string{
+		string(input.State),
+		input.FailedPhase,
+		normalizeFailureText(input.Error),
+		normalizeFailureText(input.GateOutput),
+	}, "\n")))))
+	return fmt.Sprintf("fail-%x", sum)
+}
+
+func normalizeFailureText(text string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(strings.ToLower(text))), " ")
+}
+
+func remediationFingerprint(sourceFingerprint, unlockDimension string, retryCount int) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		sourceFingerprint,
+		unlockDimension,
+		strconv.Itoa(retryCount),
+	}, "\n")))
+	return fmt.Sprintf("rem-%x", sum)
+}
+
+func copyMeta(meta map[string]string) map[string]string {
+	if len(meta) == 0 {
+		return map[string]string{}
+	}
+	cloned := make(map[string]string, len(meta))
+	for key, value := range meta {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func validatePathComponent(component string) error {

--- a/cli/internal/recovery/recovery_prop_test.go
+++ b/cli/internal/recovery/recovery_prop_test.go
@@ -14,6 +14,9 @@ func TestPropApplyToMetaPreservesRecoveryFields(t *testing.T) {
 		vesselID := rapid.StringMatching(`[a-z0-9-]{1,24}`).Draw(t, "vesselID")
 		retryOutcome := rapid.SampledFrom([]string{"suppressed", "not_attempted", "enqueued"}).Draw(t, "retryOutcome")
 		unlockDimension := rapid.SampledFrom([]string{"", "source", "workflow", "decision"}).Draw(t, "unlockDimension")
+		retryCount := rapid.IntRange(0, 3).Draw(t, "retryCount")
+		retryCap := rapid.IntRange(retryCount, retryCount+3).Draw(t, "retryCap")
+		retryAfter := time.Unix(int64(rapid.Int64().Draw(t, "retryAfterUnix")), 0).UTC()
 
 		artifact := &Artifact{
 			VesselID:        vesselID,
@@ -22,6 +25,9 @@ func TestPropApplyToMetaPreservesRecoveryFields(t *testing.T) {
 			Rationale:       "needs clarification",
 			FollowUpRoute:   "needs-refinement",
 			RetrySuppressed: true,
+			RetryCount:      retryCount,
+			RetryCap:        retryCap,
+			RetryAfter:      &retryAfter,
 			RetryOutcome:    retryOutcome,
 			UnlockDimension: unlockDimension,
 			State:           string(queue.StateFailed),
@@ -41,6 +47,15 @@ func TestPropApplyToMetaPreservesRecoveryFields(t *testing.T) {
 		if meta[MetaRetrySuppressed] != strconv.FormatBool(artifact.RetrySuppressed) {
 			t.Fatalf("MetaRetrySuppressed = %q, want %q", meta[MetaRetrySuppressed], strconv.FormatBool(artifact.RetrySuppressed))
 		}
+		if meta[MetaRetryCount] != strconv.Itoa(retryCount) {
+			t.Fatalf("MetaRetryCount = %q, want %q", meta[MetaRetryCount], strconv.Itoa(retryCount))
+		}
+		if meta[MetaRetryCap] != strconv.Itoa(retryCap) {
+			t.Fatalf("MetaRetryCap = %q, want %q", meta[MetaRetryCap], strconv.Itoa(retryCap))
+		}
+		if meta[MetaRetryAfter] != retryAfter.Format(time.RFC3339) {
+			t.Fatalf("MetaRetryAfter = %q, want %q", meta[MetaRetryAfter], retryAfter.Format(time.RFC3339))
+		}
 		if meta[MetaRetryOutcome] != retryOutcome {
 			t.Fatalf("MetaRetryOutcome = %q, want %q", meta[MetaRetryOutcome], retryOutcome)
 		}
@@ -52,6 +67,34 @@ func TestPropApplyToMetaPreservesRecoveryFields(t *testing.T) {
 		}
 		if meta[MetaUnlockDimension] != unlockDimension {
 			t.Fatalf("MetaUnlockDimension = %q, want %q", meta[MetaUnlockDimension], unlockDimension)
+		}
+		if meta[MetaUnlockedBy] != unlockDimension {
+			t.Fatalf("MetaUnlockedBy = %q, want %q", meta[MetaUnlockedBy], unlockDimension)
+		}
+	})
+}
+
+func TestPropRetryReadyNeverBypassesCapOrCooldown(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		retryCount := rapid.IntRange(0, 4).Draw(t, "retryCount")
+		retryCap := rapid.IntRange(0, 4).Draw(t, "retryCap")
+		offsetMinutes := rapid.IntRange(-30, 30).Draw(t, "offsetMinutes")
+		now := time.Unix(0, 0).UTC()
+		retryAfter := now.Add(time.Duration(offsetMinutes) * time.Minute)
+
+		decision := RetryReady(&Artifact{
+			RecoveryAction: ActionRetry,
+			RetryCount:     retryCount,
+			RetryCap:       retryCap,
+			RetryAfter:     &retryAfter,
+		}, now)
+
+		want := retryCap == 0 || retryCount < retryCap
+		if now.Before(retryAfter) {
+			want = false
+		}
+		if decision.Eligible != want {
+			t.Fatalf("RetryReady(retryCount=%d, retryCap=%d, retryAfter=%s) = %v, want %v", retryCount, retryCap, retryAfter.Format(time.RFC3339), decision.Eligible, want)
 		}
 	})
 }

--- a/cli/internal/recovery/recovery_test.go
+++ b/cli/internal/recovery/recovery_test.go
@@ -13,12 +13,13 @@ import (
 )
 
 func TestSmoke_S1_TransientTimeoutClassifiesToRetry(t *testing.T) {
+	createdAt := time.Date(2026, time.April, 9, 18, 5, 0, 0, time.UTC)
 	artifact := Build(Input{
 		VesselID:  "issue-99",
 		Workflow:  "fix-bug",
 		State:     queue.StateTimedOut,
 		Error:     "context deadline exceeded",
-		CreatedAt: time.Date(2026, time.April, 9, 18, 5, 0, 0, time.UTC),
+		CreatedAt: createdAt,
 		Trace: &observability.TraceContextData{
 			TraceID: "trace",
 			SpanID:  "span",
@@ -30,6 +31,11 @@ func TestSmoke_S1_TransientTimeoutClassifiesToRetry(t *testing.T) {
 	assert.Equal(t, ActionRetry, artifact.RecoveryAction)
 	assert.False(t, artifact.RetrySuppressed)
 	assert.Equal(t, "not_attempted", artifact.RetryOutcome)
+	assert.Equal(t, 0, artifact.RetryCount)
+	assert.Equal(t, DefaultRetryCap, artifact.RetryCap)
+	require.NotNil(t, artifact.RetryAfter)
+	assert.Equal(t, createdAt.Add(DefaultRetryCooldown), artifact.RetryAfter.UTC())
+	assert.NotEmpty(t, artifact.FailureFingerprint)
 	require.NotNil(t, artifact.Trace)
 	assert.Equal(t, "trace", artifact.Trace.TraceID)
 }
@@ -52,6 +58,8 @@ func TestSmoke_S2_HarnessGapPreservesUnlockDimensionForLessonsRouting(t *testing
 	assert.Equal(t, "workflow", artifact.UnlockDimension)
 	assert.True(t, artifact.RetrySuppressed)
 	assert.Equal(t, "suppressed", artifact.RetryOutcome)
+	assert.Equal(t, 0, artifact.RetryCap)
+	assert.Nil(t, artifact.RetryAfter)
 	assert.Empty(t, artifact.FollowUpRoute)
 }
 
@@ -124,6 +132,222 @@ func TestSmoke_S6_SaveLoadAndUpdateRetryOutcomePersistsEnqueuedState(t *testing.
 	loaded, err := Load(filepath.Join(stateDir, RelativePath(artifact.VesselID)))
 	require.NoError(t, err)
 	assert.Equal(t, "enqueued", loaded.RetryOutcome)
+}
+
+func TestSmoke_S7_RetryReadyBlocksBeforeCooldownExpires(t *testing.T) {
+	now := time.Date(2026, time.April, 9, 10, 0, 0, 0, time.UTC)
+	retryAfter := now.Add(time.Minute)
+
+	decision := RetryReady(&Artifact{
+		RecoveryAction: ActionRetry,
+		RetryCount:     1,
+		RetryCap:       2,
+		RetryAfter:     &retryAfter,
+	}, now)
+
+	assert.Equal(t, RetryDecision{}, decision)
+}
+
+func TestSmoke_S8_RetryReadyBlocksWhenRetryCapReached(t *testing.T) {
+	now := time.Date(2026, time.April, 9, 10, 0, 0, 0, time.UTC)
+	retryAfter := now.Add(-time.Minute)
+
+	decision := RetryReady(&Artifact{
+		RecoveryAction: ActionRetry,
+		RetryCount:     2,
+		RetryCap:       2,
+		RetryAfter:     &retryAfter,
+	}, now)
+
+	assert.Equal(t, RetryDecision{}, decision)
+}
+
+func TestSmoke_S9_RemediationFingerprintIsStableForSameInputs(t *testing.T) {
+	first := remediationFingerprint("src-fingerprint", "cooldown", 1)
+	second := remediationFingerprint("src-fingerprint", "cooldown", 1)
+	changed := remediationFingerprint("src-fingerprint", "cooldown", 2)
+
+	assert.Equal(t, first, second)
+	assert.NotEqual(t, first, changed)
+}
+
+func TestRetryReadyRequiresCooldownAndCap(t *testing.T) {
+	now := time.Date(2026, time.April, 9, 18, 10, 0, 0, time.UTC)
+	retryAfter := now.Add(time.Minute)
+	tests := []struct {
+		name     string
+		artifact *Artifact
+		now      time.Time
+		want     RetryDecision
+	}{
+		{
+			name:     "nil artifact is never eligible",
+			artifact: nil,
+			now:      now,
+			want:     RetryDecision{},
+		},
+		{
+			name: "non-retry action is never eligible",
+			artifact: &Artifact{
+				RecoveryAction: ActionDiagnose,
+			},
+			now:  now,
+			want: RetryDecision{},
+		},
+		{
+			name: "cooldown blocks until retry after",
+			artifact: &Artifact{
+				RecoveryAction: ActionRetry,
+				RetryCount:     1,
+				RetryCap:       2,
+				RetryAfter:     &retryAfter,
+			},
+			now:  now,
+			want: RetryDecision{},
+		},
+		{
+			name: "retry becomes eligible at retry after boundary",
+			artifact: &Artifact{
+				RecoveryAction: ActionRetry,
+				RetryCount:     1,
+				RetryCap:       2,
+				RetryAfter:     &retryAfter,
+			},
+			now: retryAfter,
+			want: RetryDecision{
+				Eligible:        true,
+				UnlockDimension: "cooldown",
+			},
+		},
+		{
+			name: "cap reached blocks retry even after cooldown",
+			artifact: &Artifact{
+				RecoveryAction: ActionRetry,
+				RetryCount:     2,
+				RetryCap:       2,
+				RetryAfter:     &retryAfter,
+			},
+			now:  retryAfter.Add(time.Minute),
+			want: RetryDecision{},
+		},
+		{
+			name: "nil retry after still allows retry when under cap",
+			artifact: &Artifact{
+				RecoveryAction: ActionRetry,
+				RetryCount:     1,
+				RetryCap:       2,
+			},
+			now: now,
+			want: RetryDecision{
+				Eligible:        true,
+				UnlockDimension: "cooldown",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, RetryReady(tt.artifact, tt.now))
+		})
+	}
+}
+
+func TestBuildRecomputesRetryAfterForRetryFailures(t *testing.T) {
+	createdAt := time.Date(2026, time.April, 9, 18, 20, 0, 0, time.UTC)
+	staleRetryAfter := createdAt.Add(-time.Hour)
+	artifact := Build(Input{
+		VesselID:  "issue-42-retry-1",
+		Workflow:  "fix-bug",
+		State:     queue.StateFailed,
+		Error:     "temporary failure from upstream 503",
+		CreatedAt: createdAt,
+		Meta: map[string]string{
+			MetaRetryCount: "1",
+			MetaRetryAfter: staleRetryAfter.Format(time.RFC3339),
+		},
+	})
+
+	require.NotNil(t, artifact)
+	require.NotNil(t, artifact.RetryAfter)
+	assert.Equal(t, createdAt.Add(2*DefaultRetryCooldown), artifact.RetryAfter.UTC())
+}
+
+func TestBuildDropsStaleRetryAfterForNonRetryActions(t *testing.T) {
+	staleRetryAfter := time.Date(2026, time.April, 9, 18, 20, 0, 0, time.UTC)
+	artifact := Build(Input{
+		VesselID:  "issue-42",
+		Workflow:  "implement-harness",
+		State:     queue.StateFailed,
+		Error:     "missing requirement: acceptance criteria are ambiguous",
+		CreatedAt: staleRetryAfter.Add(time.Minute),
+		Meta: map[string]string{
+			MetaRetryAfter: staleRetryAfter.Format(time.RFC3339),
+		},
+	})
+
+	require.NotNil(t, artifact)
+	assert.Equal(t, ActionRefine, artifact.RecoveryAction)
+	assert.Nil(t, artifact.RetryAfter)
+}
+
+func TestSmoke_S10_NextRetryVesselPreservesRecoveryLineageMetadata(t *testing.T) {
+	q := queue.New(filepath.Join(t.TempDir(), "queue.jsonl"))
+	now := time.Date(2026, time.April, 9, 18, 11, 0, 0, time.UTC)
+	parent := queue.Vessel{
+		ID:          "issue-42",
+		Source:      "github-issue",
+		Ref:         "https://github.com/owner/repo/issues/42",
+		Workflow:    "fix-bug",
+		State:       queue.StateFailed,
+		Error:       "temporary failure from upstream 503",
+		FailedPhase: "verify",
+		GateOutput:  "503 Service Unavailable",
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": "src-fingerprint",
+		},
+		CreatedAt: now.Add(-time.Hour),
+	}
+	artifact := Build(Input{
+		VesselID:    parent.ID,
+		Source:      parent.Source,
+		Workflow:    parent.Workflow,
+		Ref:         parent.Ref,
+		State:       parent.State,
+		FailedPhase: parent.FailedPhase,
+		Error:       parent.Error,
+		GateOutput:  parent.GateOutput,
+		Meta:        parent.Meta,
+		CreatedAt:   now.Add(-30 * time.Minute),
+	})
+
+	retry := NextRetryVessel(queue.Vessel{
+		ID:       parent.ID,
+		Source:   parent.Source,
+		Ref:      parent.Ref,
+		Workflow: parent.Workflow,
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": "src-fingerprint",
+			"issue_title":              "updated title",
+		},
+	}, parent, artifact, q, now, "cooldown")
+
+	assert.Equal(t, "issue-42-retry-1", retry.ID)
+	assert.Equal(t, "issue-42", retry.RetryOf)
+	assert.Equal(t, queue.StatePending, retry.State)
+	assert.Equal(t, "issue-42", retry.Meta["retry_of"])
+	assert.Equal(t, "temporary failure from upstream 503", retry.Meta["retry_error"])
+	assert.Equal(t, "verify", retry.Meta["failed_phase"])
+	assert.Equal(t, "503 Service Unavailable", retry.Meta["gate_output"])
+	assert.Equal(t, string(artifact.RecoveryClass), retry.Meta[MetaClass])
+	assert.Equal(t, string(artifact.RecoveryAction), retry.Meta[MetaAction])
+	assert.Equal(t, "1", retry.Meta[MetaRetryCount])
+	assert.Equal(t, "cooldown", retry.Meta[MetaUnlockedBy])
+	assert.Equal(t, "cooldown", retry.Meta[MetaUnlockDimension])
+	assert.Equal(t, "enqueued", retry.Meta[MetaRetryOutcome])
+	assert.Equal(t, artifact.FailureFingerprint, retry.Meta[MetaFailureFingerprint])
+	assert.NotEmpty(t, retry.Meta[MetaRemediationFingerprint])
+	assert.Equal(t, "updated title", retry.Meta["issue_title"])
 }
 
 func TestSaveRejectsUnsafeVesselID(t *testing.T) {

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -1537,8 +1537,17 @@ func recoveryAttributesFromMeta(meta map[string]string) observability.RecoveryDa
 		Action:          meta[recovery.MetaAction],
 		RetrySuppressed: meta[recovery.MetaRetrySuppressed],
 		RetryOutcome:    meta[recovery.MetaRetryOutcome],
-		UnlockDimension: meta[recovery.MetaUnlockDimension],
+		UnlockDimension: firstNonEmptyMeta(meta, recovery.MetaUnlockedBy, recovery.MetaUnlockDimension),
 	}
+}
+
+func firstNonEmptyMeta(meta map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(meta[key]); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func traceContextPointer(data *TraceArtifacts) *observability.TraceContextData {

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 )
 
@@ -66,6 +67,11 @@ func (s *Scanner) Scan(ctx context.Context) (ScanResult, error) {
 				return result, err
 			}
 			if enqueued {
+				if vessel.RetryOf != "" {
+					if err := recovery.UpdateRetryOutcome(s.Config.StateDir, vessel.RetryOf, "enqueued"); err != nil {
+						return result, err
+					}
+				}
 				result.Added++
 				if s.RunHooks {
 					if err := entry.src.OnEnqueue(ctx, vessel); err != nil {
@@ -97,6 +103,7 @@ func (s *Scanner) buildSources() []sourceEntry {
 					Repo:      srcCfg.Repo,
 					Tasks:     tasks,
 					Exclude:   srcCfg.Exclude,
+					StateDir:  s.Config.StateDir,
 					Queue:     s.Queue,
 					CmdRunner: s.CmdRunner,
 				},
@@ -109,6 +116,7 @@ func (s *Scanner) buildSources() []sourceEntry {
 					Repo:      srcCfg.Repo,
 					Tasks:     tasks,
 					Exclude:   srcCfg.Exclude,
+					StateDir:  s.Config.StateDir,
 					Queue:     s.Queue,
 					CmdRunner: s.CmdRunner,
 				},

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -29,6 +31,7 @@ type GitHub struct {
 	Repo      string
 	Tasks     map[string]GitHubTask
 	Exclude   []string
+	StateDir  string
 	Queue     *queue.Queue
 	CmdRunner CommandRunner
 }
@@ -80,16 +83,7 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					continue
 				}
 				fingerprint := githubSourceFingerprint(issue.Title, issue.Body, issueLabelNames(issue.Labels))
-				if g.hasExcludedLabel(issue, excludeSet) ||
-					g.Queue.HasRef(issue.URL) ||
-					g.hasMatchingFailedFingerprint(issue.URL, fingerprint) ||
-					g.hasBranch(ctx, issue.Number) ||
-					g.hasOpenPR(ctx, issue.Number) ||
-					g.hasMergedPR(ctx, issue.Number) {
-					continue
-				}
-				seen[issue.Number] = true
-				meta := map[string]string{
+				baseMeta := map[string]string{
 					"issue_num":                strconv.Itoa(issue.Number),
 					"issue_title":              issue.Title,
 					"issue_body":               issue.Body,
@@ -106,26 +100,48 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 				}
 				sl := task.StatusLabels
 				if sl != nil {
-					meta["status_label_queued"] = sl.Queued
-					meta["status_label_running"] = sl.Running
-					meta["status_label_completed"] = sl.Completed
-					meta["status_label_failed"] = sl.Failed
-					meta["status_label_timed_out"] = sl.TimedOut
+					baseMeta["status_label_queued"] = sl.Queued
+					baseMeta["status_label_running"] = sl.Running
+					baseMeta["status_label_completed"] = sl.Completed
+					baseMeta["status_label_failed"] = sl.Failed
+					baseMeta["status_label_timed_out"] = sl.TimedOut
 				}
 				lgl := task.LabelGateLabels
 				if lgl != nil {
-					meta["label_gate_label_waiting"] = lgl.Waiting
-					meta["label_gate_label_ready"] = lgl.Ready
+					baseMeta["label_gate_label_waiting"] = lgl.Waiting
+					baseMeta["label_gate_label_ready"] = lgl.Ready
 				}
-				vessels = append(vessels, queue.Vessel{
+				baseVessel := queue.Vessel{
 					ID:        fmt.Sprintf("issue-%d", issue.Number),
 					Source:    "github-issue",
 					Ref:       issue.URL,
 					Workflow:  task.Workflow,
-					Meta:      meta,
+					Meta:      baseMeta,
 					State:     queue.StatePending,
 					CreatedAt: sourceNow(),
-				})
+				}
+				if g.hasExcludedLabel(issue, excludeSet) {
+					continue
+				}
+
+				retryVessel, blocked, err := g.retryCandidate(baseVessel)
+				if err != nil {
+					return vessels, err
+				}
+				if blocked {
+					continue
+				}
+				if g.hasBranch(ctx, issue.Number) ||
+					g.hasOpenPR(ctx, issue.Number) ||
+					g.hasMergedPR(ctx, issue.Number) {
+					continue
+				}
+				seen[issue.Number] = true
+				if retryVessel != nil {
+					vessels = append(vessels, *retryVessel)
+					continue
+				}
+				vessels = append(vessels, baseVessel)
 			}
 		}
 	}
@@ -268,13 +284,48 @@ func sourceNow() time.Time {
 	return now.UTC()
 }
 
-func (g *GitHub) hasMatchingFailedFingerprint(ref, fingerprint string) bool {
-	latest, err := g.Queue.FindLatestByRef(ref)
-	if err != nil || latest == nil {
-		return false
+func (g *GitHub) retryCandidate(base queue.Vessel) (*queue.Vessel, bool, error) {
+	if g == nil || g.Queue == nil {
+		return nil, false, nil
 	}
-	isTerminalFailure := latest.State == queue.StateFailed || latest.State == queue.StateTimedOut
-	return isTerminalFailure && latest.Meta["source_input_fingerprint"] == fingerprint
+	latest, err := g.Queue.FindLatestByRef(base.Ref)
+	if err != nil || latest == nil {
+		return nil, false, nil
+	}
+	switch latest.State {
+	case queue.StatePending, queue.StateRunning, queue.StateWaiting:
+		return nil, true, nil
+	case queue.StateFailed, queue.StateTimedOut:
+		if latest.Meta["source_input_fingerprint"] != base.Meta["source_input_fingerprint"] {
+			return nil, false, nil
+		}
+		artifact, eligible, loadErr := g.loadRetryArtifact(*latest)
+		if loadErr != nil {
+			return nil, false, loadErr
+		}
+		if !eligible {
+			return nil, true, nil
+		}
+		retry := recovery.NextRetryVessel(base, *latest, artifact, g.Queue, sourceNow(), "cooldown")
+		return &retry, false, nil
+	default:
+		return nil, false, nil
+	}
+}
+
+func (g *GitHub) loadRetryArtifact(vessel queue.Vessel) (*recovery.Artifact, bool, error) {
+	if g.StateDir == "" {
+		return nil, false, nil
+	}
+	artifact, err := recovery.LoadForVessel(g.StateDir, vessel.ID)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("load recovery artifact for %s: %w", vessel.ID, err)
+	}
+	decision := recovery.RetryReady(artifact, sourceNow())
+	return artifact, decision.Eligible, nil
 }
 
 func (g *GitHub) recoveryAwareVessel(vessel queue.Vessel) queue.Vessel {

--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -3,11 +3,14 @@ package source
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 )
 
 // GitHubPR scans GitHub pull requests and produces vessels.
@@ -15,6 +18,7 @@ type GitHubPR struct {
 	Repo      string
 	Tasks     map[string]GitHubTask
 	Exclude   []string
+	StateDir  string
 	Queue     *queue.Queue
 	CmdRunner CommandRunner
 }
@@ -104,9 +108,35 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					continue
 				}
 				fingerprint := githubSourceFingerprint(pr.Title, pr.Body, issueLabelNames(pr.Labels))
-				if g.hasExcludedLabel(pr, excludeSet) ||
-					g.isBlockedByPriorVessel(pr.URL, fingerprint, task.Workflow) ||
-					g.hasBranch(ctx, pr.Number) {
+				baseVessel := queue.Vessel{
+					ID:       fmt.Sprintf("pr-%d-%s", pr.Number, task.Workflow),
+					Source:   "github-pr",
+					Ref:      prWorkflowRef(pr.URL, task.Workflow),
+					Workflow: task.Workflow,
+					Meta: map[string]string{
+						"pr_num":                   strconv.Itoa(pr.Number),
+						"pr_title":                 pr.Title,
+						"pr_body":                  pr.Body,
+						"pr_labels":                strings.Join(issueLabelNames(pr.Labels), ","),
+						"source_input_fingerprint": fingerprint,
+					},
+					State:     queue.StatePending,
+					CreatedAt: sourceNow(),
+				}
+				sl := task.StatusLabels
+				if sl != nil {
+					baseVessel.Meta["status_label_queued"] = sl.Queued
+					baseVessel.Meta["status_label_running"] = sl.Running
+					baseVessel.Meta["status_label_completed"] = sl.Completed
+					baseVessel.Meta["status_label_failed"] = sl.Failed
+					baseVessel.Meta["status_label_timed_out"] = sl.TimedOut
+				}
+				lgl := task.LabelGateLabels
+				if lgl != nil {
+					baseVessel.Meta["label_gate_label_waiting"] = lgl.Waiting
+					baseVessel.Meta["label_gate_label_ready"] = lgl.Ready
+				}
+				if g.hasExcludedLabel(pr, excludeSet) {
 					continue
 				}
 				// resolve-conflicts workflow is only meaningful for PRs in a
@@ -124,36 +154,22 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					}
 					continue
 				}
+				retryVessel, blocked, err := g.retryCandidate(baseVessel, pr.URL, fingerprint, task.Workflow)
+				if err != nil {
+					return vessels, err
+				}
+				if blocked {
+					continue
+				}
+				if g.hasBranch(ctx, pr.Number) {
+					continue
+				}
 				seen[key] = true
-				meta := map[string]string{
-					"pr_num":                   strconv.Itoa(pr.Number),
-					"pr_title":                 pr.Title,
-					"pr_body":                  pr.Body,
-					"pr_labels":                strings.Join(issueLabelNames(pr.Labels), ","),
-					"source_input_fingerprint": fingerprint,
+				if retryVessel != nil {
+					vessels = append(vessels, *retryVessel)
+					continue
 				}
-				sl := task.StatusLabels
-				if sl != nil {
-					meta["status_label_queued"] = sl.Queued
-					meta["status_label_running"] = sl.Running
-					meta["status_label_completed"] = sl.Completed
-					meta["status_label_failed"] = sl.Failed
-					meta["status_label_timed_out"] = sl.TimedOut
-				}
-				lgl := task.LabelGateLabels
-				if lgl != nil {
-					meta["label_gate_label_waiting"] = lgl.Waiting
-					meta["label_gate_label_ready"] = lgl.Ready
-				}
-				vessels = append(vessels, queue.Vessel{
-					ID:        fmt.Sprintf("pr-%d-%s", pr.Number, task.Workflow),
-					Source:    "github-pr",
-					Ref:       prWorkflowRef(pr.URL, task.Workflow),
-					Workflow:  task.Workflow,
-					Meta:      meta,
-					State:     queue.StatePending,
-					CreatedAt: sourceNow(),
-				})
+				vessels = append(vessels, baseVessel)
 			}
 		}
 	}
@@ -295,59 +311,56 @@ func priorVesselBlocksReenqueue(v *queue.Vessel, fingerprint string) bool {
 	switch v.State {
 	case queue.StatePending, queue.StateRunning, queue.StateWaiting:
 		return true
-	case queue.StateFailed:
+	case queue.StateFailed, queue.StateTimedOut:
 		return v.Meta["source_input_fingerprint"] == fingerprint
 	default:
 		return false
 	}
 }
 
-// isBlockedByPriorVessel reports whether a prior vessel already occupies
-// the dedup slot for this (PR URL, workflow) pair and so the scanner
-// should not enqueue a new vessel. It checks the new workflow-qualified
-// ref (`<url>#workflow=<name>`) first; then for backward-compat with
-// queue entries written before refs were qualified, it falls back to
-// the legacy bare-URL ref and only treats a legacy vessel as blocking
-// when it belongs to the SAME workflow as the current task.
-//
-// Blocking conditions:
-//   - A pending/running/waiting vessel at the qualified ref.
-//   - A failed vessel at the qualified ref whose fingerprint equals the
-//     current PR input fingerprint.
-//   - If no qualified vessel exists yet, a legacy bare-URL vessel whose
-//     Workflow matches and is either active (pending/running/waiting)
-//     or terminally failed with a matching fingerprint.
-//
-// Completed/cancelled/timed_out vessels do not block. This is important
-// for resolve-conflicts retries: if a prior vessel completed without
-// actually changing the PR branch and GitHub still reports CONFLICTING,
-// the scanner must be able to enqueue a fresh vessel.
-//
-// Once a qualified-ref vessel exists, it is always newer than any
-// legacy bare-URL vessel for the same PR/workflow and therefore solely
-// determines whether the dedup slot is occupied. Falling back to an
-// older legacy vessel in that case would let stale pre-upgrade state
-// incorrectly block a newer completed/cancelled run.
-//
-// This preserves the dedup guarantees of the pre-qualification scheme for
-// in-flight workflows while allowing distinct workflows over the same PR
-// (e.g., merge-pr and resolve-conflicts) to coexist.
-func (g *GitHubPR) isBlockedByPriorVessel(prURL, fingerprint, workflow string) bool {
-	qualifiedRef := prWorkflowRef(prURL, workflow)
-	latest, err := g.Queue.FindLatestByRef(qualifiedRef)
-	if err == nil {
-		return priorVesselBlocksReenqueue(latest, fingerprint)
+func (g *GitHubPR) retryCandidate(base queue.Vessel, prURL, fingerprint, workflow string) (*queue.Vessel, bool, error) {
+	if g == nil || g.Queue == nil {
+		return nil, false, nil
 	}
-	// Backward-compat: legacy queue entries were written with ref = prURL.
-	latest, err = g.Queue.FindLatestByRef(prURL)
+	latest, err := g.Queue.FindLatestByRef(prWorkflowRef(prURL, workflow))
 	if err != nil || latest == nil {
-		return false
+		latest, err = g.Queue.FindLatestByRef(prURL)
+		if err != nil || latest == nil || latest.Workflow != workflow {
+			return nil, false, nil
+		}
 	}
-	// Only a legacy vessel belonging to the SAME workflow is blocking.
-	// Otherwise a failed merge-pr vessel would block resolve-conflicts
-	// enqueue for the same PR — the exact regression this fix addresses.
-	if latest.Workflow != workflow {
-		return false
+	switch latest.State {
+	case queue.StatePending, queue.StateRunning, queue.StateWaiting:
+		return nil, true, nil
+	case queue.StateFailed, queue.StateTimedOut:
+		if latest.Meta["source_input_fingerprint"] != fingerprint {
+			return nil, false, nil
+		}
+		artifact, eligible, loadErr := g.loadRetryArtifact(*latest)
+		if loadErr != nil {
+			return nil, false, loadErr
+		}
+		if !eligible {
+			return nil, true, nil
+		}
+		retry := recovery.NextRetryVessel(base, *latest, artifact, g.Queue, sourceNow(), "cooldown")
+		return &retry, false, nil
+	default:
+		return nil, false, nil
 	}
-	return priorVesselBlocksReenqueue(latest, fingerprint)
+}
+
+func (g *GitHubPR) loadRetryArtifact(vessel queue.Vessel) (*recovery.Artifact, bool, error) {
+	if g.StateDir == "" {
+		return nil, false, nil
+	}
+	artifact, err := recovery.LoadForVessel(g.StateDir, vessel.ID)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("load recovery artifact for %s: %w", vessel.ID, err)
+	}
+	decision := recovery.RetryReady(artifact, sourceNow())
+	return artifact, decision.Eligible, nil
 }

--- a/cli/internal/source/github_pr_prop_test.go
+++ b/cli/internal/source/github_pr_prop_test.go
@@ -40,7 +40,7 @@ func TestPropPriorVesselBlocksReenqueueMatchesStateMachine(t *testing.T) {
 		switch state {
 		case queue.StatePending, queue.StateRunning, queue.StateWaiting:
 			want = true
-		case queue.StateFailed:
+		case queue.StateFailed, queue.StateTimedOut:
 			want = match
 		}
 

--- a/cli/internal/source/github_pr_test.go
+++ b/cli/internal/source/github_pr_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -245,6 +246,8 @@ func TestGitHubPRScanGHFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from gh failure, got nil")
 	}
+	assert.ErrorContains(t, err, "gh pr list")
+	assert.ErrorContains(t, err, errTest.Error())
 }
 
 func TestGitHubPRScanMalformedJSON(t *testing.T) {
@@ -265,6 +268,8 @@ func TestGitHubPRScanMalformedJSON(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for malformed JSON")
 	}
+	assert.ErrorContains(t, err, "parse gh pr list output")
+	assert.ErrorContains(t, err, "invalid character")
 }
 
 func TestGitHubPRScanSkipsUnchangedFailedVessel(t *testing.T) {
@@ -374,6 +379,223 @@ func TestGitHubPRScanReenqueuesChangedFailedVessel(t *testing.T) {
 	}
 }
 
+func TestSmoke_S4_GitHubPRScanAutoRetriesEligibleTransientFailure(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "same title", Body: "same body", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+
+	fingerprint := githubSourceFingerprint("same title", "same body", []string{"review-me"})
+	qualifiedRef := prWorkflowRef(prs[0].URL, "review-pr")
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "pr-10-review-pr",
+		Source:   "github-pr",
+		Ref:      qualifiedRef,
+		Workflow: "review-pr",
+		Meta: map[string]string{
+			"pr_num":                   "10",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("pr-10-review-pr", queue.StateTimedOut, "temporary network outage"))
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID:  "pr-10-review-pr",
+		Source:    "github-pr",
+		Workflow:  "review-pr",
+		Ref:       qualifiedRef,
+		State:     queue.StateTimedOut,
+		Error:     "temporary network outage",
+		CreatedAt: time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown),
+	})
+	require.NoError(t, recovery.Save(dir, artifact))
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "pr-10-review-pr-retry-1", vessels[0].ID)
+	assert.Equal(t, "pr-10-review-pr", vessels[0].RetryOf)
+	assert.Equal(t, "cooldown", vessels[0].Meta[recovery.MetaUnlockedBy])
+}
+
+func TestSmoke_S5_GitHubPRScanBlocksRetryUntilCooldownExpires(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "same title", Body: "same body", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+
+	fingerprint := githubSourceFingerprint("same title", "same body", []string{"review-me"})
+	qualifiedRef := prWorkflowRef(prs[0].URL, "review-pr")
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "pr-10-review-pr",
+		Source:   "github-pr",
+		Ref:      qualifiedRef,
+		Workflow: "review-pr",
+		Meta: map[string]string{
+			"pr_num":                   "10",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("pr-10-review-pr", queue.StateFailed, "temporary network outage"))
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID:  "pr-10-review-pr",
+		Source:    "github-pr",
+		Workflow:  "review-pr",
+		Ref:       qualifiedRef,
+		State:     queue.StateFailed,
+		Error:     "temporary network outage",
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, recovery.Save(dir, artifact))
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, vessels)
+}
+
+func TestSmoke_S6_GitHubPRScanBlocksNonTransientRecoveryClasses(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "needs refinement", Body: "same body", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+
+	fingerprint := githubSourceFingerprint("needs refinement", "same body", []string{"review-me"})
+	qualifiedRef := prWorkflowRef(prs[0].URL, "review-pr")
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "pr-10-review-pr",
+		Source:   "github-pr",
+		Ref:      qualifiedRef,
+		Workflow: "review-pr",
+		Meta: map[string]string{
+			"pr_num":                   "10",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("pr-10-review-pr", queue.StateFailed, "missing requirement: acceptance criteria are ambiguous"))
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID:  "pr-10-review-pr",
+		Source:    "github-pr",
+		Workflow:  "review-pr",
+		Ref:       qualifiedRef,
+		State:     queue.StateFailed,
+		Error:     "missing requirement: acceptance criteria are ambiguous",
+		CreatedAt: time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown),
+	})
+	require.NoError(t, recovery.Save(dir, artifact))
+	require.Equal(t, recovery.ActionRefine, artifact.RecoveryAction)
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, vessels)
+}
+
+func TestSmoke_S7_GitHubPRScanKeepsLegacyBlockingWhenRecoveryArtifactMissing(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "same title", Body: "same body", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+
+	fingerprint := githubSourceFingerprint("same title", "same body", []string{"review-me"})
+	qualifiedRef := prWorkflowRef(prs[0].URL, "review-pr")
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "pr-10-review-pr",
+		Source:   "github-pr",
+		Ref:      qualifiedRef,
+		Workflow: "review-pr",
+		Meta: map[string]string{
+			"pr_num":                   "10",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("pr-10-review-pr", queue.StateFailed, "temporary network outage"))
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, vessels)
+}
+
 func TestPriorVesselBlocksReenqueue(t *testing.T) {
 	t.Parallel()
 
@@ -402,7 +624,12 @@ func TestPriorVesselBlocksReenqueue(t *testing.T) {
 		},
 		{name: "completed", vessel: &queue.Vessel{State: queue.StateCompleted}, fingerprint: fingerprint, want: false},
 		{name: "cancelled", vessel: &queue.Vessel{State: queue.StateCancelled}, fingerprint: fingerprint, want: false},
-		{name: "timed out", vessel: &queue.Vessel{State: queue.StateTimedOut}, fingerprint: fingerprint, want: false},
+		{
+			name:        "timed out fingerprint match",
+			vessel:      &queue.Vessel{State: queue.StateTimedOut, Meta: map[string]string{"source_input_fingerprint": fingerprint}},
+			fingerprint: fingerprint,
+			want:        true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cli/internal/source/github_test.go
+++ b/cli/internal/source/github_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
@@ -187,6 +188,192 @@ func TestScanSkipsMergedPR(t *testing.T) {
 	if len(vessels) != 0 {
 		t.Errorf("expected 0 vessels (merged PR exists), got %d", len(vessels))
 	}
+}
+
+func TestSmoke_S2_GitHubScanAutoRetriesEligibleTransientFailure(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{{
+		Number: 42,
+		Title:  "flaky dependency",
+		Body:   "same body",
+		URL:    "https://github.com/owner/repo/issues/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}},
+	}}
+	issueBytes, _ := json.Marshal(issues)
+	r.set(issueBytes, "gh", "search", "issues",
+		"--repo", "owner/repo",
+		"--state", "open",
+		"--json", "number,title,body,url,labels",
+		"--limit", "20",
+		"--label", "bug")
+
+	fingerprint := githubSourceFingerprint("flaky dependency", "same body", []string{"bug"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      issues[0].URL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("issue-42", queue.StateFailed, "temporary failure from upstream 503"))
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID:  "issue-42",
+		Source:    "github-issue",
+		Workflow:  "fix-bug",
+		Ref:       issues[0].URL,
+		State:     queue.StateFailed,
+		Error:     "temporary failure from upstream 503",
+		CreatedAt: time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown),
+	})
+	require.NoError(t, recovery.Save(dir, artifact))
+
+	g := &GitHub{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "issue-42-retry-1", vessels[0].ID)
+	assert.Equal(t, "issue-42", vessels[0].RetryOf)
+	assert.Equal(t, "cooldown", vessels[0].Meta[recovery.MetaUnlockedBy])
+	assert.Equal(t, "1", vessels[0].Meta[recovery.MetaRetryCount])
+}
+
+func TestSmoke_S3_GitHubScanBlocksNonTransientRecoveryClasses(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{{
+		Number: 42,
+		Title:  "ambiguous acceptance criteria",
+		Body:   "same body",
+		URL:    "https://github.com/owner/repo/issues/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}},
+	}}
+	issueBytes, _ := json.Marshal(issues)
+	r.set(issueBytes, "gh", "search", "issues",
+		"--repo", "owner/repo",
+		"--state", "open",
+		"--json", "number,title,body,url,labels",
+		"--limit", "20",
+		"--label", "bug")
+
+	fingerprint := githubSourceFingerprint("ambiguous acceptance criteria", "same body", []string{"bug"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      issues[0].URL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("issue-42", queue.StateFailed, "missing requirement: acceptance criteria are ambiguous"))
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID:  "issue-42",
+		Source:    "github-issue",
+		Workflow:  "fix-bug",
+		Ref:       issues[0].URL,
+		State:     queue.StateFailed,
+		Error:     "missing requirement: acceptance criteria are ambiguous",
+		CreatedAt: time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown),
+	})
+	require.NoError(t, recovery.Save(dir, artifact))
+	require.Equal(t, recovery.ActionRefine, artifact.RecoveryAction)
+
+	g := &GitHub{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, vessels)
+}
+
+func TestSmoke_S4_GitHubScanKeepsLegacyBlockingWhenRecoveryArtifactMissing(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{{
+		Number: 42,
+		Title:  "flaky dependency",
+		Body:   "same body",
+		URL:    "https://github.com/owner/repo/issues/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}},
+	}}
+	issueBytes, _ := json.Marshal(issues)
+	r.set(issueBytes, "gh", "search", "issues",
+		"--repo", "owner/repo",
+		"--state", "open",
+		"--json", "number,title,body,url,labels",
+		"--limit", "20",
+		"--label", "bug")
+
+	fingerprint := githubSourceFingerprint("flaky dependency", "same body", []string{"bug"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      issues[0].URL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("issue-42", queue.StateFailed, "temporary failure from upstream 503"))
+
+	g := &GitHub{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, vessels)
 }
 
 func TestOnFailAppliesLabel(t *testing.T) {


### PR DESCRIPTION
## Summary
Implements https://github.com/nicholls-inc/xylem/issues/211 by adding a deterministic failure classifier, explicit retry policy metadata, and cooldown-gated auto-retry handling for transient failed or timed-out vessels while routing spec/scope failures away from churn.

## Smoke scenarios covered
- `cmd/retry/S1` — RetryCommand marks recovery artifact enqueued
- `recovery/S1` — Transient timeout classifies to retry
- `recovery/S3` — Spec gap routes to needs refinement
- `recovery/S4` — Scope gap routes to split-task refinement
- `recovery/S7` — RetryReady blocks before cooldown expires
- `recovery/S8` — RetryReady blocks when retry cap is reached
- `recovery/S10` — NextRetryVessel preserves recovery lineage metadata
- `source/github/S1` — OnFail routes spec-gap failures to `needs-refinement`
- `source/github/S2` — GitHub scan auto-retries eligible transient failures
- `source/github/S3` — GitHub scan blocks non-transient recovery classes
- `source/github/S4` — GitHub scan keeps legacy blocking when `failure-review.json` is absent
- `source/github-pr/S4` — GitHubPR scan auto-retries eligible transient failures
- `source/github-pr/S5` — GitHubPR scan blocks retry until cooldown expires
- `source/github-pr/S6` — GitHubPR scan blocks non-transient recovery classes
- `source/github-pr/S7` — GitHubPR scan keeps legacy blocking when `failure-review.json` is absent

## Changes summary
### Files modified
- `cli/internal/recovery/recovery.go`
- `cli/internal/recovery/recovery_test.go`
- `cli/internal/recovery/recovery_prop_test.go`
- `cli/internal/source/github.go`
- `cli/internal/source/github_test.go`
- `cli/internal/source/github_pr.go`
- `cli/internal/source/github_pr_test.go`
- `cli/internal/source/github_pr_prop_test.go`
- `cli/internal/scanner/scanner.go`
- `cli/internal/runner/runner.go`
- `cli/cmd/xylem/retry.go`
- `cli/cmd/xylem/retry_test.go`

### Key types and functions
- Expanded `recovery.Artifact` with retry counters, retry cap, cooldown timestamp, failure fingerprint, remediation fingerprint metadata, and unlock dimension tracking.
- Added `recovery.RetryDecision`, `recovery.RetryReady`, `recovery.LoadForVessel`, `recovery.NextRetryVessel`, `recovery.RetryID`, `computeFailureFingerprint`, and `remediationFingerprint`.
- Updated `recovery.Build` and `recovery.ApplyToMeta` to emit deterministic class/action/rationale, retry policy metadata, and follow-up routing.
- Updated `source.GitHub.retryCandidate` and `source.GitHubPR.retryCandidate` to load `failure-review.json`, auto-enqueue cooldown-eligible transient retries, and preserve legacy blocking when no artifact exists.
- Updated `source.GitHub.OnFail` / `OnTimedOut` to route spec-gap and scope-gap failures to `needs-refinement`.
- Updated `scanner.Scanner.Scan` and `cmdRetry` to mark retry outcomes as `enqueued` when retries are created.
- Updated runner recovery observability wiring to include the richer recovery metadata surface.

## Test plan
- `cd cli && goimports -w .`
- `cd cli && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #211