### PR TITLE
Require implement-harness branches to rebase on origin/main before push and PR creation

### DIFF
--- a/.xylem/prompts/implement-harness/pr_draft.md
+++ b/.xylem/prompts/implement-harness/pr_draft.md
@@ -5,9 +5,13 @@ Your sole deliverable is a file named `pr_draft.json` at the worktree root. If t
 1. Stage and commit all changes with the message: `feat: {{.Issue.Title}}`
    Reference the issue in the commit body: `Implements {{.Issue.URL}}`
 
-2. Push the branch.
+2. Before pushing, run `git fetch origin main && git rebase origin/main`.
 
-3. Write `pr_draft.json` at the worktree root with this exact structure:
+3. After the rebase, rerun `go vet ./... && go build ./cmd/xylem && go test ./...` from `cli/`.
+
+4. Push the rebased branch. If the rebase rewrote commits, use `git push --force-with-lease`.
+
+5. Write `pr_draft.json` at the worktree root with this exact structure:
 
 ```json
 {

--- a/.xylem/workflows/implement-harness.yaml
+++ b/.xylem/workflows/implement-harness.yaml
@@ -52,10 +52,43 @@ phases:
     max_turns: 15
     llm: copilot
     model: gpt-5.4
+    gate:
+      type: command
+      run: |
+        set -euo pipefail
+
+        current_branch=$(git branch --show-current)
+        if [ -z "$current_branch" ]; then
+          echo "ERROR: current branch is empty"
+          exit 1
+        fi
+
+        git fetch origin main "$current_branch"
+
+        if ! git merge-base --is-ancestor origin/main HEAD; then
+          echo "ERROR: branch is behind origin/main; rebase before pushing"
+          exit 1
+        fi
+
+        if [ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/$current_branch")" ]; then
+          echo "ERROR: remote branch does not match HEAD; push the rebased branch before continuing"
+          exit 1
+        fi
+
+        cd cli
+        go vet ./...
+        go build ./cmd/xylem
+        go test ./...
   - name: pr_create
     type: command
     run: |
       set -euo pipefail
+
+      git fetch origin main
+      if ! git merge-base --is-ancestor origin/main HEAD; then
+        echo "ERROR: branch is behind origin/main; rebase before creating the PR"
+        exit 1
+      fi
 
       DRAFT_FILE="pr_draft.json"
       if [ ! -f "$DRAFT_FILE" ]; then

--- a/cli/internal/workflow/implement_harness_workflow_test.go
+++ b/cli/internal/workflow/implement_harness_workflow_test.go
@@ -1,0 +1,137 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	implementHarnessFetchMain = "git fetch origin main"
+	implementHarnessFetchHead = `git fetch origin main "$current_branch"`
+	implementHarnessMergeBase = "git merge-base --is-ancestor origin/main HEAD"
+	implementHarnessRemoteRef = `git rev-parse "origin/$current_branch"`
+	implementHarnessGoVet     = "go vet ./..."
+	implementHarnessGoBuild   = "go build ./cmd/xylem"
+	implementHarnessGoTest    = "go test ./..."
+	implementHarnessPRCreate  = "gh pr create"
+)
+
+func checkedInWorkflowPath(t *testing.T, name string) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller() failed")
+
+	return filepath.Join(filepath.Dir(file), "..", "..", "..", ".xylem", "workflows", name)
+}
+
+func checkedInPromptPath(t *testing.T, name string) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller() failed")
+
+	return filepath.Join(filepath.Dir(file), "..", "..", "..", ".xylem", "prompts", "implement-harness", name)
+}
+
+func findPhaseByName(t *testing.T, phases []Phase, name string) *Phase {
+	t.Helper()
+
+	for i := range phases {
+		if phases[i].Name == name {
+			return &phases[i]
+		}
+	}
+
+	t.Fatalf("phase %q not found", name)
+	return nil
+}
+
+func commandContainsInOrder(command string, parts ...string) bool {
+	searchStart := 0
+	for _, part := range parts {
+		idx := strings.Index(command[searchStart:], part)
+		if idx == -1 {
+			return false
+		}
+		searchStart += idx + len(part)
+	}
+
+	return true
+}
+
+func TestSmoke_S2_ImplementHarnessWorkflowChecksRebasedBranchBeforePRDraftCompletes(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := checkedInWorkflowPath(t, "implement-harness.yaml")
+	data, err := os.ReadFile(workflowPath)
+	require.NoError(t, err, "ReadFile(%q)", workflowPath)
+
+	var wf Workflow
+	require.NoError(t, yaml.Unmarshal(data, &wf), "yaml.Unmarshal(%q)", workflowPath)
+
+	prDraft := findPhaseByName(t, wf.Phases, "pr_draft")
+	require.NotNil(t, prDraft.Gate, "workflow %q missing pr_draft gate", wf.Name)
+	assert.Equal(t, "command", prDraft.Gate.Type)
+	assert.Contains(t, prDraft.Gate.Run, implementHarnessFetchHead)
+	assert.Contains(t, prDraft.Gate.Run, implementHarnessMergeBase)
+	assert.Contains(t, prDraft.Gate.Run, implementHarnessRemoteRef)
+	assert.Contains(t, prDraft.Gate.Run, `ERROR: branch is behind origin/main; rebase before pushing`)
+	assert.Contains(t, prDraft.Gate.Run, `ERROR: remote branch does not match HEAD; push the rebased branch before continuing`)
+	assert.True(t, commandContainsInOrder(
+		prDraft.Gate.Run,
+		implementHarnessFetchHead,
+		implementHarnessMergeBase,
+		implementHarnessRemoteRef,
+		implementHarnessGoVet,
+		implementHarnessGoBuild,
+		implementHarnessGoTest,
+	))
+}
+
+func TestSmoke_S3_ImplementHarnessWorkflowChecksMainFreshnessBeforePRCreate(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := checkedInWorkflowPath(t, "implement-harness.yaml")
+	data, err := os.ReadFile(workflowPath)
+	require.NoError(t, err, "ReadFile(%q)", workflowPath)
+
+	var wf Workflow
+	require.NoError(t, yaml.Unmarshal(data, &wf), "yaml.Unmarshal(%q)", workflowPath)
+
+	prCreate := findPhaseByName(t, wf.Phases, "pr_create")
+	assert.Equal(t, "command", prCreate.Type)
+	assert.Contains(t, prCreate.Run, implementHarnessFetchMain)
+	assert.Contains(t, prCreate.Run, implementHarnessMergeBase)
+	assert.Contains(t, prCreate.Run, `ERROR: branch is behind origin/main; rebase before creating the PR`)
+	assert.True(t, commandContainsInOrder(prCreate.Run, implementHarnessFetchMain, implementHarnessMergeBase, implementHarnessPRCreate))
+}
+
+func TestSmoke_S4_ImplementHarnessPRDraftPromptRequiresRebaseRetestAndForcePush(t *testing.T) {
+	t.Parallel()
+
+	promptPath := checkedInPromptPath(t, "pr_draft.md")
+	data, err := os.ReadFile(promptPath)
+	require.NoError(t, err, "ReadFile(%q)", promptPath)
+
+	prompt := string(data)
+	assert.Contains(t, prompt, "`git fetch origin main && git rebase origin/main`")
+	assert.Contains(t, prompt, "`go vet ./... && go build ./cmd/xylem && go test ./...`")
+	assert.Contains(t, prompt, "`git push --force-with-lease`")
+	assert.True(t, commandContainsInOrder(
+		prompt,
+		"git fetch origin main",
+		"git rebase origin/main",
+		"go vet ./...",
+		"go build ./cmd/xylem",
+		"go test ./...",
+		"git push --force-with-lease",
+	))
+}


### PR DESCRIPTION
## Summary
- Implements [issue #218](https://github.com/nicholls-inc/xylem/issues/218) by requiring the `implement-harness` publish path to verify that `HEAD` is rebased onto `origin/main` before push/PR creation proceeds.
- Adds a `pr_draft` workflow gate that rejects stale or unpushed rebases and reruns `go vet`, `go build`, and `go test` after the branch is up to date.
- Updates the `implement-harness` PR drafting instructions so the agent rebases, retests, and uses `git push --force-with-lease` when the rebase rewrites history.

## Smoke scenarios covered
- **S2** `TestSmoke_S2_ImplementHarnessWorkflowChecksRebasedBranchBeforePRDraftCompletes` — verifies the checked-in `pr_draft` gate fetches `origin/main` and the current branch, checks that `origin/main` is an ancestor of `HEAD`, checks that `origin/$current_branch` matches `HEAD`, then runs `go vet ./...`, `go build ./cmd/xylem`, and `go test ./...`.
- **S3** `TestSmoke_S3_ImplementHarnessWorkflowChecksMainFreshnessBeforePRCreate` — verifies `pr_create` fetches `origin/main` and blocks PR creation when the branch is behind main.
- **S4** `TestSmoke_S4_ImplementHarnessPRDraftPromptRequiresRebaseRetestAndForcePush` — verifies the `pr_draft` prompt requires rebasing onto `origin/main`, rerunning validation, and pushing with `git push --force-with-lease`.

## Changes summary
- **Modified** `.xylem/workflows/implement-harness.yaml` to add a command gate on `pr_draft` and a main-freshness guard in `pr_create`.
- **Modified** `.xylem/prompts/implement-harness/pr_draft.md` to require rebase, retest, and force-with-lease push instructions before writing the draft artifact.
- **Added** `cli/internal/workflow/implement_harness_workflow_test.go` with helpers `checkedInWorkflowPath`, `checkedInPromptPath`, `findPhaseByName`, and `commandContainsInOrder`, plus smoke tests covering the new workflow and prompt requirements.

## Test plan
- `cd cli && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #218