### PR TITLE
feat: add remediation-aware scanner retry gating

### DIFF
--- a/cli/cmd/xylem/retry.go
+++ b/cli/cmd/xylem/retry.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -41,10 +40,19 @@ func cmdRetry(q *queue.Queue, cfg *config.Config, id string, fromScratch bool) e
 
 	newID := retryID(vessel.ID, q)
 
-	meta := make(map[string]string)
-	for k, v := range vessel.Meta {
-		meta[k] = v
-	}
+	meta := recovery.PrepareRetryMeta(vessel.Meta, recovery.Build(recovery.Input{
+		VesselID:    vessel.ID,
+		Source:      vessel.Source,
+		Workflow:    vessel.Workflow,
+		Ref:         vessel.Ref,
+		State:       vessel.State,
+		FailedPhase: vessel.FailedPhase,
+		Error:       vessel.Error,
+		GateOutput:  vessel.GateOutput,
+		RetryOf:     vessel.RetryOf,
+		Meta:        vessel.Meta,
+		CreatedAt:   commandNow(),
+	}), "", vessel.Meta[recovery.MetaRemediationFingerprint])
 	meta["retry_of"] = vessel.ID
 	if vessel.Error != "" {
 		meta["retry_error"] = vessel.Error
@@ -159,15 +167,5 @@ func copyFile(src, dst string) error {
 
 func retryID(originalID string, q *queue.Queue) string {
 	vessels, _ := q.List()
-	maxRetry := 0
-	prefix := originalID + "-retry-"
-	for _, v := range vessels {
-		if strings.HasPrefix(v.ID, prefix) {
-			numStr := strings.TrimPrefix(v.ID, prefix)
-			if n, err := strconv.Atoi(numStr); err == nil && n > maxRetry {
-				maxRetry = n
-			}
-		}
-	}
-	return fmt.Sprintf("%s-retry-%d", originalID, maxRetry+1)
+	return recovery.NextRetryID(originalID, vessels)
 }

--- a/cli/internal/recovery/recovery.go
+++ b/cli/internal/recovery/recovery.go
@@ -1,34 +1,50 @@
 package recovery
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 )
 
 const (
 	artifactFileName = "failure-review.json"
 	schemaVersion    = "v1"
 
-	MetaClass           = "recovery_class"
-	MetaAction          = "recovery_action"
-	MetaRationale       = "recovery_rationale"
-	MetaFollowUpRoute   = "recovery_followup_route"
-	MetaRetrySuppressed = "recovery_retry_suppressed"
-	MetaRetryOutcome    = "recovery_retry_outcome"
-	MetaUnlockDimension = "recovery_unlock_dimension"
+	MetaClass                  = "recovery_class"
+	MetaAction                 = "recovery_action"
+	MetaRationale              = "recovery_rationale"
+	MetaFollowUpRoute          = "recovery_followup_route"
+	MetaRetrySuppressed        = "recovery_retry_suppressed"
+	MetaRetryOutcome           = "recovery_retry_outcome"
+	MetaUnlockDimension        = "recovery_unlock_dimension"
+	MetaUnlockedBy             = "recovery_unlocked_by"
+	MetaRetryCount             = "recovery_retry_count"
+	MetaRetryCap               = "recovery_retry_cap"
+	MetaRetryAfter             = "recovery_retry_after"
+	MetaFailureFingerprint     = "failure_fingerprint"
+	MetaRemediationFingerprint = "remediation_fingerprint"
 )
 
 var safePathComponent = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+const (
+	defaultStateDir      = ".xylem"
+	defaultRetryCap      = 2
+	defaultRetryCooldown = 15 * time.Minute
+)
 
 type Class string
 
@@ -51,25 +67,39 @@ const (
 )
 
 type Artifact struct {
-	SchemaVersion   string                          `json:"schema_version"`
-	VesselID        string                          `json:"vessel_id"`
-	Source          string                          `json:"source,omitempty"`
-	Workflow        string                          `json:"workflow,omitempty"`
-	Ref             string                          `json:"ref,omitempty"`
-	State           string                          `json:"state"`
-	FailedPhase     string                          `json:"failed_phase,omitempty"`
-	Error           string                          `json:"error,omitempty"`
-	GateOutput      string                          `json:"gate_output,omitempty"`
-	RecoveryClass   Class                           `json:"recovery_class"`
-	RecoveryAction  Action                          `json:"recovery_action"`
-	Rationale       string                          `json:"rationale"`
-	FollowUpRoute   string                          `json:"follow_up_route,omitempty"`
-	RetrySuppressed bool                            `json:"retry_suppressed"`
-	RetryOutcome    string                          `json:"retry_outcome,omitempty"`
-	UnlockDimension string                          `json:"unlock_dimension,omitempty"`
-	RetryOf         string                          `json:"retry_of,omitempty"`
-	Trace           *observability.TraceContextData `json:"trace,omitempty"`
-	CreatedAt       time.Time                       `json:"created_at"`
+	SchemaVersion      string                          `json:"schema_version"`
+	VesselID           string                          `json:"vessel_id"`
+	Source             string                          `json:"source,omitempty"`
+	Workflow           string                          `json:"workflow,omitempty"`
+	Ref                string                          `json:"ref,omitempty"`
+	State              string                          `json:"state"`
+	FailedPhase        string                          `json:"failed_phase,omitempty"`
+	Error              string                          `json:"error,omitempty"`
+	GateOutput         string                          `json:"gate_output,omitempty"`
+	RecoveryClass      Class                           `json:"recovery_class"`
+	RecoveryAction     Action                          `json:"recovery_action"`
+	Rationale          string                          `json:"rationale"`
+	FollowUpRoute      string                          `json:"follow_up_route,omitempty"`
+	FailureFingerprint string                          `json:"failure_fingerprint,omitempty"`
+	RetrySuppressed    bool                            `json:"retry_suppressed"`
+	RetryOutcome       string                          `json:"retry_outcome,omitempty"`
+	RetryCount         int                             `json:"retry_count,omitempty"`
+	RetryCap           int                             `json:"retry_cap,omitempty"`
+	RetryAfter         *time.Time                      `json:"retry_after,omitempty"`
+	UnlockDimension    string                          `json:"unlock_dimension,omitempty"`
+	RetryOf            string                          `json:"retry_of,omitempty"`
+	Unlock             *Unlock                         `json:"unlock,omitempty"`
+	Trace              *observability.TraceContextData `json:"trace,omitempty"`
+	CreatedAt          time.Time                       `json:"created_at"`
+}
+
+type Unlock struct {
+	SourceInputFingerprint string `json:"source_input_fingerprint,omitempty"`
+	HarnessDigest          string `json:"harness_digest,omitempty"`
+	WorkflowDigest         string `json:"workflow_digest,omitempty"`
+	DecisionDigest         string `json:"decision_digest,omitempty"`
+	RemediationEpoch       string `json:"remediation_epoch,omitempty"`
+	RemediationFingerprint string `json:"remediation_fingerprint,omitempty"`
 }
 
 type Input struct {
@@ -96,6 +126,16 @@ func Build(input Input) *Artifact {
 	class, action, rationale := classify(input)
 	followUpRoute := followUpRouteFor(action)
 	retrySuppressed := action != ActionRetry
+	retryCount := parseMetaInt(input.Meta, MetaRetryCount)
+	retryCap := parseMetaInt(input.Meta, MetaRetryCap)
+	if action == ActionRetry && retryCap <= 0 {
+		retryCap = defaultRetryCap
+	}
+	retryAfter := parseMetaTime(input.Meta, MetaRetryAfter)
+	if action == ActionRetry && retryAfter == nil {
+		next := createdAt.Add(defaultRetryBackoff(retryCount))
+		retryAfter = &next
+	}
 	retryOutcome := strings.TrimSpace(metaValue(input.Meta, MetaRetryOutcome))
 	if retryOutcome == "" {
 		if retrySuppressed {
@@ -106,32 +146,40 @@ func Build(input Input) *Artifact {
 	}
 
 	unlockDimension := strings.TrimSpace(metaValue(input.Meta, MetaUnlockDimension))
+	if unlockDimension == "" {
+		unlockDimension = strings.TrimSpace(metaValue(input.Meta, MetaUnlockedBy))
+	}
 	trace := input.Trace
 	if trace != nil && trace.TraceID == "" && trace.SpanID == "" {
 		trace = nil
 	}
 
-	return &Artifact{
-		SchemaVersion:   schemaVersion,
-		VesselID:        input.VesselID,
-		Source:          input.Source,
-		Workflow:        input.Workflow,
-		Ref:             input.Ref,
-		State:           string(input.State),
-		FailedPhase:     input.FailedPhase,
-		Error:           input.Error,
-		GateOutput:      input.GateOutput,
-		RecoveryClass:   class,
-		RecoveryAction:  action,
-		Rationale:       rationale,
-		FollowUpRoute:   followUpRoute,
-		RetrySuppressed: retrySuppressed,
-		RetryOutcome:    retryOutcome,
-		UnlockDimension: unlockDimension,
-		RetryOf:         input.RetryOf,
-		Trace:           trace,
-		CreatedAt:       createdAt,
+	artifact := &Artifact{
+		SchemaVersion:      schemaVersion,
+		VesselID:           input.VesselID,
+		Source:             input.Source,
+		Workflow:           input.Workflow,
+		Ref:                input.Ref,
+		State:              string(input.State),
+		FailedPhase:        input.FailedPhase,
+		Error:              input.Error,
+		GateOutput:         input.GateOutput,
+		RecoveryClass:      class,
+		RecoveryAction:     action,
+		Rationale:          rationale,
+		FollowUpRoute:      followUpRoute,
+		FailureFingerprint: failureFingerprint(input.State, input.FailedPhase, input.Error, input.GateOutput),
+		RetrySuppressed:    retrySuppressed,
+		RetryOutcome:       retryOutcome,
+		RetryCount:         retryCount,
+		RetryCap:           retryCap,
+		RetryAfter:         retryAfter,
+		UnlockDimension:    unlockDimension,
+		RetryOf:            input.RetryOf,
+		Trace:              trace,
+		CreatedAt:          createdAt,
 	}
+	return artifact
 }
 
 func ApplyToMeta(meta map[string]string, artifact *Artifact) map[string]string {
@@ -155,10 +203,37 @@ func ApplyToMeta(meta map[string]string, artifact *Artifact) map[string]string {
 	} else {
 		delete(meta, MetaRetryOutcome)
 	}
+	if artifact.RetryCount > 0 {
+		meta[MetaRetryCount] = strconv.Itoa(artifact.RetryCount)
+	} else {
+		delete(meta, MetaRetryCount)
+	}
+	if artifact.RetryCap > 0 {
+		meta[MetaRetryCap] = strconv.Itoa(artifact.RetryCap)
+	} else {
+		delete(meta, MetaRetryCap)
+	}
+	if artifact.RetryAfter != nil {
+		meta[MetaRetryAfter] = artifact.RetryAfter.UTC().Format(time.RFC3339Nano)
+	} else {
+		delete(meta, MetaRetryAfter)
+	}
 	if artifact.UnlockDimension != "" {
 		meta[MetaUnlockDimension] = artifact.UnlockDimension
+		meta[MetaUnlockedBy] = artifact.UnlockDimension
 	} else {
 		delete(meta, MetaUnlockDimension)
+		delete(meta, MetaUnlockedBy)
+	}
+	if artifact.FailureFingerprint != "" {
+		meta[MetaFailureFingerprint] = artifact.FailureFingerprint
+	} else {
+		delete(meta, MetaFailureFingerprint)
+	}
+	if artifact.Unlock != nil && artifact.Unlock.RemediationFingerprint != "" {
+		meta[MetaRemediationFingerprint] = artifact.Unlock.RemediationFingerprint
+	} else {
+		delete(meta, MetaRemediationFingerprint)
 	}
 	return meta
 }
@@ -256,11 +331,349 @@ func UpdateRetryOutcome(stateDir, vesselID, outcome string) error {
 	return Save(stateDir, artifact)
 }
 
+type RetryGateDecision struct {
+	Blocked                bool
+	UnlockDimension        string
+	FailureFingerprint     string
+	RemediationFingerprint string
+	Artifact               *Artifact
+}
+
+func PopulateUnlock(stateDir string, artifact *Artifact, sourceFingerprint string, now time.Time) error {
+	if artifact == nil {
+		return nil
+	}
+	unlock, err := computeUnlock(normalizeStateDir(stateDir), artifact.Workflow, sourceFingerprint, artifact, now)
+	if err != nil {
+		return err
+	}
+	artifact.Unlock = unlock
+	return nil
+}
+
+func EvaluateRetryGate(stateDir string, latest *queue.Vessel, currentWorkflow, currentSourceFingerprint string, now time.Time) (RetryGateDecision, error) {
+	if latest == nil {
+		return RetryGateDecision{}, nil
+	}
+	switch latest.State {
+	case queue.StatePending, queue.StateRunning, queue.StateWaiting:
+		return RetryGateDecision{Blocked: true}, nil
+	case queue.StateFailed, queue.StateTimedOut:
+	default:
+		return RetryGateDecision{}, nil
+	}
+
+	artifact, err := Load(Path(normalizeStateDir(stateDir), latest.ID))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return RetryGateDecision{Blocked: latest.Meta["source_input_fingerprint"] == currentSourceFingerprint}, nil
+		}
+		return RetryGateDecision{}, err
+	}
+	if artifact.Workflow == "" {
+		artifact.Workflow = currentWorkflow
+	}
+
+	stored := *artifact
+	storedSourceFingerprint := latest.Meta["source_input_fingerprint"]
+	if stored.Unlock != nil && stored.Unlock.SourceInputFingerprint != "" {
+		storedSourceFingerprint = stored.Unlock.SourceInputFingerprint
+	}
+	if stored.Unlock == nil || stored.Unlock.RemediationFingerprint == "" {
+		if err := PopulateUnlock(stateDir, &stored, storedSourceFingerprint, stored.CreatedAt); err != nil {
+			return RetryGateDecision{}, err
+		}
+	}
+
+	current := *artifact
+	if err := PopulateUnlock(stateDir, &current, currentSourceFingerprint, now.UTC()); err != nil {
+		return RetryGateDecision{}, err
+	}
+	if current.RecoveryAction != ActionRetry {
+		return RetryGateDecision{Blocked: true, Artifact: &current}, nil
+	}
+	if current.RetryCap > 0 && current.RetryCount >= current.RetryCap {
+		return RetryGateDecision{Blocked: true, Artifact: &current}, nil
+	}
+	if current.RetryAfter != nil && now.UTC().Before(current.RetryAfter.UTC()) {
+		return RetryGateDecision{Blocked: true, Artifact: &current}, nil
+	}
+	if stored.Unlock == nil || current.Unlock == nil || stored.Unlock.RemediationFingerprint == current.Unlock.RemediationFingerprint {
+		return RetryGateDecision{Blocked: true, Artifact: &current}, nil
+	}
+
+	return RetryGateDecision{
+		Blocked:                false,
+		UnlockDimension:        unlockDimension(*stored.Unlock, *current.Unlock),
+		FailureFingerprint:     current.FailureFingerprint,
+		RemediationFingerprint: current.Unlock.RemediationFingerprint,
+		Artifact:               &current,
+	}, nil
+}
+
+func PrepareRetryMeta(base map[string]string, artifact *Artifact, unlockDimension, remediationFingerprint string) map[string]string {
+	meta := make(map[string]string, len(base)+8)
+	for k, v := range base {
+		meta[k] = v
+	}
+	delete(meta, MetaRetryAfter)
+	delete(meta, MetaRetryOutcome)
+	if artifact == nil {
+		return meta
+	}
+	meta[MetaClass] = string(artifact.RecoveryClass)
+	meta[MetaAction] = string(artifact.RecoveryAction)
+	meta[MetaFailureFingerprint] = artifact.FailureFingerprint
+	if artifact.RetryCap > 0 {
+		meta[MetaRetryCap] = strconv.Itoa(artifact.RetryCap)
+	}
+	meta[MetaRetryCount] = strconv.Itoa(artifact.RetryCount + 1)
+	if unlockDimension != "" {
+		meta[MetaUnlockDimension] = unlockDimension
+		meta[MetaUnlockedBy] = unlockDimension
+	}
+	if remediationFingerprint != "" {
+		meta[MetaRemediationFingerprint] = remediationFingerprint
+	}
+	return meta
+}
+
+func RetryRootID(id string) string {
+	root := id
+	for {
+		next, ok := trimRetrySuffix(root)
+		if !ok {
+			return root
+		}
+		root = next
+	}
+}
+
+func NextRetryID(originalID string, vessels []queue.Vessel) string {
+	root := RetryRootID(originalID)
+	maxRetry := 0
+	prefix := root + "-retry-"
+	for _, v := range vessels {
+		if !strings.HasPrefix(v.ID, prefix) {
+			continue
+		}
+		numStr := strings.TrimPrefix(v.ID, prefix)
+		if n, err := strconv.Atoi(numStr); err == nil && n > maxRetry {
+			maxRetry = n
+		}
+	}
+	return fmt.Sprintf("%s-retry-%d", root, maxRetry+1)
+}
+
 func metaValue(meta map[string]string, key string) string {
 	if meta == nil {
 		return ""
 	}
 	return meta[key]
+}
+
+func parseMetaInt(meta map[string]string, key string) int {
+	value := strings.TrimSpace(metaValue(meta, key))
+	if value == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+func parseMetaTime(meta map[string]string, key string) *time.Time {
+	value := strings.TrimSpace(metaValue(meta, key))
+	if value == "" {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return nil
+	}
+	parsed = parsed.UTC()
+	return &parsed
+}
+
+func defaultRetryBackoff(retryCount int) time.Duration {
+	if retryCount < 0 {
+		retryCount = 0
+	}
+	return defaultRetryCooldown << retryCount
+}
+
+func failureFingerprint(state queue.VesselState, failedPhase, errMsg, gateOutput string) string {
+	return hashStrings(
+		string(state),
+		strings.TrimSpace(failedPhase),
+		strings.TrimSpace(errMsg),
+		strings.TrimSpace(gateOutput),
+	)
+}
+
+func computeUnlock(stateDir, workflowName, sourceFingerprint string, artifact *Artifact, now time.Time) (*Unlock, error) {
+	harnessDigest, err := harnessDigest(stateDir)
+	if err != nil {
+		return nil, err
+	}
+	workflowDigest, err := workflowDigest(stateDir, workflowName)
+	if err != nil {
+		return nil, err
+	}
+	unlock := &Unlock{
+		SourceInputFingerprint: strings.TrimSpace(sourceFingerprint),
+		HarnessDigest:          harnessDigest,
+		WorkflowDigest:         workflowDigest,
+		DecisionDigest:         decisionDigest(artifact),
+		RemediationEpoch:       remediationEpoch(artifact, now.UTC()),
+	}
+	unlock.RemediationFingerprint = remediationFingerprint(unlock)
+	return unlock, nil
+}
+
+func harnessDigest(stateDir string) (string, error) {
+	return digestFile(filepath.Join(stateDir, "HARNESS.md"))
+}
+
+func workflowDigest(stateDir, workflowName string) (string, error) {
+	if strings.TrimSpace(workflowName) == "" {
+		return "", nil
+	}
+	workflowPath := filepath.Join(stateDir, "workflows", workflowName+".yaml")
+	workflowBytes, err := os.ReadFile(workflowPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read workflow %q: %w", workflowPath, err)
+	}
+
+	files := []string{filepath.Clean(workflowPath)}
+	if wf, loadErr := workflow.Load(workflowPath); loadErr == nil {
+		seen := map[string]struct{}{filepath.Clean(workflowPath): {}}
+		for _, phase := range wf.Phases {
+			if phase.Type == "command" || strings.TrimSpace(phase.PromptFile) == "" {
+				continue
+			}
+			path := filepath.Clean(phase.PromptFile)
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+			files = append(files, path)
+		}
+	}
+
+	sort.Strings(files)
+	payload := make([]string, 0, len(files)*2+1)
+	payload = append(payload, string(workflowBytes))
+	for _, path := range files[1:] {
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			if errors.Is(readErr, os.ErrNotExist) {
+				continue
+			}
+			return "", fmt.Errorf("read workflow dependency %q: %w", path, readErr)
+		}
+		payload = append(payload, path, string(data))
+	}
+	return hashStrings(payload...), nil
+}
+
+func decisionDigest(artifact *Artifact) string {
+	if artifact == nil {
+		return ""
+	}
+	retryAfter := ""
+	if artifact.RetryAfter != nil {
+		retryAfter = artifact.RetryAfter.UTC().Format(time.RFC3339Nano)
+	}
+	return hashStrings(
+		string(artifact.RecoveryClass),
+		string(artifact.RecoveryAction),
+		artifact.Rationale,
+		artifact.FollowUpRoute,
+		strconv.Itoa(artifact.RetryCount),
+		strconv.Itoa(artifact.RetryCap),
+		retryAfter,
+	)
+}
+
+func remediationEpoch(artifact *Artifact, now time.Time) string {
+	if artifact == nil || artifact.RetryAfter == nil {
+		return ""
+	}
+	retryAfter := artifact.RetryAfter.UTC().Format(time.RFC3339Nano)
+	if now.Before(artifact.RetryAfter.UTC()) {
+		return "cooldown:pending:" + retryAfter
+	}
+	return "cooldown:eligible:" + retryAfter
+}
+
+func remediationFingerprint(unlock *Unlock) string {
+	if unlock == nil {
+		return ""
+	}
+	return hashStrings(
+		unlock.SourceInputFingerprint,
+		unlock.HarnessDigest,
+		unlock.WorkflowDigest,
+		unlock.DecisionDigest,
+		unlock.RemediationEpoch,
+	)
+}
+
+func digestFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	return hashStrings(path, string(data)), nil
+}
+
+func hashStrings(parts ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\n")))
+	return hex.EncodeToString(sum[:])
+}
+
+func unlockDimension(stored, current Unlock) string {
+	switch {
+	case stored.SourceInputFingerprint != current.SourceInputFingerprint:
+		return "source"
+	case stored.HarnessDigest != current.HarnessDigest:
+		return "harness"
+	case stored.WorkflowDigest != current.WorkflowDigest:
+		return "workflow"
+	case stored.DecisionDigest != current.DecisionDigest:
+		return "decision"
+	case stored.RemediationEpoch != current.RemediationEpoch:
+		return "cooldown"
+	default:
+		return ""
+	}
+}
+
+func normalizeStateDir(stateDir string) string {
+	if strings.TrimSpace(stateDir) == "" {
+		return defaultStateDir
+	}
+	return stateDir
+}
+
+func trimRetrySuffix(id string) (string, bool) {
+	idx := strings.LastIndex(id, "-retry-")
+	if idx < 0 {
+		return "", false
+	}
+	if _, err := strconv.Atoi(id[idx+len("-retry-"):]); err != nil {
+		return "", false
+	}
+	return id[:idx], true
 }
 
 func containsAny(text string, substrings ...string) bool {

--- a/cli/internal/recovery/recovery_test.go
+++ b/cli/internal/recovery/recovery_test.go
@@ -1,6 +1,7 @@
 package recovery
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -152,4 +153,128 @@ func TestUpdateRetryOutcomeRejectsUnsafeVesselID(t *testing.T) {
 	if got := err.Error(); got == "" || !strings.Contains(got, "invalid vessel ID") {
 		t.Fatalf("UpdateRetryOutcome() error = %q, want invalid vessel ID", got)
 	}
+}
+
+func TestEvaluateRetryGateUnlockDimensions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		mutateStateDir    func(t *testing.T, stateDir string)
+		mutateArtifact    func(t *testing.T, artifact *Artifact)
+		nowOffset         time.Duration
+		sourceFingerprint string
+		wantBlocked       bool
+		wantUnlock        string
+	}{
+		{
+			name:              "source",
+			nowOffset:         20 * time.Minute,
+			sourceFingerprint: "source-new",
+			wantUnlock:        "source",
+		},
+		{
+			name:      "harness",
+			nowOffset: 20 * time.Minute,
+			mutateStateDir: func(t *testing.T, stateDir string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(filepath.Join(stateDir, "HARNESS.md"), []byte("updated harness"), 0o644))
+			},
+			sourceFingerprint: "source-old",
+			wantUnlock:        "harness",
+		},
+		{
+			name:      "workflow",
+			nowOffset: 20 * time.Minute,
+			mutateStateDir: func(t *testing.T, stateDir string) {
+				t.Helper()
+				promptPath := filepath.Join(stateDir, "prompts", "fix-bug.md")
+				workflowYAML := "name: fix-bug\nphases:\n  - name: analyze\n    prompt_file: " + promptPath + "\n    max_turns: 2\n"
+				require.NoError(t, os.WriteFile(filepath.Join(stateDir, "workflows", "fix-bug.yaml"), []byte(workflowYAML), 0o644))
+			},
+			sourceFingerprint: "source-old",
+			wantUnlock:        "workflow",
+		},
+		{
+			name:      "decision",
+			nowOffset: 20 * time.Minute,
+			mutateArtifact: func(t *testing.T, artifact *Artifact) {
+				t.Helper()
+				artifact.RetryCap = 1
+			},
+			sourceFingerprint: "source-old",
+			wantUnlock:        "decision",
+		},
+		{
+			name:              "cooldown",
+			nowOffset:         20 * time.Minute,
+			sourceFingerprint: "source-old",
+			wantUnlock:        "cooldown",
+		},
+		{
+			name:              "unchanged blocked",
+			nowOffset:         5 * time.Minute,
+			sourceFingerprint: "source-old",
+			wantBlocked:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stateDir := setupRecoveryStateDir(t)
+			createdAt := time.Date(2026, time.April, 9, 18, 0, 0, 0, time.UTC)
+			artifact := Build(Input{
+				VesselID:  "issue-42",
+				Source:    "github-issue",
+				Workflow:  "fix-bug",
+				Ref:       "https://github.com/owner/repo/issues/42",
+				State:     queue.StateTimedOut,
+				Error:     "context deadline exceeded",
+				CreatedAt: createdAt,
+			})
+			require.NoError(t, PopulateUnlock(stateDir, artifact, "source-old", createdAt))
+			require.NoError(t, Save(stateDir, artifact))
+
+			if tt.mutateStateDir != nil {
+				tt.mutateStateDir(t, stateDir)
+			}
+			if tt.mutateArtifact != nil {
+				mutated, err := Load(Path(stateDir, artifact.VesselID))
+				require.NoError(t, err)
+				tt.mutateArtifact(t, mutated)
+				require.NoError(t, Save(stateDir, mutated))
+			}
+
+			latest := &queue.Vessel{
+				ID:       artifact.VesselID,
+				Source:   "github-issue",
+				Ref:      artifact.Ref,
+				Workflow: artifact.Workflow,
+				State:    queue.StateTimedOut,
+				Meta: map[string]string{
+					"source_input_fingerprint": "source-old",
+				},
+			}
+			decision, err := EvaluateRetryGate(stateDir, latest, artifact.Workflow, tt.sourceFingerprint, createdAt.Add(tt.nowOffset))
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantBlocked, decision.Blocked)
+			assert.Equal(t, tt.wantUnlock, decision.UnlockDimension)
+		})
+	}
+}
+
+func setupRecoveryStateDir(t *testing.T) string {
+	t.Helper()
+
+	stateDir := t.TempDir()
+	promptDir := filepath.Join(stateDir, "prompts")
+	workflowDir := filepath.Join(stateDir, "workflows")
+	require.NoError(t, os.MkdirAll(promptDir, 0o755))
+	require.NoError(t, os.MkdirAll(workflowDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "HARNESS.md"), []byte("initial harness"), 0o644))
+	promptPath := filepath.Join(promptDir, "fix-bug.md")
+	require.NoError(t, os.WriteFile(promptPath, []byte("initial prompt"), 0o644))
+	workflowYAML := "name: fix-bug\nphases:\n  - name: analyze\n    prompt_file: " + promptPath + "\n    max_turns: 1\n"
+	require.NoError(t, os.WriteFile(filepath.Join(workflowDir, "fix-bug.yaml"), []byte(workflowYAML), 0o644))
+	return stateDir
 }

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -1353,7 +1353,7 @@ func (r *Runner) failUpdatedVessel(vessel *queue.Vessel, errMsg string) {
 	vessel.State = queue.StateFailed
 	vessel.Error = errMsg
 	vessel.EndedAt = &now
-	vessel.Meta = recovery.ApplyToMeta(vessel.Meta, recovery.Build(recovery.Input{
+	artifact := recovery.Build(recovery.Input{
 		VesselID:    vessel.ID,
 		Source:      vessel.Source,
 		Workflow:    vessel.Workflow,
@@ -1365,7 +1365,11 @@ func (r *Runner) failUpdatedVessel(vessel *queue.Vessel, errMsg string) {
 		RetryOf:     vessel.RetryOf,
 		Meta:        vessel.Meta,
 		CreatedAt:   now,
-	}))
+	})
+	if err := recovery.PopulateUnlock(r.Config.StateDir, artifact, vessel.Meta["source_input_fingerprint"], now); err != nil {
+		log.Printf("warn: populate recovery unlock for vessel %s: %v", vessel.ID, err)
+	}
+	vessel.Meta = recovery.ApplyToMeta(vessel.Meta, artifact)
 	if updateErr := r.Queue.UpdateVessel(*vessel); updateErr != nil {
 		if r.cancelledTransition(vessel.ID, updateErr) {
 			return
@@ -1383,7 +1387,7 @@ func (r *Runner) annotateRecoveryMetadata(id string, state queue.VesselState, er
 	if err != nil || current == nil {
 		return
 	}
-	current.Meta = recovery.ApplyToMeta(current.Meta, recovery.Build(recovery.Input{
+	artifact := recovery.Build(recovery.Input{
 		VesselID:    current.ID,
 		Source:      current.Source,
 		Workflow:    current.Workflow,
@@ -1396,7 +1400,11 @@ func (r *Runner) annotateRecoveryMetadata(id string, state queue.VesselState, er
 		Meta:        current.Meta,
 		Trace:       trace,
 		CreatedAt:   r.runtimeNow(),
-	}))
+	})
+	if err := recovery.PopulateUnlock(r.Config.StateDir, artifact, current.Meta["source_input_fingerprint"], artifact.CreatedAt); err != nil {
+		log.Printf("warn: populate recovery unlock for vessel %s: %v", id, err)
+	}
+	current.Meta = recovery.ApplyToMeta(current.Meta, artifact)
 	if updateErr := r.Queue.UpdateVessel(*current); updateErr != nil {
 		log.Printf("warn: annotate recovery metadata for vessel %s: %v", id, updateErr)
 	}
@@ -1493,6 +1501,9 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 			Trace:       traceContextPointer(vrs.trace),
 			CreatedAt:   now,
 		})
+		if err := recovery.PopulateUnlock(r.Config.StateDir, reviewArtifact, artifactVessel.Meta["source_input_fingerprint"], now); err != nil {
+			log.Printf("warn: populate recovery unlock: %v", err)
+		}
 		if err := recovery.Save(r.Config.StateDir, reviewArtifact); err != nil {
 			log.Printf("warn: save recovery artifact: %v", err)
 		} else {

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 )
 
@@ -67,6 +68,11 @@ func (s *Scanner) Scan(ctx context.Context) (ScanResult, error) {
 			}
 			if enqueued {
 				result.Added++
+				if vessel.RetryOf != "" {
+					if err := recovery.UpdateRetryOutcome(s.Config.StateDir, vessel.RetryOf, "enqueued"); err != nil {
+						log.Printf("warn: record retry outcome for %s failed: %v", vessel.RetryOf, err)
+					}
+				}
 				if s.RunHooks {
 					if err := entry.src.OnEnqueue(ctx, vessel); err != nil {
 						log.Printf("warn: OnEnqueue hook for vessel %s failed: %v", vessel.ID, err)
@@ -95,6 +101,7 @@ func (s *Scanner) buildSources() []sourceEntry {
 			entries = append(entries, sourceEntry{
 				src: &source.GitHub{
 					Repo:      srcCfg.Repo,
+					StateDir:  s.Config.StateDir,
 					Tasks:     tasks,
 					Exclude:   srcCfg.Exclude,
 					Queue:     s.Queue,
@@ -107,6 +114,7 @@ func (s *Scanner) buildSources() []sourceEntry {
 			entries = append(entries, sourceEntry{
 				src: &source.GitHubPR{
 					Repo:      srcCfg.Repo,
+					StateDir:  s.Config.StateDir,
 					Tasks:     tasks,
 					Exclude:   srcCfg.Exclude,
 					Queue:     s.Queue,

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -27,6 +27,7 @@ type GitHubTask struct {
 // GitHub scans GitHub issues and produces vessels.
 type GitHub struct {
 	Repo      string
+	StateDir  string
 	Tasks     map[string]GitHubTask
 	Exclude   []string
 	Queue     *queue.Queue
@@ -80,16 +81,23 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					continue
 				}
 				fingerprint := githubSourceFingerprint(issue.Title, issue.Body, issueLabelNames(issue.Labels))
+				prior, err := g.Queue.FindLatestByRef(issue.URL)
+				if err != nil {
+					prior = nil
+				}
+				retryDecision, err := recovery.EvaluateRetryGate(g.StateDir, prior, task.Workflow, fingerprint, sourceNow())
+				if err != nil {
+					return vessels, fmt.Errorf("evaluate retry gate for %s: %w", issue.URL, err)
+				}
 				if g.hasExcludedLabel(issue, excludeSet) ||
-					g.Queue.HasRef(issue.URL) ||
-					g.hasMatchingFailedFingerprint(issue.URL, fingerprint) ||
+					retryDecision.Blocked ||
 					g.hasBranch(ctx, issue.Number) ||
 					g.hasOpenPR(ctx, issue.Number) ||
 					g.hasMergedPR(ctx, issue.Number) {
 					continue
 				}
 				seen[issue.Number] = true
-				meta := map[string]string{
+				meta := recovery.PrepareRetryMeta(map[string]string{
 					"issue_num":                strconv.Itoa(issue.Number),
 					"issue_title":              issue.Title,
 					"issue_body":               issue.Body,
@@ -103,6 +111,16 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					// (close/merge) and keeping the issue's UI state
 					// consistent with its workflow state.
 					"trigger_label": label,
+				}, retryDecision.Artifact, retryDecision.UnlockDimension, retryDecision.RemediationFingerprint)
+				id := fmt.Sprintf("issue-%d", issue.Number)
+				retryOf := ""
+				if prior != nil && (prior.State == queue.StateFailed || prior.State == queue.StateTimedOut) {
+					all, listErr := g.Queue.List()
+					if listErr != nil {
+						return vessels, fmt.Errorf("list queue for retry id: %w", listErr)
+					}
+					id = recovery.NextRetryID(prior.ID, all)
+					retryOf = prior.ID
 				}
 				sl := task.StatusLabels
 				if sl != nil {
@@ -118,11 +136,12 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					meta["label_gate_label_ready"] = lgl.Ready
 				}
 				vessels = append(vessels, queue.Vessel{
-					ID:        fmt.Sprintf("issue-%d", issue.Number),
+					ID:        id,
 					Source:    "github-issue",
 					Ref:       issue.URL,
 					Workflow:  task.Workflow,
 					Meta:      meta,
+					RetryOf:   retryOf,
 					State:     queue.StatePending,
 					CreatedAt: sourceNow(),
 				})
@@ -266,15 +285,6 @@ func sourceNow() time.Time {
 		return time.Now().UTC()
 	}
 	return now.UTC()
-}
-
-func (g *GitHub) hasMatchingFailedFingerprint(ref, fingerprint string) bool {
-	latest, err := g.Queue.FindLatestByRef(ref)
-	if err != nil || latest == nil {
-		return false
-	}
-	isTerminalFailure := latest.State == queue.StateFailed || latest.State == queue.StateTimedOut
-	return isTerminalFailure && latest.Meta["source_input_fingerprint"] == fingerprint
 }
 
 func (g *GitHub) recoveryAwareVessel(vessel queue.Vessel) queue.Vessel {

--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -8,11 +8,13 @@ import (
 	"strings"
 
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 )
 
 // GitHubPR scans GitHub pull requests and produces vessels.
 type GitHubPR struct {
 	Repo      string
+	StateDir  string
 	Tasks     map[string]GitHubTask
 	Exclude   []string
 	Queue     *queue.Queue
@@ -104,8 +106,16 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					continue
 				}
 				fingerprint := githubSourceFingerprint(pr.Title, pr.Body, issueLabelNames(pr.Labels))
+				prior, err := g.latestPriorVessel(pr.URL, task.Workflow)
+				if err != nil {
+					return vessels, fmt.Errorf("find prior vessel for %s: %w", pr.URL, err)
+				}
+				retryDecision, err := recovery.EvaluateRetryGate(g.StateDir, prior, task.Workflow, fingerprint, sourceNow())
+				if err != nil {
+					return vessels, fmt.Errorf("evaluate retry gate for %s: %w", pr.URL, err)
+				}
 				if g.hasExcludedLabel(pr, excludeSet) ||
-					g.isBlockedByPriorVessel(pr.URL, fingerprint, task.Workflow) ||
+					retryDecision.Blocked ||
 					g.hasBranch(ctx, pr.Number) {
 					continue
 				}
@@ -125,12 +135,22 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					continue
 				}
 				seen[key] = true
-				meta := map[string]string{
+				meta := recovery.PrepareRetryMeta(map[string]string{
 					"pr_num":                   strconv.Itoa(pr.Number),
 					"pr_title":                 pr.Title,
 					"pr_body":                  pr.Body,
 					"pr_labels":                strings.Join(issueLabelNames(pr.Labels), ","),
 					"source_input_fingerprint": fingerprint,
+				}, retryDecision.Artifact, retryDecision.UnlockDimension, retryDecision.RemediationFingerprint)
+				id := fmt.Sprintf("pr-%d-%s", pr.Number, task.Workflow)
+				retryOf := ""
+				if prior != nil && (prior.State == queue.StateFailed || prior.State == queue.StateTimedOut) {
+					all, listErr := g.Queue.List()
+					if listErr != nil {
+						return vessels, fmt.Errorf("list queue for retry id: %w", listErr)
+					}
+					id = recovery.NextRetryID(prior.ID, all)
+					retryOf = prior.ID
 				}
 				sl := task.StatusLabels
 				if sl != nil {
@@ -146,11 +166,12 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					meta["label_gate_label_ready"] = lgl.Ready
 				}
 				vessels = append(vessels, queue.Vessel{
-					ID:        fmt.Sprintf("pr-%d-%s", pr.Number, task.Workflow),
+					ID:        id,
 					Source:    "github-pr",
 					Ref:       prWorkflowRef(pr.URL, task.Workflow),
 					Workflow:  task.Workflow,
 					Meta:      meta,
+					RetryOf:   retryOf,
 					State:     queue.StatePending,
 					CreatedAt: sourceNow(),
 				})
@@ -295,59 +316,35 @@ func priorVesselBlocksReenqueue(v *queue.Vessel, fingerprint string) bool {
 	switch v.State {
 	case queue.StatePending, queue.StateRunning, queue.StateWaiting:
 		return true
-	case queue.StateFailed:
+	case queue.StateFailed, queue.StateTimedOut:
 		return v.Meta["source_input_fingerprint"] == fingerprint
 	default:
 		return false
 	}
 }
 
-// isBlockedByPriorVessel reports whether a prior vessel already occupies
-// the dedup slot for this (PR URL, workflow) pair and so the scanner
-// should not enqueue a new vessel. It checks the new workflow-qualified
-// ref (`<url>#workflow=<name>`) first; then for backward-compat with
-// queue entries written before refs were qualified, it falls back to
-// the legacy bare-URL ref and only treats a legacy vessel as blocking
-// when it belongs to the SAME workflow as the current task.
-//
-// Blocking conditions:
-//   - A pending/running/waiting vessel at the qualified ref.
-//   - A failed vessel at the qualified ref whose fingerprint equals the
-//     current PR input fingerprint.
-//   - If no qualified vessel exists yet, a legacy bare-URL vessel whose
-//     Workflow matches and is either active (pending/running/waiting)
-//     or terminally failed with a matching fingerprint.
-//
-// Completed/cancelled/timed_out vessels do not block. This is important
-// for resolve-conflicts retries: if a prior vessel completed without
-// actually changing the PR branch and GitHub still reports CONFLICTING,
-// the scanner must be able to enqueue a fresh vessel.
-//
-// Once a qualified-ref vessel exists, it is always newer than any
-// legacy bare-URL vessel for the same PR/workflow and therefore solely
-// determines whether the dedup slot is occupied. Falling back to an
-// older legacy vessel in that case would let stale pre-upgrade state
-// incorrectly block a newer completed/cancelled run.
+// latestPriorVessel returns the vessel that currently occupies the dedup slot
+// for this (PR URL, workflow) pair. It checks the new workflow-qualified ref
+// first and then falls back to the legacy bare-URL ref for backward
+// compatibility.
 //
 // This preserves the dedup guarantees of the pre-qualification scheme for
 // in-flight workflows while allowing distinct workflows over the same PR
 // (e.g., merge-pr and resolve-conflicts) to coexist.
-func (g *GitHubPR) isBlockedByPriorVessel(prURL, fingerprint, workflow string) bool {
+func (g *GitHubPR) latestPriorVessel(prURL, workflow string) (*queue.Vessel, error) {
 	qualifiedRef := prWorkflowRef(prURL, workflow)
 	latest, err := g.Queue.FindLatestByRef(qualifiedRef)
 	if err == nil {
-		return priorVesselBlocksReenqueue(latest, fingerprint)
+		return latest, nil
 	}
 	// Backward-compat: legacy queue entries were written with ref = prURL.
 	latest, err = g.Queue.FindLatestByRef(prURL)
 	if err != nil || latest == nil {
-		return false
+		return nil, nil
 	}
-	// Only a legacy vessel belonging to the SAME workflow is blocking.
-	// Otherwise a failed merge-pr vessel would block resolve-conflicts
-	// enqueue for the same PR — the exact regression this fix addresses.
+	// Only a legacy vessel belonging to the SAME workflow is relevant.
 	if latest.Workflow != workflow {
-		return false
+		return nil, nil
 	}
-	return priorVesselBlocksReenqueue(latest, fingerprint)
+	return latest, nil
 }

--- a/cli/internal/source/github_pr_prop_test.go
+++ b/cli/internal/source/github_pr_prop_test.go
@@ -40,7 +40,7 @@ func TestPropPriorVesselBlocksReenqueueMatchesStateMachine(t *testing.T) {
 		switch state {
 		case queue.StatePending, queue.StateRunning, queue.StateWaiting:
 			want = true
-		case queue.StateFailed:
+		case queue.StateFailed, queue.StateTimedOut:
 			want = match
 		}
 

--- a/cli/internal/source/github_pr_test.go
+++ b/cli/internal/source/github_pr_test.go
@@ -3,11 +3,14 @@ package source
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -374,6 +377,69 @@ func TestGitHubPRScanReenqueuesChangedFailedVessel(t *testing.T) {
 	}
 }
 
+func TestGitHubPRScanWorkflowChangeUnlocksRetry(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := setupRecoveryScanStateDir(t, dir, "review-pr")
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "same title", Body: "same body", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+
+	fingerprint := githubSourceFingerprint("same title", "same body", []string{"review-me"})
+	createdAt := time.Now().UTC().Add(-20 * time.Minute)
+	seed := queue.Vessel{
+		ID:       "pr-10-review-pr",
+		Source:   "github-pr",
+		Ref:      prWorkflowRef("https://github.com/owner/repo/pull/10", "review-pr"),
+		Workflow: "review-pr",
+		Meta: map[string]string{
+			"pr_num":                   "10",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StateTimedOut,
+		CreatedAt: createdAt,
+	}
+	_, err := q.Enqueue(seed)
+	require.NoError(t, err)
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID:  seed.ID,
+		Source:    seed.Source,
+		Workflow:  seed.Workflow,
+		Ref:       seed.Ref,
+		State:     seed.State,
+		Error:     "context deadline exceeded",
+		Meta:      seed.Meta,
+		CreatedAt: createdAt,
+	})
+	require.NoError(t, recovery.PopulateUnlock(stateDir, artifact, fingerprint, createdAt))
+	require.NoError(t, recovery.Save(stateDir, artifact))
+	promptPath := filepath.Join(stateDir, "prompts", "review-pr.md")
+	workflowYAML := "name: review-pr\nphases:\n  - name: analyze\n    prompt_file: " + promptPath + "\n    max_turns: 2\n"
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "workflows", "review-pr.yaml"), []byte(workflowYAML), 0o644))
+
+	src := &GitHubPR{
+		Repo:      "owner/repo",
+		StateDir:  stateDir,
+		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, seed.ID, vessels[0].RetryOf)
+	assert.Equal(t, "workflow", vessels[0].Meta[recovery.MetaUnlockedBy])
+	assert.Equal(t, "pr-10-review-pr-retry-1", vessels[0].ID)
+}
+
 func TestPriorVesselBlocksReenqueue(t *testing.T) {
 	t.Parallel()
 
@@ -402,7 +468,12 @@ func TestPriorVesselBlocksReenqueue(t *testing.T) {
 		},
 		{name: "completed", vessel: &queue.Vessel{State: queue.StateCompleted}, fingerprint: fingerprint, want: false},
 		{name: "cancelled", vessel: &queue.Vessel{State: queue.StateCancelled}, fingerprint: fingerprint, want: false},
-		{name: "timed out", vessel: &queue.Vessel{State: queue.StateTimedOut}, fingerprint: fingerprint, want: false},
+		{
+			name:        "timed out fingerprint match",
+			vessel:      &queue.Vessel{State: queue.StateTimedOut, Meta: map[string]string{"source_input_fingerprint": fingerprint}},
+			fingerprint: fingerprint,
+			want:        true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cli/internal/source/github_test.go
+++ b/cli/internal/source/github_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
@@ -392,6 +394,84 @@ func TestScanPersistsTriggerLabelInMeta(t *testing.T) {
 	}
 }
 
+func TestGitHubScanHarnessChangeUnlocksRetry(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := setupRecoveryScanStateDir(t, dir, "fix-bug")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{
+		{
+			Number: 42,
+			Title:  "same title",
+			Body:   "same body",
+			URL:    "https://github.com/owner/repo/issues/42",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "bug"}},
+		},
+	}
+	issueBytes, _ := json.Marshal(issues)
+	r.set(issueBytes, "gh", "search", "issues",
+		"--repo", "owner/repo",
+		"--state", "open",
+		"--json", "number,title,body,url,labels",
+		"--limit", "20",
+		"--label", "bug")
+	for _, prefix := range []string{"fix", "feat"} {
+		r.set([]byte(""), "git", "ls-remote", "--heads", "origin", fmt.Sprintf("%s/issue-%d-*", prefix, 42))
+		r.set([]byte("[]"), "gh", "pr", "list", "--repo", "owner/repo", "--search", fmt.Sprintf("head:%s/issue-%d-", prefix, 42), "--state", "open", "--json", "number,headRefName", "--limit", "5")
+		r.set([]byte("[]"), "gh", "pr", "list", "--repo", "owner/repo", "--search", fmt.Sprintf("head:%s/issue-%d-", prefix, 42), "--state", "merged", "--json", "number,headRefName", "--limit", "5")
+	}
+
+	fingerprint := githubSourceFingerprint("same title", "same body", []string{"bug"})
+	createdAt := time.Now().UTC().Add(-20 * time.Minute)
+	seed := queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      "https://github.com/owner/repo/issues/42",
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StateTimedOut,
+		CreatedAt: createdAt,
+	}
+	_, err := q.Enqueue(seed)
+	require.NoError(t, err)
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID:  seed.ID,
+		Source:    seed.Source,
+		Workflow:  seed.Workflow,
+		Ref:       seed.Ref,
+		State:     seed.State,
+		Error:     "context deadline exceeded",
+		Meta:      seed.Meta,
+		CreatedAt: createdAt,
+	})
+	require.NoError(t, recovery.PopulateUnlock(stateDir, artifact, fingerprint, createdAt))
+	require.NoError(t, recovery.Save(stateDir, artifact))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "HARNESS.md"), []byte("updated harness"), 0o644))
+
+	g := &GitHub{
+		Repo:      "owner/repo",
+		StateDir:  stateDir,
+		Tasks:     map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "issue-42", vessels[0].RetryOf)
+	assert.Equal(t, "harness", vessels[0].Meta[recovery.MetaUnlockedBy])
+	assert.Equal(t, "issue-42-retry-1", vessels[0].ID)
+	assert.Equal(t, artifact.FailureFingerprint, vessels[0].Meta[recovery.MetaFailureFingerprint])
+}
+
 func TestOnCompleteRemovesTriggerLabel(t *testing.T) {
 	// Property: after a vessel completes successfully, its trigger
 	// label is removed from the source issue via a separate gh call.
@@ -429,6 +509,22 @@ func TestOnCompleteRemovesTriggerLabel(t *testing.T) {
 	if strings.Contains(trig, "--add-label") {
 		t.Errorf("call 1: trigger-label removal must not add anything, got %q", trig)
 	}
+}
+
+func setupRecoveryScanStateDir(t *testing.T, baseDir, workflowName string) string {
+	t.Helper()
+
+	stateDir := filepath.Join(baseDir, ".xylem")
+	workflowDir := filepath.Join(stateDir, "workflows")
+	promptDir := filepath.Join(stateDir, "prompts")
+	require.NoError(t, os.MkdirAll(workflowDir, 0o755))
+	require.NoError(t, os.MkdirAll(promptDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "HARNESS.md"), []byte("initial harness"), 0o644))
+	promptPath := filepath.Join(promptDir, workflowName+".md")
+	require.NoError(t, os.WriteFile(promptPath, []byte("initial prompt"), 0o644))
+	workflowYAML := "name: " + workflowName + "\nphases:\n  - name: analyze\n    prompt_file: " + promptPath + "\n    max_turns: 1\n"
+	require.NoError(t, os.WriteFile(filepath.Join(workflowDir, workflowName+".yaml"), []byte(workflowYAML), 0o644))
+	return stateDir
 }
 
 func TestOnCompleteBackwardCompatNoTriggerLabel(t *testing.T) {


### PR DESCRIPTION
## Summary
- persist remediation-aware recovery fingerprints and unlock dimensions for failed/timed-out vessels
- gate issue and PR scan-time re-enqueue on recovery decisions plus source/harness/workflow/decision/cooldown changes
- carry retry metadata through manual retries and add coverage for recovery and source unlock scenarios

Closes https://github.com/nicholls-inc/xylem/issues/213