### PR TITLE
feat(config): add generic providers map with tiered LLM routing

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 const minTimeout = 30 * time.Second
 
 const DefaultAuditLogPath = "audit.jsonl"
+const DefaultLLMRoutingTier = "med"
 
 // DefaultProtectedSurfaces is the default list of paths that xylem's
 // runtime verifier treats as off-limits to vessel modifications.
@@ -55,24 +57,44 @@ const DefaultAuditLogPath = "audit.jsonl"
 var DefaultProtectedSurfaces = []string{}
 
 type Config struct {
-	Repo          string                  `yaml:"repo,omitempty"`
-	Sources       map[string]SourceConfig `yaml:"sources,omitempty"`
-	Tasks         map[string]Task         `yaml:"tasks,omitempty"`
-	Concurrency   int                     `yaml:"concurrency"`
-	MaxTurns      int                     `yaml:"max_turns"`
-	Timeout       string                  `yaml:"timeout"`
-	StateDir      string                  `yaml:"state_dir"`
-	Exclude       []string                `yaml:"exclude,omitempty"`
-	DefaultBranch string                  `yaml:"default_branch,omitempty"`
-	CleanupAfter  string                  `yaml:"cleanup_after,omitempty"`
-	LLM           string                  `yaml:"llm,omitempty"`
-	Model         string                  `yaml:"model,omitempty"`
-	Claude        ClaudeConfig            `yaml:"claude"`
-	Copilot       CopilotConfig           `yaml:"copilot,omitempty"`
-	Daemon        DaemonConfig            `yaml:"daemon,omitempty"`
-	Harness       HarnessConfig           `yaml:"harness,omitempty"`
-	Observability ObservabilityConfig     `yaml:"observability,omitempty"`
-	Cost          CostConfig              `yaml:"cost,omitempty"`
+	Repo          string                    `yaml:"repo,omitempty"`
+	Sources       map[string]SourceConfig   `yaml:"sources,omitempty"`
+	Tasks         map[string]Task           `yaml:"tasks,omitempty"`
+	Concurrency   int                       `yaml:"concurrency"`
+	MaxTurns      int                       `yaml:"max_turns"`
+	Timeout       string                    `yaml:"timeout"`
+	StateDir      string                    `yaml:"state_dir"`
+	Exclude       []string                  `yaml:"exclude,omitempty"`
+	DefaultBranch string                    `yaml:"default_branch,omitempty"`
+	CleanupAfter  string                    `yaml:"cleanup_after,omitempty"`
+	LLM           string                    `yaml:"llm,omitempty"`
+	Model         string                    `yaml:"model,omitempty"`
+	Providers     map[string]ProviderConfig `yaml:"providers,omitempty"`
+	LLMRouting    LLMRoutingConfig          `yaml:"llm_routing,omitempty"`
+	Claude        ClaudeConfig              `yaml:"claude"`
+	Copilot       CopilotConfig             `yaml:"copilot,omitempty"`
+	Daemon        DaemonConfig              `yaml:"daemon,omitempty"`
+	Harness       HarnessConfig             `yaml:"harness,omitempty"`
+	Observability ObservabilityConfig       `yaml:"observability,omitempty"`
+	Cost          CostConfig                `yaml:"cost,omitempty"`
+}
+
+type ProviderConfig struct {
+	Kind         string            `yaml:"kind"`
+	Command      string            `yaml:"command"`
+	Flags        string            `yaml:"flags,omitempty"`
+	Tiers        map[string]string `yaml:"tiers,omitempty"`
+	Env          map[string]string `yaml:"env,omitempty"`
+	AllowedTools []string          `yaml:"allowed_tools,omitempty"`
+}
+
+type LLMRoutingConfig struct {
+	DefaultTier string                 `yaml:"default_tier,omitempty"`
+	Tiers       map[string]TierRouting `yaml:"tiers,omitempty"`
+}
+
+type TierRouting struct {
+	Providers []string `yaml:"providers"`
 }
 
 type SourceConfig struct {
@@ -124,6 +146,7 @@ type PREventsConfig struct {
 type Task struct {
 	Labels          []string         `yaml:"labels,omitempty"`
 	Workflow        string           `yaml:"workflow"`
+	Tier            string           `yaml:"tier,omitempty"`
 	Ref             string           `yaml:"ref,omitempty"`
 	StatusLabels    *StatusLabels    `yaml:"status_labels,omitempty"`
 	LabelGateLabels *LabelGateLabels `yaml:"label_gate_labels,omitempty"`
@@ -263,6 +286,7 @@ func (c *Config) normalize() {
 			},
 		}
 	}
+	c.normalizeProviders()
 }
 
 func (c *Config) Validate() error {
@@ -313,6 +337,8 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("--bare requires ANTHROPIC_API_KEY in claude.env")
 		}
 	}
+
+	c.normalizeProviders()
 
 	if c.Daemon.ScanInterval != "" {
 		if _, err := time.ParseDuration(c.Daemon.ScanInterval); err != nil {
@@ -401,7 +427,7 @@ func (c *Config) Validate() error {
 		return err
 	}
 
-	if err := c.validateProviderDefaultModels(); err != nil {
+	if err := c.validateProviders(); err != nil {
 		return err
 	}
 
@@ -637,7 +663,95 @@ func (c *Config) validateCost() error {
 // validateProviderDefaultModels ensures every active LLM provider has a
 // default_model configured. A provider is active if it is the global llm value
 // or referenced by any source's llm field.
-func (c *Config) validateProviderDefaultModels() error {
+func (c *Config) validateProviders() error {
+	if len(c.Providers) == 0 && len(c.LLMRouting.Tiers) == 0 {
+		return nil
+	}
+
+	for name, provider := range c.Providers {
+		switch provider.Kind {
+		case "claude", "copilot":
+		default:
+			return fmt.Errorf("providers.%s.kind must be one of claude or copilot, got %q", name, provider.Kind)
+		}
+
+		for tierName := range c.LLMRouting.Tiers {
+			model, ok := provider.Tiers[tierName]
+			if !ok || strings.TrimSpace(model) == "" {
+				return fmt.Errorf("providers.%s.tiers.%s must be set because llm_routing.tiers.%s is configured", name, tierName, tierName)
+			}
+		}
+
+		if provider.Kind == "claude" && strings.Contains(provider.Flags, "--bare") {
+			if provider.Env == nil || strings.TrimSpace(provider.Env["ANTHROPIC_API_KEY"]) == "" {
+				return fmt.Errorf("--bare requires ANTHROPIC_API_KEY in providers.%s.env", name)
+			}
+		}
+	}
+
+	if strings.TrimSpace(c.LLMRouting.DefaultTier) == "" {
+		return fmt.Errorf("llm_routing.default_tier must be set")
+	}
+	if _, ok := c.LLMRouting.Tiers[c.LLMRouting.DefaultTier]; !ok {
+		return fmt.Errorf("llm_routing.default_tier %q must exist in llm_routing.tiers", c.LLMRouting.DefaultTier)
+	}
+
+	for tierName, routing := range c.LLMRouting.Tiers {
+		for _, providerName := range routing.Providers {
+			if _, ok := c.Providers[providerName]; !ok {
+				return fmt.Errorf("llm_routing.tiers.%s.providers references unknown provider %q", tierName, providerName)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Config) normalizeProviders() {
+	defaultTier := strings.TrimSpace(c.LLMRouting.DefaultTier)
+	if defaultTier == "" {
+		defaultTier = DefaultLLMRoutingTier
+		c.LLMRouting.DefaultTier = defaultTier
+	}
+
+	if len(c.Providers) == 0 {
+		providers := make(map[string]ProviderConfig)
+		active := c.activeLegacyProviders()
+		if c.shouldSynthesizeClaudeProvider(active["claude"]) {
+			providers["claude"] = ProviderConfig{
+				Kind:         "claude",
+				Command:      c.Claude.Command,
+				Flags:        c.Claude.Flags,
+				Tiers:        map[string]string{defaultTier: c.Claude.DefaultModel},
+				Env:          copyStringMap(c.Claude.Env),
+				AllowedTools: append([]string(nil), c.Claude.AllowedTools...),
+			}
+		}
+		if c.shouldSynthesizeCopilotProvider(active["copilot"]) {
+			providers["copilot"] = ProviderConfig{
+				Kind:    "copilot",
+				Command: c.Copilot.Command,
+				Flags:   c.Copilot.Flags,
+				Tiers:   map[string]string{defaultTier: c.Copilot.DefaultModel},
+				Env:     copyStringMap(c.Copilot.Env),
+			}
+		}
+		if len(providers) > 0 {
+			c.Providers = providers
+		}
+	}
+
+	if len(c.LLMRouting.Tiers) == 0 {
+		providerNames := orderedProviderNames(c.Providers, c.LLM)
+		if len(providerNames) > 0 {
+			c.LLMRouting.Tiers = map[string]TierRouting{
+				defaultTier: {Providers: providerNames},
+			}
+		}
+	}
+}
+
+func (c *Config) activeLegacyProviders() map[string]bool {
 	active := map[string]bool{}
 	switch c.LLM {
 	case "", "claude":
@@ -653,13 +767,61 @@ func (c *Config) validateProviderDefaultModels() error {
 			active["copilot"] = true
 		}
 	}
-	if active["claude"] && c.Claude.DefaultModel == "" {
-		return fmt.Errorf("claude.default_model must be set when claude is an active provider")
+	return active
+}
+
+func (c *Config) shouldSynthesizeClaudeProvider(active bool) bool {
+	if active {
+		return true
 	}
-	if active["copilot"] && c.Copilot.DefaultModel == "" {
-		return fmt.Errorf("copilot.default_model must be set when copilot is an active provider")
+	return strings.TrimSpace(c.Claude.DefaultModel) != "" ||
+		strings.TrimSpace(c.Claude.Flags) != "" ||
+		len(c.Claude.Env) > 0 ||
+		len(c.Claude.AllowedTools) > 0 ||
+		strings.TrimSpace(c.Claude.Template) != "" ||
+		(strings.TrimSpace(c.Claude.Command) != "" && strings.TrimSpace(c.Claude.Command) != "claude")
+}
+
+func (c *Config) shouldSynthesizeCopilotProvider(active bool) bool {
+	if active {
+		return true
 	}
-	return nil
+	return strings.TrimSpace(c.Copilot.DefaultModel) != "" ||
+		strings.TrimSpace(c.Copilot.Flags) != "" ||
+		len(c.Copilot.Env) > 0 ||
+		(strings.TrimSpace(c.Copilot.Command) != "" && strings.TrimSpace(c.Copilot.Command) != "copilot")
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func orderedProviderNames(providers map[string]ProviderConfig, preferred string) []string {
+	if len(providers) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(providers))
+	for name := range providers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if preferred == "" {
+		return names
+	}
+	for i, name := range names {
+		if name != preferred {
+			continue
+		}
+		return append([]string{name}, append(names[:i], names[i+1:]...)...)
+	}
+	return names
 }
 
 func validateGitHubSource(name string, src SourceConfig) error {

--- a/cli/internal/config/config_prop_test.go
+++ b/cli/internal/config/config_prop_test.go
@@ -132,3 +132,101 @@ func TestPropHarnessReviewOutputDirRejectsTraversal(t *testing.T) {
 		}
 	})
 }
+
+func TestPropNormalizeLegacyProvidersPreservesDefaultTierModels(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		includeClaude := rapid.Bool().Draw(t, "include-claude")
+		includeCopilot := rapid.Bool().Draw(t, "include-copilot")
+		if !includeClaude && !includeCopilot {
+			includeClaude = true
+		}
+
+		cfg := Config{
+			Concurrency: 1,
+			MaxTurns:    10,
+			Timeout:     "30m",
+			LLMRouting: LLMRoutingConfig{
+				DefaultTier: rapid.SampledFrom([]string{"high", "med", "low"}).Draw(t, "default-tier"),
+			},
+			Claude: ClaudeConfig{
+				Command:      "claude",
+				DefaultModel: rapid.StringMatching(`[a-z0-9.-]{4,24}`).Draw(t, "claude-model"),
+			},
+			Copilot: CopilotConfig{
+				Command:      "copilot",
+				DefaultModel: rapid.StringMatching(`[a-z0-9.-]{4,24}`).Draw(t, "copilot-model"),
+			},
+		}
+		cfg.LLM = rapid.SampledFrom([]string{"", "claude", "copilot"}).Draw(t, "llm")
+		if !includeClaude {
+			cfg.Claude = ClaudeConfig{Command: "claude"}
+		}
+		if !includeCopilot {
+			cfg.Copilot = CopilotConfig{Command: "copilot"}
+		}
+
+		cfg.normalizeProviders()
+
+		defaultTier := cfg.LLMRouting.DefaultTier
+		if defaultTier == "" {
+			t.Fatal("normalizeProviders() left default tier empty")
+		}
+
+		wantProviders := map[string]string{}
+		if includeClaude || cfg.LLM == "claude" || cfg.LLM == "" {
+			wantProviders["claude"] = cfg.Claude.DefaultModel
+		}
+		if includeCopilot || cfg.LLM == "copilot" {
+			wantProviders["copilot"] = cfg.Copilot.DefaultModel
+		}
+		if len(cfg.Providers) != len(wantProviders) {
+			t.Fatalf("normalizeProviders() produced providers %#v, want %#v", cfg.Providers, wantProviders)
+		}
+		for name, wantModel := range wantProviders {
+			provider, ok := cfg.Providers[name]
+			if !ok {
+				t.Fatalf("normalizeProviders() missing provider %q in %#v", name, cfg.Providers)
+			}
+			if got := provider.Tiers[defaultTier]; got != wantModel {
+				t.Fatalf("%s tier model = %q, want %q", name, got, wantModel)
+			}
+		}
+
+		routing, ok := cfg.LLMRouting.Tiers[defaultTier]
+		if !ok {
+			t.Fatalf("normalizeProviders() missing routing tier %q in %#v", defaultTier, cfg.LLMRouting.Tiers)
+		}
+
+		wantOrder := make([]string, 0, len(wantProviders))
+		for _, name := range []string{"claude", "copilot"} {
+			if _, ok := wantProviders[name]; ok {
+				wantOrder = append(wantOrder, name)
+			}
+		}
+		if cfg.LLM != "" && containsString(wantOrder, cfg.LLM) && wantOrder[0] != cfg.LLM {
+			wantOrder = append([]string{cfg.LLM}, removeString(wantOrder, cfg.LLM)...)
+		}
+		if !reflect.DeepEqual(routing.Providers, wantOrder) {
+			t.Fatalf("default provider order = %#v, want %#v", routing.Providers, wantOrder)
+		}
+	})
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func removeString(values []string, skip string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != skip {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -187,7 +187,7 @@ claude:
 }
 
 func validConfig() *Config {
-	return &Config{
+	cfg := &Config{
 		Repo: "owner/name",
 		Tasks: map[string]Task{
 			"fix-bugs": {Labels: []string{"bug"}, Workflow: "fix-bug"},
@@ -208,7 +208,13 @@ func validConfig() *Config {
 			Command:      "claude",
 			DefaultModel: "claude-sonnet-4-6",
 		},
+		Copilot: CopilotConfig{
+			Command:      "copilot",
+			DefaultModel: "gpt-5.4",
+		},
 	}
+	cfg.normalize()
+	return cfg
 }
 
 func TestValidateMissingRepoInGitHubSource(t *testing.T) {
@@ -606,9 +612,12 @@ claude:
 	if cfg.Claude.DefaultModel != "claude-sonnet-4-20250514" {
 		t.Fatalf("Claude.DefaultModel = %q, want claude-sonnet-4-20250514", cfg.Claude.DefaultModel)
 	}
+	if got := cfg.Providers["claude"].Tiers[DefaultLLMRoutingTier]; got != "claude-sonnet-4-20250514" {
+		t.Fatalf("Providers[claude].Tiers[%q] = %q, want claude-sonnet-4-20250514", DefaultLLMRoutingTier, got)
+	}
 }
 
-func TestValidateClaudeDefaultModelRequired(t *testing.T) {
+func TestValidateLegacyClaudeDefaultModelRequired(t *testing.T) {
 	path := writeConfigFile(t, `sources:
   github:
     type: github
@@ -625,7 +634,243 @@ claude:
 `)
 
 	_, err := Load(path)
-	requireErrorContains(t, err, "claude.default_model must be set")
+	requireErrorContains(t, err, "providers.claude.tiers.med must be set")
+}
+
+func TestLoadLegacyProvidersNormalizesIntoRouting(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+        tier: high
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+llm: copilot
+model: gpt-5.4
+claude:
+  command: "claude"
+  flags: "--dangerously-skip-permissions"
+  default_model: "claude-sonnet-4-6"
+  env:
+    ANTHROPIC_API_KEY: "test-key"
+copilot:
+  command: "copilot"
+  flags: "--yolo --autopilot"
+  default_model: "gpt-5.4"
+  env:
+    GITHUB_TOKEN: "gh-token"
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+
+	require.Equal(t, "high", cfg.Sources["github"].Tasks["fix-bugs"].Tier)
+	require.Equal(t, DefaultLLMRoutingTier, cfg.LLMRouting.DefaultTier)
+	require.Equal(t, []string{"copilot", "claude"}, cfg.LLMRouting.Tiers[DefaultLLMRoutingTier].Providers)
+	require.Equal(t, ProviderConfig{
+		Kind:    "claude",
+		Command: "claude",
+		Flags:   "--dangerously-skip-permissions",
+		Tiers: map[string]string{
+			DefaultLLMRoutingTier: "claude-sonnet-4-6",
+		},
+		Env: map[string]string{
+			"ANTHROPIC_API_KEY": "test-key",
+		},
+	}, cfg.Providers["claude"])
+	require.Equal(t, ProviderConfig{
+		Kind:    "copilot",
+		Command: "copilot",
+		Flags:   "--yolo --autopilot",
+		Tiers: map[string]string{
+			DefaultLLMRoutingTier: "gpt-5.4",
+		},
+		Env: map[string]string{
+			"GITHUB_TOKEN": "gh-token",
+		},
+	}, cfg.Providers["copilot"])
+}
+
+func TestLoadNewProvidersAndRoutingShape(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+providers:
+  claude:
+    kind: claude
+    command: "claude"
+    flags: "--dangerously-skip-permissions"
+    tiers:
+      high: "claude-opus-4-6"
+      med: "claude-sonnet-4-6"
+      low: "claude-haiku-4-5"
+    env:
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
+  copilot:
+    kind: copilot
+    command: "copilot"
+    flags: "--yolo --autopilot"
+    tiers:
+      high: "gpt-5.4"
+      med: "gpt-5.2-codex"
+      low: "gpt-5-mini"
+    env:
+      GITHUB_TOKEN: "${COPILOT_GITHUB_TOKEN}"
+llm_routing:
+  default_tier: med
+  tiers:
+    high:
+      providers: [claude]
+    med:
+      providers: [claude, copilot]
+    low:
+      providers: [copilot, claude]
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+
+	require.Equal(t, "med", cfg.LLMRouting.DefaultTier)
+	require.Equal(t, []string{"claude"}, cfg.LLMRouting.Tiers["high"].Providers)
+	require.Equal(t, []string{"claude", "copilot"}, cfg.LLMRouting.Tiers["med"].Providers)
+	require.Equal(t, []string{"copilot", "claude"}, cfg.LLMRouting.Tiers["low"].Providers)
+	require.Equal(t, "claude-opus-4-6", cfg.Providers["claude"].Tiers["high"])
+	require.Equal(t, "gpt-5-mini", cfg.Providers["copilot"].Tiers["low"])
+}
+
+func TestValidateRoutingRejectsUnknownProvider(t *testing.T) {
+	cfg := validConfig()
+	cfg.Providers = map[string]ProviderConfig{
+		"claude": {
+			Kind:    "claude",
+			Command: "claude",
+			Tiers: map[string]string{
+				"med": "claude-sonnet-4-6",
+			},
+		},
+	}
+	cfg.LLMRouting = LLMRoutingConfig{
+		DefaultTier: "med",
+		Tiers: map[string]TierRouting{
+			"med": {Providers: []string{"claude", "copilot"}},
+		},
+	}
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, `llm_routing.tiers.med.providers references unknown provider "copilot"`)
+}
+
+func TestValidateRoutingRejectsMissingTierModel(t *testing.T) {
+	cfg := validConfig()
+	cfg.Providers = map[string]ProviderConfig{
+		"claude": {
+			Kind:    "claude",
+			Command: "claude",
+			Tiers: map[string]string{
+				"med": "claude-sonnet-4-6",
+			},
+		},
+	}
+	cfg.LLMRouting = LLMRoutingConfig{
+		DefaultTier: "med",
+		Tiers: map[string]TierRouting{
+			"med":  {Providers: []string{"claude"}},
+			"high": {Providers: []string{"claude"}},
+		},
+	}
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, "providers.claude.tiers.high must be set")
+}
+
+func TestValidateRoutingRejectsUnknownKind(t *testing.T) {
+	cfg := validConfig()
+	cfg.Providers = map[string]ProviderConfig{
+		"gemini": {
+			Kind:    "gemini",
+			Command: "gemini",
+			Tiers: map[string]string{
+				"med": "gemini-pro",
+			},
+		},
+	}
+	cfg.LLMRouting = LLMRoutingConfig{
+		DefaultTier: "med",
+		Tiers: map[string]TierRouting{
+			"med": {Providers: []string{"gemini"}},
+		},
+	}
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, `providers.gemini.kind must be one of claude or copilot`)
+}
+
+func TestValidateRoutingRejectsUnknownDefaultTier(t *testing.T) {
+	cfg := validConfig()
+	cfg.Providers = map[string]ProviderConfig{
+		"claude": {
+			Kind:    "claude",
+			Command: "claude",
+			Tiers: map[string]string{
+				"med": "claude-sonnet-4-6",
+			},
+		},
+	}
+	cfg.LLMRouting = LLMRoutingConfig{
+		DefaultTier: "high",
+		Tiers: map[string]TierRouting{
+			"med": {Providers: []string{"claude"}},
+		},
+	}
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, `llm_routing.default_tier "high" must exist in llm_routing.tiers`)
+}
+
+func TestLoadProvidersWithoutRoutingSynthesizesDefaultChain(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+llm: copilot
+providers:
+  claude:
+    kind: claude
+    command: "claude"
+    tiers:
+      med: "claude-sonnet-4-6"
+  copilot:
+    kind: copilot
+    command: "copilot"
+    tiers:
+      med: "gpt-5.4"
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+
+	require.Equal(t, DefaultLLMRoutingTier, cfg.LLMRouting.DefaultTier)
+	require.Equal(t, []string{"copilot", "claude"}, cfg.LLMRouting.Tiers[DefaultLLMRoutingTier].Providers)
 }
 
 func TestLoadStatusLabels(t *testing.T) {
@@ -1782,6 +2027,279 @@ func TestSmoke_S38_ScheduledSourceRejectsInvalidSchedule(t *testing.T) {
 	err := cfg.Validate()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "schedule is invalid")
+}
+
+func TestSmoke_S39_LegacyProvidersNormalizeWithPreferredProviderFirst(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+        tier: high
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+llm: copilot
+model: "gpt-5.4"
+claude:
+  command: "claude"
+  flags: "--dangerously-skip-permissions"
+  default_model: "claude-sonnet-4-6"
+  env:
+    ANTHROPIC_API_KEY: "test-key"
+copilot:
+  command: "copilot"
+  flags: "--yolo --autopilot"
+  default_model: "gpt-5.4"
+  env:
+    GITHUB_TOKEN: "gh-token"
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Contains(t, cfg.Sources, "github")
+	require.Contains(t, cfg.Sources["github"].Tasks, "fix-bugs")
+	require.Contains(t, cfg.Providers, "claude")
+	require.Contains(t, cfg.Providers, "copilot")
+	require.Contains(t, cfg.LLMRouting.Tiers, DefaultLLMRoutingTier)
+
+	assert.Equal(t, "high", cfg.Sources["github"].Tasks["fix-bugs"].Tier)
+	assert.Equal(t, DefaultLLMRoutingTier, cfg.LLMRouting.DefaultTier)
+	assert.Equal(t, []string{"copilot", "claude"}, cfg.LLMRouting.Tiers[DefaultLLMRoutingTier].Providers)
+	assert.Equal(t, ProviderConfig{
+		Kind:    "claude",
+		Command: "claude",
+		Flags:   "--dangerously-skip-permissions",
+		Tiers: map[string]string{
+			DefaultLLMRoutingTier: "claude-sonnet-4-6",
+		},
+		Env: map[string]string{
+			"ANTHROPIC_API_KEY": "test-key",
+		},
+	}, cfg.Providers["claude"])
+	assert.Equal(t, ProviderConfig{
+		Kind:    "copilot",
+		Command: "copilot",
+		Flags:   "--yolo --autopilot",
+		Tiers: map[string]string{
+			DefaultLLMRoutingTier: "gpt-5.4",
+		},
+		Env: map[string]string{
+			"GITHUB_TOKEN": "gh-token",
+		},
+	}, cfg.Providers["copilot"])
+}
+
+func TestSmoke_S40_NewProvidersAndRoutingShapeLoadsCleanly(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+providers:
+  claude:
+    kind: claude
+    command: "claude"
+    flags: "--dangerously-skip-permissions"
+    tiers:
+      high: "claude-opus-4-6"
+      med: "claude-sonnet-4-6"
+      low: "claude-haiku-4-5"
+    env:
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
+  copilot:
+    kind: copilot
+    command: "copilot"
+    flags: "--yolo --autopilot"
+    tiers:
+      high: "gpt-5.4"
+      med: "gpt-5.2-codex"
+      low: "gpt-5-mini"
+    env:
+      GITHUB_TOKEN: "${COPILOT_GITHUB_TOKEN}"
+llm_routing:
+  default_tier: med
+  tiers:
+    high:
+      providers: [claude]
+    med:
+      providers: [claude, copilot]
+    low:
+      providers: [copilot, claude]
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Contains(t, cfg.Providers, "claude")
+	require.Contains(t, cfg.Providers, "copilot")
+	require.Contains(t, cfg.LLMRouting.Tiers, "high")
+	require.Contains(t, cfg.LLMRouting.Tiers, "med")
+	require.Contains(t, cfg.LLMRouting.Tiers, "low")
+
+	assert.Equal(t, "med", cfg.LLMRouting.DefaultTier)
+	assert.Equal(t, []string{"claude"}, cfg.LLMRouting.Tiers["high"].Providers)
+	assert.Equal(t, []string{"claude", "copilot"}, cfg.LLMRouting.Tiers["med"].Providers)
+	assert.Equal(t, []string{"copilot", "claude"}, cfg.LLMRouting.Tiers["low"].Providers)
+	assert.Equal(t, "claude", cfg.Providers["claude"].Kind)
+	assert.Equal(t, "claude-opus-4-6", cfg.Providers["claude"].Tiers["high"])
+	assert.Equal(t, "claude-haiku-4-5", cfg.Providers["claude"].Tiers["low"])
+	assert.Equal(t, "copilot", cfg.Providers["copilot"].Kind)
+	assert.Equal(t, "gpt-5.2-codex", cfg.Providers["copilot"].Tiers["med"])
+	assert.Equal(t, "gpt-5-mini", cfg.Providers["copilot"].Tiers["low"])
+}
+
+func TestSmoke_S41_RoutingValidationRejectsInvalidConfigurations(t *testing.T) {
+	const prefix = `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+`
+
+	tests := []struct {
+		name string
+		yaml string
+		want []string
+	}{
+		{
+			name: "unknown provider in tier chain",
+			yaml: prefix + `providers:
+  claude:
+    kind: claude
+    command: "claude"
+    tiers:
+      med: "claude-sonnet-4-6"
+llm_routing:
+  default_tier: med
+  tiers:
+    med:
+      providers: [claude, copilot]
+`,
+			want: []string{
+				`llm_routing.tiers.med.providers references unknown provider "copilot"`,
+			},
+		},
+		{
+			name: "missing tier model on provider",
+			yaml: prefix + `providers:
+  claude:
+    kind: claude
+    command: "claude"
+    tiers:
+      med: "claude-sonnet-4-6"
+llm_routing:
+  default_tier: med
+  tiers:
+    med:
+      providers: [claude]
+    high:
+      providers: [claude]
+`,
+			want: []string{
+				"providers.claude.tiers.high must be set",
+			},
+		},
+		{
+			name: "unknown provider kind",
+			yaml: prefix + `providers:
+  gemini:
+    kind: gemini
+    command: "gemini"
+    tiers:
+      med: "gemini-pro"
+llm_routing:
+  default_tier: med
+  tiers:
+    med:
+      providers: [gemini]
+`,
+			want: []string{
+				`providers.gemini.kind must be one of claude or copilot`,
+			},
+		},
+		{
+			name: "bad default tier",
+			yaml: prefix + `providers:
+  claude:
+    kind: claude
+    command: "claude"
+    tiers:
+      med: "claude-sonnet-4-6"
+llm_routing:
+  default_tier: high
+  tiers:
+    med:
+      providers: [claude]
+`,
+			want: []string{
+				`llm_routing.default_tier "high" must exist in llm_routing.tiers`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Load(writeConfigFile(t, tt.yaml))
+			require.Error(t, err)
+			for _, want := range tt.want {
+				assert.Contains(t, err.Error(), want)
+			}
+		})
+	}
+}
+
+func TestSmoke_S42_ProvidersWithoutRoutingSynthesizeDefaultChain(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-bugs:
+        labels: [bug]
+        workflow: fix-bug
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+llm: copilot
+providers:
+  claude:
+    kind: claude
+    command: "claude"
+    tiers:
+      med: "claude-sonnet-4-6"
+  copilot:
+    kind: copilot
+    command: "copilot"
+    tiers:
+      med: "gpt-5.4"
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Contains(t, cfg.LLMRouting.Tiers, DefaultLLMRoutingTier)
+
+	assert.Equal(t, DefaultLLMRoutingTier, cfg.LLMRouting.DefaultTier)
+	assert.Equal(t, []string{"copilot", "claude"}, cfg.LLMRouting.Tiers[DefaultLLMRoutingTier].Providers)
+	assert.Equal(t, "claude-sonnet-4-6", cfg.Providers["claude"].Tiers[DefaultLLMRoutingTier])
+	assert.Equal(t, "gpt-5.4", cfg.Providers["copilot"].Tiers[DefaultLLMRoutingTier])
 }
 
 func TestSourceTimeoutValid(t *testing.T) {


### PR DESCRIPTION
## Summary
+- Implements [issue #223](https://github.com/nicholls-inc/xylem/issues/223).
+- Replaces hardcoded provider defaults with a generic `providers` map plus `llm_routing`, including effort-tier-aware model selection and legacy config normalization.
+- Adds validation and regression coverage for legacy provider migration, routing shape, and synthesized default provider chains.
+
+## Smoke scenarios covered
+- S39 — Legacy providers normalize with preferred provider first
+- S40 — New providers and routing shape loads cleanly
+- S41 — Routing validation rejects invalid configurations
+- S42 — Providers without routing synthesize default chain
+
+## Changes summary
+- Modified `cli/internal/config/config.go`
+  - Added `ProviderConfig`, `LLMRoutingConfig`, `TierRouting`, and `Task.Tier`.
+  - Added `Config.Providers` and `Config.LLMRouting`.
+  - Reworked normalization through `normalizeProviders`, `activeLegacyProviders`, and provider-order synthesis.
+  - Replaced default-model validation with `validateProviders` for provider kind, tier completeness, routing references, and default-tier checks.
+- Modified `cli/internal/config/config_test.go`
+  - Added coverage for legacy `claude`/`copilot` normalization into routing.
+  - Added coverage for the new `providers` + `llm_routing` shape and invalid routing configurations.
+  - Added smoke coverage for scenarios S39-S42.
+- Modified `cli/internal/config/config_prop_test.go`
+  - Added `TestPropNormalizeLegacyProvidersPreservesDefaultTierModels` to stress legacy normalization across provider combinations and default-tier permutations.
+
+## Test plan
+- `cd cli && goimports -l .`
+- `cd cli && golangci-lint run`
+- `cd cli && go vet ./...`
+- `cd cli && go build ./cmd/xylem`
+- `cd cli && go test ./...`

Fixes #223