### PR TITLE
feat(profiles): add embedded core profile package and composition

### DIFF
--- a/cli/internal/profiles/core/HARNESS.md.tmpl
+++ b/cli/internal/profiles/core/HARNESS.md.tmpl
@@ -1,0 +1,14 @@
+# Project Overview
+<!-- Describe what this project does -->
+
+# Architecture
+<!-- Describe the codebase structure -->
+
+# Build & Test
+<!-- List the exact build, test, and lint commands -->
+
+# Golden Principles
+<!-- List rules the agent must always follow — e.g., "always run gofmt", "never modify generated files" -->
+
+# Dependencies
+<!-- Note any external services or tools the agent needs -->

--- a/cli/internal/profiles/core/profile.lock.tmpl
+++ b/cli/internal/profiles/core/profile.lock.tmpl
@@ -1,0 +1,7 @@
+profile_version: 1
+profiles:
+{{- range .Profiles }}
+  - name: {{ .Name }}
+    version: {{ .Version }}
+{{- end }}
+locked_at: {{ .LockedAt }}

--- a/cli/internal/profiles/core/prompts/fix-bug/analyze.md
+++ b/cli/internal/profiles/core/prompts/fix-bug/analyze.md
@@ -1,0 +1,15 @@
+Analyze the following GitHub issue and identify the relevant code.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+{{.Issue.Body}}
+
+Read the codebase and identify:
+1. Which files are relevant to this issue
+2. The root cause (for bugs) or the requirements (for features)
+3. Any dependencies or constraints
+
+If you determine the issue is already resolved in the default branch or no code changes are needed, include the exact standalone line "XYLEM_NOOP" in your final output and explain why no further phases should run.
+
+Write your analysis clearly and concisely.

--- a/cli/internal/profiles/core/prompts/fix-bug/implement.md
+++ b/cli/internal/profiles/core/prompts/fix-bug/implement.md
@@ -1,0 +1,19 @@
+Implement the changes according to the plan.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+{{if .GateResult}}
+## Previous Gate Failure
+The following gate check failed after the previous attempt. Fix the issues and try again:
+
+{{.GateResult}}
+{{end}}
+
+Implement the changes now. Follow the plan precisely.

--- a/cli/internal/profiles/core/prompts/fix-bug/plan.md
+++ b/cli/internal/profiles/core/prompts/fix-bug/plan.md
@@ -1,0 +1,13 @@
+Based on the analysis from the previous phase, create an implementation plan.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Previous Analysis
+{{.PreviousOutputs.analyze}}
+
+Write a step-by-step plan that includes:
+1. What changes need to be made and in which files
+2. The order of changes
+3. Any tests that need to be added or updated
+4. Potential risks or edge cases

--- a/cli/internal/profiles/core/prompts/fix-bug/pr.md
+++ b/cli/internal/profiles/core/prompts/fix-bug/pr.md
@@ -1,0 +1,20 @@
+Create a pull request for the changes.
+
+This phase crosses the highest-blast-radius publication boundary the runner
+currently classifies. By default xylem allows `git_push` and `pr_create`
+so autonomous drains can finish, but repositories may add a workflow gate or
+`harness.policy.rules` that requires approval. Do not work around any configured
+policy boundary.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+Commit all changes with a clear commit message. Push the branch and create a PR
+only when the repository policy and workflow allow `git_push` and `pr_create`. Use:
+gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>"

--- a/cli/internal/profiles/core/prompts/implement-feature/analyze.md
+++ b/cli/internal/profiles/core/prompts/implement-feature/analyze.md
@@ -1,0 +1,15 @@
+Analyze the following GitHub issue and identify the relevant code.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+{{.Issue.Body}}
+
+Read the codebase and identify:
+1. Which files are relevant to this issue
+2. The root cause (for bugs) or the requirements (for features)
+3. Any dependencies or constraints
+
+If you determine the issue is already resolved in the default branch or no code changes are needed, include the exact standalone line "XYLEM_NOOP" in your final output and explain why no further phases should run.
+
+Write your analysis clearly and concisely.

--- a/cli/internal/profiles/core/prompts/implement-feature/implement.md
+++ b/cli/internal/profiles/core/prompts/implement-feature/implement.md
@@ -1,0 +1,19 @@
+Implement the changes according to the plan.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+{{if .GateResult}}
+## Previous Gate Failure
+The following gate check failed after the previous attempt. Fix the issues and try again:
+
+{{.GateResult}}
+{{end}}
+
+Implement the changes now. Follow the plan precisely.

--- a/cli/internal/profiles/core/prompts/implement-feature/plan.md
+++ b/cli/internal/profiles/core/prompts/implement-feature/plan.md
@@ -1,0 +1,13 @@
+Based on the analysis from the previous phase, create an implementation plan.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Previous Analysis
+{{.PreviousOutputs.analyze}}
+
+Write a step-by-step plan that includes:
+1. What changes need to be made and in which files
+2. The order of changes
+3. Any tests that need to be added or updated
+4. Potential risks or edge cases

--- a/cli/internal/profiles/core/prompts/implement-feature/pr.md
+++ b/cli/internal/profiles/core/prompts/implement-feature/pr.md
@@ -1,0 +1,20 @@
+Create a pull request for the changes.
+
+This phase crosses the highest-blast-radius publication boundary the runner
+currently classifies. By default xylem allows `git_push` and `pr_create`
+so autonomous drains can finish, but repositories may add a workflow gate or
+`harness.policy.rules` that requires approval. Do not work around any configured
+policy boundary.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+Commit all changes with a clear commit message. Push the branch and create a PR
+only when the repository policy and workflow allow `git_push` and `pr_create`. Use:
+gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>"

--- a/cli/internal/profiles/core/workflows/fix-bug.yaml
+++ b/cli/internal/profiles/core/workflows/fix-bug.yaml
@@ -1,0 +1,35 @@
+name: fix-bug
+description: "Diagnose and fix a bug from a GitHub issue"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/fix-bug/analyze.md
+    max_turns: 5
+    noop:
+      match: XYLEM_NOOP
+  - name: plan
+    prompt_file: .xylem/prompts/fix-bug/plan.md
+    max_turns: 3
+  - name: implement
+    prompt_file: .xylem/prompts/fix-bug/implement.md
+    max_turns: 15
+    gate:
+      type: command
+      run: "make test"
+      retries: 2
+      # Optional live smoke test example:
+      # type: live
+      # retries: 1
+      # live:
+      #   mode: http
+      #   http:
+      #     base_url: "http://127.0.0.1:3000"
+      #     steps:
+      #       - name: health
+      #         url: /health
+      #         expect_status: 200
+  - name: pr
+    prompt_file: .xylem/prompts/fix-bug/pr.md
+    max_turns: 3
+    # Publication phase: git_push/pr_create are allowed by default so autonomous
+    # drains can finish. Add a review gate or restrictive harness.policy.rules
+    # if you want a human checkpoint here.

--- a/cli/internal/profiles/core/workflows/implement-feature.yaml
+++ b/cli/internal/profiles/core/workflows/implement-feature.yaml
@@ -1,0 +1,35 @@
+name: implement-feature
+description: "Implement a feature from a GitHub issue"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/implement-feature/analyze.md
+    max_turns: 5
+    noop:
+      match: XYLEM_NOOP
+  - name: plan
+    prompt_file: .xylem/prompts/implement-feature/plan.md
+    max_turns: 3
+    gate:
+      type: label
+      wait_for: "plan-approved"
+      timeout: "24h"
+  - name: implement
+    prompt_file: .xylem/prompts/implement-feature/implement.md
+    max_turns: 15
+    gate:
+      type: command
+      run: "make test"
+      retries: 2
+      # Swap to a live gate when you need running-system verification:
+      # type: live
+      # live:
+      #   mode: command+assert
+      #   command_assert:
+      #     run: "./scripts/check-ready.sh"
+      #     expect_stdout_regex: "READY"
+  - name: pr
+    prompt_file: .xylem/prompts/implement-feature/pr.md
+    max_turns: 3
+    # Publication phase: git_push/pr_create are allowed by default so autonomous
+    # drains can finish. Add a review gate or restrictive harness.policy.rules
+    # if you want a human checkpoint here.

--- a/cli/internal/profiles/core/xylem.yml.tmpl
+++ b/cli/internal/profiles/core/xylem.yml.tmpl
@@ -1,0 +1,50 @@
+# xylem configuration
+# Docs: https://github.com/nicholls-inc/claude-code-marketplace/tree/main/xylem
+
+sources:
+  bugs:
+    type: github
+    repo: "{{ .Repo }}"
+    exclude: [wontfix, duplicate, in-progress, no-bot]
+    tasks:
+      fix-bugs:
+        labels: [bug, ready-for-work]
+        workflow: fix-bug
+  # features:
+  #   type: github
+  #   repo: "{{ .Repo }}"
+  #   exclude: [wontfix, duplicate, in-progress, no-bot]
+  #   tasks:
+  #     implement-features:
+  #       labels: [enhancement, low-effort, ready-for-work]
+  #       workflow: implement-feature
+
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+state_dir: ".xylem"
+
+# Default harness policy denies writes to xylem control files and allows
+# git_push/pr_create so autonomous drains can finish. If you want a strategic
+# human gate before publication, add workflow review steps or
+# harness.policy.rules that require approval for those actions.
+
+# llm selects the global default LLM provider: "claude" (default) or "copilot"
+llm: claude
+
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+  flags: "--bare --dangerously-skip-permissions"
+  env:
+    ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
+  # allowed_tools:
+  #   - "Bash(gh issue view *)"
+  #   - "Bash(gh pr create *)"
+  #   - "WebFetch"
+
+# copilot:
+#   command: "copilot"
+#   flags: ""
+#   default_model: ""
+#   env: {}

--- a/cli/internal/profiles/profiles.go
+++ b/cli/internal/profiles/profiles.go
@@ -1,0 +1,187 @@
+package profiles
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed core/** self-hosting-xylem/**
+var profileFS embed.FS
+
+var profileVersions = map[string]int{
+	"core":               1,
+	"self-hosting-xylem": 1,
+}
+
+var coreForbiddenDaemonFields = map[string]struct{}{
+	"auto_upgrade":    {},
+	"auto_merge":      {},
+	"auto_merge_repo": {},
+}
+
+type Profile struct {
+	Name    string
+	Version int
+	FS      fs.FS
+}
+
+type ComposedProfile struct {
+	Profiles       []Profile
+	Workflows      map[string][]byte
+	Prompts        map[string][]byte
+	Sources        map[string][]byte
+	ConfigOverlays [][]byte
+}
+
+type overlayConfig struct {
+	Daemon  map[string]any `yaml:"daemon"`
+	Sources map[string]any `yaml:"sources"`
+}
+
+func Load(name string) (*Profile, error) {
+	version, ok := profileVersions[name]
+	if !ok {
+		return nil, fmt.Errorf("load profile %q: unknown profile", name)
+	}
+
+	subFS, err := fs.Sub(profileFS, name)
+	if err != nil {
+		return nil, fmt.Errorf("load profile %q: %w", name, err)
+	}
+	if _, err := fs.Stat(subFS, "."); err != nil {
+		return nil, fmt.Errorf("load profile %q: %w", name, err)
+	}
+
+	return &Profile{
+		Name:    name,
+		Version: version,
+		FS:      subFS,
+	}, nil
+}
+
+func Compose(names ...string) (*ComposedProfile, error) {
+	if len(names) == 0 {
+		return nil, fmt.Errorf("compose profiles: no profiles requested")
+	}
+
+	composed := &ComposedProfile{
+		Workflows: make(map[string][]byte),
+		Prompts:   make(map[string][]byte),
+		Sources:   make(map[string][]byte),
+	}
+
+	workflowOwners := make(map[string]string)
+	sourceOwners := make(map[string]string)
+
+	for _, name := range names {
+		profile, err := Load(name)
+		if err != nil {
+			return nil, fmt.Errorf("compose profiles: %w", err)
+		}
+		composed.Profiles = append(composed.Profiles, *profile)
+
+		if err := fs.WalkDir(profile.FS, ".", func(filePath string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return fmt.Errorf("walk profile %q: %w", profile.Name, walkErr)
+			}
+			if d.IsDir() {
+				return nil
+			}
+
+			data, err := fs.ReadFile(profile.FS, filePath)
+			if err != nil {
+				return fmt.Errorf("read profile %q asset %q: %w", profile.Name, filePath, err)
+			}
+
+			switch {
+			case filePath == "xylem.yml.tmpl" || filePath == "xylem.overlay.yml":
+				if err := validateOverlay(profile.Name, filePath, data); err != nil {
+					return err
+				}
+				if err := mergeSources(profile.Name, filePath, data, composed.Sources, sourceOwners); err != nil {
+					return err
+				}
+				composed.ConfigOverlays = append(composed.ConfigOverlays, cloneBytes(data))
+			case strings.HasPrefix(filePath, "workflows/") && strings.HasSuffix(filePath, ".yaml"):
+				workflowName := strings.TrimSuffix(path.Base(filePath), path.Ext(filePath))
+				if prev, ok := composed.Workflows[workflowName]; ok && !bytes.Equal(prev, data) {
+					return fmt.Errorf("compose profiles: workflow %q conflicts between %q and %q", workflowName, workflowOwners[workflowName], profile.Name)
+				}
+				composed.Workflows[workflowName] = cloneBytes(data)
+				workflowOwners[workflowName] = profile.Name
+			case strings.HasPrefix(filePath, "prompts/") && strings.HasSuffix(filePath, ".md"):
+				promptKey := strings.TrimSuffix(strings.TrimPrefix(filePath, "prompts/"), ".md")
+				composed.Prompts[promptKey] = cloneBytes(data)
+			case strings.HasPrefix(filePath, "sources/") && strings.HasSuffix(filePath, ".yaml"):
+				sourceName := strings.TrimSuffix(path.Base(filePath), path.Ext(filePath))
+				if prevOwner, ok := sourceOwners[sourceName]; ok {
+					return fmt.Errorf("compose profiles: source %q conflicts between %q and %q", sourceName, prevOwner, profile.Name)
+				}
+				composed.Sources[sourceName] = cloneBytes(data)
+				sourceOwners[sourceName] = profile.Name
+			}
+
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	return composed, nil
+}
+
+func validateOverlay(profileName, filePath string, data []byte) error {
+	var overlay overlayConfig
+	if err := yaml.Unmarshal(data, &overlay); err != nil {
+		return fmt.Errorf("compose profiles: parse %q overlay %q: %w", profileName, filePath, err)
+	}
+
+	if profileName != "core" {
+		return nil
+	}
+	for field := range overlay.Daemon {
+		if _, forbidden := coreForbiddenDaemonFields[field]; forbidden {
+			return fmt.Errorf("compose profiles: core overlay %q must not set daemon.%s", filePath, field)
+		}
+	}
+
+	return nil
+}
+
+func mergeSources(profileName, filePath string, data []byte, dest map[string][]byte, owners map[string]string) error {
+	var overlay overlayConfig
+	if err := yaml.Unmarshal(data, &overlay); err != nil {
+		return fmt.Errorf("compose profiles: parse %q overlay %q: %w", profileName, filePath, err)
+	}
+
+	names := make([]string, 0, len(overlay.Sources))
+	for sourceName := range overlay.Sources {
+		names = append(names, sourceName)
+	}
+	sort.Strings(names)
+
+	for _, sourceName := range names {
+		if prevOwner, ok := owners[sourceName]; ok {
+			return fmt.Errorf("compose profiles: source %q conflicts between %q and %q", sourceName, prevOwner, profileName)
+		}
+		payload, err := yaml.Marshal(overlay.Sources[sourceName])
+		if err != nil {
+			return fmt.Errorf("compose profiles: marshal source %q from %q overlay %q: %w", sourceName, profileName, filePath, err)
+		}
+		dest[sourceName] = payload
+		owners[sourceName] = profileName
+	}
+
+	return nil
+}
+
+func cloneBytes(data []byte) []byte {
+	return append([]byte(nil), data...)
+}

--- a/cli/internal/profiles/profiles_prop_test.go
+++ b/cli/internal/profiles/profiles_prop_test.go
@@ -1,0 +1,93 @@
+package profiles
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropComposeCoreReturnsIndependentBytes(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		first, err := Compose("core")
+		if err != nil {
+			t.Fatalf("Compose(core) error = %v", err)
+		}
+
+		stable, err := Compose("core")
+		if err != nil {
+			t.Fatalf("Compose(core) second call error = %v", err)
+		}
+		expected := composedSignature(stable)
+
+		assets := composedAssets(first)
+		if len(assets) == 0 {
+			t.Fatal("Compose(core) returned no assets")
+		}
+		asset := assets[rapid.IntRange(0, len(assets)-1).Draw(t, "assetIndex")]
+		if len(asset.data) == 0 {
+			t.Fatalf("asset %q is empty", asset.name)
+		}
+		byteIndex := rapid.IntRange(0, len(asset.data)-1).Draw(t, "byteIndex")
+		asset.data[byteIndex] ^= 0xff
+
+		if got := composedSignature(stable); got != expected {
+			t.Fatalf("mutating %s changed another composition: got %q, want %q", asset.name, got, expected)
+		}
+
+		fresh, err := Compose("core")
+		if err != nil {
+			t.Fatalf("Compose(core) fresh call error = %v", err)
+		}
+		if got := composedSignature(fresh); got != expected {
+			t.Fatalf("Compose(core) fresh signature mismatch after mutating %s: got %q, want %q", asset.name, got, expected)
+		}
+	})
+}
+
+type assetRef struct {
+	name string
+	data []byte
+}
+
+func composedSignature(composed *ComposedProfile) string {
+	return joinMap(composed.Workflows) + "|" +
+		joinMap(composed.Prompts) + "|" +
+		joinMap(composed.Sources) + "|" +
+		joinOverlays(composed.ConfigOverlays)
+}
+
+func joinMap(m map[string][]byte) string {
+	keys := sortedKeys(m)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+string(m[key]))
+	}
+	return strings.Join(parts, "\n--\n")
+}
+
+func joinOverlays(overlays [][]byte) string {
+	parts := make([]string, 0, len(overlays))
+	for _, overlay := range overlays {
+		parts = append(parts, string(overlay))
+	}
+	return strings.Join(parts, "\n==\n")
+}
+
+func composedAssets(composed *ComposedProfile) []assetRef {
+	assets := make([]assetRef, 0, len(composed.Workflows)+len(composed.Prompts)+len(composed.Sources)+len(composed.ConfigOverlays))
+	for _, key := range sortedKeys(composed.Workflows) {
+		assets = append(assets, assetRef{name: "workflow:" + key, data: composed.Workflows[key]})
+	}
+	for _, key := range sortedKeys(composed.Prompts) {
+		assets = append(assets, assetRef{name: "prompt:" + key, data: composed.Prompts[key]})
+	}
+	for _, key := range sortedKeys(composed.Sources) {
+		assets = append(assets, assetRef{name: "source:" + key, data: composed.Sources[key]})
+	}
+	for i, overlay := range composed.ConfigOverlays {
+		assets = append(assets, assetRef{name: fmt.Sprintf("overlay:%d", i), data: overlay})
+	}
+	return assets
+}

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -1,0 +1,196 @@
+package profiles
+
+import (
+	"io/fs"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadCore(t *testing.T) {
+	profile, err := Load("core")
+	require.NoError(t, err)
+
+	assert.Equal(t, "core", profile.Name)
+	assert.Equal(t, 1, profile.Version)
+
+	data, err := fs.ReadFile(profile.FS, "HARNESS.md.tmpl")
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "# Project Overview")
+}
+
+func TestSmoke_S1_LoadCoreProfileReturnsEmbeddedAssets(t *testing.T) {
+	t.Parallel()
+
+	profile, err := Load("core")
+	require.NoError(t, err)
+
+	require.NotNil(t, profile)
+	assert.Equal(t, "core", profile.Name)
+	assert.Equal(t, 1, profile.Version)
+
+	harnessTemplate, err := fs.ReadFile(profile.FS, "HARNESS.md.tmpl")
+	require.NoError(t, err)
+	assert.Contains(t, string(harnessTemplate), "# Project Overview")
+
+	configTemplate, err := fs.ReadFile(profile.FS, "xylem.yml.tmpl")
+	require.NoError(t, err)
+	assert.Contains(t, string(configTemplate), `repo: "{{ .Repo }}"`)
+
+	lockTemplate, err := fs.ReadFile(profile.FS, "profile.lock.tmpl")
+	require.NoError(t, err)
+	assert.Contains(t, string(lockTemplate), "profile_version: 1")
+	assert.Contains(t, string(lockTemplate), "{{ .LockedAt }}")
+}
+
+func TestLoadUnknownProfile(t *testing.T) {
+	profile, err := Load("nonexistent")
+	require.Error(t, err)
+	assert.Nil(t, profile)
+	assert.Contains(t, err.Error(), "nonexistent")
+	assert.Contains(t, err.Error(), "unknown profile")
+}
+
+func TestComposeCoreIncludesSeededAssets(t *testing.T) {
+	composed, err := Compose("core")
+	require.NoError(t, err)
+
+	require.Len(t, composed.Profiles, 1)
+	assert.Equal(t, "core", composed.Profiles[0].Name)
+	assert.Equal(t, 1, composed.Profiles[0].Version)
+
+	assert.Equal(t, []string{"fix-bug", "implement-feature"}, sortedKeys(composed.Workflows))
+	assert.Equal(t, []string{
+		"fix-bug/analyze",
+		"fix-bug/implement",
+		"fix-bug/plan",
+		"fix-bug/pr",
+		"implement-feature/analyze",
+		"implement-feature/implement",
+		"implement-feature/plan",
+		"implement-feature/pr",
+	}, sortedKeys(composed.Prompts))
+	assert.Equal(t, []string{"bugs"}, sortedKeys(composed.Sources))
+	require.Len(t, composed.ConfigOverlays, 1)
+	assert.Contains(t, string(composed.Workflows["fix-bug"]), `name: fix-bug`)
+	assert.Contains(t, string(composed.Workflows["implement-feature"]), `name: implement-feature`)
+	assert.Contains(t, string(composed.Prompts["fix-bug/pr"]), "publication boundary")
+	assert.Contains(t, string(composed.ConfigOverlays[0]), `repo: "{{ .Repo }}"`)
+}
+
+func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
+	t.Parallel()
+
+	composed, err := Compose("core")
+	require.NoError(t, err)
+
+	require.NotNil(t, composed)
+	require.Len(t, composed.Profiles, 1)
+	assert.Equal(t, "core", composed.Profiles[0].Name)
+	assert.Equal(t, 1, composed.Profiles[0].Version)
+
+	assert.Equal(t, []string{"fix-bug", "implement-feature"}, sortedKeys(composed.Workflows))
+	assert.Equal(t, []string{
+		"fix-bug/analyze",
+		"fix-bug/implement",
+		"fix-bug/plan",
+		"fix-bug/pr",
+		"implement-feature/analyze",
+		"implement-feature/implement",
+		"implement-feature/plan",
+		"implement-feature/pr",
+	}, sortedKeys(composed.Prompts))
+	assert.Equal(t, []string{"bugs"}, sortedKeys(composed.Sources))
+	require.Len(t, composed.ConfigOverlays, 1)
+
+	assert.Contains(t, string(composed.Workflows["fix-bug"]), "name: fix-bug")
+	assert.Contains(t, string(composed.Workflows["implement-feature"]), "name: implement-feature")
+	assert.Contains(t, string(composed.Prompts["fix-bug/pr"]), "publication boundary")
+	assert.Contains(t, string(composed.ConfigOverlays[0]), `repo: "{{ .Repo }}"`)
+}
+
+func TestComposeUnknownProfile(t *testing.T) {
+	composed, err := Compose("nonexistent")
+	require.Error(t, err)
+	assert.Nil(t, composed)
+	assert.Contains(t, err.Error(), "nonexistent")
+	assert.Contains(t, err.Error(), "unknown profile")
+}
+
+func TestSmoke_S3_ComposeUnknownProfileReturnsClearError(t *testing.T) {
+	t.Parallel()
+
+	composed, err := Compose("nonexistent")
+	require.Error(t, err)
+
+	assert.Nil(t, composed)
+	assert.Contains(t, err.Error(), "nonexistent")
+	assert.Contains(t, err.Error(), "unknown profile")
+}
+
+func TestComposeRequiresAtLeastOneProfile(t *testing.T) {
+	composed, err := Compose()
+	require.Error(t, err)
+	assert.Nil(t, composed)
+	assert.Contains(t, err.Error(), "no profiles requested")
+}
+
+func TestComposeRejectsConflictingSourceKeys(t *testing.T) {
+	composed, err := Compose("core", "core")
+	require.Error(t, err)
+	assert.Nil(t, composed)
+	assert.Contains(t, err.Error(), `source "bugs" conflicts`)
+	assert.True(t, strings.Count(err.Error(), `"core"`) >= 2, "expected both conflicting profiles in error: %q", err.Error())
+}
+
+func TestComposeRejectsWorkflowConflictsAcrossProfiles(t *testing.T) {
+	tests := []struct {
+		name     string
+		profiles []string
+	}{
+		{
+			name:     "core first",
+			profiles: []string{"core", "self-hosting-xylem"},
+		},
+		{
+			name:     "self hosting first",
+			profiles: []string{"self-hosting-xylem", "core"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			composed, err := Compose(tt.profiles...)
+			require.Error(t, err)
+			assert.Nil(t, composed)
+			assert.Contains(t, err.Error(), `workflow "fix-bug" conflicts`)
+			for _, profileName := range tt.profiles {
+				assert.Contains(t, err.Error(), profileName)
+			}
+		})
+	}
+}
+
+func TestSmoke_S4_ComposeCoreAndSelfHostingXylemRejectsWorkflowConflicts(t *testing.T) {
+	t.Parallel()
+
+	composed, err := Compose("core", "self-hosting-xylem")
+	require.Error(t, err)
+
+	assert.Nil(t, composed)
+	assert.Contains(t, err.Error(), `workflow "fix-bug" conflicts`)
+	assert.Contains(t, err.Error(), "core")
+	assert.Contains(t, err.Error(), "self-hosting-xylem")
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cli/internal/profiles/self-hosting-xylem/profile.lock.tmpl
+++ b/cli/internal/profiles/self-hosting-xylem/profile.lock.tmpl
@@ -1,0 +1,7 @@
+profile_version: 1
+profiles:
+{{- range .Profiles }}
+  - name: {{ .Name }}
+    version: {{ .Version }}
+{{- end }}
+locked_at: {{ .LockedAt }}

--- a/cli/internal/profiles/self-hosting-xylem/workflows/fix-bug.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/fix-bug.yaml
@@ -1,0 +1,6 @@
+name: fix-bug
+description: "Conflicting placeholder for composition validation"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/fix-bug/analyze.md
+    max_turns: 1

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -1,0 +1,3 @@
+# Reserved for follow-up self-hosting overlay migration.
+daemon:
+  scan_interval: "60s"


### PR DESCRIPTION
## Summary

Implements [issue #231](https://github.com/nicholls-inc/xylem/issues/231) by adding a new embedded `cli/internal/profiles` package that becomes the authoritative source for shipped profile assets and composition behavior, without changing `xylem init` in this PR.

## Smoke scenarios covered

- **S1** — Load core profile returns embedded assets
- **S2** — Compose core includes seeded workflows and templates
- **S3** — Compose unknown profile returns clear error
- **S4** — Compose core and self-hosting-xylem rejects workflow conflicts

## Changes summary

- **Files added:** 19 under `cli/internal/profiles/`
- **Key package API:** `Profile`, `ComposedProfile`, `Load(name string)`, `Compose(names ...string)` in `cli/internal/profiles/profiles.go`
- **Composition behavior:** embeds `core/**` and `self-hosting-xylem/**`, validates forbidden core daemon fields, merges overlay sources additively, preserves ordered config overlays, and rejects conflicting workflow/source ownership across profiles
- **Seeded assets:** extracted `fix-bug` and `implement-feature` workflow YAML plus 8 prompt templates into `cli/internal/profiles/core/workflows/` and `cli/internal/profiles/core/prompts/`
- **Templates and overlays:** added `core/HARNESS.md.tmpl`, `core/xylem.yml.tmpl`, `core/profile.lock.tmpl`, plus the self-hosting scaffold overlay and conflicting workflow fixture
- **Tests:** added `profiles_test.go` smoke/unit coverage and `profiles_prop_test.go` property coverage for independent/idempotent composed bytes

## Test plan

- `cd cli && go test ./internal/profiles/...`
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && goimports -l . && go vet ./... && golangci-lint run && go build ./cmd/xylem && go test ./...`
- `cd cli && go vet ./... && go build ./cmd/xylem && go test ./...`

Fixes #231