### PR TITLE
feat: wire CLI cost telemetry and vessel reports

### DIFF
--- a/cli/cmd/xylem/status.go
+++ b/cli/cmd/xylem/status.go
@@ -32,8 +32,11 @@ func newStatusCmd() *cobra.Command {
 
 type statusRow struct {
 	queue.Vessel
-	Health    string                 `json:"health"`
-	Anomalies []runner.VesselAnomaly `json:"anomalies,omitempty"`
+	Health           string                 `json:"health"`
+	Anomalies        []runner.VesselAnomaly `json:"anomalies,omitempty"`
+	EstimatedCostUSD float64                `json:"estimated_cost_usd,omitempty"`
+	UsageSource      string                 `json:"usage_source,omitempty"`
+	BudgetWarning    bool                   `json:"budget_warning,omitempty"`
 }
 
 func cmdStatus(cfg *config.Config, q *queue.Queue, jsonMode bool, stateFilter string) error {
@@ -64,9 +67,12 @@ func cmdStatus(cfg *config.Config, q *queue.Queue, jsonMode bool, stateFilter st
 	for i, vessel := range vessels {
 		status := runner.AnalyzeVesselStatus(vessel, summaries[vessel.ID])
 		rows[i] = statusRow{
-			Vessel:    vessel,
-			Health:    string(status.Health),
-			Anomalies: status.Anomalies,
+			Vessel:           vessel,
+			Health:           string(status.Health),
+			Anomalies:        status.Anomalies,
+			EstimatedCostUSD: summaryCost(summaries[vessel.ID]),
+			UsageSource:      summaryUsageSource(summaries[vessel.ID]),
+			BudgetWarning:    summaries[vessel.ID] != nil && summaries[vessel.ID].BudgetWarning,
 		}
 	}
 	fleet := runner.AnalyzeFleetStatus(vessels, summaries)
@@ -83,10 +89,10 @@ func cmdStatus(cfg *config.Config, q *queue.Queue, jsonMode bool, stateFilter st
 		return nil
 	}
 
-	fmt.Printf("%-14s  %-14s  %-20s  %-10s  %-10s  %-42s  %-12s  %s\n",
-		"ID", "Source", "Workflow", "State", "Health", "Info", "Started", "Duration")
-	fmt.Printf("%-14s  %-14s  %-20s  %-10s  %-10s  %-42s  %-12s  %s\n",
-		"----", "------", "-----", "-----", "------", "----", "-------", "--------")
+	fmt.Printf("%-14s  %-14s  %-20s  %-10s  %-10s  %-12s  %-42s  %-12s  %s\n",
+		"ID", "Source", "Workflow", "State", "Health", "Cost", "Info", "Started", "Duration")
+	fmt.Printf("%-14s  %-14s  %-20s  %-10s  %-10s  %-12s  %-42s  %-12s  %s\n",
+		"----", "------", "-----", "-----", "------", "----", "----", "-------", "--------")
 
 	counts := map[queue.VesselState]int{}
 	for i, j := range vessels {
@@ -105,9 +111,9 @@ func cmdStatus(cfg *config.Config, q *queue.Queue, jsonMode bool, stateFilter st
 		if wf == "" {
 			wf = "(prompt)"
 		}
-		info := vesselInfo(j, rows[i].Anomalies)
-		fmt.Printf("%-14s  %-14s  %-20s  %-10s  %-10s  %-42s  %-12s  %s\n",
-			j.ID, j.Source, wf, string(j.State), rows[i].Health, info, started, duration)
+		info := vesselInfo(j, summaries[j.ID], rows[i].Anomalies)
+		fmt.Printf("%-14s  %-14s  %-20s  %-10s  %-10s  %-12s  %-42s  %-12s  %s\n",
+			j.ID, j.Source, wf, string(j.State), rows[i].Health, formatSummaryCost(summaries[j.ID]), info, started, duration)
 	}
 
 	fmt.Printf("\nSummary: %d pending, %d running, %d completed, %d failed, %d cancelled, %d waiting, %d timed_out\n",
@@ -124,7 +130,7 @@ func cmdStatus(cfg *config.Config, q *queue.Queue, jsonMode bool, stateFilter st
 }
 
 // vesselInfo returns additional context for the Info column based on vessel state.
-func vesselInfo(v queue.Vessel, anomalies []runner.VesselAnomaly) string {
+func vesselInfo(v queue.Vessel, summary *runner.VesselSummary, anomalies []runner.VesselAnomaly) string {
 	parts := make([]string, 0, len(anomalies)+1)
 	if v.State == queue.StateWaiting && v.WaitingFor != "" {
 		elapsed := "unknown"
@@ -139,7 +145,41 @@ func vesselInfo(v queue.Vessel, anomalies []runner.VesselAnomaly) string {
 		}
 		parts = append(parts, anomaly.Message)
 	}
+	if summary != nil && summary.UsageUnavailableReason != "" && summary.UsageSource == "unavailable" {
+		parts = append(parts, summary.UsageUnavailableReason)
+	}
 	return strings.Join(parts, "; ")
+}
+
+func summaryCost(summary *runner.VesselSummary) float64 {
+	if summary == nil {
+		return 0
+	}
+	return summary.TotalCostUSDEst
+}
+
+func summaryUsageSource(summary *runner.VesselSummary) string {
+	if summary == nil {
+		return ""
+	}
+	return string(summary.UsageSource)
+}
+
+func formatSummaryCost(summary *runner.VesselSummary) string {
+	if summary == nil {
+		return "—"
+	}
+	switch summary.UsageSource {
+	case "estimated", "provider":
+		return fmt.Sprintf("$%.4f", summary.TotalCostUSDEst)
+	case "not_applicable", "unavailable":
+		return "n/a"
+	default:
+		if summary.TotalCostUSDEst > 0 {
+			return fmt.Sprintf("$%.4f", summary.TotalCostUSDEst)
+		}
+		return "—"
+	}
 }
 
 func pauseMarkerPath(cfg *config.Config) string {

--- a/cli/cmd/xylem/status_test.go
+++ b/cli/cmd/xylem/status_test.go
@@ -403,7 +403,8 @@ func TestStatusSurfacesHealthAndPatterns(t *testing.T) {
   "total_input_tokens_est": 0,
   "total_output_tokens_est": 0,
   "total_tokens_est": 0,
-  "total_cost_usd_est": 0,
+  "total_cost_usd_est": 0.25,
+  "usage_source": "estimated",
   "budget_exceeded": true,
   "note": "test"
 }`
@@ -425,6 +426,9 @@ func TestStatusSurfacesHealthAndPatterns(t *testing.T) {
 	}
 	if !strings.Contains(out, "budget exceeded") {
 		t.Fatalf("expected anomaly details in output, got: %s", out)
+	}
+	if !strings.Contains(out, "$0.2500") {
+		t.Fatalf("expected estimated cost in output, got: %s", out)
 	}
 	if !strings.Contains(out, "Health: 1 healthy, 0 degraded, 1 unhealthy") {
 		t.Fatalf("expected health summary counts, got: %s", out)
@@ -465,6 +469,64 @@ func TestStatusJSONIncludesHealthAndAnomalies(t *testing.T) {
 	}
 	if len(rows[0].Anomalies) != 1 || rows[0].Anomalies[0].Code != "waiting_on_gate" {
 		t.Fatalf("expected waiting_on_gate anomaly, got %#v", rows[0].Anomalies)
+	}
+}
+
+func TestStatusSurfacesUnavailableUsageReason(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testStatusConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	started := now.Add(-2 * time.Minute)
+	ended := now.Add(-time.Minute)
+
+	q.Enqueue(queue.Vessel{ //nolint:errcheck
+		ID: "issue-usage-unavailable", Source: "github-issue", Workflow: "fix-bug",
+		State: queue.StateCompleted, CreatedAt: now,
+		StartedAt: &started, EndedAt: &ended,
+	})
+
+	summaryDir := filepath.Join(cfg.StateDir, "phases", "issue-usage-unavailable")
+	if err := os.MkdirAll(summaryDir, 0o755); err != nil {
+		t.Fatalf("mkdir summary dir: %v", err)
+	}
+	summary := `{
+  "vessel_id": "issue-usage-unavailable",
+  "source": "github-issue",
+  "workflow": "fix-bug",
+  "state": "completed",
+  "started_at": "2026-04-08T20:00:00Z",
+  "ended_at": "2026-04-08T20:01:00Z",
+  "duration_ms": 60000,
+  "phases": [
+    {
+      "name": "implement",
+      "type": "prompt",
+      "duration_ms": 1000,
+      "status": "completed",
+      "usage_source": "unavailable",
+      "usage_unavailable_reason": "provider did not return token usage"
+    }
+  ],
+  "usage_source": "unavailable",
+  "usage_unavailable_reason": "provider did not return token usage",
+  "note": "test"
+}`
+	if err := os.WriteFile(filepath.Join(summaryDir, "summary.json"), []byte(summary), 0o644); err != nil {
+		t.Fatalf("write summary: %v", err)
+	}
+
+	var err error
+	out := captureStdout(func() { err = cmdStatus(cfg, q, false, "") })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "n/a") {
+		t.Fatalf("expected n/a cost in output, got: %s", out)
+	}
+	if !strings.Contains(out, "provider did not return token usage") {
+		t.Fatalf("expected unavailable usage reason in info column, got: %s", out)
 	}
 }
 

--- a/cli/internal/cost/cost.go
+++ b/cli/internal/cost/cost.go
@@ -29,6 +29,16 @@ const (
 	PurposeEvaluation Purpose = "evaluation"
 )
 
+// UsageSource identifies where usage telemetry came from.
+type UsageSource string
+
+const (
+	UsageSourceProvider      UsageSource = "provider"
+	UsageSourceEstimated     UsageSource = "estimated"
+	UsageSourceUnavailable   UsageSource = "unavailable"
+	UsageSourceNotApplicable UsageSource = "not_applicable"
+)
+
 // UsageRecord captures a single token-usage event.
 type UsageRecord struct {
 	MissionID    string    `json:"mission_id"`
@@ -60,14 +70,44 @@ type BudgetAlert struct {
 
 // CostReport summarises cost data for a mission.
 type CostReport struct {
-	MissionID    string                `json:"mission_id"`
-	TotalTokens  int                   `json:"total_tokens"`
-	TotalCostUSD float64               `json:"total_cost_usd"`
-	ByRole       map[AgentRole]float64 `json:"by_role"`
-	ByPurpose    map[Purpose]float64   `json:"by_purpose"`
-	ByModel      map[string]float64    `json:"by_model"`
-	RecordCount  int                   `json:"record_count"`
-	GeneratedAt  time.Time             `json:"generated_at"`
+	MissionID              string                `json:"mission_id"`
+	Source                 string                `json:"source,omitempty"`
+	Workflow               string                `json:"workflow,omitempty"`
+	Ref                    string                `json:"ref,omitempty"`
+	State                  string                `json:"state,omitempty"`
+	TotalTokens            int                   `json:"total_tokens"`
+	TotalCostUSD           float64               `json:"total_cost_usd"`
+	TotalDurationMS        int64                 `json:"total_duration_ms,omitempty"`
+	ByRole                 map[AgentRole]float64 `json:"by_role"`
+	ByPurpose              map[Purpose]float64   `json:"by_purpose"`
+	ByModel                map[string]float64    `json:"by_model"`
+	RecordCount            int                   `json:"record_count"`
+	UsageSource            UsageSource           `json:"usage_source,omitempty"`
+	UsageUnavailableReason string                `json:"usage_unavailable_reason,omitempty"`
+	BudgetExceeded         bool                  `json:"budget_exceeded,omitempty"`
+	BudgetWarning          bool                  `json:"budget_warning,omitempty"`
+	BudgetAlertCount       int                   `json:"budget_alert_count,omitempty"`
+	TraceID                string                `json:"trace_id,omitempty"`
+	SpanID                 string                `json:"span_id,omitempty"`
+	EvidenceManifestPath   string                `json:"evidence_manifest_path,omitempty"`
+	Phases                 []PhaseReport         `json:"phases,omitempty"`
+	GeneratedAt            time.Time             `json:"generated_at"`
+}
+
+// PhaseReport captures phase-level latency and cost details for a mission report.
+type PhaseReport struct {
+	Name                   string      `json:"name"`
+	Type                   string      `json:"type"`
+	Provider               string      `json:"provider,omitempty"`
+	Model                  string      `json:"model,omitempty"`
+	DurationMS             int64       `json:"duration_ms"`
+	Status                 string      `json:"status"`
+	InputTokens            int         `json:"input_tokens"`
+	OutputTokens           int         `json:"output_tokens"`
+	TotalTokens            int         `json:"total_tokens"`
+	CostUSD                float64     `json:"cost_usd"`
+	UsageSource            UsageSource `json:"usage_source,omitempty"`
+	UsageUnavailableReason string      `json:"usage_unavailable_reason,omitempty"`
 }
 
 // ModelLadder maps each agent role to a preferred model name.

--- a/cli/internal/observability/vessel.go
+++ b/cli/internal/observability/vessel.go
@@ -106,12 +106,14 @@ func PhaseSpanAttributes(data PhaseSpanData) []SpanAttribute {
 
 // PhaseResultData holds phase result information for attribute extraction.
 type PhaseResultData struct {
-	InputTokensEst     int     `json:"input_tokens_est"`
-	OutputTokensEst    int     `json:"output_tokens_est"`
-	CostUSDEst         float64 `json:"cost_usd_est"`
-	DurationMS         int64   `json:"duration_ms"`
-	Status             string  `json:"status"`
-	OutputArtifactPath string  `json:"output_artifact_path,omitempty"`
+	InputTokensEst         int     `json:"input_tokens_est"`
+	OutputTokensEst        int     `json:"output_tokens_est"`
+	CostUSDEst             float64 `json:"cost_usd_est"`
+	DurationMS             int64   `json:"duration_ms"`
+	Status                 string  `json:"status"`
+	UsageSource            string  `json:"usage_source,omitempty"`
+	UsageUnavailableReason string  `json:"usage_unavailable_reason,omitempty"`
+	OutputArtifactPath     string  `json:"output_artifact_path,omitempty"`
 }
 
 // PhaseResultAttributes returns span attributes added to a phase span
@@ -123,7 +125,31 @@ func PhaseResultAttributes(data PhaseResultData) []SpanAttribute {
 		{Key: "xylem.phase.cost_usd_est", Value: fmt.Sprintf("%.6f", data.CostUSDEst)},
 		{Key: "xylem.phase.duration_ms", Value: fmt.Sprintf("%d", data.DurationMS)},
 		{Key: "xylem.phase.status", Value: data.Status},
+		{Key: "xylem.phase.usage_source", Value: data.UsageSource},
+		{Key: "xylem.phase.usage_unavailable_reason", Value: data.UsageUnavailableReason},
 		{Key: "xylem.phase.output_artifact_path", Value: data.OutputArtifactPath},
+	}
+}
+
+// VesselCostData holds vessel-level cost telemetry attributes.
+type VesselCostData struct {
+	TotalTokens            int     `json:"total_tokens"`
+	TotalCostUSDEst        float64 `json:"total_cost_usd_est"`
+	UsageSource            string  `json:"usage_source,omitempty"`
+	UsageUnavailableReason string  `json:"usage_unavailable_reason,omitempty"`
+	BudgetExceeded         bool    `json:"budget_exceeded"`
+	BudgetWarning          bool    `json:"budget_warning"`
+}
+
+// VesselCostAttributes returns span attributes for vessel-level cost telemetry.
+func VesselCostAttributes(data VesselCostData) []SpanAttribute {
+	return []SpanAttribute{
+		{Key: "xylem.vessel.total_tokens_est", Value: fmt.Sprintf("%d", data.TotalTokens)},
+		{Key: "xylem.vessel.total_cost_usd_est", Value: fmt.Sprintf("%.6f", data.TotalCostUSDEst)},
+		{Key: "xylem.vessel.usage_source", Value: data.UsageSource},
+		{Key: "xylem.vessel.usage_unavailable_reason", Value: data.UsageUnavailableReason},
+		{Key: "xylem.vessel.budget_exceeded", Value: fmt.Sprintf("%t", data.BudgetExceeded)},
+		{Key: "xylem.vessel.budget_warning", Value: fmt.Sprintf("%t", data.BudgetWarning)},
 	}
 }
 

--- a/cli/internal/observability/vessel_prop_test.go
+++ b/cli/internal/observability/vessel_prop_test.go
@@ -176,7 +176,7 @@ func TestPropPhaseAttrsIndexStringified(t *testing.T) {
 	})
 }
 
-func TestPropPhaseResultAttrsAlwaysSix(t *testing.T) {
+func TestPropPhaseResultAttrsAlwaysEight(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		attrs := PhaseResultAttributes(PhaseResultData{
 			InputTokensEst:     rapid.IntRange(0, 1000000).Draw(t, "input_tokens"),
@@ -186,8 +186,8 @@ func TestPropPhaseResultAttrsAlwaysSix(t *testing.T) {
 			Status:             genVesselString().Draw(t, "status"),
 			OutputArtifactPath: genVesselString().Draw(t, "output_artifact_path"),
 		})
-		if len(attrs) != 6 {
-			t.Fatalf("expected 6 attributes, got %d", len(attrs))
+		if len(attrs) != 8 {
+			t.Fatalf("expected 8 attributes, got %d", len(attrs))
 		}
 	})
 }

--- a/cli/internal/observability/vessel_test.go
+++ b/cli/internal/observability/vessel_test.go
@@ -95,17 +95,19 @@ func TestSmoke_S4_PhaseResultAttributesFormatsTokensAndCost(t *testing.T) {
 	})
 	got := attrMap(attrs)
 
-	if len(attrs) != 6 {
-		t.Fatalf("expected 6 attributes, got %d", len(attrs))
+	if len(attrs) != 8 {
+		t.Fatalf("expected 8 attributes, got %d", len(attrs))
 	}
 
 	want := map[string]string{
-		"xylem.phase.input_tokens_est":     "1200",
-		"xylem.phase.output_tokens_est":    "300",
-		"xylem.phase.cost_usd_est":         "0.008100",
-		"xylem.phase.duration_ms":          "4500",
-		"xylem.phase.status":               "completed",
-		"xylem.phase.output_artifact_path": "phases/vessel-1/analyse.output",
+		"xylem.phase.input_tokens_est":         "1200",
+		"xylem.phase.output_tokens_est":        "300",
+		"xylem.phase.cost_usd_est":             "0.008100",
+		"xylem.phase.duration_ms":              "4500",
+		"xylem.phase.status":                   "completed",
+		"xylem.phase.usage_source":             "",
+		"xylem.phase.usage_unavailable_reason": "",
+		"xylem.phase.output_artifact_path":     "phases/vessel-1/analyse.output",
 	}
 	for key, value := range want {
 		if got[key] != value {

--- a/cli/internal/reporter/reporter.go
+++ b/cli/internal/reporter/reporter.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 )
@@ -27,26 +28,37 @@ type Reporter struct {
 
 // PhaseResult holds the outcome of a single phase for the summary comment.
 type PhaseResult struct {
-	Name     string
-	Duration time.Duration
-	Status   string // "completed", "failed", or "no-op"
+	Name                   string
+	Duration               time.Duration
+	Status                 string // "completed", "failed", or "no-op"
+	Provider               string
+	Model                  string
+	InputTokensEst         int
+	OutputTokensEst        int
+	CostUSDEst             float64
+	UsageSource            cost.UsageSource
+	UsageUnavailableReason string
 }
 
 // PhaseComplete posts a comment on the GitHub issue when a phase completes successfully.
-func (r *Reporter) PhaseComplete(ctx context.Context, issueNum int, phaseName string, duration time.Duration, output string) error {
+func (r *Reporter) PhaseComplete(ctx context.Context, issueNum int, phaseResult PhaseResult, output string) error {
 	span := observability.StartGlobalSpan(ctx, "reporter:phase_complete", observability.ReporterSpanAttributes(observability.ReporterSpanData{
 		Action:    "phase_complete",
 		Repo:      r.Repo,
 		IssueNum:  issueNum,
-		PhaseName: phaseName,
+		PhaseName: phaseResult.Name,
 	}))
 	defer span.End()
 
 	truncated := truncateOutput(output, MaxOutputLen)
+	usageLine := formatPhaseUsageLine(phaseResult)
+	if usageLine != "" {
+		usageLine += "\n\n"
+	}
 
 	body := fmt.Sprintf(
-		"**xylem — phase `%s` completed** (%s)\n\n<details>\n<summary>Phase output (click to expand)</summary>\n\n%s\n\n</details>",
-		phaseName, duration, truncated,
+		"**xylem — phase `%s` completed** (%s)\n\n%s<details>\n<summary>Phase output (click to expand)</summary>\n\n%s\n\n</details>",
+		phaseResult.Name, phaseResult.Duration, usageLine, truncated,
 	)
 
 	if err := postComment(ctx, r.Runner, r.Repo, issueNum, body); err != nil {
@@ -96,16 +108,28 @@ func (r *Reporter) VesselCompleted(ctx context.Context, issueNum int, phases []P
 	} else {
 		sb.WriteString("**xylem — all phases completed**\n\n")
 	}
-	sb.WriteString("| Phase | Duration | Status |\n")
-	sb.WriteString("|-------|----------|--------|\n")
+	sb.WriteString("| Phase | Duration | Cost | Tokens | Status |\n")
+	sb.WriteString("|-------|----------|------|--------|--------|\n")
 
 	var total time.Duration
+	var totalTokens int
+	var totalCost float64
+	var usageSource cost.UsageSource
 	for _, p := range phases {
-		fmt.Fprintf(&sb, "| %s | %s | %s |\n", p.Name, p.Duration, p.Status)
+		fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s |\n", p.Name, p.Duration, formatPhaseCostCell(p), formatPhaseTokenCell(p), p.Status)
 		total += p.Duration
+		totalTokens += p.InputTokensEst + p.OutputTokensEst
+		totalCost += p.CostUSDEst
+		if p.UsageSource != "" && p.UsageSource != cost.UsageSourceNotApplicable {
+			usageSource = p.UsageSource
+		}
 	}
 
 	fmt.Fprintf(&sb, "\nTotal: %s", total)
+	if usageSummary := formatAggregateUsageSummary(totalCost, totalTokens, usageSource); usageSummary != "" {
+		sb.WriteString(" — ")
+		sb.WriteString(usageSummary)
+	}
 	if evidenceSection := formatEvidenceSection(manifest); evidenceSection != "" {
 		sb.WriteString("\n\n")
 		sb.WriteString(evidenceSection)
@@ -158,4 +182,48 @@ func truncateOutput(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "\n\n(output truncated — full output in .xylem/phases/<id>/<phase>.output)"
+}
+
+func formatPhaseUsageLine(result PhaseResult) string {
+	if result.UsageSource == "" && result.CostUSDEst == 0 && result.InputTokensEst == 0 && result.OutputTokensEst == 0 {
+		return ""
+	}
+	if result.UsageSource == cost.UsageSourceNotApplicable {
+		return "_Usage:_ n/a — non-LLM phase"
+	}
+	if result.UsageSource == cost.UsageSourceUnavailable {
+		reason := result.UsageUnavailableReason
+		if reason == "" {
+			reason = "usage unavailable"
+		}
+		return "_Usage:_ n/a — " + reason
+	}
+	return fmt.Sprintf("_Usage:_ %s, %s", formatPhaseCostCell(result), formatPhaseTokenCell(result))
+}
+
+func formatPhaseCostCell(result PhaseResult) string {
+	if result.UsageSource == "" && result.CostUSDEst == 0 && result.InputTokensEst == 0 && result.OutputTokensEst == 0 {
+		return "—"
+	}
+	if result.UsageSource == cost.UsageSourceNotApplicable || result.UsageSource == cost.UsageSourceUnavailable {
+		return "—"
+	}
+	return fmt.Sprintf("$%.4f", result.CostUSDEst)
+}
+
+func formatPhaseTokenCell(result PhaseResult) string {
+	if result.UsageSource == "" && result.CostUSDEst == 0 && result.InputTokensEst == 0 && result.OutputTokensEst == 0 {
+		return "—"
+	}
+	if result.UsageSource == cost.UsageSourceNotApplicable || result.UsageSource == cost.UsageSourceUnavailable {
+		return "—"
+	}
+	return fmt.Sprintf("%d", result.InputTokensEst+result.OutputTokensEst)
+}
+
+func formatAggregateUsageSummary(totalCost float64, totalTokens int, usageSource cost.UsageSource) string {
+	if usageSource == "" || usageSource == cost.UsageSourceNotApplicable || usageSource == cost.UsageSourceUnavailable {
+		return ""
+	}
+	return fmt.Sprintf("$%.4f, %d tokens (%s)", totalCost, totalTokens, usageSource)
 }

--- a/cli/internal/reporter/reporter_test.go
+++ b/cli/internal/reporter/reporter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/stretchr/testify/assert"
@@ -55,11 +56,23 @@ func newReporterTracer(t *testing.T) *tracetest.SpanRecorder {
 	return rec
 }
 
+func estimatedPhase(name string, duration time.Duration, status string, costUSD float64, inputTokens, outputTokens int) PhaseResult {
+	return PhaseResult{
+		Name:            name,
+		Duration:        duration,
+		Status:          status,
+		CostUSDEst:      costUSD,
+		InputTokensEst:  inputTokens,
+		OutputTokensEst: outputTokens,
+		UsageSource:     cost.UsageSourceEstimated,
+	}
+}
+
 func TestPhaseComplete(t *testing.T) {
 	mock := &mockRunner{}
 	r := &Reporter{Runner: mock, Repo: "owner/repo"}
 
-	err := r.PhaseComplete(context.Background(), 42, "analyze", 2*time.Minute+15*time.Second, "some output here")
+	err := r.PhaseComplete(context.Background(), 42, estimatedPhase("analyze", 2*time.Minute+15*time.Second, "completed", 0.0123, 320, 110), "some output here")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -69,6 +82,9 @@ func TestPhaseComplete(t *testing.T) {
 	}
 	if !strings.Contains(mock.lastBody, "2m15s") {
 		t.Errorf("expected duration in comment, got: %s", mock.lastBody)
+	}
+	if !strings.Contains(mock.lastBody, "_Usage:_ $0.0123, 430") {
+		t.Errorf("expected usage summary in comment, got: %s", mock.lastBody)
 	}
 	if !strings.Contains(mock.lastBody, "some output here") {
 		t.Errorf("expected output in comment, got: %s", mock.lastBody)
@@ -83,7 +99,7 @@ func TestPhaseCompleteEmitsReporterSpan(t *testing.T) {
 	mock := &mockRunner{}
 	r := &Reporter{Runner: mock, Repo: "owner/repo"}
 
-	require.NoError(t, r.PhaseComplete(context.Background(), 42, "analyze", time.Second, "ok"))
+	require.NoError(t, r.PhaseComplete(context.Background(), 42, estimatedPhase("analyze", time.Second, "completed", 0.001, 20, 10), "ok"))
 
 	var found bool
 	for _, span := range rec.Ended() {
@@ -107,7 +123,7 @@ func TestPhaseCompleteGhArgs(t *testing.T) {
 	mock := &mockRunner{}
 	r := &Reporter{Runner: mock, Repo: "owner/repo"}
 
-	_ = r.PhaseComplete(context.Background(), 42, "analyze", time.Second, "out")
+	_ = r.PhaseComplete(context.Background(), 42, estimatedPhase("analyze", time.Second, "completed", 0.001, 20, 10), "out")
 
 	wantArgs := []string{"gh", "issue", "comment", "42", "--repo", "owner/repo", "--body"}
 	if len(mock.lastArgs) < len(wantArgs) {
@@ -125,7 +141,7 @@ func TestPhaseCompleteTruncation(t *testing.T) {
 	r := &Reporter{Runner: mock, Repo: "owner/repo"}
 
 	longOutput := strings.Repeat("x", MaxOutputLen+1000)
-	err := r.PhaseComplete(context.Background(), 7, "build", time.Second, longOutput)
+	err := r.PhaseComplete(context.Background(), 7, estimatedPhase("build", time.Second, "completed", 0.001, 20, 10), longOutput)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -143,7 +159,7 @@ func TestPhaseCompleteExactMaxLen(t *testing.T) {
 	r := &Reporter{Runner: mock, Repo: "owner/repo"}
 
 	exactOutput := strings.Repeat("y", MaxOutputLen)
-	err := r.PhaseComplete(context.Background(), 1, "test", time.Second, exactOutput)
+	err := r.PhaseComplete(context.Background(), 1, estimatedPhase("test", time.Second, "completed", 0.001, 20, 10), exactOutput)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -201,9 +217,9 @@ func TestVesselCompleted(t *testing.T) {
 	r := &Reporter{Runner: mock, Repo: "owner/repo"}
 
 	phases := []PhaseResult{
-		{Name: "analyze", Duration: 2*time.Minute + 15*time.Second, Status: "completed"},
-		{Name: "implement", Duration: 5*time.Minute + 30*time.Second, Status: "completed"},
-		{Name: "pr", Duration: time.Minute, Status: "completed"},
+		estimatedPhase("analyze", 2*time.Minute+15*time.Second, "completed", 0.0123, 320, 110),
+		estimatedPhase("implement", 5*time.Minute+30*time.Second, "completed", 0.0345, 500, 140),
+		estimatedPhase("pr", time.Minute, "completed", 0.0042, 90, 30),
 	}
 
 	err := r.VesselCompleted(context.Background(), 5, phases, nil)
@@ -214,19 +230,19 @@ func TestVesselCompleted(t *testing.T) {
 	if !strings.Contains(mock.lastBody, "all phases completed") {
 		t.Errorf("expected header in comment, got: %s", mock.lastBody)
 	}
-	if !strings.Contains(mock.lastBody, "| analyze | 2m15s | completed |") {
+	if !strings.Contains(mock.lastBody, "| analyze | 2m15s | $0.0123 | 430 | completed |") {
 		t.Errorf("expected analyze row in table, got: %s", mock.lastBody)
 	}
-	if !strings.Contains(mock.lastBody, "| implement | 5m30s | completed |") {
+	if !strings.Contains(mock.lastBody, "| implement | 5m30s | $0.0345 | 640 | completed |") {
 		t.Errorf("expected implement row in table, got: %s", mock.lastBody)
 	}
-	if !strings.Contains(mock.lastBody, "| pr | 1m0s | completed |") {
+	if !strings.Contains(mock.lastBody, "| pr | 1m0s | $0.0042 | 120 | completed |") {
 		t.Errorf("expected pr row in table, got: %s", mock.lastBody)
 	}
-	if !strings.Contains(mock.lastBody, "Total: 8m45s") {
+	if !strings.Contains(mock.lastBody, "Total: 8m45s — $0.0510, 1190 tokens (estimated)") {
 		t.Errorf("expected total duration in comment, got: %s", mock.lastBody)
 	}
-	if !strings.Contains(mock.lastBody, "| Phase | Duration | Status |") {
+	if !strings.Contains(mock.lastBody, "| Phase | Duration | Cost | Tokens | Status |") {
 		t.Errorf("expected table header in comment, got: %s", mock.lastBody)
 	}
 	if strings.Contains(mock.lastBody, "### Verification evidence") {
@@ -250,7 +266,7 @@ func TestVesselCompletedNoOp(t *testing.T) {
 	if !strings.Contains(mock.lastBody, "workflow completed early via no-op") {
 		t.Fatalf("expected no-op completion header, got: %s", mock.lastBody)
 	}
-	if !strings.Contains(mock.lastBody, "| analyze | 2s | no-op |") {
+	if !strings.Contains(mock.lastBody, "| analyze | 2s | — | — | no-op |") {
 		t.Fatalf("expected no-op row in table, got: %s", mock.lastBody)
 	}
 }
@@ -260,7 +276,7 @@ func TestVesselCompletedWithEvidence(t *testing.T) {
 	r := &Reporter{Runner: mock, Repo: "owner/repo"}
 
 	phases := []PhaseResult{
-		{Name: "implement", Duration: 5 * time.Second, Status: "completed"},
+		estimatedPhase("implement", 5*time.Second, "completed", 0.004, 50, 20),
 	}
 
 	manifest := &evidence.Manifest{
@@ -303,11 +319,11 @@ func TestSmoke_S20_VesselCompletedNilManifestProducesOutputIdenticalToCurrentBeh
 	got := renderVesselCompletedBody(t, phases, nil)
 	want := `**xylem — all phases completed**
 
-| Phase | Duration | Status |
-|-------|----------|--------|
-| analyze | 2m15s | completed |
-| implement | 5m30s | completed |
-| pr | 1m0s | completed |
+| Phase | Duration | Cost | Tokens | Status |
+|-------|----------|------|--------|--------|
+| analyze | 2m15s | — | — | completed |
+| implement | 5m30s | — | — | completed |
+| pr | 1m0s | — | — | completed |
 
 Total: 8m45s`
 
@@ -405,11 +421,11 @@ func TestSmoke_S24_ExistingVesselCompletedScenariosPassNilManifest(t *testing.T)
 		got := renderVesselCompletedBody(t, phases, nil)
 		want := `**xylem — all phases completed**
 
-| Phase | Duration | Status |
-|-------|----------|--------|
-| analyze | 2m15s | completed |
-| implement | 5m30s | completed |
-| pr | 1m0s | completed |
+| Phase | Duration | Cost | Tokens | Status |
+|-------|----------|------|--------|--------|
+| analyze | 2m15s | — | — | completed |
+| implement | 5m30s | — | — | completed |
+| pr | 1m0s | — | — | completed |
 
 Total: 8m45s`
 
@@ -427,9 +443,9 @@ Total: 8m45s`
 
 Remaining phases were skipped intentionally because a phase output matched its configured no-op marker.
 
-| Phase | Duration | Status |
-|-------|----------|--------|
-| analyze | 2s | no-op |
+| Phase | Duration | Cost | Tokens | Status |
+|-------|----------|------|--------|--------|
+| analyze | 2s | — | — | no-op |
 
 Total: 2s`
 
@@ -446,9 +462,9 @@ func TestSmoke_S30_VesselCompletedNilManifestProducesIdenticalOutputToCurrentBeh
 	body := renderVesselCompletedBody(t, phases, nil)
 	want := `**xylem — all phases completed**
 
-| Phase | Duration | Status |
-|-------|----------|--------|
-| prompt | 7s | completed |
+| Phase | Duration | Cost | Tokens | Status |
+|-------|----------|------|--------|--------|
+| prompt | 7s | — | — | completed |
 
 Total: 7s`
 
@@ -456,6 +472,37 @@ Total: 7s`
 	assert.Equal(t, want, body)
 	assert.NotContains(t, bodyLower, "evidence")
 	assert.NotContains(t, bodyLower, "manifest")
+}
+
+func TestUsageFormattingHandlesUnavailableUsage(t *testing.T) {
+	result := PhaseResult{
+		Name:                   "implement",
+		Duration:               5 * time.Second,
+		Status:                 "completed",
+		UsageSource:            cost.UsageSourceUnavailable,
+		UsageUnavailableReason: "provider did not return token usage",
+	}
+
+	assert.Equal(t, "_Usage:_ n/a — provider did not return token usage", formatPhaseUsageLine(result))
+	assert.Equal(t, "—", formatPhaseCostCell(result))
+	assert.Equal(t, "—", formatPhaseTokenCell(result))
+}
+
+func TestVesselCompletedOmitsAggregateUsageForUnavailablePhase(t *testing.T) {
+	body := renderVesselCompletedBody(t, []PhaseResult{
+		{
+			Name:                   "implement",
+			Duration:               5 * time.Second,
+			Status:                 "completed",
+			UsageSource:            cost.UsageSourceUnavailable,
+			UsageUnavailableReason: "provider did not return token usage",
+		},
+	}, nil)
+
+	assert.Contains(t, body, "| implement | 5s | — | — | completed |")
+	assert.Contains(t, body, "Total: 5s")
+	assert.NotContains(t, body, "tokens (")
+	assert.NotContains(t, body, "$0.")
 }
 
 func TestLabelTimeout(t *testing.T) {
@@ -482,7 +529,7 @@ func TestGhFailureNonFatal(t *testing.T) {
 		{
 			name: "PhaseComplete",
 			call: func(r *Reporter) error {
-				return r.PhaseComplete(context.Background(), 1, "analyze", time.Second, "out")
+				return r.PhaseComplete(context.Background(), 1, estimatedPhase("analyze", time.Second, "completed", 0.001, 20, 10), "out")
 			},
 		},
 		{
@@ -598,7 +645,7 @@ func TestPostCommentArgs(t *testing.T) {
 			mock := &mockRunner{}
 			r := &Reporter{Runner: mock, Repo: tc.repo}
 
-			_ = r.PhaseComplete(context.Background(), tc.issueNum, "test", time.Second, "out")
+			_ = r.PhaseComplete(context.Background(), tc.issueNum, estimatedPhase("test", time.Second, "completed", 0.001, 20, 10), "out")
 
 			if len(mock.lastArgs) < len(tc.wantArgs) {
 				t.Fatalf("expected at least %d args, got %d: %v", len(tc.wantArgs), len(mock.lastArgs), mock.lastArgs)
@@ -653,11 +700,12 @@ func TestPhaseCompleteCommentFormat(t *testing.T) {
 	mock := &mockRunner{}
 	r := &Reporter{Runner: mock, Repo: "owner/repo"}
 
-	_ = r.PhaseComplete(context.Background(), 1, "deploy", 5*time.Second, "deployed successfully")
+	_ = r.PhaseComplete(context.Background(), 1, estimatedPhase("deploy", 5*time.Second, "completed", 0.0025, 40, 15), "deployed successfully")
 
 	// Verify the full structure matches the spec format
 	expectedParts := []string{
 		"**xylem — phase `deploy` completed** (5s)",
+		"_Usage:_ $0.0025, 55",
 		"<details>",
 		"<summary>Phase output (click to expand)</summary>",
 		"deployed successfully",

--- a/cli/internal/runner/health.go
+++ b/cli/internal/runner/health.go
@@ -124,6 +124,9 @@ func AnalyzeVesselStatus(vessel queue.Vessel, summary *VesselSummary) VesselStat
 			}
 			addAnomaly("budget_exceeded", severity, "budget exceeded")
 		}
+		if summary.BudgetWarning && !summary.BudgetExceeded {
+			addAnomaly("budget_warning", "warning", "budget warning")
+		}
 		for _, phase := range summary.Phases {
 			if phase.GatePassed != nil && !*phase.GatePassed {
 				msg := "gate failed"

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -239,6 +239,18 @@ drainLoop:
 					AnomalyCount: len(status.Anomalies),
 					Anomalies:    AnomalyCodes(status.Anomalies),
 				}))
+				if r.Config != nil && r.Config.StateDir != "" {
+					if summary, loadErr := LoadVesselSummary(r.Config.StateDir, j.ID); loadErr == nil && summary != nil {
+						vesselSpan.AddAttributes(observability.VesselCostAttributes(observability.VesselCostData{
+							TotalTokens:            summary.TotalTokensEst,
+							TotalCostUSDEst:        summary.TotalCostUSDEst,
+							UsageSource:            string(summary.UsageSource),
+							UsageUnavailableReason: summary.UsageUnavailableReason,
+							BudgetExceeded:         summary.BudgetExceeded,
+							BudgetWarning:          summary.BudgetWarning,
+						}))
+					}
+				}
 				vesselSpan.AddAttributes(observability.RecoveryAttributes(recoveryAttributesFromMeta(finalVessel.Meta)))
 			}
 
@@ -849,10 +861,26 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			phaseSpanStatus = phaseStatus
 
 			// Report phase completion (non-fatal)
-			phaseResults = append(phaseResults, reporter.PhaseResult{Name: p.Name, Duration: phaseDuration, Status: phaseStatus})
+			phaseReport := reporter.PhaseResult{
+				Name:                   p.Name,
+				Duration:               phaseDuration,
+				Status:                 phaseStatus,
+				Provider:               provider,
+				Model:                  model,
+				InputTokensEst:         inputTokensEst,
+				OutputTokensEst:        outputTokensEst,
+				CostUSDEst:             costUSDEst,
+				UsageSource:            cost.UsageSourceEstimated,
+				UsageUnavailableReason: "",
+			}
+			if p.Type == "command" {
+				phaseReport.UsageSource = cost.UsageSourceNotApplicable
+				phaseReport.UsageUnavailableReason = "non-llm phase"
+			}
+			phaseResults = append(phaseResults, phaseReport)
 			if issueNum > 0 && r.Reporter != nil {
 				r.logReporterError("post phase-complete comment", vessel.ID,
-					r.Reporter.PhaseComplete(ctx, issueNum, p.Name, phaseDuration, string(output)))
+					r.Reporter.PhaseComplete(ctx, issueNum, phaseReport, string(output)))
 			}
 
 			if phaseStatus == "no-op" {
@@ -1042,48 +1070,104 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 	cmd, args := buildPromptOnlyCmdArgs(r.Config, prompt)
 	provider := resolveProvider(r.Config, nil, nil, nil)
 	model := resolveModel(r.Config, nil, nil, nil, provider)
+	phaseDef := workflow.Phase{Name: "prompt"}
+	phaseStartedAt := r.runtimeNow()
 	beforeSnapshot, checkProtectedSurfaces, err := r.takeProtectedSurfaceSnapshot(ctx, worktreePath)
 	if err != nil {
 		snapErr := fmt.Errorf("protected surface snapshot failed: %w", err)
+		if vrs != nil {
+			vrs.addPhase(vrs.phaseSummary(r.Config, nil, nil, phaseDef, "", 0, 0, 0.0, r.runtimeSince(phaseStartedAt), "failed", nil, snapErr.Error()))
+		}
 		r.failVessel(vessel.ID, snapErr.Error())
 		if err := src.OnFail(ctx, vessel); err != nil {
 			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+		}
+		issueNum := r.parseIssueNum(vessel)
+		if issueNum > 0 && r.Reporter != nil {
+			r.logReporterError("post vessel-failed comment", vessel.ID,
+				r.Reporter.VesselFailed(ctx, issueNum, phaseDef.Name, snapErr.Error(), ""))
 		}
 		return "failed"
 	}
 
 	output, runErr := r.runPhaseWithRateLimitRetry(ctx, worktreePath, prompt, cmd, args)
+	phaseDuration := r.runtimeSince(phaseStartedAt)
 	if r.vesselCancelled(ctx, vessel.ID) {
 		return r.cancelVessel(vessel, worktreePath, vrs, nil)
 	}
 	if runErr != nil {
+		if vrs != nil {
+			vrs.addPhase(vrs.phaseSummary(r.Config, nil, nil, phaseDef, "", 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()))
+		}
 		r.failVessel(vessel.ID, runErr.Error())
 		if err := src.OnFail(ctx, vessel); err != nil {
 			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+		}
+		issueNum := r.parseIssueNum(vessel)
+		if issueNum > 0 && r.Reporter != nil {
+			r.logReporterError("post vessel-failed comment", vessel.ID,
+				r.Reporter.VesselFailed(ctx, issueNum, phaseDef.Name, runErr.Error(), ""))
 		}
 		return "failed"
 	}
 	if checkProtectedSurfaces {
 		if err := r.verifyProtectedSurfaces(vessel, workflow.Phase{Name: "prompt-only"}, worktreePath, beforeSnapshot); err != nil {
+			if vrs != nil {
+				vrs.addPhase(vrs.phaseSummary(r.Config, nil, nil, phaseDef, "", 0, 0, 0.0, phaseDuration, "failed", nil, err.Error()))
+			}
 			r.failVessel(vessel.ID, err.Error())
 			if err := src.OnFail(ctx, vessel); err != nil {
 				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+			}
+			issueNum := r.parseIssueNum(vessel)
+			if issueNum > 0 && r.Reporter != nil {
+				r.logReporterError("post vessel-failed comment", vessel.ID,
+					r.Reporter.VesselFailed(ctx, issueNum, phaseDef.Name, err.Error(), ""))
 			}
 			return "failed"
 		}
 	}
 	recordedAt := r.runtimeNow()
+	var phaseResults []reporter.PhaseResult
 	if vrs != nil {
-		vrs.recordPromptOnlyUsage(model, prompt, string(output), recordedAt)
+		inputTokensEst, outputTokensEst, costUSDEst := vrs.recordLLMUsage(model, prompt, string(output), recordedAt)
+		phaseSummary := vrs.phaseSummary(r.Config, nil, nil, phaseDef, "", inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, "")
+		phaseReport := reporter.PhaseResult{
+			Name:                   phaseDef.Name,
+			Duration:               phaseDuration,
+			Status:                 "completed",
+			Provider:               provider,
+			Model:                  model,
+			InputTokensEst:         inputTokensEst,
+			OutputTokensEst:        outputTokensEst,
+			CostUSDEst:             costUSDEst,
+			UsageSource:            cost.UsageSourceEstimated,
+			UsageUnavailableReason: "",
+		}
 		if vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() {
 			errMsg := fmt.Sprintf("budget exceeded: estimated cost $%.4f, estimated tokens %d",
 				vrs.costTracker.TotalCost(), vrs.costTracker.TotalTokens())
+			phaseSummary.Status = "failed"
+			phaseSummary.Error = errMsg
+			vrs.addPhase(phaseSummary)
 			r.failVessel(vessel.ID, errMsg)
 			if err := src.OnFail(ctx, vessel); err != nil {
 				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
 			}
+			issueNum := r.parseIssueNum(vessel)
+			if issueNum > 0 && r.Reporter != nil {
+				r.logReporterError("post vessel-failed comment", vessel.ID,
+					r.Reporter.VesselFailed(ctx, issueNum, phaseDef.Name, errMsg, ""))
+			}
 			return "failed"
 		}
+		vrs.addPhase(phaseSummary)
+		phaseResults = append(phaseResults, phaseReport)
+	}
+	issueNum := r.parseIssueNum(vessel)
+	if issueNum > 0 && r.Reporter != nil && len(phaseResults) > 0 {
+		r.logReporterError("post phase-complete comment", vessel.ID,
+			r.Reporter.PhaseComplete(ctx, issueNum, phaseResults[0], string(output)))
 	}
 
 	if r.vesselCancelled(ctx, vessel.ID) {
@@ -1093,7 +1177,7 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 		log.Printf("warn: OnComplete hook for vessel %s: %v", vessel.ID, err)
 	}
 
-	return r.completeVessel(ctx, vessel, worktreePath, nil, vrs, nil)
+	return r.completeVessel(ctx, vessel, worktreePath, phaseResults, vrs, nil)
 }
 
 func (r *Runner) runBuiltinWorkflow(ctx context.Context, vessel queue.Vessel, src source.Source, vrs *vesselRunState, handler BuiltinWorkflowHandler) string {
@@ -1124,10 +1208,12 @@ func (r *Runner) runBuiltinWorkflow(ctx context.Context, vessel queue.Vessel, sr
 	}
 	if vrs != nil {
 		vrs.addPhase(PhaseSummary{
-			Name:       vessel.Workflow,
-			Type:       "builtin",
-			DurationMS: r.runtimeSince(startedAt).Milliseconds(),
-			Status:     "completed",
+			Name:                   vessel.Workflow,
+			Type:                   "builtin",
+			DurationMS:             r.runtimeSince(startedAt).Milliseconds(),
+			Status:                 "completed",
+			UsageSource:            cost.UsageSourceNotApplicable,
+			UsageUnavailableReason: "builtin workflow did not execute an llm phase",
 		})
 	}
 	if r.vesselCancelled(ctx, vessel.ID) {
@@ -1454,9 +1540,10 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 
 	if vrs.costTracker != nil {
 		reportPath := filepath.Join(r.Config.StateDir, "phases", vessel.ID, costReportFileName)
+		report := vrs.buildCostReport(summary)
 		if err := os.MkdirAll(filepath.Dir(reportPath), 0o755); err != nil {
 			log.Printf("warn: save cost report: %v", fmt.Errorf("create dir: %w", err))
-		} else if err := cost.SaveReport(reportPath, vrs.costTracker.Report(vessel.ID)); err != nil {
+		} else if err := cost.SaveReport(reportPath, report); err != nil {
 			log.Printf("warn: save cost report: %v", err)
 		} else {
 			summary.CostReportPath = costReportRelativePath(vessel.ID)
@@ -2044,10 +2131,26 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 
 		// Report phase completion.
 		issueNum := r.parseIssueNum(vessel)
+		phaseReport := reporter.PhaseResult{
+			Name:                   p.Name,
+			Duration:               phaseDuration,
+			Provider:               provider,
+			Model:                  model,
+			InputTokensEst:         inputTokensEst,
+			OutputTokensEst:        outputTokensEst,
+			CostUSDEst:             costUSDEst,
+			UsageSource:            cost.UsageSourceEstimated,
+			UsageUnavailableReason: "",
+		}
+		if p.Type == "command" {
+			phaseReport.UsageSource = cost.UsageSourceNotApplicable
+			phaseReport.UsageUnavailableReason = "non-llm phase"
+		}
 		if phaseMatchedNoOp(&p, string(output)) {
+			phaseReport.Status = "no-op"
 			if issueNum > 0 && r.Reporter != nil {
 				r.logReporterError("post phase-complete comment", vessel.ID,
-					r.Reporter.PhaseComplete(ctx, issueNum, p.Name, phaseDuration, string(output)))
+					r.Reporter.PhaseComplete(ctx, issueNum, phaseReport, string(output)))
 			}
 			phaseSpanStatus = "no-op"
 			finishCurrentPhaseSpan(nil)
@@ -2060,9 +2163,10 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			}
 		}
 
+		phaseReport.Status = "completed"
 		if issueNum > 0 && r.Reporter != nil {
 			r.logReporterError("post phase-complete comment", vessel.ID,
-				r.Reporter.PhaseComplete(ctx, issueNum, p.Name, phaseDuration, string(output)))
+				r.Reporter.PhaseComplete(ctx, issueNum, phaseReport, string(output)))
 		}
 
 		// Handle gate.
@@ -2381,6 +2485,8 @@ func buildPhaseResultData(cfg *config.Config, srcCfg *config.SourceConfig, wf *w
 		OutputArtifactPath: outputArtifactPath,
 	}
 	if phaseTypeLabel(p) != "prompt" {
+		data.UsageSource = string(cost.UsageSourceNotApplicable)
+		data.UsageUnavailableReason = "non-llm phase"
 		return data
 	}
 
@@ -2389,6 +2495,7 @@ func buildPhaseResultData(cfg *config.Config, srcCfg *config.SourceConfig, wf *w
 	data.InputTokensEst = cost.EstimateTokens(renderedPrompt)
 	data.OutputTokensEst = cost.EstimateTokens(output)
 	data.CostUSDEst = cost.EstimateCost(data.InputTokensEst, data.OutputTokensEst, cost.LookupPricing(model))
+	data.UsageSource = string(cost.UsageSourceEstimated)
 	return data
 }
 

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"github.com/nicholls-inc/xylem/cli/internal/gate"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
@@ -2533,6 +2534,7 @@ func TestSmoke_WS6_S17_PromptOnlyVesselSummaryArtifact(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)
 	cfg.StateDir = filepath.Join(dir, ".xylem")
+	setPricedModel(cfg)
 
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
 	_, _ = q.Enqueue(makePromptVessel(1, "prompt-only summary"))
@@ -2546,29 +2548,26 @@ func TestSmoke_WS6_S17_PromptOnlyVesselSummaryArtifact(t *testing.T) {
 	summary := loadSummary(t, cfg.StateDir, "prompt-1")
 	assert.Equal(t, "completed", summary.State)
 	assert.Equal(t, "prompt-1", summary.VesselID)
-}
+	require.Len(t, summary.Phases, 1)
+	assert.Equal(t, "prompt", summary.Phases[0].Name)
+	assert.Equal(t, "prompt", summary.Phases[0].Type)
+	assert.Equal(t, "completed", summary.Phases[0].Status)
+	assert.Equal(t, cost.UsageSourceEstimated, summary.Phases[0].UsageSource)
+	assert.Positive(t, summary.Phases[0].InputTokensEst)
+	assert.Positive(t, summary.Phases[0].OutputTokensEst)
+	assert.Positive(t, summary.Phases[0].CostUSDEst)
+	assert.Equal(t, summary.TotalTokensEst, summary.Phases[0].InputTokensEst+summary.Phases[0].OutputTokensEst)
+	assert.Equal(t, summary.TotalCostUSDEst, summary.Phases[0].CostUSDEst)
 
-func TestSmoke_WS6_S18_PromptOnlyVesselSummaryEmptyPhases(t *testing.T) {
-	dir := t.TempDir()
-	cfg := makeTestConfig(dir, 1)
-	cfg.StateDir = filepath.Join(dir, ".xylem")
-
-	q := queue.New(filepath.Join(dir, "queue.jsonl"))
-	_, _ = q.Enqueue(makePromptVessel(1, "prompt-only empty phases"))
-
-	r := New(cfg, q, &mockWorktree{path: dir}, &mockCmdRunner{})
-	result, err := r.DrainAndWait(context.Background())
-	if err != nil {
-		t.Fatalf("Drain() error = %v", err)
-	}
-	if result.Completed != 1 {
-		t.Fatalf("Completed = %d, want 1", result.Completed)
-	}
-
-	summary := loadSummary(t, cfg.StateDir, "prompt-1")
-	if len(summary.Phases) != 0 {
-		t.Fatalf("len(summary.Phases) = %d, want 0", len(summary.Phases))
-	}
+	report, err := cost.LoadReport(filepath.Join(cfg.StateDir, "phases", "prompt-1", costReportFileName))
+	require.NoError(t, err)
+	require.Len(t, report.Phases, 1)
+	assert.Equal(t, "prompt", report.Phases[0].Name)
+	assert.Equal(t, "prompt", report.Phases[0].Type)
+	assert.Equal(t, "completed", report.Phases[0].Status)
+	assert.Equal(t, cost.UsageSourceEstimated, report.Phases[0].UsageSource)
+	assert.Equal(t, summary.TotalTokensEst, report.Phases[0].TotalTokens)
+	assert.Equal(t, summary.TotalCostUSDEst, report.Phases[0].CostUSD)
 }
 
 func TestDrainCommandGatePasses(t *testing.T) {

--- a/cli/internal/runner/summary.go
+++ b/cli/internal/runner/summary.go
@@ -40,14 +40,18 @@ type VesselSummary struct {
 
 	Phases []PhaseSummary `json:"phases"`
 
-	TotalInputTokensEst  int     `json:"total_input_tokens_est"`
-	TotalOutputTokensEst int     `json:"total_output_tokens_est"`
-	TotalTokensEst       int     `json:"total_tokens_est"`
-	TotalCostUSDEst      float64 `json:"total_cost_usd_est"`
+	TotalInputTokensEst    int              `json:"total_input_tokens_est"`
+	TotalOutputTokensEst   int              `json:"total_output_tokens_est"`
+	TotalTokensEst         int              `json:"total_tokens_est"`
+	TotalCostUSDEst        float64          `json:"total_cost_usd_est"`
+	UsageSource            cost.UsageSource `json:"usage_source,omitempty"`
+	UsageUnavailableReason string           `json:"usage_unavailable_reason,omitempty"`
 
 	BudgetMaxCostUSD *float64 `json:"budget_max_cost_usd,omitempty"`
 	BudgetMaxTokens  *int     `json:"budget_max_tokens,omitempty"`
 	BudgetExceeded   bool     `json:"budget_exceeded"`
+	BudgetWarning    bool     `json:"budget_warning,omitempty"`
+	BudgetAlertCount int      `json:"budget_alert_count,omitempty"`
 
 	EvidenceManifestPath string           `json:"evidence_manifest_path,omitempty"`
 	CostReportPath       string           `json:"cost_report_path,omitempty"`
@@ -85,18 +89,20 @@ type RecoverySummary struct {
 
 // PhaseSummary records the outcome of a single phase.
 type PhaseSummary struct {
-	Name            string  `json:"name"`
-	Type            string  `json:"type"`
-	Provider        string  `json:"provider,omitempty"`
-	Model           string  `json:"model,omitempty"`
-	DurationMS      int64   `json:"duration_ms"`
-	Status          string  `json:"status"`
-	InputTokensEst  int     `json:"input_tokens_est"`
-	OutputTokensEst int     `json:"output_tokens_est"`
-	CostUSDEst      float64 `json:"cost_usd_est"`
-	GateType        string  `json:"gate_type,omitempty"`
-	GatePassed      *bool   `json:"gate_passed,omitempty"`
-	Error           string  `json:"error,omitempty"`
+	Name                   string           `json:"name"`
+	Type                   string           `json:"type"`
+	Provider               string           `json:"provider,omitempty"`
+	Model                  string           `json:"model,omitempty"`
+	DurationMS             int64            `json:"duration_ms"`
+	Status                 string           `json:"status"`
+	InputTokensEst         int              `json:"input_tokens_est"`
+	OutputTokensEst        int              `json:"output_tokens_est"`
+	CostUSDEst             float64          `json:"cost_usd_est"`
+	UsageSource            cost.UsageSource `json:"usage_source,omitempty"`
+	UsageUnavailableReason string           `json:"usage_unavailable_reason,omitempty"`
+	GateType               string           `json:"gate_type,omitempty"`
+	GatePassed             *bool            `json:"gate_passed,omitempty"`
+	Error                  string           `json:"error,omitempty"`
 }
 
 type vesselRunState struct {
@@ -132,8 +138,8 @@ func newVesselRunState(cfg *config.Config, vessel queue.Vessel, startedAt time.T
 		return s
 	}
 
+	s.costTracker = cost.NewTracker(cfg.VesselBudget())
 	if budget := cfg.VesselBudget(); budget != nil {
-		s.costTracker = cost.NewTracker(budget)
 		if budget.CostLimitUSD > 0 {
 			v := budget.CostLimitUSD
 			s.budgetMaxCostUSD = &v
@@ -197,9 +203,13 @@ func (s *vesselRunState) buildSummary(state string, endedAt time.Time) *VesselSu
 	summary.TotalOutputTokensEst += s.extraOutputTokensEst
 	summary.TotalCostUSDEst += s.extraCostUSDEst
 	summary.TotalTokensEst = summary.TotalInputTokensEst + summary.TotalOutputTokensEst
+	summary.UsageSource, summary.UsageUnavailableReason = summarizeUsageSource(summary.Phases, summary.TotalTokensEst, summary.TotalCostUSDEst)
 
 	if s.costTracker != nil {
 		summary.BudgetExceeded = s.costTracker.BudgetExceeded()
+		alerts := s.costTracker.Alerts()
+		summary.BudgetAlertCount = len(alerts)
+		summary.BudgetWarning = hasBudgetWarning(alerts)
 	}
 
 	return summary
@@ -254,6 +264,7 @@ func (s *vesselRunState) phaseSummary(cfg *config.Config, srcCfg *config.SourceC
 		Status:     status,
 		Error:      errMsg,
 	}
+	summary.UsageSource, summary.UsageUnavailableReason = phaseUsageSource(summary.Type)
 
 	if p.Gate != nil {
 		summary.GateType = p.Gate.Type
@@ -275,6 +286,51 @@ func (s *vesselRunState) phaseSummary(cfg *config.Config, srcCfg *config.SourceC
 	return summary
 }
 
+func (s *vesselRunState) buildCostReport(summary *VesselSummary) *cost.CostReport {
+	if s == nil || s.costTracker == nil || summary == nil {
+		return nil
+	}
+
+	report := s.costTracker.Report(s.vesselID)
+	report.Source = summary.Source
+	report.Workflow = summary.Workflow
+	report.Ref = summary.Ref
+	report.State = summary.State
+	report.TotalDurationMS = summary.DurationMS
+	report.UsageSource = summary.UsageSource
+	report.UsageUnavailableReason = summary.UsageUnavailableReason
+	if report.RecordCount > 0 && report.UsageSource == cost.UsageSourceNotApplicable {
+		report.UsageSource = cost.UsageSourceEstimated
+		report.UsageUnavailableReason = ""
+	}
+	report.BudgetExceeded = summary.BudgetExceeded
+	report.BudgetWarning = summary.BudgetWarning
+	report.BudgetAlertCount = summary.BudgetAlertCount
+	if summary.Trace != nil {
+		report.TraceID = summary.Trace.TraceID
+		report.SpanID = summary.Trace.SpanID
+	}
+	report.EvidenceManifestPath = summary.EvidenceManifestPath
+	report.Phases = make([]cost.PhaseReport, 0, len(summary.Phases))
+	for _, phase := range summary.Phases {
+		report.Phases = append(report.Phases, cost.PhaseReport{
+			Name:                   phase.Name,
+			Type:                   phase.Type,
+			Provider:               phase.Provider,
+			Model:                  phase.Model,
+			DurationMS:             phase.DurationMS,
+			Status:                 phase.Status,
+			InputTokens:            phase.InputTokensEst,
+			OutputTokens:           phase.OutputTokensEst,
+			TotalTokens:            phase.InputTokensEst + phase.OutputTokensEst,
+			CostUSD:                phase.CostUSDEst,
+			UsageSource:            phase.UsageSource,
+			UsageUnavailableReason: phase.UsageUnavailableReason,
+		})
+	}
+	return report
+}
+
 func phaseTypeLabel(p workflow.Phase) string {
 	if p.Type == "command" {
 		return "command"
@@ -285,6 +341,43 @@ func phaseTypeLabel(p workflow.Phase) string {
 func gatePassedPointer(passed bool) *bool {
 	v := passed
 	return &v
+}
+
+func phaseUsageSource(phaseType string) (cost.UsageSource, string) {
+	switch phaseType {
+	case "prompt":
+		return cost.UsageSourceEstimated, ""
+	default:
+		return cost.UsageSourceNotApplicable, "non-llm phase"
+	}
+}
+
+func summarizeUsageSource(phases []PhaseSummary, totalTokens int, totalCost float64) (cost.UsageSource, string) {
+	if totalTokens > 0 || totalCost > 0 {
+		return cost.UsageSourceEstimated, ""
+	}
+
+	for _, phase := range phases {
+		switch phase.UsageSource {
+		case cost.UsageSourceEstimated, cost.UsageSourceProvider:
+			return phase.UsageSource, ""
+		}
+	}
+
+	if len(phases) == 0 {
+		return cost.UsageSourceNotApplicable, "run did not execute an llm phase"
+	}
+
+	return cost.UsageSourceNotApplicable, "run did not execute an llm phase"
+}
+
+func hasBudgetWarning(alerts []cost.BudgetAlert) bool {
+	for _, alert := range alerts {
+		if alert.Type == "warning" {
+			return true
+		}
+	}
+	return false
 }
 
 func evidenceManifestRelativePath(vesselID string) string {

--- a/cli/internal/runner/summary_test.go
+++ b/cli/internal/runner/summary_test.go
@@ -148,6 +148,27 @@ func TestSmoke_S10_BuildSummaryComputesTotalCostUSDEstAsSumOfPhaseCosts(t *testi
 	assert.InDelta(t, 0.0046, summary.TotalCostUSDEst, 1e-9)
 }
 
+func TestSummarizeUsageSourceHandlesMissingUsageScenarios(t *testing.T) {
+	t.Run("non llm phases", func(t *testing.T) {
+		source, reason := summarizeUsageSource([]PhaseSummary{
+			{Name: "verify", Type: "command", UsageSource: cost.UsageSourceNotApplicable, UsageUnavailableReason: "non-llm phase"},
+		}, 0, 0)
+
+		assert.Equal(t, cost.UsageSourceNotApplicable, source)
+		assert.Equal(t, "run did not execute an llm phase", reason)
+	})
+
+	t.Run("mixed phases retains available usage source", func(t *testing.T) {
+		source, reason := summarizeUsageSource([]PhaseSummary{
+			{Name: "verify", Type: "command", UsageSource: cost.UsageSourceNotApplicable, UsageUnavailableReason: "non-llm phase"},
+			{Name: "implement", Type: "prompt", UsageSource: cost.UsageSourceProvider},
+		}, 0, 0)
+
+		assert.Equal(t, cost.UsageSourceProvider, source)
+		assert.Empty(t, reason)
+	})
+}
+
 func TestSmoke_S11_BuildSummarySetsDurationMSFromStartedAtToCallTime(t *testing.T) {
 	startedAt := time.Now().UTC().Add(-2 * time.Second)
 	vrs := newVesselRunState(nil, queue.Vessel{
@@ -334,7 +355,6 @@ func TestSmoke_S18a_PersistRunArtifactsWritesCostAndBudgetReviewInputs(t *testin
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)
 	cfg.StateDir = filepath.Join(dir, ".xylem-state")
-	cfg.Cost.Budget = &config.BudgetConfig{MaxCostUSD: 1}
 
 	startedAt := time.Date(2026, time.April, 8, 20, 32, 30, 0, time.UTC)
 	vessel := runningSmokeVessel("vessel-cost-artifacts", "github", "fix-bug", startedAt)
@@ -348,7 +368,7 @@ func TestSmoke_S18a_PersistRunArtifactsWritesCostAndBudgetReviewInputs(t *testin
 		Model:        "claude-sonnet-4-6",
 		InputTokens:  1000,
 		OutputTokens: 1000,
-		CostUSD:      1.2,
+		CostUSD:      0.6,
 		Timestamp:    startedAt.Add(time.Second),
 	})
 	require.NoError(t, err)
@@ -366,10 +386,49 @@ func TestSmoke_S18a_PersistRunArtifactsWritesCostAndBudgetReviewInputs(t *testin
 	report, err := cost.LoadReport(filepath.Join(cfg.StateDir, "phases", vessel.ID, costReportFileName))
 	require.NoError(t, err)
 	assert.Equal(t, vessel.ID, report.MissionID)
+	assert.Equal(t, cost.UsageSourceEstimated, report.UsageSource)
 
 	alertsData, err := os.ReadFile(filepath.Join(cfg.StateDir, "phases", vessel.ID, budgetAlertsFileName))
 	require.NoError(t, err)
-	assert.Contains(t, string(alertsData), `"type": "exceeded"`)
+	assert.JSONEq(t, "[]", string(alertsData))
+	assert.Zero(t, summary.BudgetAlertCount)
+	assert.False(t, summary.BudgetWarning)
+}
+
+func TestPersistRunArtifactsSummarizesBudgetWarnings(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem-state")
+	cfg.Cost.Budget = &config.BudgetConfig{MaxCostUSD: 1}
+
+	startedAt := time.Date(2026, time.April, 8, 20, 33, 30, 0, time.UTC)
+	vessel := runningSmokeVessel("vessel-budget-warning", "github", "fix-bug", startedAt)
+	vrs := newVesselRunState(cfg, vessel, startedAt)
+	require.NotNil(t, vrs.costTracker)
+
+	err := vrs.costTracker.Record(cost.UsageRecord{
+		MissionID:    vessel.ID,
+		AgentRole:    cost.RoleGenerator,
+		Purpose:      cost.PurposeReasoning,
+		Model:        "claude-sonnet-4-6",
+		InputTokens:  1000,
+		OutputTokens: 1000,
+		CostUSD:      0.85,
+		Timestamp:    startedAt.Add(time.Second),
+	})
+	require.NoError(t, err)
+
+	r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{}, &mockCmdRunner{})
+	r.persistRunArtifacts(vessel, string(queue.StateCompleted), vrs, nil, startedAt.Add(2*time.Second))
+
+	summary := loadSummary(t, cfg.StateDir, vessel.ID)
+	assert.True(t, summary.BudgetWarning)
+	assert.False(t, summary.BudgetExceeded)
+	assert.Equal(t, 1, summary.BudgetAlertCount)
+
+	alertsData, err := os.ReadFile(filepath.Join(cfg.StateDir, "phases", vessel.ID, budgetAlertsFileName))
+	require.NoError(t, err)
+	assert.Contains(t, string(alertsData), `"type": "warning"`)
 }
 
 func TestSmoke_S18b_PersistRunArtifactsLinksExistingEvalReport(t *testing.T) {
@@ -838,8 +897,17 @@ func TestDrainPromptOnlyWritesSummaryArtifact(t *testing.T) {
 	if summary.State != "completed" {
 		t.Fatalf("State = %q, want completed", summary.State)
 	}
-	if len(summary.Phases) != 0 {
-		t.Fatalf("len(Phases) = %d, want 0", len(summary.Phases))
+	if len(summary.Phases) != 1 {
+		t.Fatalf("len(Phases) = %d, want 1", len(summary.Phases))
+	}
+	if summary.Phases[0].Name != "prompt" {
+		t.Fatalf("Phases[0].Name = %q, want prompt", summary.Phases[0].Name)
+	}
+	if summary.Phases[0].Type != "prompt" {
+		t.Fatalf("Phases[0].Type = %q, want prompt", summary.Phases[0].Type)
+	}
+	if summary.Phases[0].UsageSource != cost.UsageSourceEstimated {
+		t.Fatalf("Phases[0].UsageSource = %q, want %q", summary.Phases[0].UsageSource, cost.UsageSourceEstimated)
 	}
 	if summary.TotalTokensEst <= 0 {
 		t.Fatalf("TotalTokensEst = %d, want > 0", summary.TotalTokensEst)


### PR DESCRIPTION
## Summary
- persist per-vessel cost reports and budget alert artifacts from the runner path even when usage is estimated or unavailable
- surface usage source, cost, and budget warning details in status output, reporter comments, and vessel observability attributes
- extend tests around usage aggregation, threshold warnings, and unavailable-usage edge cases

Closes https://github.com/nicholls-inc/xylem/issues/55