### PR TITLE
feat(source): add github-pr-events pr_opened/pr_head_updated triggers

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -133,6 +133,8 @@ type PREventsConfig struct {
 	ReviewSubmitted bool     `yaml:"review_submitted,omitempty"`
 	ChecksFailed    bool     `yaml:"checks_failed,omitempty"`
 	Commented       bool     `yaml:"commented,omitempty"`
+	PROpened        bool     `yaml:"pr_opened,omitempty"`
+	PRHeadUpdated   bool     `yaml:"pr_head_updated,omitempty"`
 	// AuthorAllow is an allowlist of GitHub logins whose reviews/comments
 	// create vessels. If non-empty, events from any other login are skipped.
 	// YAML footgun: bot logins like "copilot-pull-request-reviewer[bot]"
@@ -141,6 +143,7 @@ type PREventsConfig struct {
 	// AuthorDeny is a denylist of GitHub logins whose reviews/comments
 	// never create vessels. AuthorDeny takes precedence over AuthorAllow.
 	AuthorDeny []string `yaml:"author_deny,omitempty"`
+	Debounce   string   `yaml:"debounce,omitempty"`
 }
 
 type Task struct {
@@ -866,14 +869,28 @@ func validateGitHubPREventsSource(name string, src SourceConfig) error {
 		if task.On == nil {
 			return fmt.Errorf("source %q task %q: must include an 'on' block with at least one trigger", name, tname)
 		}
-		if len(task.On.Labels) == 0 && !task.On.ReviewSubmitted && !task.On.ChecksFailed && !task.On.Commented {
-			return fmt.Errorf("source %q task %q: 'on' block must specify at least one trigger (labels, review_submitted, checks_failed, or commented)", name, tname)
+		if len(task.On.Labels) == 0 &&
+			!task.On.ReviewSubmitted &&
+			!task.On.ChecksFailed &&
+			!task.On.Commented &&
+			!task.On.PROpened &&
+			!task.On.PRHeadUpdated {
+			return fmt.Errorf("source %q task %q: 'on' block must specify at least one trigger (labels, review_submitted, checks_failed, commented, pr_opened, or pr_head_updated)", name, tname)
 		}
 		// Authored-event triggers must specify an author filter to prevent
 		// self-trigger loops (e.g. xylem responds to its own review as hnipps,
 		// that review triggers another vessel, ad infinitum).
 		if (task.On.ReviewSubmitted || task.On.Commented) && len(task.On.AuthorAllow) == 0 && len(task.On.AuthorDeny) == 0 {
 			return fmt.Errorf("source %q task %q: tasks with review_submitted or commented must specify author_allow or author_deny to prevent self-trigger loops", name, tname)
+		}
+		if strings.TrimSpace(task.On.Debounce) != "" {
+			debounce, err := time.ParseDuration(task.On.Debounce)
+			if err != nil {
+				return fmt.Errorf("source %q task %q: parse debounce %q: %w", name, tname, task.On.Debounce, err)
+			}
+			if debounce < 0 {
+				return fmt.Errorf("source %q task %q: debounce must be non-negative", name, tname)
+			}
 		}
 	}
 	return nil

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -1212,6 +1212,9 @@ func TestValidateGitHubPREventsValid(t *testing.T) {
 						On: &PREventsConfig{
 							Labels:          []string{"needs-review"},
 							ReviewSubmitted: true,
+							PROpened:        true,
+							PRHeadUpdated:   true,
+							Debounce:        "10m",
 							AuthorAllow:     []string{"copilot-pull-request-reviewer[bot]"},
 						},
 					},
@@ -1222,6 +1225,58 @@ func TestValidateGitHubPREventsValid(t *testing.T) {
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("expected valid config, got: %v", err)
 	}
+}
+
+func TestValidateGitHubPREventsInvalidDebounce(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"review": {
+						Workflow: "handle-review",
+						On: &PREventsConfig{
+							PROpened: true,
+							Debounce: "nope",
+						},
+					},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "parse debounce")
+}
+
+func TestValidateGitHubPREventsRejectsNegativeDebounce(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"review": {
+						Workflow: "handle-review",
+						On: &PREventsConfig{
+							PROpened: true,
+							Debounce: "-1s",
+						},
+					},
+				},
+			},
+		},
+	}
+	err := cfg.Validate()
+	requireErrorContains(t, err, "debounce must be non-negative")
 }
 
 func TestValidateGitHubPREventsReviewSubmittedRequiresAuthorFilter(t *testing.T) {
@@ -1314,6 +1369,30 @@ func TestValidateGitHubPREventsChecksFailedNoAuthorFilter(t *testing.T) {
 					"checks": {
 						Workflow: "fix-ci",
 						On:       &PREventsConfig{ChecksFailed: true},
+					},
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid, got: %v", err)
+	}
+}
+
+func TestValidateGitHubPREventsPROpenedNoAuthorFilter(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]SourceConfig{
+			"pr-events": {
+				Type: "github-pr-events",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"review": {
+						Workflow: "review-pr",
+						On:       &PREventsConfig{PROpened: true},
 					},
 				},
 			},
@@ -2300,6 +2379,40 @@ providers:
 	assert.Equal(t, []string{"copilot", "claude"}, cfg.LLMRouting.Tiers[DefaultLLMRoutingTier].Providers)
 	assert.Equal(t, "claude-sonnet-4-6", cfg.Providers["claude"].Tiers[DefaultLLMRoutingTier])
 	assert.Equal(t, "gpt-5.4", cfg.Providers["copilot"].Tiers[DefaultLLMRoutingTier])
+}
+
+func TestSmoke_S43_GitHubPREventsLoadsPROpenedPRHeadUpdatedAndDebounce(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  pr-lifecycle:
+    type: github-pr-events
+    repo: owner/name
+    tasks:
+      review:
+        workflow: review-pr
+        on:
+          pr_opened: true
+          pr_head_updated: true
+          debounce: 10m
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  default_model: "claude-sonnet-4-6"
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+
+	src, ok := cfg.Sources["pr-lifecycle"]
+	require.True(t, ok)
+
+	task, ok := src.Tasks["review"]
+	require.True(t, ok)
+	require.NotNil(t, task.On)
+	assert.True(t, task.On.PROpened)
+	assert.True(t, task.On.PRHeadUpdated)
+	assert.Equal(t, "10m", task.On.Debounce)
+	assert.Equal(t, "review-pr", task.Workflow)
 }
 
 func TestSourceTimeoutValid(t *testing.T) {

--- a/cli/internal/cost/budgetgate.go
+++ b/cli/internal/cost/budgetgate.go
@@ -1,0 +1,34 @@
+package cost
+
+// Decision is the scanner-facing result of a budget-gate check.
+type Decision struct {
+	Allowed      bool
+	Reason       string
+	RemainingUSD float64
+}
+
+// BudgetGate is the scanner integration seam for budget-aware enqueue gating.
+// This implementation is intentionally permissive until the real tracker-backed
+// budget classifier lands.
+type BudgetGate struct {
+	budget *Budget
+}
+
+// NewBudgetGate builds a gate for the given budget. A nil budget always allows.
+func NewBudgetGate(budget *Budget) *BudgetGate {
+	return &BudgetGate{budget: budget}
+}
+
+// Check reports whether a candidate of the given class may be enqueued.
+// The current implementation is a no-op stub so future budget wiring is a
+// single-call change at the scanner boundary.
+func (g *BudgetGate) Check(_ string) Decision {
+	decision := Decision{Allowed: true}
+	if g == nil || g.budget == nil {
+		return decision
+	}
+	if g.budget.CostLimitUSD > 0 {
+		decision.RemainingUSD = g.budget.CostLimitUSD
+	}
+	return decision
+}

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -5,8 +5,10 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
@@ -19,10 +21,15 @@ type CommandRunner interface {
 
 // Scanner scans configured sources for actionable tasks and enqueues vessels.
 type Scanner struct {
-	Config    *config.Config
-	Queue     *queue.Queue
-	CmdRunner CommandRunner
-	RunHooks  bool
+	Config     *config.Config
+	Queue      *queue.Queue
+	CmdRunner  CommandRunner
+	RunHooks   bool
+	BudgetGate budgetGate
+}
+
+type budgetGate interface {
+	Check(class string) cost.Decision
 }
 
 // ScanResult summarises a scan run.
@@ -34,7 +41,13 @@ type ScanResult struct {
 
 // New creates a Scanner.
 func New(cfg *config.Config, q *queue.Queue, runner CommandRunner) *Scanner {
-	return &Scanner{Config: cfg, Queue: q, CmdRunner: runner, RunHooks: true}
+	return &Scanner{
+		Config:     cfg,
+		Queue:      q,
+		CmdRunner:  runner,
+		RunHooks:   true,
+		BudgetGate: cost.NewBudgetGate(cfg.VesselBudget()),
+	}
 }
 
 // Scan queries configured sources, filters candidates, and enqueues new vessels.
@@ -62,6 +75,14 @@ func (s *Scanner) Scan(ctx context.Context) (ScanResult, error) {
 				vessel.Meta["config_source"] = entry.configName
 			}
 
+			class := vessel.Workflow
+			decision := s.budgetGate().Check(class)
+			if !decision.Allowed {
+				log.Printf("audit: budget.skipped class=%s vessel_source=%s reason=%s remaining_usd=%.4f", class, vessel.Source, decision.Reason, decision.RemainingUSD)
+				result.Skipped++
+				continue
+			}
+
 			enqueued, err := s.Queue.Enqueue(vessel)
 			if err != nil {
 				return result, err
@@ -84,6 +105,13 @@ func (s *Scanner) Scan(ctx context.Context) (ScanResult, error) {
 		}
 	}
 	return result, nil
+}
+
+func (s *Scanner) budgetGate() budgetGate {
+	if s.BudgetGate != nil {
+		return s.BudgetGate
+	}
+	return cost.NewBudgetGate(s.Config.VesselBudget())
 }
 
 type sourceEntry struct {
@@ -129,6 +157,7 @@ func (s *Scanner) buildSources() []sourceEntry {
 					Repo:      srcCfg.Repo,
 					Tasks:     prEventsTasks,
 					Exclude:   srcCfg.Exclude,
+					StateDir:  s.Config.StateDir,
 					Queue:     s.Queue,
 					CmdRunner: s.CmdRunner,
 				},
@@ -193,8 +222,14 @@ func convertPREventsTasks(cfgTasks map[string]config.Task) map[string]source.PRE
 			task.ReviewSubmitted = t.On.ReviewSubmitted
 			task.ChecksFailed = t.On.ChecksFailed
 			task.Commented = t.On.Commented
+			task.PROpened = t.On.PROpened
+			task.PRHeadUpdated = t.On.PRHeadUpdated
 			task.AuthorAllow = t.On.AuthorAllow
 			task.AuthorDeny = t.On.AuthorDeny
+			task.Debounce = source.UnsetPREventsDebounce
+			if t.On.Debounce != "" {
+				task.Debounce, _ = time.ParseDuration(t.On.Debounce)
+			}
 		}
 		tasks[name] = task
 	}

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -14,8 +14,12 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/review"
+	"github.com/nicholls-inc/xylem/cli/internal/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockRunner struct {
@@ -943,6 +947,163 @@ func TestScanPREvents(t *testing.T) {
 	if vessels[0].Workflow != "handle-review" {
 		t.Errorf("expected workflow handle-review, got %q", vessels[0].Workflow)
 	}
+}
+
+func TestConvertPREventsTasksParsesDebounce(t *testing.T) {
+	tasks := convertPREventsTasks(map[string]config.Task{
+		"review": {
+			Workflow: "review-pr",
+			On: &config.PREventsConfig{
+				PROpened:        true,
+				PRHeadUpdated:   true,
+				Debounce:        "10m",
+				ReviewSubmitted: true,
+			},
+		},
+		"defaulted": {
+			Workflow: "review-pr",
+			On: &config.PREventsConfig{
+				Commented: true,
+			},
+		},
+	})
+
+	if got := tasks["review"].Debounce; got != 10*time.Minute {
+		t.Fatalf("review debounce = %v, want 10m", got)
+	}
+	if !tasks["review"].PROpened || !tasks["review"].PRHeadUpdated || !tasks["review"].ReviewSubmitted {
+		t.Fatalf("review task triggers were not copied: %#v", tasks["review"])
+	}
+	if got := tasks["defaulted"].Debounce; got != source.UnsetPREventsDebounce {
+		t.Fatalf("defaulted debounce = %v, want unset sentinel %v", got, source.UnsetPREventsDebounce)
+	}
+}
+
+type stubBudgetGate struct {
+	decision cost.Decision
+	classes  []string
+}
+
+func (g *stubBudgetGate) Check(class string) cost.Decision {
+	g.classes = append(g.classes, class)
+	return g.decision
+}
+
+func TestScanBudgetGateSkipDoesNotEnqueueOrRunHooks(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		StateDir:    dir,
+		Claude:      config.ClaudeConfig{Command: "claude"},
+		Sources: map[string]config.SourceConfig{
+			"github": {
+				Type: "github",
+				Repo: "owner/repo",
+				Tasks: map[string]config.Task{
+					"fix-bugs": {Labels: []string{"bug"}, Workflow: "fix-bug"},
+				},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+	r.set(issueJSON([]ghIssue{{
+		Number: 1,
+		Title:  "blocked by budget",
+		Body:   "body",
+		URL:    "https://github.com/owner/repo/issues/1",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}},
+	}}), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+
+	gate := &stubBudgetGate{decision: cost.Decision{Allowed: false, Reason: "stub exhausted", RemainingUSD: 0}}
+	s := New(cfg, q, r)
+	s.BudgetGate = gate
+
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if result.Added != 0 || result.Skipped != 1 {
+		t.Fatalf("Scan result = %#v, want 0 added and 1 skipped", result)
+	}
+	if len(gate.classes) != 1 || gate.classes[0] != "fix-bug" {
+		t.Fatalf("budget gate classes = %#v, want [fix-bug]", gate.classes)
+	}
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected no queued vessels, got %d", len(vessels))
+	}
+	for _, call := range r.calls {
+		if len(call) >= 3 && call[0] == "gh" && call[1] == "issue" && call[2] == "edit" {
+			t.Fatalf("unexpected OnEnqueue label edit call: %#v", call)
+		}
+	}
+}
+
+func TestSmoke_S47_BudgetGateSkipLeavesSourceUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		StateDir:    dir,
+		Claude:      config.ClaudeConfig{Command: "claude"},
+		Sources: map[string]config.SourceConfig{
+			"github": {
+				Type: "github",
+				Repo: "owner/repo",
+				Tasks: map[string]config.Task{
+					"fix-bugs": {Labels: []string{"bug"}, Workflow: "fix-bug"},
+				},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+	r.set(issueJSON([]ghIssue{{
+		Number: 1,
+		Title:  "blocked by budget",
+		Body:   "body",
+		URL:    "https://github.com/owner/repo/issues/1",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}},
+	}}), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+
+	gate := &stubBudgetGate{decision: cost.Decision{Allowed: false, Reason: "stub exhausted", RemainingUSD: 0}}
+	s := New(cfg, q, r)
+	s.BudgetGate = gate
+
+	result, err := s.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Added)
+	assert.Equal(t, 1, result.Skipped)
+	require.Equal(t, []string{"fix-bug"}, gate.classes)
+
+	vessels, err := q.List()
+	require.NoError(t, err)
+	assert.Empty(t, vessels)
+	for _, call := range r.calls {
+		assert.False(t, len(call) >= 3 && call[0] == "gh" && call[1] == "issue" && call[2] == "edit", "unexpected OnEnqueue label edit call: %#v", call)
+	}
+
+	gate.decision = cost.Decision{Allowed: true, RemainingUSD: 12.5}
+	result, err = s.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Added)
+
+	vessels, err = q.List()
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "github-issue", vessels[0].Source)
+	assert.Equal(t, "fix-bug", vessels[0].Workflow)
 }
 
 type ghMergeCommitForScanner struct {

--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -46,6 +46,7 @@ type ghPR struct {
 	Body        string `json:"body"`
 	URL         string `json:"url"`
 	HeadRefName string `json:"headRefName"`
+	HeadOID     string `json:"headRefOid"`
 	Mergeable   string `json:"mergeable"`
 	Labels      []struct {
 		Name string `json:"name"`

--- a/cli/internal/source/github_pr_events.go
+++ b/cli/internal/source/github_pr_events.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
@@ -18,12 +19,15 @@ type PREventsTask struct {
 	ReviewSubmitted bool
 	ChecksFailed    bool
 	Commented       bool
+	PROpened        bool
+	PRHeadUpdated   bool
 	// AuthorAllow restricts authored events (reviews, comments) to the
 	// listed GitHub logins. Empty slice = no allowlist.
 	AuthorAllow []string
 	// AuthorDeny skips authored events from these GitHub logins.
 	// AuthorDeny takes precedence over AuthorAllow.
 	AuthorDeny []string
+	Debounce   time.Duration
 }
 
 // GitHubPREvents scans GitHub PRs for specific events and produces vessels.
@@ -31,8 +35,10 @@ type GitHubPREvents struct {
 	Repo      string
 	Tasks     map[string]PREventsTask
 	Exclude   []string
+	StateDir  string
 	Queue     *queue.Queue
 	CmdRunner CommandRunner
+	Now       func() time.Time
 
 	// selfLogin is the authenticated gh CLI user's login, looked up once
 	// per Scan. Used to unconditionally filter out events authored by
@@ -135,6 +141,9 @@ func (g *GitHubPREvents) Scan(ctx context.Context) ([]queue.Vessel, error) {
 		excludeSet[ex] = true
 	}
 
+	g.selfLogin = ""
+	g.selfLoginResolved = false
+
 	// List open PRs
 	args := []string{
 		"pr", "list",
@@ -189,6 +198,22 @@ func (g *GitHubPREvents) Scan(ctx context.Context) ([]queue.Vessel, error) {
 				}
 			}
 
+			if task.PROpened {
+				v, err := g.scanPROpened(pr, task)
+				if err != nil {
+					return vessels, err
+				}
+				vessels = append(vessels, v...)
+			}
+
+			if task.PRHeadUpdated {
+				v, err := g.scanPRHeadUpdated(ctx, pr, task)
+				if err != nil {
+					return vessels, err
+				}
+				vessels = append(vessels, v...)
+			}
+
 			// Review submitted trigger
 			if task.ReviewSubmitted {
 				v, err := g.scanReviews(ctx, pr, task)
@@ -221,7 +246,63 @@ func (g *GitHubPREvents) Scan(ctx context.Context) ([]queue.Vessel, error) {
 	return vessels, nil
 }
 
+func (g *GitHubPREvents) scanPROpened(pr ghPR, task PREventsTask) ([]queue.Vessel, error) {
+	blocked, err := g.shouldDebounceTrigger(preventPROpened, pr.Number, task)
+	if err != nil {
+		return nil, fmt.Errorf("debounce pr_opened for PR %d: %w", pr.Number, err)
+	}
+	if blocked {
+		return nil, nil
+	}
+
+	ref := fmt.Sprintf("%s#pr-opened", pr.URL)
+	if g.Queue.HasRefAny(ref) {
+		return nil, nil
+	}
+
+	return []queue.Vessel{
+		g.newPREventVessel(pr, task, preventPROpened, fmt.Sprintf("pr-%d-pr-opened", pr.Number), ref, nil),
+	}, nil
+}
+
+func (g *GitHubPREvents) scanPRHeadUpdated(ctx context.Context, pr ghPR, task PREventsTask) ([]queue.Vessel, error) {
+	blocked, err := g.shouldDebounceTrigger(preventPRHeadUpdated, pr.Number, task)
+	if err != nil {
+		return nil, fmt.Errorf("debounce pr_head_updated for PR %d: %w", pr.Number, err)
+	}
+	if blocked {
+		return nil, nil
+	}
+
+	headOID, err := g.loadPRHeadOID(ctx, pr.Number)
+	if err != nil {
+		return nil, nil
+	}
+	if headOID == "" {
+		return nil, nil
+	}
+
+	ref := fmt.Sprintf("%s#head-%s", pr.URL, headOID)
+	if g.Queue.HasRefAny(ref) {
+		return nil, nil
+	}
+
+	return []queue.Vessel{
+		g.newPREventVessel(pr, task, preventPRHeadUpdated, fmt.Sprintf("pr-%d-head-%s", pr.Number, headOID[:minLen(len(headOID), 8)]), ref, map[string]string{
+			"pr_head_sha": headOID,
+		}),
+	}, nil
+}
+
 func (g *GitHubPREvents) scanReviews(ctx context.Context, pr ghPR, task PREventsTask) ([]queue.Vessel, error) {
+	blocked, err := g.shouldDebounceTrigger(preventReviewSubmitted, pr.Number, task)
+	if err != nil {
+		return nil, fmt.Errorf("debounce review_submitted for PR %d: %w", pr.Number, err)
+	}
+	if blocked {
+		return nil, nil
+	}
+
 	args := []string{
 		"api",
 		fmt.Sprintf("repos/%s/pulls/%d/reviews", g.Repo, pr.Number),
@@ -234,6 +315,15 @@ func (g *GitHubPREvents) scanReviews(ctx context.Context, pr ghPR, task PREvents
 
 	selfLogin := g.resolveSelfLogin(ctx)
 	events := parseAuthoredEvents(out)
+	if debounceCollapsesEvents(task, preventReviewSubmitted) {
+		events = newestEligibleAuthoredEvents(events, func(ev ghAuthoredEvent) bool {
+			if ev.ID == 0 || shouldSkipAuthoredEvent(ev.Login, selfLogin, task) {
+				return false
+			}
+			ref := fmt.Sprintf("%s#review-%d", pr.URL, ev.ID)
+			return !g.Queue.HasRefAny(ref)
+		})
+	}
 
 	var vessels []queue.Vessel
 	for _, ev := range events {
@@ -248,20 +338,9 @@ func (g *GitHubPREvents) scanReviews(ctx context.Context, pr ghPR, task PREvents
 		if g.Queue.HasRefAny(ref) {
 			continue
 		}
-		vessels = append(vessels, queue.Vessel{
-			ID:       fmt.Sprintf("pr-%d-review-%s", pr.Number, reviewID),
-			Source:   "github-pr-events",
-			Ref:      ref,
-			Workflow: task.Workflow,
-			Meta: map[string]string{
-				"pr_num":         strconv.Itoa(pr.Number),
-				"event_type":     "review_submitted",
-				"pr_head_branch": pr.HeadRefName,
-				"review_author":  ev.Login,
-			},
-			State:     queue.StatePending,
-			CreatedAt: sourceNow(),
-		})
+		vessels = append(vessels, g.newPREventVessel(pr, task, preventReviewSubmitted, fmt.Sprintf("pr-%d-review-%s", pr.Number, reviewID), ref, map[string]string{
+			"review_author": ev.Login,
+		}))
 	}
 	return vessels, nil
 }
@@ -272,6 +351,14 @@ type ghCheck struct {
 }
 
 func (g *GitHubPREvents) scanChecksFailed(ctx context.Context, pr ghPR, task PREventsTask) ([]queue.Vessel, error) {
+	blocked, err := g.shouldDebounceTrigger(preventChecksFailed, pr.Number, task)
+	if err != nil {
+		return nil, fmt.Errorf("debounce checks_failed for PR %d: %w", pr.Number, err)
+	}
+	if blocked {
+		return nil, nil
+	}
+
 	args := []string{
 		"pr", "checks", strconv.Itoa(pr.Number),
 		"--repo", g.Repo,
@@ -299,19 +386,10 @@ func (g *GitHubPREvents) scanChecksFailed(ctx context.Context, pr ghPR, task PRE
 		return nil, nil
 	}
 
-	// Use head SHA via gh pr view for dedup
-	shaArgs := []string{
-		"pr", "view", strconv.Itoa(pr.Number),
-		"--repo", g.Repo,
-		"--json", "headRefOid",
-		"--jq", ".headRefOid",
-	}
-	shaOut, err := g.CmdRunner.Run(ctx, "gh", shaArgs...)
+	sha, err := g.loadPRHeadOID(ctx, pr.Number)
 	if err != nil {
 		return nil, nil // non-fatal
 	}
-
-	sha := strings.TrimSpace(string(shaOut))
 	if sha == "" {
 		return nil, nil
 	}
@@ -322,23 +400,21 @@ func (g *GitHubPREvents) scanChecksFailed(ctx context.Context, pr ghPR, task PRE
 	}
 
 	return []queue.Vessel{
-		{
-			ID:       fmt.Sprintf("pr-%d-checks-failed-%s", pr.Number, sha[:minLen(len(sha), 8)]),
-			Source:   "github-pr-events",
-			Ref:      ref,
-			Workflow: task.Workflow,
-			Meta: map[string]string{
-				"pr_num":         strconv.Itoa(pr.Number),
-				"event_type":     "checks_failed",
-				"pr_head_branch": pr.HeadRefName,
-			},
-			State:     queue.StatePending,
-			CreatedAt: sourceNow(),
-		},
+		g.newPREventVessel(pr, task, preventChecksFailed, fmt.Sprintf("pr-%d-checks-failed-%s", pr.Number, sha[:minLen(len(sha), 8)]), ref, map[string]string{
+			"pr_head_sha": sha,
+		}),
 	}, nil
 }
 
 func (g *GitHubPREvents) scanComments(ctx context.Context, pr ghPR, task PREventsTask) ([]queue.Vessel, error) {
+	blocked, err := g.shouldDebounceTrigger(preventCommented, pr.Number, task)
+	if err != nil {
+		return nil, fmt.Errorf("debounce commented for PR %d: %w", pr.Number, err)
+	}
+	if blocked {
+		return nil, nil
+	}
+
 	args := []string{
 		"api",
 		fmt.Sprintf("repos/%s/issues/%d/comments", g.Repo, pr.Number),
@@ -351,6 +427,15 @@ func (g *GitHubPREvents) scanComments(ctx context.Context, pr ghPR, task PREvent
 
 	selfLogin := g.resolveSelfLogin(ctx)
 	events := parseAuthoredEvents(out)
+	if debounceCollapsesEvents(task, preventCommented) {
+		events = newestEligibleAuthoredEvents(events, func(ev ghAuthoredEvent) bool {
+			if ev.ID == 0 || shouldSkipAuthoredEvent(ev.Login, selfLogin, task) {
+				return false
+			}
+			ref := fmt.Sprintf("%s#comment-%d", pr.URL, ev.ID)
+			return !g.Queue.HasRefAny(ref)
+		})
+	}
 
 	var vessels []queue.Vessel
 	for _, ev := range events {
@@ -365,25 +450,16 @@ func (g *GitHubPREvents) scanComments(ctx context.Context, pr ghPR, task PREvent
 		if g.Queue.HasRefAny(ref) {
 			continue
 		}
-		vessels = append(vessels, queue.Vessel{
-			ID:       fmt.Sprintf("pr-%d-comment-%s", pr.Number, commentID),
-			Source:   "github-pr-events",
-			Ref:      ref,
-			Workflow: task.Workflow,
-			Meta: map[string]string{
-				"pr_num":         strconv.Itoa(pr.Number),
-				"event_type":     "commented",
-				"pr_head_branch": pr.HeadRefName,
-				"comment_author": ev.Login,
-			},
-			State:     queue.StatePending,
-			CreatedAt: sourceNow(),
-		})
+		vessels = append(vessels, g.newPREventVessel(pr, task, preventCommented, fmt.Sprintf("pr-%d-comment-%s", pr.Number, commentID), ref, map[string]string{
+			"comment_author": ev.Login,
+		}))
 	}
 	return vessels, nil
 }
 
-func (g *GitHubPREvents) OnEnqueue(_ context.Context, _ queue.Vessel) error          { return nil }
+func (g *GitHubPREvents) OnEnqueue(_ context.Context, vessel queue.Vessel) error {
+	return g.persistDebounce(vessel)
+}
 func (g *GitHubPREvents) OnStart(_ context.Context, _ queue.Vessel) error            { return nil }
 func (g *GitHubPREvents) OnWait(_ context.Context, _ queue.Vessel) error             { return nil }
 func (g *GitHubPREvents) OnResume(_ context.Context, _ queue.Vessel) error           { return nil }
@@ -413,4 +489,56 @@ func minLen(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func (g *GitHubPREvents) loadPRHeadOID(ctx context.Context, prNumber int) (string, error) {
+	args := []string{
+		"pr", "view", strconv.Itoa(prNumber),
+		"--repo", g.Repo,
+		"--json", "headRefOid",
+		"--jq", ".headRefOid",
+	}
+	out, err := g.CmdRunner.Run(ctx, "gh", args...)
+	if err != nil {
+		return "", fmt.Errorf("gh pr view headRefOid for PR %d: %w", prNumber, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (g *GitHubPREvents) newPREventVessel(pr ghPR, task PREventsTask, eventType, id, ref string, extraMeta map[string]string) queue.Vessel {
+	createdAt := g.now()
+	meta := map[string]string{
+		"pr_num":         strconv.Itoa(pr.Number),
+		"event_type":     eventType,
+		"pr_head_branch": pr.HeadRefName,
+	}
+	for key, value := range extraMeta {
+		meta[key] = value
+	}
+	g.markDebounceMeta(meta, eventType, pr.Number, task, createdAt)
+	return queue.Vessel{
+		ID:        id,
+		Source:    g.Name(),
+		Ref:       ref,
+		Workflow:  task.Workflow,
+		Meta:      meta,
+		State:     queue.StatePending,
+		CreatedAt: createdAt,
+	}
+}
+
+func newestEligibleAuthoredEvents(events []ghAuthoredEvent, keep func(ghAuthoredEvent) bool) []ghAuthoredEvent {
+	for i := len(events) - 1; i >= 0; i-- {
+		if keep(events[i]) {
+			return []ghAuthoredEvent{events[i]}
+		}
+	}
+	return nil
+}
+
+func (g *GitHubPREvents) now() time.Time {
+	if g.Now != nil {
+		return g.Now().UTC().Truncate(time.Second)
+	}
+	return sourceNow().UTC().Truncate(time.Second)
 }

--- a/cli/internal/source/github_pr_events_debounce.go
+++ b/cli/internal/source/github_pr_events_debounce.go
@@ -1,0 +1,228 @@
+package source
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gofrs/flock"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+const (
+	// UnsetPREventsDebounce marks "no explicit debounce configured" so trigger-
+	// specific defaults can still distinguish unset from an explicit zero value.
+	UnsetPREventsDebounce = time.Duration(-1)
+
+	preventLabel           = "label"
+	preventReviewSubmitted = "review_submitted"
+	preventChecksFailed    = "checks_failed"
+	preventCommented       = "commented"
+	preventPROpened        = "pr_opened"
+	preventPRHeadUpdated   = "pr_head_updated"
+
+	defaultPREventDebounce = 10 * time.Minute
+)
+
+type prEventDebounceRecord struct {
+	Source    string `json:"source"`
+	Trigger   string `json:"trigger"`
+	PRNumber  int    `json:"pr_number"`
+	EmittedAt string `json:"emitted_at"`
+}
+
+type prEventDebounceState map[string]prEventDebounceRecord
+
+func debounceStateKey(sourceName, trigger string, prNumber int) string {
+	return fmt.Sprintf("%s|%s|%d", sourceName, trigger, prNumber)
+}
+
+func effectivePREventDebounce(task PREventsTask, trigger string) time.Duration {
+	if task.Debounce >= 0 {
+		return task.Debounce
+	}
+	switch trigger {
+	case preventPRHeadUpdated:
+		return defaultPREventDebounce
+	default:
+		return 0
+	}
+}
+
+func debounceCollapsesEvents(task PREventsTask, trigger string) bool {
+	return effectivePREventDebounce(task, trigger) > 0
+}
+
+func (g *GitHubPREvents) shouldDebounceTrigger(trigger string, prNumber int, task PREventsTask) (bool, error) {
+	debounce := effectivePREventDebounce(task, trigger)
+	if debounce <= 0 || strings.TrimSpace(g.StateDir) == "" {
+		return false, nil
+	}
+	lastEmittedAt, err := g.loadDebounceEmittedAt(trigger, prNumber)
+	if err != nil {
+		return false, err
+	}
+	if lastEmittedAt == nil {
+		return false, nil
+	}
+	return g.now().Before(lastEmittedAt.Add(debounce)), nil
+}
+
+func (g *GitHubPREvents) markDebounceMeta(meta map[string]string, trigger string, prNumber int, task PREventsTask, emittedAt time.Time) {
+	if effectivePREventDebounce(task, trigger) <= 0 {
+		return
+	}
+	meta["pr_event.debounce_trigger"] = trigger
+	meta["pr_event.debounce_pr_number"] = strconv.Itoa(prNumber)
+	meta["pr_event.debounce_emitted_at"] = emittedAt.UTC().Truncate(time.Second).Format(time.RFC3339)
+}
+
+func (g *GitHubPREvents) persistDebounce(vessel queue.Vessel) error {
+	trigger := vessel.Meta["pr_event.debounce_trigger"]
+	if trigger == "" || strings.TrimSpace(g.StateDir) == "" {
+		return nil
+	}
+	prNumber, err := strconv.Atoi(vessel.Meta["pr_event.debounce_pr_number"])
+	if err != nil {
+		return fmt.Errorf("parse pr_event debounce pr_number for %s: %w", vessel.ID, err)
+	}
+	emittedAt, err := time.Parse(time.RFC3339, vessel.Meta["pr_event.debounce_emitted_at"])
+	if err != nil {
+		return fmt.Errorf("parse pr_event debounce emitted_at for %s: %w", vessel.ID, err)
+	}
+	return g.storeDebounceEmittedAt(trigger, prNumber, emittedAt)
+}
+
+func (g *GitHubPREvents) loadDebounceEmittedAt(trigger string, prNumber int) (*time.Time, error) {
+	state, err := g.readDebounceState()
+	if err != nil {
+		return nil, err
+	}
+	record, ok := state[g.debounceKey(trigger, prNumber)]
+	if !ok || strings.TrimSpace(record.EmittedAt) == "" {
+		return nil, nil
+	}
+	emittedAt, err := time.Parse(time.RFC3339, record.EmittedAt)
+	if err != nil {
+		return nil, fmt.Errorf("parse debounce emitted_at %q: %w", record.EmittedAt, err)
+	}
+	emittedAt = emittedAt.UTC()
+	return &emittedAt, nil
+}
+
+func (g *GitHubPREvents) storeDebounceEmittedAt(trigger string, prNumber int, emittedAt time.Time) error {
+	if err := os.MkdirAll(filepath.Dir(g.debounceStatePath()), 0o755); err != nil {
+		return fmt.Errorf("create pr events debounce state directory: %w", err)
+	}
+	lock := flock.New(g.debounceStatePath() + ".lock")
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("lock pr events debounce state: %w", err)
+	}
+	defer func() {
+		_ = lock.Unlock()
+	}()
+
+	state, err := g.readDebounceStateUnlocked()
+	if err != nil {
+		return err
+	}
+	state[g.debounceKey(trigger, prNumber)] = prEventDebounceRecord{
+		Source:    g.Name(),
+		Trigger:   trigger,
+		PRNumber:  prNumber,
+		EmittedAt: emittedAt.UTC().Truncate(time.Second).Format(time.RFC3339),
+	}
+	data, err := marshalDebounceState(state)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(g.debounceStatePath(), data, 0o644); err != nil {
+		return fmt.Errorf("write pr events debounce state: %w", err)
+	}
+	return nil
+}
+
+func (g *GitHubPREvents) readDebounceState() (prEventDebounceState, error) {
+	if err := os.MkdirAll(filepath.Dir(g.debounceStatePath()), 0o755); err != nil {
+		return nil, fmt.Errorf("create pr events debounce state directory: %w", err)
+	}
+	lock := flock.New(g.debounceStatePath() + ".lock")
+	if err := lock.RLock(); err != nil {
+		return nil, fmt.Errorf("lock pr events debounce state for read: %w", err)
+	}
+	defer func() {
+		_ = lock.Unlock()
+	}()
+	return g.readDebounceStateUnlocked()
+}
+
+func (g *GitHubPREvents) readDebounceStateUnlocked() (prEventDebounceState, error) {
+	data, err := os.ReadFile(g.debounceStatePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return prEventDebounceState{}, nil
+		}
+		return nil, fmt.Errorf("read pr events debounce state: %w", err)
+	}
+	state, err := unmarshalDebounceState(data)
+	if err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func marshalDebounceState(state prEventDebounceState) ([]byte, error) {
+	canonical := make(map[string]prEventDebounceRecord, len(state))
+	keys := make([]string, 0, len(state))
+	for key := range state {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	for _, key := range keys {
+		canonical[key] = state[key]
+	}
+	data, err := json.MarshalIndent(canonical, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal pr events debounce state: %w", err)
+	}
+	if len(data) > 0 {
+		data = append(data, '\n')
+	}
+	return data, nil
+}
+
+func unmarshalDebounceState(data []byte) (prEventDebounceState, error) {
+	state := prEventDebounceState{}
+	if err := json.Unmarshal(data, &state); err == nil {
+		return state, nil
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var record prEventDebounceRecord
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			return nil, fmt.Errorf("parse pr events debounce state line: %w", err)
+		}
+		sourceName := record.Source
+		if strings.TrimSpace(sourceName) == "" {
+			sourceName = "github-pr-events"
+		}
+		state[debounceStateKey(sourceName, record.Trigger, record.PRNumber)] = record
+	}
+	return state, nil
+}
+
+func (g *GitHubPREvents) debounceStatePath() string {
+	return filepath.Join(g.StateDir, "state", "pr-events", "debounce.json")
+}
+
+func (g *GitHubPREvents) debounceKey(trigger string, prNumber int) string {
+	return debounceStateKey(g.Name(), trigger, prNumber)
+}

--- a/cli/internal/source/github_pr_events_prop_test.go
+++ b/cli/internal/source/github_pr_events_prop_test.go
@@ -1,0 +1,48 @@
+package source
+
+import (
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+)
+
+func preEventTriggerGen() *rapid.Generator[string] {
+	return rapid.SampledFrom([]string{
+		preventLabel,
+		preventReviewSubmitted,
+		preventChecksFailed,
+		preventCommented,
+		preventPROpened,
+		preventPRHeadUpdated,
+	})
+}
+
+func TestPropPREventExplicitDebounceOverridesDefaults(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		trigger := preEventTriggerGen().Draw(t, "trigger")
+		debounce := time.Duration(rapid.Int64Range(0, int64(24*time.Hour)).Draw(t, "debounce"))
+		task := PREventsTask{Debounce: debounce}
+
+		if got := effectivePREventDebounce(task, trigger); got != debounce {
+			t.Fatalf("effectivePREventDebounce(%q) = %v, want %v", trigger, got, debounce)
+		}
+	})
+}
+
+func TestPropPREventDefaultDebounceMatchesTrigger(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		trigger := preEventTriggerGen().Draw(t, "trigger")
+		task := PREventsTask{Debounce: UnsetPREventsDebounce}
+
+		want := time.Duration(0)
+		switch trigger {
+		case preventPRHeadUpdated:
+			want = 10 * time.Minute
+		}
+
+		if got := effectivePREventDebounce(task, trigger); got != want {
+			t.Fatalf("effectivePREventDebounce(%q) = %v, want %v", trigger, got, want)
+		}
+	})
+}

--- a/cli/internal/source/github_pr_events_test.go
+++ b/cli/internal/source/github_pr_events_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func prEventsListJSON(prs []ghPR) []byte {
@@ -132,6 +136,7 @@ func TestPREventsScanReviewSubmitted(t *testing.T) {
 			"reviews": {
 				Workflow:        "handle-review",
 				ReviewSubmitted: true,
+				Debounce:        0,
 				AuthorAllow:     []string{"copilot-pull-request-reviewer[bot]"},
 			},
 		},
@@ -273,6 +278,7 @@ func TestPREventsScanCommented(t *testing.T) {
 			"comments": {
 				Workflow:    "respond-comment",
 				Commented:   true,
+				Debounce:    0,
 				AuthorAllow: []string{"alice"},
 			},
 		},
@@ -431,6 +437,216 @@ func TestPREventsScanDedupCompletedRef(t *testing.T) {
 	}
 }
 
+func TestPREventsScanPROpenedDedupByPR(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 11, Title: "PR 11", URL: "https://github.com/owner/repo/pull/11", HeadRefName: "branch-11"},
+	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review": {
+				Workflow: "review-pr",
+				PROpened: true,
+			},
+		},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	if vessels[0].Meta["event_type"] != "pr_opened" {
+		t.Fatalf("Meta[event_type] = %q, want pr_opened", vessels[0].Meta["event_type"])
+	}
+	if !strings.Contains(vessels[0].Ref, "#pr-opened") {
+		t.Fatalf("Ref = %q, want #pr-opened suffix", vessels[0].Ref)
+	}
+	if _, err := q.Enqueue(vessels[0]); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if err := g.OnEnqueue(context.Background(), vessels[0]); err != nil {
+		t.Fatalf("OnEnqueue: %v", err)
+	}
+
+	vessels, err = g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan again: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels after dedup, got %d", len(vessels))
+	}
+}
+
+func TestPREventsScanPRHeadUpdatedDedupsPerHead(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 12, Title: "PR 12", URL: "https://github.com/owner/repo/pull/12", HeadRefName: "branch-12"},
+	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+	r.set([]byte("abc12345def"), "gh", "pr", "view", "12", "--repo", "owner/repo", "--json", "headRefOid", "--jq", ".headRefOid")
+
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review": {
+				Workflow:      "review-pr",
+				PRHeadUpdated: true,
+				Debounce:      0,
+			},
+		},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	if !strings.Contains(vessels[0].Ref, "#head-abc12345def") {
+		t.Fatalf("Ref = %q, want #head-abc12345def", vessels[0].Ref)
+	}
+	if _, err := q.Enqueue(vessels[0]); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if err := g.OnEnqueue(context.Background(), vessels[0]); err != nil {
+		t.Fatalf("OnEnqueue: %v", err)
+	}
+
+	vessels, err = g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan same head: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels for repeated head, got %d", len(vessels))
+	}
+
+	r.set([]byte("fedcba987654"), "gh", "pr", "view", "12", "--repo", "owner/repo", "--json", "headRefOid", "--jq", ".headRefOid")
+	vessels, err = g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan new head: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel for new head, got %d", len(vessels))
+	}
+	if !strings.Contains(vessels[0].Ref, "#head-fedcba987654") {
+		t.Fatalf("Ref = %q, want #head-fedcba987654", vessels[0].Ref)
+	}
+}
+
+func TestPREventDefaultDebounceMatchesSpec(t *testing.T) {
+	cases := []struct {
+		trigger string
+		want    time.Duration
+	}{
+		{trigger: preventPROpened, want: 0},
+		{trigger: preventPRHeadUpdated, want: 10 * time.Minute},
+		{trigger: preventReviewSubmitted, want: 0},
+		{trigger: preventChecksFailed, want: 0},
+		{trigger: preventCommented, want: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.trigger, func(t *testing.T) {
+			got := effectivePREventDebounce(PREventsTask{Debounce: UnsetPREventsDebounce}, tc.trigger)
+			if got != tc.want {
+				t.Fatalf("effectivePREventDebounce(%q) = %v, want %v", tc.trigger, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPREventsScanPRHeadUpdatedDebouncesAcrossHeads(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 13, Title: "PR 13", URL: "https://github.com/owner/repo/pull/13", HeadRefName: "branch-13"},
+	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+	r.set([]byte("11111111aaaa"), "gh", "pr", "view", "13", "--repo", "owner/repo", "--json", "headRefOid", "--jq", ".headRefOid")
+
+	now := time.Date(2026, 4, 9, 21, 0, 0, 0, time.UTC)
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review": {
+				Workflow:      "review-pr",
+				PRHeadUpdated: true,
+				Debounce:      UnsetPREventsDebounce,
+			},
+		},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	if _, err := q.Enqueue(vessels[0]); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if err := g.OnEnqueue(context.Background(), vessels[0]); err != nil {
+		t.Fatalf("OnEnqueue: %v", err)
+	}
+
+	now = now.Add(5 * time.Minute)
+	r.set([]byte("22222222bbbb"), "gh", "pr", "view", "13", "--repo", "owner/repo", "--json", "headRefOid", "--jq", ".headRefOid")
+	vessels, err = g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan inside debounce window: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels inside debounce window, got %d", len(vessels))
+	}
+
+	now = now.Add(6 * time.Minute)
+	vessels, err = g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan after debounce window: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel after debounce window, got %d", len(vessels))
+	}
+	if !strings.Contains(vessels[0].Ref, "#head-22222222bbbb") {
+		t.Fatalf("Ref = %q, want #head-22222222bbbb", vessels[0].Ref)
+	}
+}
+
+func TestPREventsDebounceStatePathMatchesSpec(t *testing.T) {
+	g := &GitHubPREvents{StateDir: ".xylem"}
+	if got := g.debounceStatePath(); got != filepath.Join(".xylem", "state", "pr-events", "debounce.json") {
+		t.Fatalf("debounceStatePath() = %q", got)
+	}
+}
+
 func TestPREventsBranchName(t *testing.T) {
 	g := &GitHubPREvents{}
 	vessel := queue.Vessel{
@@ -446,40 +662,183 @@ func TestPREventsBranchName(t *testing.T) {
 	}
 }
 
-func TestPREventsOnStartNoOp(t *testing.T) {
-	g := &GitHubPREvents{}
-	err := g.OnStart(context.Background(), queue.Vessel{})
+func TestPREventsLifecycleHooksWithoutDebounceMetaLeaveStateUntouched(t *testing.T) {
+	dir := t.TempDir()
+	g := &GitHubPREvents{StateDir: dir}
+	if err := g.storeDebounceEmittedAt(preventPRHeadUpdated, 42, time.Date(2026, 4, 9, 21, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("seed debounce state: %v", err)
+	}
+	want, err := os.ReadFile(g.debounceStatePath())
 	if err != nil {
-		t.Fatalf("OnStart should be no-op, got: %v", err)
+		t.Fatalf("read seeded debounce state: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		run  func(context.Context, queue.Vessel) error
+	}{
+		{name: "on enqueue", run: g.OnEnqueue},
+		{name: "on start", run: g.OnStart},
+		{name: "on wait", run: g.OnWait},
+		{name: "on resume", run: g.OnResume},
+		{name: "on complete", run: g.OnComplete},
+		{name: "on fail", run: g.OnFail},
+		{name: "on timed out", run: g.OnTimedOut},
+		{name: "remove running label", run: g.RemoveRunningLabel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.run(context.Background(), queue.Vessel{}); err != nil {
+				t.Fatalf("%s: %v", tt.name, err)
+			}
+			got, err := os.ReadFile(g.debounceStatePath())
+			if err != nil {
+				t.Fatalf("read debounce state after %s: %v", tt.name, err)
+			}
+			if string(got) != string(want) {
+				t.Fatalf("%s mutated debounce state:\nwant %s\ngot  %s", tt.name, want, got)
+			}
+		})
 	}
 }
 
-func TestPREventsOnEnqueueNoOp(t *testing.T) {
-	g := &GitHubPREvents{}
-	if err := g.OnEnqueue(context.Background(), queue.Vessel{}); err != nil {
-		t.Fatalf("OnEnqueue should be no-op, got: %v", err)
+func TestSmoke_S44_PROpenedScansExactlyOncePerPR(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 21, Title: "PR 21", URL: "https://github.com/owner/repo/pull/21", HeadRefName: "feature/pr-opened"},
 	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review": {
+				Workflow: "review-pr",
+				PROpened: true,
+			},
+		},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+
+	v := vessels[0]
+	assert.Equal(t, "pr_opened", v.Meta["event_type"])
+	assert.Equal(t, "21", v.Meta["pr_num"])
+	assert.Equal(t, "feature/pr-opened", v.Meta["pr_head_branch"])
+	assert.Contains(t, v.Ref, "#pr-opened")
+
+	_, err = q.Enqueue(v)
+	require.NoError(t, err)
+	require.NoError(t, g.OnEnqueue(context.Background(), v))
+
+	vessels, err = g.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, vessels)
 }
 
-func TestPREventsOnCompleteNoOp(t *testing.T) {
-	g := &GitHubPREvents{}
-	if err := g.OnComplete(context.Background(), queue.Vessel{}); err != nil {
-		t.Fatalf("OnComplete should be no-op, got: %v", err)
+func TestSmoke_S45_PRHeadUpdatedScansPerHeadSHA(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 22, Title: "PR 22", URL: "https://github.com/owner/repo/pull/22", HeadRefName: "feature/head-updated"},
 	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+	r.set([]byte("aaaabbbbcccc"), "gh", "pr", "view", "22", "--repo", "owner/repo", "--json", "headRefOid", "--jq", ".headRefOid")
+
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review": {
+				Workflow:      "review-pr",
+				PRHeadUpdated: true,
+				Debounce:      0,
+			},
+		},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "pr_head_updated", vessels[0].Meta["event_type"])
+	assert.Contains(t, vessels[0].Ref, "#head-aaaabbbbcccc")
+
+	_, err = q.Enqueue(vessels[0])
+	require.NoError(t, err)
+	require.NoError(t, g.OnEnqueue(context.Background(), vessels[0]))
+
+	vessels, err = g.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, vessels)
+
+	r.set([]byte("dddd1111eeee"), "gh", "pr", "view", "22", "--repo", "owner/repo", "--json", "headRefOid", "--jq", ".headRefOid")
+	vessels, err = g.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Contains(t, vessels[0].Ref, "#head-dddd1111eeee")
 }
 
-func TestPREventsOnFailNoOp(t *testing.T) {
-	g := &GitHubPREvents{}
-	if err := g.OnFail(context.Background(), queue.Vessel{}); err != nil {
-		t.Fatalf("OnFail should be no-op, got: %v", err)
-	}
-}
+func TestSmoke_S46_PRHeadUpdatedDefaultDebounceCapsRapidHeadAdvances(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
 
-func TestPREventsOnTimedOutNoOp(t *testing.T) {
-	g := &GitHubPREvents{}
-	if err := g.OnTimedOut(context.Background(), queue.Vessel{}); err != nil {
-		t.Fatalf("OnTimedOut should be no-op, got: %v", err)
+	prs := []ghPR{
+		{Number: 23, Title: "PR 23", URL: "https://github.com/owner/repo/pull/23", HeadRefName: "feature/debounce"},
 	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+	r.set([]byte("111122223333"), "gh", "pr", "view", "23", "--repo", "owner/repo", "--json", "headRefOid", "--jq", ".headRefOid")
+
+	now := time.Date(2026, 4, 9, 21, 0, 0, 0, time.UTC)
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review": {
+				Workflow:      "review-pr",
+				PRHeadUpdated: true,
+				Debounce:      UnsetPREventsDebounce,
+			},
+		},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	vessels, err := g.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+
+	_, err = q.Enqueue(vessels[0])
+	require.NoError(t, err)
+	require.NoError(t, g.OnEnqueue(context.Background(), vessels[0]))
+
+	now = now.Add(5 * time.Minute)
+	r.set([]byte("444455556666"), "gh", "pr", "view", "23", "--repo", "owner/repo", "--json", "headRefOid", "--jq", ".headRefOid")
+	vessels, err = g.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, vessels)
+
+	now = now.Add(6 * time.Minute)
+	vessels, err = g.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Contains(t, vessels[0].Ref, "#head-444455556666")
 }
 
 func TestPREventsScanGHError(t *testing.T) {


### PR DESCRIPTION
## Summary
- Implements [issue #233](https://github.com/nicholls-inc/xylem/issues/233).
- Adds `pr_opened` and `pr_head_updated` triggers to `github-pr-events`, with per-PR and per-head-SHA deduplication plus persisted debounce state in `.xylem/state/pr-events/debounce.json`.
- Wires scanner-side budget gating through `cost.BudgetGate` so skipped enqueues do not mutate source state or run enqueue hooks.

## Smoke scenarios covered
- S44 — PR opened scans exactly once per PR
- S45 — PR head updated scans per head SHA
- S46 — PR head updated default debounce caps rapid head advances
- S47 — Budget gate skip leaves source unchanged

## Changes summary
- **Added files:** `cli/internal/cost/budgetgate.go`, `cli/internal/source/github_pr_events_debounce.go`, `cli/internal/source/github_pr_events_prop_test.go`
- **Modified files:** `cli/internal/config/config.go`, `cli/internal/config/config_test.go`, `cli/internal/scanner/scanner.go`, `cli/internal/scanner/scanner_test.go`, `cli/internal/source/github_pr.go`, `cli/internal/source/github_pr_events.go`, `cli/internal/source/github_pr_events_test.go`
- **Key types/functions:** `config.PREventsConfig`, `source.PREventsTask`, `scanner.convertPREventsTasks`, `scanner.(*Scanner).budgetGate`, `cost.NewBudgetGate`, `(*GitHubPREvents).scanPROpened`, `(*GitHubPREvents).scanPRHeadUpdated`, `(*GitHubPREvents).OnEnqueue`, `effectivePREventDebounce`, `persistDebounce`, `loadDebounceEmittedAt`, and `storeDebounceEmittedAt`

## Test plan
- `cd cli && goimports -w . && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`
- `cd cli && go vet ./... && go build ./cmd/xylem && go test ./...`

Fixes #233