### PR TITLE
feat(cmd): add bootstrap analyze and audit subcommands

### DIFF
--- a/cli/cmd/xylem/bootstrap.go
+++ b/cli/cmd/xylem/bootstrap.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	bootstrap "github.com/nicholls-inc/xylem/cli/internal/bootstrap"
+)
+
+type analyzeRepoOutput struct {
+	Root        string            `json:"root"`
+	Timestamp   string            `json:"timestamp"`
+	Languages   []string          `json:"languages"`
+	Frameworks  []string          `json:"frameworks"`
+	BuildTools  []string          `json:"build_tools"`
+	EntryPoints []string          `json:"entry_points"`
+	Dimensions  map[string]string `json:"dimensions"`
+}
+
+type auditLegibilityOutput struct {
+	Root       string                 `json:"root"`
+	Timestamp  string                 `json:"timestamp"`
+	Overall    float64                `json:"overall"`
+	Dimensions []auditDimensionOutput `json:"dimensions"`
+}
+
+type auditDimensionOutput struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Weight      float64  `json:"weight"`
+	Score       float64  `json:"score"`
+	Gaps        []string `json:"gaps"`
+	AutoFixable bool     `json:"auto_fixable"`
+}
+
+func newBootstrapCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bootstrap",
+		Short: "Analyze repository bootstrap surfaces",
+	}
+
+	cmd.AddCommand(
+		newBootstrapAnalyzeRepoCmd(),
+		newBootstrapAuditLegibilityCmd(),
+	)
+
+	return cmd
+}
+
+func newBootstrapAnalyzeRepoCmd() *cobra.Command {
+	var rootPath string
+	var outputPath string
+
+	cmd := &cobra.Command{
+		Use:   "analyze-repo",
+		Short: "Analyze repository languages, tooling, and entry points",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root, err := resolveBootstrapRoot(rootPath)
+			if err != nil {
+				return err
+			}
+
+			profile, err := bootstrap.AnalyzeRepo(root)
+			if err != nil {
+				return fmt.Errorf("analyze repo: %w", err)
+			}
+
+			out := analyzeRepoOutput{
+				Root:        root,
+				Timestamp:   profile.AnalyzedAt.UTC().Format(timeFormatRFC3339),
+				Languages:   normalizeLanguages(profile.Languages),
+				Frameworks:  normalizeFrameworks(profile.Frameworks),
+				BuildTools:  normalizeBuildTools(profile.BuildTools),
+				EntryPoints: normalizeEntryPoints(profile.EntryPoints),
+				Dimensions:  describeDimensions(bootstrap.DefaultDimensions()),
+			}
+
+			return writeBootstrapOutput(cmd.OutOrStdout(), outputPath, out)
+		},
+	}
+
+	cmd.Flags().StringVar(&rootPath, "root", ".", "Repository root to analyze")
+	cmd.Flags().StringVar(&outputPath, "output", "", "Write JSON to a file instead of stdout")
+	return cmd
+}
+
+func newBootstrapAuditLegibilityCmd() *cobra.Command {
+	var rootPath string
+	var outputPath string
+
+	cmd := &cobra.Command{
+		Use:   "audit-legibility",
+		Short: "Audit repository legibility and bootstrap readiness",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root, err := resolveBootstrapRoot(rootPath)
+			if err != nil {
+				return err
+			}
+
+			profile, err := bootstrap.AnalyzeRepo(root)
+			if err != nil {
+				return fmt.Errorf("analyze repo for audit: %w", err)
+			}
+
+			report, err := bootstrap.AuditLegibility(root, profile)
+			if err != nil {
+				return fmt.Errorf("audit legibility: %w", err)
+			}
+
+			out := auditLegibilityOutput{
+				Root:      root,
+				Timestamp: report.AuditedAt.UTC().Format(timeFormatRFC3339),
+				Overall:   report.Overall,
+			}
+			for _, dim := range report.Dimensions {
+				out.Dimensions = append(out.Dimensions, auditDimensionOutput{
+					Name:        dim.Dimension.Name,
+					Description: dim.Dimension.Description,
+					Weight:      dim.Dimension.Weight,
+					Score:       dim.Score,
+					Gaps:        append([]string(nil), dim.Gaps...),
+					AutoFixable: dim.AutoFixable,
+				})
+			}
+
+			return writeBootstrapOutput(cmd.OutOrStdout(), outputPath, out)
+		},
+	}
+
+	cmd.Flags().StringVar(&rootPath, "root", ".", "Repository root to audit")
+	cmd.Flags().StringVar(&outputPath, "output", "", "Write JSON to a file instead of stdout")
+	return cmd
+}
+
+const timeFormatRFC3339 = "2006-01-02T15:04:05Z07:00"
+
+func resolveBootstrapRoot(rootPath string) (string, error) {
+	absRoot, err := filepath.Abs(rootPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve root %q: %w", rootPath, err)
+	}
+	return absRoot, nil
+}
+
+func writeBootstrapOutput(stdout io.Writer, outputPath string, payload interface{}) error {
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal bootstrap output: %w", err)
+	}
+	data = append(data, '\n')
+
+	if outputPath == "" || outputPath == "-" {
+		if _, err := stdout.Write(data); err != nil {
+			return fmt.Errorf("write bootstrap output: %w", err)
+		}
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+	if err := os.WriteFile(outputPath, data, 0o644); err != nil {
+		return fmt.Errorf("write output %q: %w", outputPath, err)
+	}
+	return nil
+}
+
+func normalizeLanguages(languages []bootstrap.Language) []string {
+	result := make([]string, 0, len(languages))
+	for _, lang := range languages {
+		result = append(result, normalizeBootstrapName(lang.Name))
+	}
+	return uniqueSortedStrings(result)
+}
+
+func normalizeFrameworks(frameworks []bootstrap.Framework) []string {
+	result := make([]string, 0, len(frameworks))
+	for _, framework := range frameworks {
+		result = append(result, normalizeBootstrapName(framework.Name))
+	}
+	return uniqueSortedStrings(result)
+}
+
+func normalizeBuildTools(buildTools []bootstrap.BuildTool) []string {
+	result := make([]string, 0, len(buildTools))
+	for _, buildTool := range buildTools {
+		result = append(result, normalizeBootstrapName(buildTool.Name))
+	}
+	return uniqueSortedStrings(result)
+}
+
+func normalizeEntryPoints(entryPoints []bootstrap.EntryPoint) []string {
+	result := make([]string, 0, len(entryPoints))
+	for _, entryPoint := range entryPoints {
+		switch {
+		case entryPoint.Path != "":
+			result = append(result, filepath.ToSlash(entryPoint.Path))
+		case entryPoint.Name != "":
+			result = append(result, entryPoint.Name)
+		}
+	}
+	return uniqueSortedStrings(result)
+}
+
+func describeDimensions(dimensions []bootstrap.Dimension) map[string]string {
+	descriptions := make(map[string]string, len(dimensions))
+	for _, dim := range dimensions {
+		descriptions[dimensionKey(dim.Name)] = dim.Description
+	}
+	return descriptions
+}
+
+func uniqueSortedStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func normalizeBootstrapName(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func dimensionKey(name string) string {
+	switch name {
+	case "Bootstrap Self-Sufficiency":
+		return "self_sufficiency"
+	case "Task Entry Points":
+		return "task_entry_points"
+	case "Validation Harness":
+		return "validation_harness"
+	case "Linting/Formatting":
+		return "linting_formatting"
+	case "Codebase Map":
+		return "codebase_map"
+	case "Doc Structure":
+		return "doc_structure"
+	case "Decision Records":
+		return "decision_records"
+	default:
+		replacer := strings.NewReplacer("/", " ", "-", " ")
+		return strings.Join(strings.Fields(strings.ToLower(replacer.Replace(name))), "_")
+	}
+}

--- a/cli/cmd/xylem/bootstrap_test.go
+++ b/cli/cmd/xylem/bootstrap_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSmoke_S1_BootstrapHelpShowsSubcommands(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"bootstrap", "--help"})
+
+	out := captureStdout(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	assert.Contains(t, out, "analyze-repo")
+	assert.Contains(t, out, "audit-legibility")
+}
+
+func TestBootstrapAnalyzeRepoBypassesPersistentPreRunE(t *testing.T) {
+	t.Setenv("PATH", "")
+	root := t.TempDir()
+	wantRoot, err := filepath.Abs(root)
+	require.NoError(t, err)
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"bootstrap", "analyze-repo", "--root", root})
+
+	out := captureStdout(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	var got analyzeRepoOutput
+	require.NoError(t, json.Unmarshal([]byte(out), &got), "output:\n%s", out)
+
+	assert.Equal(t, wantRoot, got.Root)
+	assert.Empty(t, got.Languages)
+	assert.Empty(t, got.EntryPoints)
+	assert.NotEmpty(t, got.Dimensions)
+}
+
+func TestSmoke_S2_AnalyzeRepoWritesSchemaJSON(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), ".xylem", "state", "bootstrap", "repo.json")
+	wantRoot, err := filepath.Abs(repoRoot(t))
+	require.NoError(t, err)
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"bootstrap", "analyze-repo", "--root", repoRoot(t), "--output", outputPath})
+
+	require.NoError(t, cmd.Execute())
+
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	var got analyzeRepoOutput
+	require.NoError(t, json.Unmarshal(data, &got), "output:\n%s", string(data))
+	_, err = time.Parse(timeFormatRFC3339, got.Timestamp)
+	require.NoError(t, err)
+
+	assert.Equal(t, wantRoot, got.Root)
+	assert.Contains(t, got.Languages, "go")
+	assert.Contains(t, got.EntryPoints, "cli/cmd/xylem")
+	assert.NotEmpty(t, got.Frameworks)
+	assert.NotEmpty(t, got.BuildTools)
+	assert.NotEmpty(t, got.Dimensions)
+	assert.Contains(t, got.Dimensions, "self_sufficiency")
+	assert.Contains(t, got.Dimensions, "validation_harness")
+}
+
+func TestSmoke_S3_AuditLegibilityWritesValidJSON(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), ".xylem", "state", "bootstrap", "legibility.json")
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"bootstrap", "audit-legibility", "--root", repoRoot(t), "--output", outputPath})
+
+	require.NoError(t, cmd.Execute())
+
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	var got auditLegibilityOutput
+	require.NoError(t, json.Unmarshal(data, &got), "output:\n%s", string(data))
+	_, err = time.Parse(timeFormatRFC3339, got.Timestamp)
+	require.NoError(t, err)
+
+	wantRoot, err := filepath.Abs(repoRoot(t))
+	require.NoError(t, err)
+
+	assert.Equal(t, wantRoot, got.Root)
+	assert.GreaterOrEqual(t, got.Overall, 0.0)
+	assert.LessOrEqual(t, got.Overall, 1.0)
+	assert.Len(t, got.Dimensions, 7)
+
+	foundValidationHarness := false
+	for _, dim := range got.Dimensions {
+		if dim.Name == "Validation Harness" {
+			foundValidationHarness = true
+			assert.NotEmpty(t, dim.Description)
+			break
+		}
+	}
+	assert.True(t, foundValidationHarness, "expected Validation Harness dimension in %v", got.Dimensions)
+}
+
+func TestSmoke_S4_RootHelpListsBootstrapSubcommand(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"--help"})
+
+	out := captureStdout(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	assert.Contains(t, out, "bootstrap")
+}

--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -37,7 +37,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "enqueue", "daemon", "retry", "visualize", "version"}
+	expected := []string{"init", "bootstrap", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "enqueue", "daemon", "retry", "visualize", "version"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -31,7 +31,7 @@ func newRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Name() == "init" || cmd.Name() == "shim-dispatch" || cmd.Name() == "version" || cmd.CommandPath() == "xylem dtu" || strings.HasPrefix(cmd.CommandPath(), "xylem dtu ") {
+			if cmd.Name() == "init" || cmd.Name() == "shim-dispatch" || cmd.Name() == "version" || cmd.CommandPath() == "xylem dtu" || strings.HasPrefix(cmd.CommandPath(), "xylem dtu ") || cmd.CommandPath() == "xylem bootstrap" || strings.HasPrefix(cmd.CommandPath(), "xylem bootstrap ") {
 				return nil
 			}
 
@@ -81,6 +81,7 @@ func newRootCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		newInitCmd(),
+		newBootstrapCmd(),
 		newDtuCmd(),
 		newShimDispatchCmd(),
 		newScanCmd(),

--- a/cli/internal/bootstrap/bootstrap.go
+++ b/cli/internal/bootstrap/bootstrap.go
@@ -3,6 +3,8 @@ package bootstrap
 import (
 	"encoding/json"
 	"fmt"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"sort"
@@ -58,6 +60,7 @@ type TechStack struct {
 type EntryPoint struct {
 	Name    string
 	Command string
+	Path    string `json:"path,omitempty"`
 	// Exists indicates the entry point file was found on disk.
 	Exists bool `json:"exists"`
 	Error  string
@@ -142,6 +145,10 @@ var buildToolDefs = []struct {
 	Name       string
 	Commands   map[string]string
 }{
+	{"go.mod", "Go", map[string]string{"build": "go build ./...", "test": "go test ./..."}},
+	{"package.json", "npm", map[string]string{"build": "npm run build", "test": "npm test"}},
+	{"pnpm-lock.yaml", "pnpm", map[string]string{"build": "pnpm build", "test": "pnpm test"}},
+	{"yarn.lock", "yarn", map[string]string{"build": "yarn build", "test": "yarn test"}},
 	{"Makefile", "Make", map[string]string{"build": "make", "test": "make test"}},
 	{"Dockerfile", "Docker", map[string]string{"build": "docker build ."}},
 	{"docker-compose.yml", "Docker Compose", map[string]string{"up": "docker-compose up"}},
@@ -161,8 +168,6 @@ var entryPointDefs = []struct {
 }{
 	{"Makefile", "make", "make"},
 	{"package.json", "npm", "npm start"},
-	{"main.go", "go run", "go run ."},
-	{"cmd/main.go", "go run cmd", "go run ./cmd"},
 	{"manage.py", "django", "python manage.py runserver"},
 	{"app.py", "python app", "python app.py"},
 	{"Cargo.toml", "cargo run", "cargo run"},
@@ -271,29 +276,67 @@ func DetectLanguages(path string) []Language {
 
 // DetectFrameworks checks for framework indicator files at the repo root.
 func DetectFrameworks(path string) []Framework {
-	var frameworks []Framework
-	for _, fi := range frameworkIndicators {
-		target := filepath.Join(path, fi.File)
-		if _, err := os.Stat(target); err == nil {
-			frameworks = append(frameworks, Framework{
+	frameworks := make(map[string]Framework)
+	_ = walkRepoFiles(path, func(relFile, absFile string, _ os.FileInfo) error {
+		base := filepath.Base(relFile)
+		for _, fi := range frameworkIndicators {
+			if base != filepath.Base(fi.File) {
+				continue
+			}
+			addFramework(frameworks, Framework{
 				Name:       fi.Name,
 				Language:   fi.Language,
-				Indicators: []string{fi.Indicator},
+				Indicators: []string{relFile},
 				Confidence: 0.9,
 			})
 		}
+
+		if base == "go.mod" {
+			data, err := os.ReadFile(absFile)
+			if err != nil {
+				return nil
+			}
+			content := string(data)
+			for dep, name := range map[string]string{
+				"github.com/spf13/cobra": "Cobra",
+				"github.com/spf13/viper": "Viper",
+			} {
+				if strings.Contains(content, dep) {
+					addFramework(frameworks, Framework{
+						Name:       name,
+						Language:   "Go",
+						Indicators: []string{fmt.Sprintf("%s:%s", relFile, dep)},
+						Confidence: 0.85,
+					})
+				}
+			}
+		}
+
+		return nil
+	})
+
+	result := make([]Framework, 0, len(frameworks))
+	for _, fw := range frameworks {
+		sort.Strings(fw.Indicators)
+		result = append(result, fw)
 	}
-	return frameworks
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Name != result[j].Name {
+			return result[i].Name < result[j].Name
+		}
+		return strings.Join(result[i].Indicators, ",") < strings.Join(result[j].Indicators, ",")
+	})
+	return result
 }
 
-// DetectBuildTools checks for build tool config files at the repo root.
+// DetectBuildTools checks for build tool config files anywhere in the repo tree.
 func DetectBuildTools(path string) []BuildTool {
 	var tools []BuildTool
 	seen := make(map[string]bool)
-	for _, bt := range buildToolDefs {
-		target := filepath.Join(path, bt.ConfigFile)
-		if _, err := os.Stat(target); err == nil {
-			if seen[bt.Name] {
+	_ = walkRepoFiles(path, func(relFile string, _ string, _ os.FileInfo) error {
+		base := filepath.Base(relFile)
+		for _, bt := range buildToolDefs {
+			if base != filepath.Base(bt.ConfigFile) || seen[bt.Name] {
 				continue
 			}
 			seen[bt.Name] = true
@@ -303,28 +346,176 @@ func DetectBuildTools(path string) []BuildTool {
 			}
 			tools = append(tools, BuildTool{
 				Name:       bt.Name,
-				ConfigFile: bt.ConfigFile,
+				ConfigFile: relFile,
 				Commands:   cmds,
 			})
 		}
-	}
+		return nil
+	})
+	sort.Slice(tools, func(i, j int) bool {
+		if tools[i].Name != tools[j].Name {
+			return tools[i].Name < tools[j].Name
+		}
+		return tools[i].ConfigFile < tools[j].ConfigFile
+	})
 	return tools
 }
 
-// DiscoverEntryPoints checks for known entry point files.
+// DiscoverEntryPoints checks for known entry point files and runnable main packages.
 func DiscoverEntryPoints(path string) []EntryPoint {
 	var eps []EntryPoint
-	for _, ep := range entryPointDefs {
-		target := filepath.Join(path, ep.File)
-		if _, err := os.Stat(target); err == nil {
-			eps = append(eps, EntryPoint{
-				Name:    ep.Name,
-				Command: ep.Command,
-				Exists:  true,
-			})
+	seen := make(map[string]bool)
+	_ = walkRepoFiles(path, func(relFile, absFile string, _ os.FileInfo) error {
+		base := filepath.Base(relFile)
+		relDir := repoRel(filepath.Dir(relFile))
+
+		for _, ep := range entryPointDefs {
+			if base != filepath.Base(ep.File) {
+				continue
+			}
+			entry := entryPointFromKnownFile(ep.Name, relDir, relFile)
+			if entry.Path == "" {
+				entry.Path = relDir
+			}
+			key := entry.Name + "|" + entry.Path
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			eps = append(eps, entry)
 		}
-	}
+
+		if base == "main.go" {
+			isMain, err := isMainPackage(absFile)
+			if err != nil || !isMain {
+				return nil
+			}
+			entry := EntryPoint{
+				Name:    "go run",
+				Command: goRunCommand(relDir),
+				Path:    relDir,
+				Exists:  true,
+			}
+			key := entry.Name + "|" + entry.Path
+			if !seen[key] {
+				seen[key] = true
+				eps = append(eps, entry)
+			}
+		}
+		return nil
+	})
+	sort.Slice(eps, func(i, j int) bool {
+		if eps[i].Path != eps[j].Path {
+			return eps[i].Path < eps[j].Path
+		}
+		return eps[i].Name < eps[j].Name
+	})
 	return eps
+}
+
+func addFramework(frameworks map[string]Framework, fw Framework) {
+	if existing, ok := frameworks[fw.Name]; ok {
+		existing.Confidence = maxFloat(existing.Confidence, fw.Confidence)
+		existing.Indicators = appendUniqueStrings(existing.Indicators, fw.Indicators...)
+		frameworks[fw.Name] = existing
+		return
+	}
+	fw.Indicators = appendUniqueStrings(nil, fw.Indicators...)
+	frameworks[fw.Name] = fw
+}
+
+func appendUniqueStrings(dst []string, values ...string) []string {
+	seen := make(map[string]struct{}, len(dst))
+	for _, v := range dst {
+		seen[v] = struct{}{}
+	}
+	for _, v := range values {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		dst = append(dst, v)
+		seen[v] = struct{}{}
+	}
+	return dst
+}
+
+func maxFloat(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func walkRepoFiles(root string, fn func(relFile, absFile string, info os.FileInfo) error) error {
+	return filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			if p != root && isSkippableDir(filepath.Base(p)) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return nil
+		}
+		return fn(repoRel(rel), p, info)
+	})
+}
+
+func repoRel(path string) string {
+	if path == "." || path == "" {
+		return "."
+	}
+	return filepath.ToSlash(path)
+}
+
+func entryPointFromKnownFile(name, relDir, relFile string) EntryPoint {
+	switch name {
+	case "make":
+		cmd := "make"
+		path := relDir
+		if relDir != "." {
+			cmd = fmt.Sprintf("make -C %s", relDir)
+		}
+		return EntryPoint{Name: name, Command: cmd, Path: path, Exists: true}
+	case "npm":
+		cmd := "npm start"
+		if relDir != "." {
+			cmd = fmt.Sprintf("npm --prefix %s start", relDir)
+		}
+		return EntryPoint{Name: name, Command: cmd, Path: relDir, Exists: true}
+	case "cargo run":
+		cmd := "cargo run"
+		if relDir != "." {
+			cmd = fmt.Sprintf("cargo run --manifest-path %s/Cargo.toml", relDir)
+		}
+		return EntryPoint{Name: name, Command: cmd, Path: relDir, Exists: true}
+	case "django":
+		return EntryPoint{Name: name, Command: fmt.Sprintf("python %s runserver", relFile), Path: relFile, Exists: true}
+	case "python app":
+		return EntryPoint{Name: name, Command: fmt.Sprintf("python %s", relFile), Path: relFile, Exists: true}
+	default:
+		return EntryPoint{Name: name, Exists: true}
+	}
+}
+
+func goRunCommand(relDir string) string {
+	if relDir == "." {
+		return "go run ."
+	}
+	return "go run ./" + relDir
+}
+
+func isMainPackage(path string) (bool, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.PackageClauseOnly)
+	if err != nil {
+		return false, err
+	}
+	return file.Name != nil && file.Name.Name == "main", nil
 }
 
 // DetectTechStack determines technologies and their agent-compatibility.
@@ -496,7 +687,7 @@ func scoreBootstrapSelfSufficiency(path string, profile *RepoProfile) (float64, 
 		gaps = append(gaps, "no README found")
 	}
 
-	if anyFileExists(path, []string{"go.mod", "package.json", "requirements.txt", "Cargo.toml", "pyproject.toml", "Gemfile", "pom.xml"}) {
+	if anyRepoFileExists(path, []string{"go.mod", "package.json", "requirements.txt", "Cargo.toml", "pyproject.toml", "Gemfile", "pom.xml"}) {
 		score += 0.3
 	} else {
 		gaps = append(gaps, "no dependency manifest found")
@@ -642,7 +833,7 @@ func scoreCodebaseMap(path string) (float64, []string, bool) {
 		gaps = append(gaps, "no architecture documentation found")
 	}
 
-	if anyDirExists(path, []string{"src", "lib", "internal", "pkg", "cmd"}) {
+	if anyRepoDirExists(path, []string{"src", "lib", "internal", "pkg", "cmd"}) {
 		score += 0.5
 	} else {
 		gaps = append(gaps, "no organized directory structure (src/, lib/, internal/, pkg/, cmd/)")
@@ -986,6 +1177,51 @@ func anyDirExists(base string, dirs []string) bool {
 		}
 	}
 	return false
+}
+
+func anyRepoFileExists(base string, files []string) bool {
+	targets := make(map[string]struct{}, len(files))
+	for _, file := range files {
+		targets[file] = struct{}{}
+	}
+
+	found := false
+	_ = walkRepoFiles(base, func(relFile, _ string, _ os.FileInfo) error {
+		if _, ok := targets[filepath.Base(relFile)]; ok {
+			found = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+
+func anyRepoDirExists(base string, dirs []string) bool {
+	targets := make(map[string]struct{}, len(dirs))
+	for _, dir := range dirs {
+		targets[dir] = struct{}{}
+	}
+
+	found := false
+	_ = filepath.Walk(base, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() {
+			return nil
+		}
+		if p != base && isSkippableDir(filepath.Base(p)) {
+			return filepath.SkipDir
+		}
+		if p != base {
+			if _, ok := targets[filepath.Base(p)]; ok {
+				found = true
+				return filepath.SkipAll
+			}
+		}
+		return nil
+	})
+	return found
 }
 
 // anyExists returns true if any of the given repo-relative paths exist as files or directories.

--- a/cli/internal/bootstrap/bootstrap_prop_test.go
+++ b/cli/internal/bootstrap/bootstrap_prop_test.go
@@ -231,6 +231,53 @@ func TestPropClampScoreIdempotent(t *testing.T) {
 	})
 }
 
+func TestPropDiscoverEntryPointsReturnsRelativeGoPaths(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		root := propTempDir(t)
+		depth := rapid.IntRange(0, 4).Draw(t, "depth")
+
+		parts := make([]string, 0, depth)
+		for i := 0; i < depth; i++ {
+			parts = append(parts, rapid.StringMatching(`[a-z]{1,8}`).Draw(t, "part"))
+		}
+
+		relDir := "."
+		if len(parts) > 0 {
+			relDir = filepath.Join(parts...)
+		}
+
+		mainFile := filepath.Join(root, relDir, "main.go")
+		if err := os.MkdirAll(filepath.Dir(mainFile), 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(mainFile, []byte("package main\nfunc main() {}\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		entryPoints := DiscoverEntryPoints(root)
+		wantPath := repoRel(relDir)
+		wantCommand := goRunCommand(wantPath)
+
+		found := false
+		for _, entryPoint := range entryPoints {
+			if entryPoint.Path != wantPath {
+				continue
+			}
+			found = true
+			if filepath.IsAbs(entryPoint.Path) {
+				t.Fatalf("entry point path should be relative: %q", entryPoint.Path)
+			}
+			if entryPoint.Command != wantCommand {
+				t.Fatalf("entry point command = %q, want %q", entryPoint.Command, wantCommand)
+			}
+		}
+
+		if !found {
+			t.Fatalf("expected entry point path %q in %v", wantPath, entryPoints)
+		}
+	})
+}
+
 func TestPropDetectedLanguagesMatchExtensions(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		extOptions := []string{".go", ".py", ".js", ".ts", ".rs", ".java", ".rb"}

--- a/cli/internal/bootstrap/bootstrap_test.go
+++ b/cli/internal/bootstrap/bootstrap_test.go
@@ -24,11 +24,27 @@ func setupRepo(t *testing.T, files []string, dirs []string) string {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatalf("mkdir %q: %v", dir, err)
 		}
-		if err := os.WriteFile(p, []byte("// placeholder"), 0o644); err != nil {
+		if err := os.WriteFile(p, fixtureFileContent(f), 0o644); err != nil {
 			t.Fatalf("write %q: %v", p, err)
 		}
 	}
 	return root
+}
+
+func fixtureFileContent(path string) []byte {
+	base := filepath.Base(path)
+	switch {
+	case strings.HasSuffix(path, "main.go"):
+		return []byte("package main\nfunc main() {}\n")
+	case strings.HasSuffix(path, ".go"):
+		return []byte("package fixture\n")
+	case base == "go.mod":
+		return []byte("module example.com/test\n")
+	case base == "package.json":
+		return []byte("{\"name\":\"fixture\"}\n")
+	default:
+		return []byte("// placeholder")
+	}
 }
 
 func TestDetectLanguages(t *testing.T) {
@@ -208,6 +224,35 @@ func TestDetectFrameworks(t *testing.T) {
 	}
 }
 
+func TestDetectFrameworksFindsNestedGoModDependencies(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "cli", "go.mod")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	content := "module example.com/test\n\nrequire github.com/spf13/cobra v1.10.2\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	frameworks := DetectFrameworks(root)
+	names := make(map[string]Framework, len(frameworks))
+	for _, framework := range frameworks {
+		names[framework.Name] = framework
+	}
+
+	if _, ok := names["Go Modules"]; !ok {
+		t.Fatalf("expected Go Modules in %v", frameworks)
+	}
+	cobra, ok := names["Cobra"]
+	if !ok {
+		t.Fatalf("expected Cobra in %v", frameworks)
+	}
+	if !strings.Contains(strings.Join(cobra.Indicators, ","), "cli/go.mod") {
+		t.Fatalf("expected Cobra indicators to mention cli/go.mod, got %v", cobra.Indicators)
+	}
+}
+
 func TestDetectBuildTools(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -286,6 +331,22 @@ func TestDetectBuildToolsNoDuplicates(t *testing.T) {
 	}
 }
 
+func TestDetectBuildToolsFindsNestedGoMod(t *testing.T) {
+	root := setupRepo(t, []string{"cli/go.mod"}, nil)
+	tools := DetectBuildTools(root)
+
+	for _, tool := range tools {
+		if tool.Name == "Go" {
+			if tool.ConfigFile != "cli/go.mod" {
+				t.Fatalf("Go config file = %q, want cli/go.mod", tool.ConfigFile)
+			}
+			return
+		}
+	}
+
+	t.Fatalf("expected Go build tool in %v", tools)
+}
+
 func TestDiscoverEntryPoints(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -361,6 +422,29 @@ func TestDiscoverEntryPointsExists(t *testing.T) {
 			t.Fatalf("expected no error for entry point %q, got %q", ep.Name, ep.Error)
 		}
 	}
+}
+
+func TestDiscoverEntryPointsFindsNestedGoMainPackage(t *testing.T) {
+	root := t.TempDir()
+	entryFile := filepath.Join(root, "cli", "cmd", "xylem", "main.go")
+	if err := os.MkdirAll(filepath.Dir(entryFile), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(entryFile, []byte("package main\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	entryPoints := DiscoverEntryPoints(root)
+	for _, entryPoint := range entryPoints {
+		if entryPoint.Path == "cli/cmd/xylem" {
+			if entryPoint.Command != "go run ./cli/cmd/xylem" {
+				t.Fatalf("command = %q, want go run ./cli/cmd/xylem", entryPoint.Command)
+			}
+			return
+		}
+	}
+
+	t.Fatalf("expected cli/cmd/xylem entry point in %v", entryPoints)
 }
 
 func TestDetectTechStack(t *testing.T) {
@@ -1250,6 +1334,62 @@ func TestBootstrapIntegration(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, "feature-list.json")); err != nil {
 		t.Fatalf("feature-list.json not created: %v", err)
 	}
+}
+
+func TestAuditLegibilityFindsNestedDependencyManifest(t *testing.T) {
+	root := setupRepo(t, []string{"README.md", "CLAUDE.md", "cli/go.mod"}, nil)
+
+	profile, err := AnalyzeRepo(root)
+	if err != nil {
+		t.Fatalf("AnalyzeRepo: %v", err)
+	}
+
+	report, err := AuditLegibility(root, profile)
+	if err != nil {
+		t.Fatalf("AuditLegibility: %v", err)
+	}
+
+	for _, ds := range report.Dimensions {
+		if ds.Dimension.Name != "Bootstrap Self-Sufficiency" {
+			continue
+		}
+		for _, gap := range ds.Gaps {
+			if gap == "no dependency manifest found" {
+				t.Fatalf("unexpected dependency-manifest gap for nested go.mod: %v", ds.Gaps)
+			}
+		}
+		return
+	}
+
+	t.Fatal("missing Bootstrap Self-Sufficiency dimension")
+}
+
+func TestAuditLegibilityFindsNestedCodeDirectories(t *testing.T) {
+	root := setupRepo(t, []string{"docs/architecture.md", "cli/cmd/xylem/main.go"}, []string{"cli/internal"})
+
+	profile, err := AnalyzeRepo(root)
+	if err != nil {
+		t.Fatalf("AnalyzeRepo: %v", err)
+	}
+
+	report, err := AuditLegibility(root, profile)
+	if err != nil {
+		t.Fatalf("AuditLegibility: %v", err)
+	}
+
+	for _, ds := range report.Dimensions {
+		if ds.Dimension.Name != "Codebase Map" {
+			continue
+		}
+		for _, gap := range ds.Gaps {
+			if gap == "no organized directory structure (src/, lib/, internal/, pkg/, cmd/)" {
+				t.Fatalf("unexpected organized-directory gap for nested cmd/internal: %v", ds.Gaps)
+			}
+		}
+		return
+	}
+
+	t.Fatal("missing Codebase Map dimension")
 }
 
 func TestDetectConventionFiles(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements [issue #234](https://github.com/nicholls-inc/xylem/issues/234) by exposing the dormant `cli/internal/bootstrap` analysis surfaces through a new top-level `xylem bootstrap` command group.

## Smoke scenarios covered

- `S1` — Bootstrap help shows subcommands
- `S2` — Analyze repo writes schema JSON
- `S3` — Audit legibility writes valid JSON
- `S4` — Root help lists bootstrap subcommand

## Changes summary

### Files added

- `cli/cmd/xylem/bootstrap.go`
- `cli/cmd/xylem/bootstrap_test.go`

### Files modified

- `cli/cmd/xylem/root.go`
- `cli/cmd/xylem/cobra_test.go`
- `cli/internal/bootstrap/bootstrap.go`
- `cli/internal/bootstrap/bootstrap_test.go`
- `cli/internal/bootstrap/bootstrap_prop_test.go`

### Key types and functions

- Added command/output wiring in `newBootstrapCmd`, `newBootstrapAnalyzeRepoCmd`, and `newBootstrapAuditLegibilityCmd`.
- Added JSON-facing output types `analyzeRepoOutput`, `auditLegibilityOutput`, and `auditDimensionOutput`, plus helpers `resolveBootstrapRoot`, `writeBootstrapOutput`, `normalizeEntryPoints`, and `dimensionKey`.
- Registered `bootstrap` in the root command and skipped the normal config/tooling pre-run for `xylem bootstrap` so these commands can run against arbitrary repositories.
- Refreshed `cli/internal/bootstrap` so `DetectFrameworks` and `DiscoverEntryPoints` produce repo-relative, workflow-friendly output, including Go entry points and nested `go.mod`-driven framework detection.
- Expanded coverage with bootstrap command smoke tests, dormant-package unit tests, and property tests around score bounds, deterministic dimensions, relative entry points, and non-overwriting bootstrap behavior.

## Test plan

- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #234