### PR TITLE
feat(policy): add workflow class taxonomy and legacy policy mapping

### DIFF
--- a/cli/internal/policy/class.go
+++ b/cli/internal/policy/class.go
@@ -1,0 +1,108 @@
+package policy
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Class string
+
+const (
+	Delivery           Class = "delivery"
+	HarnessMaintenance Class = "harness-maintenance"
+	Ops                Class = "ops"
+)
+
+type Operation string
+
+const (
+	OpWriteControlPlane   Operation = "write_control_plane"
+	OpCommitDefaultBranch Operation = "commit_default_branch"
+	OpPushBranch          Operation = "push_branch"
+	OpCreatePR            Operation = "create_pr"
+	OpMergePR             Operation = "merge_pr"
+	OpReloadDaemon        Operation = "reload_daemon"
+	OpReadSecrets         Operation = "read_secrets"
+)
+
+type Decision struct {
+	Allowed bool
+	Rule    string
+	Audit   bool
+}
+
+type rule struct {
+	class     Class
+	operation Operation
+	decision  Decision
+}
+
+var defaultRules = []rule{
+	{class: Delivery, operation: OpWriteControlPlane, decision: Decision{Rule: "delivery.no_control_plane_writes"}},
+	{class: HarnessMaintenance, operation: OpWriteControlPlane, decision: Decision{Allowed: true, Rule: "harness_maintenance.worktree_writes_allowed", Audit: true}},
+	{class: Ops, operation: OpWriteControlPlane, decision: Decision{Rule: "ops.no_control_plane_writes"}},
+
+	{class: Delivery, operation: OpCommitDefaultBranch, decision: Decision{Rule: "delivery.default_branch_commits_denied"}},
+	{class: HarnessMaintenance, operation: OpCommitDefaultBranch, decision: Decision{Rule: "harness_maintenance.default_branch_commits_denied"}},
+	{class: Ops, operation: OpCommitDefaultBranch, decision: Decision{Rule: "ops.default_branch_commits_denied"}},
+
+	{class: Delivery, operation: OpPushBranch, decision: Decision{Allowed: true, Rule: "delivery.feature_branch_push_allowed"}},
+	{class: HarnessMaintenance, operation: OpPushBranch, decision: Decision{Allowed: true, Rule: "harness_maintenance.feature_branch_push_allowed"}},
+	{class: Ops, operation: OpPushBranch, decision: Decision{Allowed: true, Rule: "ops.feature_branch_push_allowed"}},
+
+	{class: Delivery, operation: OpCreatePR, decision: Decision{Allowed: true, Rule: "delivery.pr_creation_allowed"}},
+	{class: HarnessMaintenance, operation: OpCreatePR, decision: Decision{Allowed: true, Rule: "harness_maintenance.pr_creation_allowed"}},
+	{class: Ops, operation: OpCreatePR, decision: Decision{Allowed: true, Rule: "ops.pr_creation_allowed"}},
+
+	{class: Delivery, operation: OpMergePR, decision: Decision{Rule: "delivery.pr_merge_denied"}},
+	{class: HarnessMaintenance, operation: OpMergePR, decision: Decision{Rule: "harness_maintenance.pr_merge_denied"}},
+	{class: Ops, operation: OpMergePR, decision: Decision{Allowed: true, Rule: "ops.pr_merge_label_gated", Audit: true}},
+
+	{class: Delivery, operation: OpReloadDaemon, decision: Decision{Rule: "delivery.reload_denied"}},
+	{class: HarnessMaintenance, operation: OpReloadDaemon, decision: Decision{Rule: "harness_maintenance.reload_denied"}},
+	{class: Ops, operation: OpReloadDaemon, decision: Decision{Allowed: true, Rule: "ops.reload_on_merge", Audit: true}},
+
+	{class: Delivery, operation: OpReadSecrets, decision: Decision{Rule: "delivery.read_secrets_denied"}},
+	{class: HarnessMaintenance, operation: OpReadSecrets, decision: Decision{Rule: "harness_maintenance.read_secrets_denied"}},
+	{class: Ops, operation: OpReadSecrets, decision: Decision{Rule: "ops.read_secrets_denied"}},
+}
+
+var allClasses = []Class{Delivery, HarnessMaintenance, Ops}
+
+var allOperations = []Operation{
+	OpWriteControlPlane,
+	OpCommitDefaultBranch,
+	OpPushBranch,
+	OpCreatePR,
+	OpMergePR,
+	OpReloadDaemon,
+	OpReadSecrets,
+}
+
+func Evaluate(class Class, op Operation) Decision {
+	return evaluateWithRules(class, op, defaultRules)
+}
+
+func ParseClass(s string) (Class, error) {
+	switch strings.TrimSpace(s) {
+	case "":
+		return Delivery, nil
+	case string(Delivery):
+		return Delivery, nil
+	case string(HarnessMaintenance):
+		return HarnessMaintenance, nil
+	case string(Ops):
+		return Ops, nil
+	default:
+		return "", fmt.Errorf("unknown workflow class %q (must be %q, %q, or %q)", s, Delivery, HarnessMaintenance, Ops)
+	}
+}
+
+func evaluateWithRules(class Class, op Operation, rules []rule) Decision {
+	for _, rule := range rules {
+		if rule.class == class && rule.operation == op {
+			return rule.decision
+		}
+	}
+	return Decision{Rule: "policy.default_deny"}
+}

--- a/cli/internal/policy/class_prop_test.go
+++ b/cli/internal/policy/class_prop_test.go
@@ -1,0 +1,29 @@
+package policy
+
+import (
+	"math/rand"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropEvaluateStableUnderRuleReordering(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		rules := append([]rule(nil), defaultRules...)
+		seed := rapid.Int64().Draw(t, "seed")
+		rng := rand.New(rand.NewSource(seed))
+		rng.Shuffle(len(rules), func(i, j int) {
+			rules[i], rules[j] = rules[j], rules[i]
+		})
+
+		for _, class := range allClasses {
+			for _, op := range allOperations {
+				want := Evaluate(class, op)
+				got := evaluateWithRules(class, op, rules)
+				if got != want {
+					t.Fatalf("evaluateWithRules(%q, %q) = %+v, want %+v after shuffle seed=%d", class, op, got, want, seed)
+				}
+			}
+		}
+	})
+}

--- a/cli/internal/policy/class_test.go
+++ b/cli/internal/policy/class_test.go
@@ -1,0 +1,122 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSmoke_S1_DeliveryControlPlaneWritesAreDenied(t *testing.T) {
+	got := Evaluate(Delivery, OpWriteControlPlane)
+
+	require.False(t, got.Allowed)
+	assert.Equal(t, "delivery.no_control_plane_writes", got.Rule)
+	assert.False(t, got.Audit)
+}
+
+func TestSmoke_S2_HarnessMaintenanceDefaultBranchCommitsAreDenied(t *testing.T) {
+	got := Evaluate(HarnessMaintenance, OpCommitDefaultBranch)
+
+	require.False(t, got.Allowed)
+	assert.Equal(t, "harness_maintenance.default_branch_commits_denied", got.Rule)
+	assert.False(t, got.Audit)
+}
+
+func TestSmoke_S3_OpsPullRequestMergesAreAllowed(t *testing.T) {
+	got := Evaluate(Ops, OpMergePR)
+
+	require.True(t, got.Allowed)
+	assert.Equal(t, "ops.pr_merge_label_gated", got.Rule)
+	assert.True(t, got.Audit)
+}
+
+func TestEvaluate(t *testing.T) {
+	tests := []struct {
+		name  string
+		class Class
+		op    Operation
+		want  Decision
+	}{
+		{
+			name:  "delivery cannot write control plane",
+			class: Delivery,
+			op:    OpWriteControlPlane,
+			want:  Decision{Rule: "delivery.no_control_plane_writes"},
+		},
+		{
+			name:  "harness maintenance can write control plane with audit",
+			class: HarnessMaintenance,
+			op:    OpWriteControlPlane,
+			want:  Decision{Allowed: true, Rule: "harness_maintenance.worktree_writes_allowed", Audit: true},
+		},
+		{
+			name:  "harness maintenance cannot commit default branch",
+			class: HarnessMaintenance,
+			op:    OpCommitDefaultBranch,
+			want:  Decision{Rule: "harness_maintenance.default_branch_commits_denied"},
+		},
+		{
+			name:  "ops can merge pr",
+			class: Ops,
+			op:    OpMergePR,
+			want:  Decision{Allowed: true, Rule: "ops.pr_merge_label_gated", Audit: true},
+		},
+		{
+			name:  "ops can reload daemon with audit",
+			class: Ops,
+			op:    OpReloadDaemon,
+			want:  Decision{Allowed: true, Rule: "ops.reload_on_merge", Audit: true},
+		},
+		{
+			name:  "delivery can create pr",
+			class: Delivery,
+			op:    OpCreatePR,
+			want:  Decision{Allowed: true, Rule: "delivery.pr_creation_allowed"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Evaluate(tt.class, tt.op); got != tt.want {
+				t.Fatalf("Evaluate(%q, %q) = %+v, want %+v", tt.class, tt.op, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseClass(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Class
+		wantErr string
+	}{
+		{name: "empty defaults to delivery", input: "", want: Delivery},
+		{name: "delivery", input: "delivery", want: Delivery},
+		{name: "harness maintenance", input: "harness-maintenance", want: HarnessMaintenance},
+		{name: "ops", input: "ops", want: Ops},
+		{name: "invalid", input: "runtime", wantErr: `unknown workflow class "runtime"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseClass(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ParseClass(%q) error = nil, want %q", tt.input, tt.wantErr)
+				}
+				if err.Error() != tt.wantErr+` (must be "delivery", "harness-maintenance", or "ops")` {
+					t.Fatalf("ParseClass(%q) error = %q", tt.input, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseClass(%q) error = %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseClass(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"gopkg.in/yaml.v3"
 )
 
@@ -19,12 +20,28 @@ var validPhaseName = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 // Workflow defines a multi-phase execution plan loaded from a YAML file.
 type Workflow struct {
+	Name                          string       `yaml:"name"`
+	Description                   string       `yaml:"description,omitempty"`
+	Class                         policy.Class `yaml:"class,omitempty"`
+	LLM                           *string      `yaml:"llm,omitempty"`
+	Model                         *string      `yaml:"model,omitempty"`
+	AllowAdditiveProtectedWrites  bool         `yaml:"allow_additive_protected_writes,omitempty"`
+	AllowCanonicalProtectedWrites bool         `yaml:"allow_canonical_protected_writes,omitempty"`
+	Phases                        []Phase      `yaml:"phases"`
+
+	classSpecified                         bool `yaml:"-"`
+	allowAdditiveProtectedWritesSpecified  bool `yaml:"-"`
+	allowCanonicalProtectedWritesSpecified bool `yaml:"-"`
+}
+
+type workflowYAML struct {
 	Name                          string  `yaml:"name"`
 	Description                   string  `yaml:"description,omitempty"`
+	Class                         *string `yaml:"class,omitempty"`
 	LLM                           *string `yaml:"llm,omitempty"`
 	Model                         *string `yaml:"model,omitempty"`
-	AllowAdditiveProtectedWrites  bool    `yaml:"allow_additive_protected_writes,omitempty"`
-	AllowCanonicalProtectedWrites bool    `yaml:"allow_canonical_protected_writes,omitempty"`
+	AllowAdditiveProtectedWrites  *bool   `yaml:"allow_additive_protected_writes,omitempty"`
+	AllowCanonicalProtectedWrites *bool   `yaml:"allow_canonical_protected_writes,omitempty"`
 	Phases                        []Phase `yaml:"phases"`
 }
 
@@ -147,8 +164,13 @@ func Load(path string) (*Workflow, error) {
 		return nil, fmt.Errorf("read workflow file %q: %w", path, err)
 	}
 
-	var s Workflow
-	if err := yaml.Unmarshal(data, &s); err != nil {
+	var raw workflowYAML
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse workflow yaml %q: %w", path, err)
+	}
+
+	s, err := workflowFromYAML(raw)
+	if err != nil {
 		return nil, fmt.Errorf("parse workflow yaml %q: %w", path, err)
 	}
 
@@ -156,7 +178,7 @@ func Load(path string) (*Workflow, error) {
 		return nil, fmt.Errorf("validate workflow %q: %w", path, err)
 	}
 
-	return &s, nil
+	return s, nil
 }
 
 // Validate checks that the workflow definition is well-formed. workflowFilePath is
@@ -166,6 +188,18 @@ func Load(path string) (*Workflow, error) {
 func (s *Workflow) Validate(workflowFilePath string) error {
 	if s.Name == "" {
 		return fmt.Errorf(`"name" is required`)
+	}
+
+	if s.Class == "" {
+		s.Class = policy.Delivery
+	} else if parsedClass, err := policy.ParseClass(string(s.Class)); err != nil {
+		return fmt.Errorf(`"class" is invalid: %w`, err)
+	} else {
+		s.Class = parsedClass
+	}
+
+	if err := validateLegacyClassConsistency(s); err != nil {
+		return err
 	}
 
 	expectedName := strings.TrimSuffix(filepath.Base(workflowFilePath), filepath.Ext(workflowFilePath))
@@ -260,6 +294,69 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 
 	if err := validateDependencyCycles(s.Phases); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func workflowFromYAML(raw workflowYAML) (*Workflow, error) {
+	s := &Workflow{
+		Name:        raw.Name,
+		Description: raw.Description,
+		LLM:         raw.LLM,
+		Model:       raw.Model,
+		Phases:      raw.Phases,
+	}
+
+	if raw.AllowAdditiveProtectedWrites != nil {
+		s.AllowAdditiveProtectedWrites = *raw.AllowAdditiveProtectedWrites
+		s.allowAdditiveProtectedWritesSpecified = true
+	}
+	if raw.AllowCanonicalProtectedWrites != nil {
+		s.AllowCanonicalProtectedWrites = *raw.AllowCanonicalProtectedWrites
+		s.allowCanonicalProtectedWritesSpecified = true
+	}
+
+	if raw.Class != nil {
+		parsedClass, err := policy.ParseClass(*raw.Class)
+		if err != nil {
+			return nil, fmt.Errorf(`"class" is invalid: %w`, err)
+		}
+		s.Class = parsedClass
+		s.classSpecified = true
+	} else if s.AllowAdditiveProtectedWrites || s.AllowCanonicalProtectedWrites {
+		s.Class = policy.HarnessMaintenance
+	} else {
+		s.Class = policy.Delivery
+	}
+
+	if err := validateLegacyClassConsistency(s); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+func validateLegacyClassConsistency(s *Workflow) error {
+	if s == nil {
+		return nil
+	}
+
+	if !s.classSpecified || (!s.allowAdditiveProtectedWritesSpecified && !s.allowCanonicalProtectedWritesSpecified) {
+		return nil
+	}
+
+	switch s.Class {
+	case policy.Delivery:
+		if s.AllowAdditiveProtectedWrites || s.AllowCanonicalProtectedWrites {
+			return fmt.Errorf(`"class" %q conflicts with legacy protected write flags: delivery requires both legacy flags to be false`, s.Class)
+		}
+	case policy.HarnessMaintenance:
+		if !s.AllowAdditiveProtectedWrites && !s.AllowCanonicalProtectedWrites {
+			return fmt.Errorf(`"class" %q conflicts with legacy protected write flags: harness-maintenance requires at least one legacy flag to be true`, s.Class)
+		}
+	case policy.Ops:
+		return fmt.Errorf(`"class" %q conflicts with legacy protected write flags: ops cannot be combined with legacy protected write flags`, s.Class)
 	}
 
 	return nil

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -203,6 +204,7 @@ phases:
 	got, err := Load(path)
 	require.NoError(t, err)
 	assert.False(t, got.AllowAdditiveProtectedWrites)
+	assert.Equal(t, policy.Delivery, got.Class)
 }
 
 func TestLoadWorkflowAllowAdditiveProtectedWritesParsesTrue(t *testing.T) {
@@ -221,6 +223,7 @@ phases:
 	got, err := Load(path)
 	require.NoError(t, err)
 	assert.True(t, got.AllowAdditiveProtectedWrites)
+	assert.Equal(t, policy.HarnessMaintenance, got.Class)
 }
 
 func TestLoadWorkflowAllowCanonicalProtectedWrites(t *testing.T) {
@@ -263,6 +266,266 @@ phases:
 			got, err := Load(path)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got.AllowCanonicalProtectedWrites)
+			if tt.want {
+				assert.Equal(t, policy.HarnessMaintenance, got.Class)
+				return
+			}
+			assert.Equal(t, policy.Delivery, got.Class)
+		})
+	}
+}
+
+func TestLoadWorkflowClassParsesExplicitValue(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+class: ops
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, policy.Ops, got.Class)
+}
+
+func TestSmoke_S4_WorkflowClassDefaultsToDeliveryWhenOmitted(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, policy.Delivery, got.Class)
+	assert.False(t, got.AllowAdditiveProtectedWrites)
+	assert.False(t, got.AllowCanonicalProtectedWrites)
+}
+
+func TestSmoke_S5_LegacyProtectedWriteFlagsPromoteHarnessMaintenance(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+allow_canonical_protected_writes: true
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, policy.HarnessMaintenance, got.Class)
+	assert.False(t, got.AllowAdditiveProtectedWrites)
+	assert.True(t, got.AllowCanonicalProtectedWrites)
+}
+
+func TestSmoke_S6_ExplicitOpsClassLoadsWithoutLegacyFlags(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+class: ops
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, policy.Ops, got.Class)
+	assert.False(t, got.AllowAdditiveProtectedWrites)
+	assert.False(t, got.AllowCanonicalProtectedWrites)
+}
+
+func TestLoadWorkflowClassRejectsUnknownValue(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+class: runtime
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`)
+
+	_, err := Load(path)
+	requireErrorContains(t, err, `"class" is invalid: unknown workflow class "runtime"`)
+}
+
+func TestSmoke_S7_InconsistentClassAndLegacyFlagsReturnStructuredError(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+class: delivery
+allow_additive_protected_writes: true
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"class" "delivery" conflicts with legacy protected write flags`)
+	assert.Contains(t, err.Error(), "delivery requires both legacy flags to be false")
+}
+
+func TestLoadWorkflowClassRejectsLegacyFlagConflict(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "delivery conflicts with true legacy flag",
+			yaml: `name: test-workflow
+class: delivery
+allow_additive_protected_writes: true
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`,
+			wantErr: `"class" "delivery" conflicts with legacy protected write flags: delivery requires both legacy flags to be false`,
+		},
+		{
+			name: "harness maintenance conflicts with false legacy flags",
+			yaml: `name: test-workflow
+class: harness-maintenance
+allow_additive_protected_writes: false
+allow_canonical_protected_writes: false
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`,
+			wantErr: `"class" "harness-maintenance" conflicts with legacy protected write flags: harness-maintenance requires at least one legacy flag to be true`,
+		},
+		{
+			name: "ops cannot be combined with legacy flags",
+			yaml: `name: test-workflow
+class: ops
+allow_additive_protected_writes: false
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`,
+			wantErr: `"class" "ops" conflicts with legacy protected write flags: ops cannot be combined with legacy protected write flags`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			chdirTemp(t, dir)
+			createPromptFile(t, dir, "prompts/analyze.md")
+
+			path := writeWorkflowFile(t, dir, "test-workflow", tt.yaml)
+			_, err := Load(path)
+			requireErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestLoadWorkflowClassAllowsConsistentLegacyFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		yaml          string
+		wantClass     policy.Class
+		wantAdditive  bool
+		wantCanonical bool
+	}{
+		{
+			name: "delivery with explicit additive false legacy flag",
+			yaml: `name: test-workflow
+class: delivery
+allow_additive_protected_writes: false
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`,
+			wantClass:     policy.Delivery,
+			wantAdditive:  false,
+			wantCanonical: false,
+		},
+		{
+			name: "delivery with both explicit false legacy flags",
+			yaml: `name: test-workflow
+class: delivery
+allow_additive_protected_writes: false
+allow_canonical_protected_writes: false
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`,
+			wantClass:     policy.Delivery,
+			wantAdditive:  false,
+			wantCanonical: false,
+		},
+		{
+			name: "harness maintenance with additive legacy flag",
+			yaml: `name: test-workflow
+class: harness-maintenance
+allow_additive_protected_writes: true
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`,
+			wantClass:     policy.HarnessMaintenance,
+			wantAdditive:  true,
+			wantCanonical: false,
+		},
+		{
+			name: "harness maintenance with canonical legacy flag",
+			yaml: `name: test-workflow
+class: harness-maintenance
+allow_canonical_protected_writes: true
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`,
+			wantClass:     policy.HarnessMaintenance,
+			wantAdditive:  false,
+			wantCanonical: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			chdirTemp(t, dir)
+			createPromptFile(t, dir, "prompts/analyze.md")
+
+			path := writeWorkflowFile(t, dir, "test-workflow", tt.yaml)
+			got, err := Load(path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantClass, got.Class)
+			assert.Equal(t, tt.wantAdditive, got.AllowAdditiveProtectedWrites)
+			assert.Equal(t, tt.wantCanonical, got.AllowCanonicalProtectedWrites)
 		})
 	}
 }
@@ -359,7 +622,7 @@ phases:
 	requireErrorContains(t, err, `live.browser is required`)
 }
 
-func TestLoadWorkflowLiveGateRejectsInvalidJSONPathAndDuration(t *testing.T) {
+func TestLoadWorkflowLiveGateRejectsInvalidCommandAssertDuration(t *testing.T) {
 	dir := t.TempDir()
 	chdirTemp(t, dir)
 	createPromptFile(t, dir, "prompts/analyze.md")
@@ -377,13 +640,40 @@ phases:
           run: "cat status.json"
           timeout: "not-a-duration"
           expect_json:
-            - path: status
+            - path: $.status
               equals: ok
 `)
 
 	_, err := Load(path)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `invalid live.command_assert.timeout`)
+}
+
+func TestLoadWorkflowLiveGateRejectsInvalidCommandAssertJSONPath(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+    gate:
+      type: live
+      live:
+        mode: command+assert
+        command_assert:
+          run: "cat status.json"
+          timeout: "30s"
+          expect_json:
+            - path: status
+              equals: ok
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `live.command_assert.expect_json[0].path must start with '$'`)
 }
 
 func TestLoad(t *testing.T) {
@@ -426,6 +716,9 @@ phases:
 				if s.Phases[1].MaxTurns != 20 {
 					t.Fatalf("Phases[1].MaxTurns = %d, want 20", s.Phases[1].MaxTurns)
 				}
+				if s.Class != policy.Delivery {
+					t.Fatalf("Class = %q, want %q", s.Class, policy.Delivery)
+				}
 			},
 		},
 		{
@@ -465,6 +758,9 @@ phases:
 				}
 				if !s.AllowCanonicalProtectedWrites {
 					t.Fatal("AllowCanonicalProtectedWrites = false, want true")
+				}
+				if s.Class != policy.HarnessMaintenance {
+					t.Fatalf("Class = %q, want %q", s.Class, policy.HarnessMaintenance)
 				}
 				if s.Phases[0].Gate.Retries != 2 {
 					t.Fatalf("gate retries = %d, want 2", s.Phases[0].Gate.Retries)
@@ -898,6 +1194,7 @@ func TestValidate(t *testing.T) {
 		wf               Workflow
 		prompts          []string // prompt files to create relative to cwd
 		wantErr          string
+		check            func(*testing.T, Workflow)
 	}{
 		{
 			name:             "valid minimal workflow",
@@ -920,6 +1217,37 @@ func TestValidate(t *testing.T) {
 			},
 			prompts: []string{"prompt.md"},
 			wantErr: `"name" is required`,
+		},
+		{
+			name:             "invalid class",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name:  "test",
+				Class: "runtime",
+				Phases: []Phase{
+					{Name: "step1", PromptFile: "prompt.md", MaxTurns: 5},
+				},
+			},
+			prompts: []string{"prompt.md"},
+			wantErr: `"class" is invalid: unknown workflow class "runtime"`,
+		},
+		{
+			name:             "class is normalized",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name:  "test",
+				Class: " delivery ",
+				Phases: []Phase{
+					{Name: "step1", PromptFile: "prompt.md", MaxTurns: 5},
+				},
+			},
+			prompts: []string{"prompt.md"},
+			check: func(t *testing.T, s Workflow) {
+				t.Helper()
+				if s.Class != policy.Delivery {
+					t.Fatalf("Class = %q, want %q", s.Class, policy.Delivery)
+				}
+			},
 		},
 		{
 			name:             "no phases",
@@ -1371,6 +1699,9 @@ func TestValidate(t *testing.T) {
 
 			if err != nil {
 				t.Fatalf("Validate returned unexpected error: %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, tt.wf)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Implements [issue #232](https://github.com/nicholls-inc/xylem/issues/232) by adding a dedicated workflow policy taxonomy and wiring `Workflow.Class` into workflow loading and validation.
- Preserves compatibility with legacy protected-write flags by defaulting omitted classes to `delivery`, promoting legacy protected-write workflows to `harness-maintenance`, and rejecting inconsistent `class`/legacy-flag combinations with structured errors.

## Smoke scenarios covered
- `S1` — Delivery control-plane writes are denied
- `S2` — Harness-maintenance default-branch commits are denied
- `S3` — Ops pull-request merges are allowed
- `S4` — Workflow class defaults to delivery when omitted
- `S5` — Legacy protected-write flags promote harness-maintenance
- `S6` — Explicit ops class loads without legacy flags
- `S7` — Inconsistent class and legacy flags return structured error

## Changes summary
- **Added** `cli/internal/policy/class.go` with `policy.Class`, `policy.Operation`, `policy.Decision`, `Evaluate`, and `ParseClass` to encode the delivery / harness-maintenance / ops taxonomy.
- **Added** `cli/internal/policy/class_test.go` and `cli/internal/policy/class_prop_test.go` with direct smoke coverage and a property test for rule-order stability.
- **Modified** `cli/internal/workflow/workflow.go` to add `Workflow.Class`, track YAML field presence, derive class defaults from legacy flags, and validate class/legacy consistency via `workflowFromYAML` and `validateLegacyClassConsistency`.
- **Modified** `cli/internal/workflow/workflow_test.go` to cover explicit class parsing, defaulting behavior, legacy migration behavior, and conflict validation paths.

## Test plan
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #232