### PR TITLE
feat: daemon reload with Vessel.WorkflowDigest workflow snapshots

### DIFF
--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -189,6 +191,94 @@ func (daemonNoopRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, e
 	return []byte("[]"), nil
 }
 
+type daemonSmokeCmdRunner struct {
+	mu           sync.Mutex
+	runPhaseHook func(dir, prompt, name string, args ...string) ([]byte, error, bool)
+	phaseCalls   []daemonSmokePhaseCall
+}
+
+type daemonSmokePhaseCall struct {
+	dir    string
+	prompt string
+	name   string
+	args   []string
+}
+
+func (r *daemonSmokeCmdRunner) RunOutput(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (r *daemonSmokeCmdRunner) RunProcess(_ context.Context, _ string, _ string, _ ...string) error {
+	return nil
+}
+
+func (r *daemonSmokeCmdRunner) RunPhase(_ context.Context, dir string, stdin io.Reader, name string, args ...string) ([]byte, error) {
+	prompt, err := io.ReadAll(stdin)
+	if err != nil {
+		return nil, err
+	}
+
+	r.mu.Lock()
+	r.phaseCalls = append(r.phaseCalls, daemonSmokePhaseCall{
+		dir:    dir,
+		prompt: string(prompt),
+		name:   name,
+		args:   append([]string(nil), args...),
+	})
+	r.mu.Unlock()
+
+	if r.runPhaseHook != nil {
+		if out, hookErr, handled := r.runPhaseHook(dir, string(prompt), name, args...); handled {
+			return out, hookErr
+		}
+	}
+	return []byte("ok"), nil
+}
+
+type daemonSmokeWorktree struct {
+	path string
+}
+
+func (w *daemonSmokeWorktree) Create(_ context.Context, _ string) (string, error) {
+	return w.path, nil
+}
+
+func (w *daemonSmokeWorktree) Remove(_ context.Context, _ string) error {
+	return nil
+}
+
+func daemonSmokeDigest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("sha256:%x", sum)
+}
+
+func writeDaemonSmokeWorkflow(t *testing.T, dir, name string, phases map[string]string) string {
+	t.Helper()
+
+	workflowDir := filepath.Join(dir, ".xylem", "workflows")
+	require.NoError(t, os.MkdirAll(workflowDir, 0o755))
+
+	promptDir := filepath.Join(dir, ".xylem", "prompts", name)
+	require.NoError(t, os.MkdirAll(promptDir, 0o755))
+
+	for phaseName, content := range phases {
+		require.NoError(t, os.WriteFile(filepath.Join(promptDir, phaseName+".md"), []byte(content), 0o644))
+	}
+
+	workflow := fmt.Sprintf(`name: %s
+phases:
+  - name: analyze
+    prompt_file: %s
+    max_turns: 3
+  - name: implement
+    prompt_file: %s
+    max_turns: 3
+`, name, filepath.Join(promptDir, "analyze.md"), filepath.Join(promptDir, "implement.md"))
+	workflowPath := filepath.Join(workflowDir, name+".yaml")
+	require.NoError(t, os.WriteFile(workflowPath, []byte(workflow), 0o644))
+	return workflowPath
+}
+
 func TestDaemonLoopScheduledSourceRunsSingleTick(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{
@@ -366,6 +456,128 @@ func TestSmoke_S3_DaemonTickDrainsScheduledVessel(t *testing.T) {
 	assert.Equal(t, "1h", vessels[0].Meta["schedule.cadence"])
 	assert.Equal(t, "doctor", vessels[0].Meta["schedule.source_name"])
 	assert.NotEmpty(t, vessels[0].Meta["schedule.fired_at"])
+}
+
+func TestSmoke_S5_DaemonReload(t *testing.T) {
+	repoDir := t.TempDir()
+	worktreeDir := t.TempDir()
+	stateDir := filepath.Join(repoDir, ".xylem")
+	require.NoError(t, os.MkdirAll(stateDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".xylem.yml"), []byte("daemon:\n  scan_interval: 5ms\n"), 0o644))
+
+	cfg := &config.Config{
+		Concurrency: 1,
+		MaxTurns:    50,
+		Timeout:     "30s",
+		StateDir:    stateDir,
+		Claude: config.ClaudeConfig{
+			Command: "claude",
+		},
+	}
+	q := queue.New(filepath.Join(stateDir, "queue.jsonl"))
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "manual-1",
+		Source:    "manual",
+		Workflow:  "daemon-reload-smoke",
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	workflowPath := writeDaemonSmokeWorkflow(t, repoDir, "daemon-reload-smoke", map[string]string{
+		"analyze":   "Analyze using original workflow",
+		"implement": "Implement using original workflow",
+	})
+	originalWorkflow, err := os.ReadFile(workflowPath)
+	require.NoError(t, err)
+
+	reloadedPromptPath := filepath.Join(repoDir, ".xylem", "prompts", "daemon-reload-smoke", "implement-reloaded.md")
+	require.NoError(t, os.WriteFile(reloadedPromptPath, []byte("Implement using reloaded workflow"), 0o644))
+
+	restoreWd := withDaemonWorkingDir(t, repoDir)
+	defer restoreWd()
+
+	analyzeStarted := make(chan struct{})
+	reloadApplied := make(chan struct{})
+	var analyzeOnce sync.Once
+
+	cmdRunner := &daemonSmokeCmdRunner{
+		runPhaseHook: func(_ string, prompt, _ string, _ ...string) ([]byte, error, bool) {
+			if !strings.Contains(prompt, "Analyze using original workflow") {
+				return []byte("ok"), nil, true
+			}
+			analyzeOnce.Do(func() { close(analyzeStarted) })
+			select {
+			case <-reloadApplied:
+			case <-time.After(250 * time.Millisecond):
+				return nil, fmt.Errorf("timed out waiting for daemon reload"), true
+			}
+			return []byte("ok"), nil, true
+		},
+	}
+
+	drainRunner := runner.New(cfg, q, &daemonSmokeWorktree{path: worktreeDir}, cmdRunner)
+	drain := func(ctx context.Context) (runner.DrainResult, error) {
+		return drainRunner.Drain(ctx)
+	}
+
+	var reloads atomic.Int32
+	scan := func(_ context.Context) (scanner.ScanResult, error) {
+		select {
+		case <-analyzeStarted:
+		default:
+			return scanner.ScanResult{}, nil
+		}
+		if !reloads.CompareAndSwap(0, 1) {
+			return scanner.ScanResult{}, nil
+		}
+
+		require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".xylem.yml"), []byte("daemon:\n  scan_interval: 10ms\n"), 0o644))
+		reloadedWorkflow := fmt.Sprintf(`name: daemon-reload-smoke
+phases:
+  - name: analyze
+    prompt_file: %s
+    max_turns: 3
+  - name: implement
+    prompt_file: %s
+    max_turns: 3
+`, filepath.Join(repoDir, ".xylem", "prompts", "daemon-reload-smoke", "analyze.md"), reloadedPromptPath)
+		require.NoError(t, os.WriteFile(workflowPath, []byte(reloadedWorkflow), 0o644))
+		close(reloadApplied)
+		return scanner.ScanResult{}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+
+	err = daemonLoop(ctx, q, drainRunner, scan, drain, nil, nil, 5*time.Millisecond, 5*time.Millisecond, 0)
+	require.NoError(t, err)
+
+	select {
+	case <-reloadApplied:
+	default:
+		t.Fatal("expected daemon reload to be applied during the smoke scenario")
+	}
+
+	vessels, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, queue.StateCompleted, vessels[0].State)
+	assert.Equal(t, daemonSmokeDigest(originalWorkflow), vessels[0].WorkflowDigest)
+
+	snapshotPath := filepath.Join(stateDir, "vessels", vessels[0].ID, "workflow.snapshot.yaml")
+	snapshotData, err := os.ReadFile(snapshotPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalWorkflow, snapshotData)
+
+	liveWorkflow, err := os.ReadFile(workflowPath)
+	require.NoError(t, err)
+	assert.NotEqual(t, string(originalWorkflow), string(liveWorkflow))
+
+	require.Len(t, cmdRunner.phaseCalls, 2)
+	assert.Contains(t, cmdRunner.phaseCalls[1].prompt, "Implement using original workflow")
+	assert.NotContains(t, cmdRunner.phaseCalls[1].prompt, "Implement using reloaded workflow")
+	assert.Equal(t, int32(1), reloads.Load())
 }
 
 func TestSmoke_S31_TracerWiredInDaemonRunDrain(t *testing.T) {

--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -64,17 +64,20 @@ func (s VesselState) IsTerminal() bool {
 }
 
 type Vessel struct {
-	ID        string            `json:"id"`
-	Source    string            `json:"source"`
-	Ref       string            `json:"ref,omitempty"`
-	Workflow  string            `json:"workflow,omitempty"`
-	Prompt    string            `json:"prompt,omitempty"`
-	Meta      map[string]string `json:"meta,omitempty"`
-	State     VesselState       `json:"state"`
-	CreatedAt time.Time         `json:"created_at"`
-	StartedAt *time.Time        `json:"started_at,omitempty"`
-	EndedAt   *time.Time        `json:"ended_at,omitempty"`
-	Error     string            `json:"error,omitempty"`
+	ID       string `json:"id"`
+	Source   string `json:"source"`
+	Ref      string `json:"ref,omitempty"`
+	Workflow string `json:"workflow,omitempty"`
+	// WorkflowDigest fingerprints the frozen workflow YAML persisted at vessel
+	// launch so resumed phases can keep using the same definition after reloads.
+	WorkflowDigest string            `json:"workflow_digest,omitempty"`
+	Prompt         string            `json:"prompt,omitempty"`
+	Meta           map[string]string `json:"meta,omitempty"`
+	State          VesselState       `json:"state"`
+	CreatedAt      time.Time         `json:"created_at"`
+	StartedAt      *time.Time        `json:"started_at,omitempty"`
+	EndedAt        *time.Time        `json:"ended_at,omitempty"`
+	Error          string            `json:"error,omitempty"`
 
 	// v2 phase-based execution fields
 	CurrentPhase int               `json:"current_phase,omitempty"`

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -396,7 +397,7 @@ func (r *Runner) CheckWaitingVessels(ctx context.Context) {
 		if vessel.WaitingSince != nil {
 			timeoutDur := 24 * time.Hour // default
 			if vessel.Workflow != "" {
-				if s, loadErr := r.loadWorkflow(vessel.Workflow); loadErr == nil {
+				if s, loadErr := r.loadWorkflowForVessel(vessel); loadErr == nil {
 					if int(vessel.CurrentPhase) > 0 && int(vessel.CurrentPhase) <= len(s.Phases) {
 						prevPhase := s.Phases[vessel.CurrentPhase-1]
 						if prevPhase.Gate != nil && prevPhase.Gate.Timeout != "" {
@@ -526,17 +527,20 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 		return r.runBuiltinWorkflow(ctx, vessel, src, vrs, builtin)
 	}
 
-	worktreePath, ok := r.ensureWorktree(ctx, &vessel, src)
-	if !ok {
-		return "failed"
-	}
-
-	sk, err := r.loadWorkflow(vessel.Workflow)
+	vessel, sk, err := r.prepareWorkflowSnapshot(vessel)
 	if err != nil {
-		r.failVessel(vessel.ID, fmt.Sprintf("load workflow: %v", err))
+		if r.cancelledTransition(vessel.ID, err) {
+			return r.cancelVessel(vessel, "", vrs, claims)
+		}
+		r.failUpdatedVessel(&vessel, fmt.Sprintf("prepare workflow snapshot: %v", err))
 		if err := src.OnFail(ctx, vessel); err != nil {
 			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
 		}
+		return "failed"
+	}
+
+	worktreePath, ok := r.ensureWorktree(ctx, &vessel, src)
+	if !ok {
 		return "failed"
 	}
 
@@ -2936,7 +2940,7 @@ func (r *Runner) workflowProtectedWritePolicy(vessel queue.Vessel, violations []
 		return protectedSurfaceWorkflowPolicy{}, nil
 	}
 
-	sk, err := r.loadWorkflow(vessel.Workflow)
+	sk, err := r.loadWorkflowForVessel(vessel)
 	if err != nil {
 		return protectedSurfaceWorkflowPolicy{}, fmt.Errorf("load workflow %q: %w", vessel.Workflow, err)
 	}
@@ -3372,8 +3376,145 @@ func (r *Runner) sourceConfigNameFromMeta(v queue.Vessel) string {
 }
 
 func (r *Runner) loadWorkflow(name string) (*workflow.Workflow, error) {
-	path := filepath.Join(".xylem", "workflows", name+".yaml")
-	return workflow.Load(path)
+	return workflow.Load(r.workflowPath(name))
+}
+
+func (r *Runner) loadWorkflowForVessel(vessel queue.Vessel) (*workflow.Workflow, error) {
+	if strings.TrimSpace(vessel.Workflow) == "" {
+		return nil, fmt.Errorf("vessel %s has no workflow", vessel.ID)
+	}
+	if strings.TrimSpace(vessel.WorkflowDigest) == "" {
+		return r.loadWorkflow(vessel.Workflow)
+	}
+
+	snapshotPath := r.workflowSnapshotPath(vessel.ID)
+	data, err := os.ReadFile(snapshotPath)
+	if err != nil {
+		return nil, fmt.Errorf("read workflow snapshot %q: %w", snapshotPath, err)
+	}
+	if got := workflowSnapshotDigest(data); got != vessel.WorkflowDigest {
+		return nil, fmt.Errorf("workflow snapshot digest mismatch: got %s want %s", got, vessel.WorkflowDigest)
+	}
+
+	wf, err := workflow.ParseBytes(data, r.workflowPath(vessel.Workflow))
+	if err != nil {
+		return nil, fmt.Errorf("parse workflow snapshot %q: %w", snapshotPath, err)
+	}
+	if err := r.rewriteWorkflowPromptPathsToSnapshots(vessel.ID, wf); err != nil {
+		return nil, fmt.Errorf("rewrite workflow snapshot prompts: %w", err)
+	}
+	if err := wf.Validate(r.workflowPath(vessel.Workflow)); err != nil {
+		return nil, fmt.Errorf("validate workflow snapshot %q: %w", snapshotPath, err)
+	}
+	return wf, nil
+}
+
+func (r *Runner) prepareWorkflowSnapshot(vessel queue.Vessel) (queue.Vessel, *workflow.Workflow, error) {
+	if strings.TrimSpace(vessel.Workflow) == "" {
+		return vessel, nil, fmt.Errorf("vessel %s has no workflow", vessel.ID)
+	}
+	if strings.TrimSpace(vessel.WorkflowDigest) != "" {
+		wf, err := r.loadWorkflowForVessel(vessel)
+		if err != nil {
+			return vessel, nil, err
+		}
+		return vessel, wf, nil
+	}
+
+	workflowPath := r.workflowPath(vessel.Workflow)
+	data, err := os.ReadFile(workflowPath)
+	if err != nil {
+		return vessel, nil, fmt.Errorf("read workflow file %q: %w", workflowPath, err)
+	}
+
+	wf, err := workflow.LoadBytes(data, workflowPath)
+	if err != nil {
+		return vessel, nil, err
+	}
+
+	snapshotPath := r.workflowSnapshotPath(vessel.ID)
+	if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
+		return vessel, nil, fmt.Errorf("create workflow snapshot dir: %w", err)
+	}
+	if err := os.WriteFile(snapshotPath, data, 0o644); err != nil {
+		return vessel, nil, fmt.Errorf("write workflow snapshot %q: %w", snapshotPath, err)
+	}
+	if err := r.snapshotWorkflowPromptFiles(vessel.ID, wf); err != nil {
+		return vessel, nil, fmt.Errorf("snapshot workflow prompts: %w", err)
+	}
+	if err := r.rewriteWorkflowPromptPathsToSnapshots(vessel.ID, wf); err != nil {
+		return vessel, nil, fmt.Errorf("rewrite workflow prompts to snapshots: %w", err)
+	}
+
+	vessel.WorkflowDigest = workflowSnapshotDigest(data)
+	if err := r.Queue.UpdateVessel(vessel); err != nil {
+		return vessel, nil, fmt.Errorf("persist workflow digest: %w", err)
+	}
+
+	return vessel, wf, nil
+}
+
+func (r *Runner) workflowPath(name string) string {
+	return filepath.Join(".xylem", "workflows", name+".yaml")
+}
+
+func (r *Runner) workflowSnapshotPath(vesselID string) string {
+	return filepath.Join(r.workflowSnapshotDir(vesselID), "workflow.snapshot.yaml")
+}
+
+func (r *Runner) workflowSnapshotDir(vesselID string) string {
+	stateDir := ".xylem"
+	if r.Config != nil && r.Config.StateDir != "" {
+		stateDir = r.Config.StateDir
+	}
+	return filepath.Join(stateDir, "vessels", vesselID)
+}
+
+func (r *Runner) workflowPromptSnapshotPath(vesselID string, p workflow.Phase) string {
+	ext := filepath.Ext(p.PromptFile)
+	if ext == "" {
+		ext = ".md"
+	}
+	return filepath.Join(r.workflowSnapshotDir(vesselID), "prompts", p.Name+ext)
+}
+
+func (r *Runner) snapshotWorkflowPromptFiles(vesselID string, wf *workflow.Workflow) error {
+	for _, p := range wf.Phases {
+		if strings.TrimSpace(p.PromptFile) == "" {
+			continue
+		}
+		data, err := os.ReadFile(p.PromptFile)
+		if err != nil {
+			return fmt.Errorf("read prompt file %q for phase %q: %w", p.PromptFile, p.Name, err)
+		}
+		snapshotPath := r.workflowPromptSnapshotPath(vesselID, p)
+		if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
+			return fmt.Errorf("create prompt snapshot dir for phase %q: %w", p.Name, err)
+		}
+		if err := os.WriteFile(snapshotPath, data, 0o644); err != nil {
+			return fmt.Errorf("write prompt snapshot %q for phase %q: %w", snapshotPath, p.Name, err)
+		}
+	}
+	return nil
+}
+
+func (r *Runner) rewriteWorkflowPromptPathsToSnapshots(vesselID string, wf *workflow.Workflow) error {
+	for i := range wf.Phases {
+		if strings.TrimSpace(wf.Phases[i].PromptFile) == "" {
+			continue
+		}
+		snapshotPath := r.workflowPromptSnapshotPath(vesselID, wf.Phases[i])
+		if _, err := os.Stat(snapshotPath); err != nil {
+			return fmt.Errorf("stat prompt snapshot %q for phase %q: %w", snapshotPath, wf.Phases[i].Name, err)
+		}
+		wf.Phases[i].PromptFile = snapshotPath
+	}
+	return nil
+}
+
+func workflowSnapshotDigest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("sha256:%x", sum)
 }
 
 func (r *Runner) readHarness() string {

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -198,6 +199,17 @@ func TestProp_PromptOnlyUsageAccumulatesEstimatedTotals(t *testing.T) {
 		}
 		if len(summary.Phases) != 0 {
 			t.Fatalf("len(summary.Phases) = %d, want 0", len(summary.Phases))
+		}
+	})
+}
+
+func TestProp_WorkflowSnapshotDigestMatchesSHA256(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		data := []byte(rapid.StringMatching(`[\x09\x0a\x0d\x20-\x7e]{0,256}`).Draw(t, "data"))
+		sum := sha256.Sum256(data)
+		want := fmt.Sprintf("sha256:%x", sum)
+		if got := workflowSnapshotDigest(data); got != want {
+			t.Fatalf("workflowSnapshotDigest() = %q, want %q", got, want)
 		}
 	})
 }

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -8023,3 +8023,217 @@ func TestRunVesselLiveGateEmitsStepSpans(t *testing.T) {
 	assert.Equal(t, "true", stepAttrs["xylem.gate.step.passed"])
 	assert.Equal(t, gateSpan.SpanContext().SpanID(), stepSpan.Parent().SpanID())
 }
+
+func TestRunnerPrepareWorkflowSnapshotPersistsDigestAndSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(filepath.Join(dir, ".xylem"), 1)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	_, err := q.Enqueue(makeVessel(1, "snapshot"))
+	require.NoError(t, err)
+	writeWorkflowFile(t, dir, "snapshot", []testPhase{
+		{name: "implement", promptContent: "Implement the fix", maxTurns: 3},
+	})
+	withTestWorkingDir(t, dir)
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	vessel, err := q.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, vessel)
+
+	originalWorkflow, err := os.ReadFile(filepath.Join(dir, ".xylem", "workflows", "snapshot.yaml"))
+	require.NoError(t, err)
+
+	updated, wf, err := r.prepareWorkflowSnapshot(*vessel)
+	require.NoError(t, err)
+	require.NotNil(t, wf)
+	assert.Equal(t, "snapshot", wf.Name)
+	assert.Equal(t, workflowSnapshotDigest(originalWorkflow), updated.WorkflowDigest)
+
+	snapshotData, err := os.ReadFile(r.workflowSnapshotPath(updated.ID))
+	require.NoError(t, err)
+	assert.Equal(t, originalWorkflow, snapshotData)
+
+	persisted, err := q.FindByID(updated.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, updated.WorkflowDigest, persisted.WorkflowDigest)
+}
+
+func TestRunnerUsesWorkflowSnapshotAfterLiveWorkflowChanges(t *testing.T) {
+	repoDir := t.TempDir()
+	worktreeDir := t.TempDir()
+	cfg := makeTestConfig(filepath.Join(repoDir, ".xylem"), 1)
+	q := queue.New(filepath.Join(repoDir, "queue.jsonl"))
+
+	_, err := q.Enqueue(makeVessel(1, "snapshot-reuse"))
+	require.NoError(t, err)
+	writeWorkflowFile(t, repoDir, "snapshot-reuse", []testPhase{
+		{name: "analyze", promptContent: "Analyze using original workflow", maxTurns: 3},
+		{name: "implement", promptContent: "Implement using original workflow", maxTurns: 3},
+	})
+	withTestWorkingDir(t, repoDir)
+
+	workflowPath := filepath.Join(repoDir, ".xylem", "workflows", "snapshot-reuse.yaml")
+	analyzePromptPath := filepath.Join(repoDir, ".xylem", "prompts", "snapshot-reuse", "analyze.md")
+	reloadedPromptPath := filepath.Join(repoDir, ".xylem", "prompts", "snapshot-reuse", "implement-reloaded.md")
+	require.NoError(t, os.WriteFile(reloadedPromptPath, []byte("Implement using reloaded workflow"), 0o644))
+
+	originalWorkflow, err := os.ReadFile(workflowPath)
+	require.NoError(t, err)
+
+	cmdRunner := &mockCmdRunner{
+		runPhaseHook: func(_ string, prompt, _ string, _ ...string) ([]byte, error, bool) {
+			if !strings.Contains(prompt, "Analyze using original workflow") {
+				return []byte("ok"), nil, true
+			}
+			reloadedWorkflow := fmt.Sprintf(`name: snapshot-reuse
+phases:
+  - name: analyze
+    prompt_file: %s
+    max_turns: 3
+  - name: implement
+    prompt_file: %s
+    max_turns: 3
+`, analyzePromptPath, reloadedPromptPath)
+			if err := os.WriteFile(workflowPath, []byte(reloadedWorkflow), 0o644); err != nil {
+				return nil, err, true
+			}
+			return []byte("ok"), nil, true
+		},
+	}
+
+	r := New(cfg, q, &mockWorktree{path: worktreeDir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
+
+	vessel := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateCompleted, vessel.State)
+	assert.Equal(t, workflowSnapshotDigest(originalWorkflow), vessel.WorkflowDigest)
+
+	snapshotData, err := os.ReadFile(r.workflowSnapshotPath(vessel.ID))
+	require.NoError(t, err)
+	assert.Equal(t, originalWorkflow, snapshotData)
+	require.Len(t, cmdRunner.phaseCalls, 2)
+	assert.Contains(t, cmdRunner.phaseCalls[1].prompt, "Implement using original workflow")
+	assert.NotContains(t, cmdRunner.phaseCalls[1].prompt, "Implement using reloaded workflow")
+}
+
+func TestRunnerUsesSnapshottedPromptFilesAfterLivePromptChanges(t *testing.T) {
+	repoDir := t.TempDir()
+	worktreeDir := t.TempDir()
+	cfg := makeTestConfig(filepath.Join(repoDir, ".xylem"), 1)
+	q := queue.New(filepath.Join(repoDir, "queue.jsonl"))
+
+	_, err := q.Enqueue(makeVessel(1, "prompt-snapshot"))
+	require.NoError(t, err)
+	writeWorkflowFile(t, repoDir, "prompt-snapshot", []testPhase{
+		{name: "analyze", promptContent: "Analyze using original prompt", maxTurns: 3},
+		{name: "implement", promptContent: "Implement using original prompt", maxTurns: 3},
+	})
+	withTestWorkingDir(t, repoDir)
+
+	implementPromptPath := filepath.Join(repoDir, ".xylem", "prompts", "prompt-snapshot", "implement.md")
+	cmdRunner := &mockCmdRunner{
+		runPhaseHook: func(_ string, prompt, _ string, _ ...string) ([]byte, error, bool) {
+			if !strings.Contains(prompt, "Analyze using original prompt") {
+				return []byte("ok"), nil, true
+			}
+			if err := os.WriteFile(implementPromptPath, []byte("Implement using edited prompt"), 0o644); err != nil {
+				return nil, err, true
+			}
+			return []byte("ok"), nil, true
+		},
+	}
+
+	r := New(cfg, q, &mockWorktree{path: worktreeDir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
+
+	require.Len(t, cmdRunner.phaseCalls, 2)
+	assert.Contains(t, cmdRunner.phaseCalls[1].prompt, "Implement using original prompt")
+	assert.NotContains(t, cmdRunner.phaseCalls[1].prompt, "Implement using edited prompt")
+}
+
+func TestRunnerLoadWorkflowForLegacyVesselFallsBackToLiveDisk(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(filepath.Join(dir, ".xylem"), 1)
+	writeWorkflowFile(t, dir, "legacy", []testPhase{
+		{name: "plan", promptContent: "Plan the change", maxTurns: 3},
+	})
+	withTestWorkingDir(t, dir)
+
+	livePromptPath := filepath.Join(dir, ".xylem", "prompts", "legacy", "implement.md")
+	require.NoError(t, os.WriteFile(livePromptPath, []byte("Implement from live workflow"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem", "workflows", "legacy.yaml"), []byte(fmt.Sprintf(`name: legacy
+phases:
+  - name: implement
+    prompt_file: %s
+    max_turns: 3
+`, livePromptPath)), 0o644))
+
+	r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{}, &mockCmdRunner{})
+	wf, err := r.loadWorkflowForVessel(queue.Vessel{ID: "issue-1", Workflow: "legacy"})
+	require.NoError(t, err)
+	require.Len(t, wf.Phases, 1)
+	assert.Equal(t, "implement", wf.Phases[0].Name)
+}
+
+func TestRunnerLoadWorkflowForVesselUsesSnapshottedPromptFiles(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(filepath.Join(dir, ".xylem"), 1)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	_, err := q.Enqueue(makeVessel(1, "snapshotted-prompts"))
+	require.NoError(t, err)
+	writeWorkflowFile(t, dir, "snapshotted-prompts", []testPhase{
+		{name: "implement", promptContent: "Implement the fix", maxTurns: 3},
+	})
+	withTestWorkingDir(t, dir)
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	vessel, err := q.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, vessel)
+
+	updated, _, err := r.prepareWorkflowSnapshot(*vessel)
+	require.NoError(t, err)
+
+	livePromptPath := filepath.Join(dir, ".xylem", "prompts", "snapshotted-prompts", "implement.md")
+	require.NoError(t, os.Remove(livePromptPath))
+
+	wf, err := r.loadWorkflowForVessel(updated)
+	require.NoError(t, err)
+	require.Len(t, wf.Phases, 1)
+	assert.Equal(t, r.workflowPromptSnapshotPath(updated.ID, wf.Phases[0]), wf.Phases[0].PromptFile)
+}
+
+func TestRunnerLoadWorkflowForVesselRejectsSnapshotDigestMismatch(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(filepath.Join(dir, ".xylem"), 1)
+	writeWorkflowFile(t, dir, "digest-mismatch", []testPhase{
+		{name: "implement", promptContent: "Implement the fix", maxTurns: 3},
+	})
+	withTestWorkingDir(t, dir)
+
+	r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{}, &mockCmdRunner{})
+	workflowData, err := os.ReadFile(filepath.Join(dir, ".xylem", "workflows", "digest-mismatch.yaml"))
+	require.NoError(t, err)
+	snapshotPath := r.workflowSnapshotPath("issue-1")
+	require.NoError(t, os.MkdirAll(filepath.Dir(snapshotPath), 0o755))
+	require.NoError(t, os.WriteFile(snapshotPath, workflowData, 0o644))
+
+	_, err = r.loadWorkflowForVessel(queue.Vessel{
+		ID:             "issue-1",
+		Workflow:       "digest-mismatch",
+		WorkflowDigest: "sha256:deadbeef",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workflow snapshot digest mismatch")
+}

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -146,17 +146,32 @@ func Load(path string) (*Workflow, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read workflow file %q: %w", path, err)
 	}
+	return LoadBytes(data, path)
+}
 
+// ParseBytes parses workflow YAML without validating prompt file existence.
+// Call Validate on the returned workflow once any path rewriting is complete.
+func ParseBytes(data []byte, workflowFilePath string) (*Workflow, error) {
 	var s Workflow
 	if err := yaml.Unmarshal(data, &s); err != nil {
-		return nil, fmt.Errorf("parse workflow yaml %q: %w", path, err)
+		return nil, fmt.Errorf("parse workflow yaml %q: %w", workflowFilePath, err)
 	}
-
-	if err := s.Validate(path); err != nil {
-		return nil, fmt.Errorf("validate workflow %q: %w", path, err)
-	}
-
 	return &s, nil
+}
+
+// LoadBytes parses and validates workflow YAML using workflowFilePath as the
+// logical source path for filename validation and prompt-file checks.
+func LoadBytes(data []byte, workflowFilePath string) (*Workflow, error) {
+	s, err := ParseBytes(data, workflowFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.Validate(workflowFilePath); err != nil {
+		return nil, fmt.Errorf("validate workflow %q: %w", workflowFilePath, err)
+	}
+
+	return s, nil
 }
 
 // Validate checks that the workflow definition is well-formed. workflowFilePath is


### PR DESCRIPTION
## Summary

Implements [issue #236](https://github.com/nicholls-inc/xylem/issues/236) by adding a daemon-safe workflow snapshot mechanism so in-flight vessels continue running against the workflow definition captured at launch even after `.xylem.yml` or workflow files reload on disk.

## Smoke scenarios covered

- **15.3 / 5 — Daemon reload**: covered by `TestSmoke_S5_DaemonReload`, validating that a reload during an in-flight vessel updates live config/workflow files without changing the vessel's frozen workflow snapshot.

## Changes summary

### Files modified

- `cli/internal/queue/queue.go`
- `cli/internal/workflow/workflow.go`
- `cli/internal/runner/runner.go`
- `cli/internal/runner/runner_test.go`
- `cli/internal/runner/runner_prop_test.go`
- `cli/cmd/xylem/daemon_test.go`

### Key types and functions

- Added `queue.Vessel.WorkflowDigest` to persist the sha256 digest of the frozen workflow YAML for each launched vessel.
- Added `workflow.ParseBytes` and `workflow.LoadBytes` so workflow YAML can be loaded from persisted snapshot bytes while still validating against the logical workflow path.
- Added runner snapshot lifecycle helpers including `loadWorkflowForVessel`, `prepareWorkflowSnapshot`, `workflowSnapshotPath`, `snapshotWorkflowPromptFiles`, and `rewriteWorkflowPromptPathsToSnapshots` so resumed phases use snapshotted workflow and prompt files instead of mutable live definitions.
- Added regression and smoke coverage with `TestRunnerPrepareWorkflowSnapshotPersistsDigestAndSnapshot`, `TestRunnerUsesWorkflowSnapshotAfterLiveWorkflowChanges`, `TestRunnerUsesSnapshottedPromptFilesAfterLivePromptChanges`, `TestProp_WorkflowSnapshotDigestMatchesSHA256`, and `TestSmoke_S5_DaemonReload`.

## Test plan

Run from `cli/`:

- `go vet ./...`
- `go build ./cmd/xylem`
- `go test ./...`

Fixes #236