### PR TITLE
feat(runner,intermediary): enforce workflow class matrix and extend audit logging

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/cadence"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"gopkg.in/yaml.v3"
 )
 
@@ -210,6 +211,7 @@ type ProtectedSurfacesConfig struct {
 }
 
 type PolicyConfig struct {
+	Mode  string             `yaml:"mode,omitempty"`
 	Rules []PolicyRuleConfig `yaml:"rules,omitempty"`
 }
 
@@ -465,6 +467,10 @@ func (c *Config) EffectiveAuditLogPath() string {
 	return DefaultAuditLogPath
 }
 
+func (c *Config) HarnessPolicyMode() policy.Mode {
+	return policy.NormalizeMode(c.Harness.Policy.Mode)
+}
+
 func (c *Config) HarnessReviewCadence() string {
 	if !c.Harness.Review.Enabled {
 		return "manual"
@@ -541,14 +547,15 @@ func (c *Config) BuildIntermediaryPolicies() []intermediary.Policy {
 		return []intermediary.Policy{DefaultPolicy()}
 	}
 
-	rules := make([]intermediary.Rule, len(c.Harness.Policy.Rules))
-	for i, rule := range c.Harness.Policy.Rules {
-		rules[i] = intermediary.Rule{
+	rules := make([]intermediary.Rule, 0, len(c.Harness.Policy.Rules)+1)
+	for _, rule := range c.Harness.Policy.Rules {
+		rules = append(rules, intermediary.Rule{
 			Action:   rule.Action,
 			Resource: rule.Resource,
 			Effect:   intermediary.Effect(rule.Effect),
-		}
+		})
 	}
+	rules = append(rules, intermediary.Rule{Action: "*", Resource: "*", Effect: intermediary.Allow})
 
 	return []intermediary.Policy{{
 		Name:  "user",
@@ -556,28 +563,13 @@ func (c *Config) BuildIntermediaryPolicies() []intermediary.Policy {
 	}}
 }
 
-// DefaultPolicy returns the default intermediary policy. Protected control
-// surfaces are denied, and all currently classified execution actions —
-// including git_commit, git_push, and pr_create — are allowed so the daemon can
-// operate autonomously.
-//
-// Destructive git operations and deploy-class actions are not yet emitted as
-// separate intents at the runner/intermediary boundary; they currently inherit
-// the enclosing phase action. Operators who want human gates on those surfaces
-// can override the defaults with `harness.policy.rules` or workflow gates.
+// DefaultPolicy returns the default intermediary overlay policy. The workflow
+// class matrix is authoritative; this glob policy exists only as the fallback
+// allow rule that keeps user-defined rules in "tightening only" mode.
 func DefaultPolicy() intermediary.Policy {
 	return intermediary.Policy{
 		Name: "default",
 		Rules: []intermediary.Rule{
-			// Protected control surfaces are denied.
-			{Action: "file_write", Resource: ".xylem/HARNESS.md", Effect: intermediary.Deny},
-			{Action: "file_write", Resource: ".xylem.yml", Effect: intermediary.Deny},
-			{Action: "file_write", Resource: ".xylem/workflows/*", Effect: intermediary.Deny},
-			{Action: "file_write", Resource: ".xylem/prompts/*/*.md", Effect: intermediary.Deny},
-			// All other actions — including git_commit, git_push, and pr_create
-			// — are allowed. Autonomous operation requires publication steps to
-			// complete without a built-in approval pause. Override via
-			// harness.policy for stricter rules.
 			{Action: "*", Resource: "*", Effect: intermediary.Allow},
 		},
 	}
@@ -606,6 +598,9 @@ func (c *Config) validateHarness() error {
 		default:
 			return fmt.Errorf("harness.policy.rules[%d]: invalid effect %q (must be allow, deny, or require_approval)", i, rule.Effect)
 		}
+	}
+	if c.Harness.Policy.Mode != "" && c.Harness.Policy.Mode != string(policy.ModeWarn) && c.Harness.Policy.Mode != string(policy.ModeEnforce) {
+		return fmt.Errorf("harness.policy.mode: invalid mode %q (must be warn or enforce)", c.Harness.Policy.Mode)
 	}
 
 	if cadence := c.Harness.Review.Cadence; cadence != "" {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1738,6 +1739,7 @@ func TestSmoke_S2_NoHarnessSectionDefaultsActivate(t *testing.T) {
 	assert.Equal(t, 50, cfg.HarnessReviewLookbackRuns())
 	assert.Equal(t, 3, cfg.HarnessReviewMinSamples())
 	assert.Equal(t, "reviews", cfg.HarnessReviewOutputDir())
+	assert.Equal(t, policy.ModeEnforce, cfg.HarnessPolicyMode())
 	assert.True(t, cfg.ObservabilityEnabled())
 	assert.Equal(t, 1.0, cfg.ObservabilitySampleRate())
 	assert.Nil(t, cfg.VesselBudget())
@@ -1787,6 +1789,24 @@ func TestSmoke_S5_InvalidPolicyEffectRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "approve_maybe")
 }
 
+func TestSmoke_PolicyWarnModeParses(t *testing.T) {
+	cfg, err := Load(writeSmokeConfigFile(t, `harness:
+  policy:
+    mode: warn
+`))
+	require.NoError(t, err)
+	assert.Equal(t, policy.ModeWarn, cfg.HarnessPolicyMode())
+}
+
+func TestSmoke_InvalidPolicyModeRejected(t *testing.T) {
+	_, err := Load(writeSmokeConfigFile(t, `harness:
+  policy:
+    mode: block
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "harness.policy.mode")
+}
+
 func TestSmoke_S6_DefaultPolicyDeniesHarnessWrite(t *testing.T) {
 	result := newSmokeIntermediary(t, validConfig()).Evaluate(intermediary.Intent{
 		Action:   "file_write",
@@ -1795,9 +1815,8 @@ func TestSmoke_S6_DefaultPolicyDeniesHarnessWrite(t *testing.T) {
 	})
 
 	assert.Equal(t, intermediary.Deny, result.Effect)
-	require.NotNil(t, result.MatchedRule)
-	assert.Equal(t, "file_write", result.MatchedRule.Action)
-	assert.Equal(t, ".xylem/HARNESS.md", result.MatchedRule.Resource)
+	assert.Equal(t, "write_control_plane", result.Operation)
+	assert.Equal(t, "delivery.write_control_plane.deny", result.RuleMatched)
 }
 
 func TestSmoke_S7_DefaultPolicyAllowsGitPush(t *testing.T) {
@@ -1814,6 +1833,21 @@ func TestSmoke_S7_DefaultPolicyAllowsGitPush(t *testing.T) {
 	require.NotNil(t, result.MatchedRule)
 	assert.Equal(t, "*", result.MatchedRule.Action)
 	assert.Equal(t, "*", result.MatchedRule.Resource)
+}
+
+func TestSmoke_ClassMatrixAllowsHarnessMaintenanceControlPlaneWrite(t *testing.T) {
+	result := newSmokeIntermediary(t, validConfig()).
+		WithWorkflowClass(policy.HarnessMaintenance).
+		Evaluate(intermediary.Intent{
+			Action:   "file_write",
+			Resource: ".xylem/HARNESS.md",
+			AgentID:  "vessel-003",
+		})
+
+	assert.Equal(t, intermediary.Allow, result.Effect)
+	assert.Equal(t, "write_control_plane", result.Operation)
+	assert.Equal(t, "harness-maintenance.write_control_plane.allow", result.RuleMatched)
+	assert.True(t, result.Audit)
 }
 
 func TestDefaultPolicyAllowsClassifiedGitLifecycleActions(t *testing.T) {
@@ -1863,8 +1897,8 @@ func TestDefaultPolicyDeniesPromptFileWrite(t *testing.T) {
 	})
 
 	assert.Equal(t, intermediary.Deny, result.Effect)
-	require.NotNil(t, result.MatchedRule)
-	assert.Equal(t, ".xylem/prompts/*/*.md", result.MatchedRule.Resource)
+	assert.Equal(t, "write_control_plane", result.Operation)
+	assert.Equal(t, "delivery.write_control_plane.deny", result.RuleMatched)
 }
 
 func TestSmoke_S8_DefaultPolicyAllowsPhaseExecute(t *testing.T) {

--- a/cli/internal/intermediary/intermediary.go
+++ b/cli/internal/intermediary/intermediary.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 )
 
 // Effect represents the outcome of a policy evaluation.
@@ -57,15 +58,24 @@ type PolicyResult struct {
 	Effect      Effect `json:"effect"`
 	MatchedRule *Rule  `json:"matched_rule,omitempty"`
 	Reason      string `json:"reason"`
+	Operation   string `json:"operation,omitempty"`
+	RuleMatched string `json:"rule_matched,omitempty"`
+	Audit       bool   `json:"audit,omitempty"`
 }
 
 // AuditEntry records a single intermediary decision for the tamper-proof log.
 type AuditEntry struct {
-	Intent     Intent    `json:"intent"`
-	Decision   Effect    `json:"decision"`
-	Timestamp  time.Time `json:"timestamp"`
-	ApprovedBy string    `json:"approved_by,omitempty"`
-	Error      string    `json:"error,omitempty"`
+	Intent        Intent    `json:"intent"`
+	Decision      Effect    `json:"decision"`
+	Timestamp     time.Time `json:"timestamp"`
+	ApprovedBy    string    `json:"approved_by,omitempty"`
+	Error         string    `json:"error,omitempty"`
+	Audit         bool      `json:"audit,omitempty"`
+	WorkflowClass string    `json:"workflow_class,omitempty"`
+	Operation     string    `json:"operation,omitempty"`
+	RuleMatched   string    `json:"rule_matched,omitempty"`
+	FilePath      string    `json:"file_path,omitempty"`
+	VesselID      string    `json:"vessel_id,omitempty"`
 }
 
 // AuditLog provides an append-only JSONL-backed audit log with file locking.
@@ -163,19 +173,32 @@ type Executor interface {
 // crossing the sandbox boundary. It evaluates intents against policies, executes
 // allowed actions, and maintains a tamper-proof audit log.
 type Intermediary struct {
-	policies []Policy
-	auditLog *AuditLog
-	executor Executor
+	policies      []Policy
+	auditLog      *AuditLog
+	executor      Executor
+	workflowClass policy.Class
 }
 
 // NewIntermediary creates an intermediary with the given policies, audit log,
 // and executor.
 func NewIntermediary(policies []Policy, auditLog *AuditLog, executor Executor) *Intermediary {
 	return &Intermediary{
-		policies: policies,
-		auditLog: auditLog,
-		executor: executor,
+		policies:      policies,
+		auditLog:      auditLog,
+		executor:      executor,
+		workflowClass: policy.Delivery,
 	}
+}
+
+// WithWorkflowClass returns a shallow copy that evaluates intents against the
+// supplied workflow class.
+func (i *Intermediary) WithWorkflowClass(class policy.Class) *Intermediary {
+	if i == nil {
+		return nil
+	}
+	clone := *i
+	clone.workflowClass = policy.NormalizeClass(string(class))
+	return &clone
 }
 
 // Submit validates an intent, evaluates it against policies, executes it if
@@ -187,10 +210,12 @@ func NewIntermediary(policies []Policy, auditLog *AuditLog, executor Executor) *
 func (i *Intermediary) Submit(ctx context.Context, intent Intent) (Effect, error) {
 	if err := ValidateIntent(intent); err != nil {
 		entry := AuditEntry{
-			Intent:    intent,
-			Decision:  Deny,
-			Timestamp: time.Now().UTC(),
-			Error:     err.Error(),
+			Intent:        intent,
+			Decision:      Deny,
+			Timestamp:     time.Now().UTC(),
+			Error:         err.Error(),
+			WorkflowClass: string(i.workflowClass),
+			VesselID:      intent.AgentID,
 		}
 		if appendErr := i.auditLog.Append(entry); appendErr != nil {
 			return Deny, fmt.Errorf("audit validation failure: %w", appendErr)
@@ -201,9 +226,17 @@ func (i *Intermediary) Submit(ctx context.Context, intent Intent) (Effect, error
 	result := i.Evaluate(intent)
 
 	entry := AuditEntry{
-		Intent:    intent,
-		Decision:  result.Effect,
-		Timestamp: time.Now().UTC(),
+		Intent:        intent,
+		Decision:      result.Effect,
+		Timestamp:     time.Now().UTC(),
+		Audit:         result.Audit,
+		WorkflowClass: string(i.workflowClass),
+		Operation:     result.Operation,
+		RuleMatched:   result.RuleMatched,
+		VesselID:      intent.AgentID,
+	}
+	if intent.Action == "file_write" {
+		entry.FilePath = intent.Resource
 	}
 
 	switch result.Effect {
@@ -233,21 +266,41 @@ func (i *Intermediary) Submit(ctx context.Context, intent Intent) (Effect, error
 // INV: Policy evaluation is deterministic for the same input.
 // INV: Default effect is Deny if no rule matches.
 func (i *Intermediary) Evaluate(intent Intent) PolicyResult {
+	op := policy.OperationFromActionResource(intent.Action, intent.Resource)
+	matrixDecision := policy.Evaluate(i.workflowClass, op)
+	if !matrixDecision.Allowed {
+		return PolicyResult{
+			Effect:      Deny,
+			Reason:      fmt.Sprintf("matched workflow class rule %q", matrixDecision.Rule),
+			Operation:   string(op),
+			RuleMatched: matrixDecision.Rule,
+			Audit:       matrixDecision.Audit,
+		}
+	}
 	for _, policy := range i.policies {
 		for _, rule := range policy.Rules {
 			if MatchGlob(rule.Action, intent.Action) && MatchGlob(rule.Resource, intent.Resource) {
+				ruleMatched := fmt.Sprintf("%s:%s %s", policy.Name, rule.Action, rule.Resource)
+				if matrixDecision.Audit && rule.Effect == Allow && matrixDecision.Rule != "" {
+					ruleMatched = matrixDecision.Rule
+				}
 				return PolicyResult{
 					Effect:      rule.Effect,
 					MatchedRule: &rule,
 					Reason:      fmt.Sprintf("matched rule in policy %q", policy.Name),
+					Operation:   string(op),
+					RuleMatched: ruleMatched,
+					Audit:       matrixDecision.Audit,
 				}
 			}
 		}
 	}
 	// INV: Default effect is Deny if no rule matches.
 	return PolicyResult{
-		Effect: Deny,
-		Reason: "no matching rule; default deny",
+		Effect:    Deny,
+		Reason:    "no matching rule; default deny",
+		Operation: string(op),
+		Audit:     matrixDecision.Audit,
 	}
 }
 

--- a/cli/internal/intermediary/intermediary_prop_test.go
+++ b/cli/internal/intermediary/intermediary_prop_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"pgregory.net/rapid"
 )
 
@@ -198,6 +199,31 @@ func TestProp_DenyOnlyPolicyDeniesEverything(t *testing.T) {
 		result := inter.Evaluate(intent)
 		if result.Effect != Deny {
 			t.Fatalf("deny-only policy returned %q for %+v", result.Effect, intent)
+		}
+	})
+}
+
+func TestProp_ClassMatrixDenialCannotBeLoosened(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		resource := rapid.SampledFrom([]string{
+			".xylem/HARNESS.md",
+			".xylem.yml",
+			".xylem/workflows/fix-bug.yaml",
+			".xylem/prompts/fix-bug/analyze.md",
+		}).Draw(t, "resource")
+		class := rapid.SampledFrom([]policy.Class{policy.Delivery, policy.Ops}).Draw(t, "class")
+
+		dir := mustTempDir(t)
+		defer os.RemoveAll(dir)
+		al := NewAuditLog(filepath.Join(dir, "audit.jsonl"))
+		inter := NewIntermediary([]Policy{{
+			Name:  "allow-all",
+			Rules: []Rule{{Action: "*", Resource: "*", Effect: Allow}},
+		}}, al, &mockExecutor{}).WithWorkflowClass(class)
+
+		result := inter.Evaluate(Intent{Action: "file_write", Resource: resource, AgentID: "agent-1"})
+		if result.Effect != Deny {
+			t.Fatalf("effect = %q, want deny for class %q resource %q", result.Effect, class, resource)
 		}
 	})
 }

--- a/cli/internal/intermediary/intermediary_test.go
+++ b/cli/internal/intermediary/intermediary_test.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // mockExecutor records whether Execute was called and optionally returns an error.
@@ -191,6 +195,196 @@ func TestEvaluate(t *testing.T) {
 				t.Fatalf("reason: got %q, want %q", result.Reason, tt.wantReason)
 			}
 		})
+	}
+}
+
+func TestEvaluate_ClassMatrixDeniesControlPlaneForDelivery(t *testing.T) {
+	inter := NewIntermediary([]Policy{{
+		Name:  "allow-all",
+		Rules: []Rule{{Action: "*", Resource: "*", Effect: Allow}},
+	}}, newTestAuditLog(t), &mockExecutor{})
+
+	result := inter.Evaluate(Intent{Action: "file_write", Resource: ".xylem/HARNESS.md", AgentID: "a"})
+	if result.Effect != Deny {
+		t.Fatalf("effect: got %q, want %q", result.Effect, Deny)
+	}
+	if result.Operation != string(policy.OpWriteControlPlane) {
+		t.Fatalf("operation: got %q, want %q", result.Operation, policy.OpWriteControlPlane)
+	}
+	if result.RuleMatched != "delivery.write_control_plane.deny" {
+		t.Fatalf("ruleMatched: got %q", result.RuleMatched)
+	}
+}
+
+func TestEvaluate_ClassMatrixAllowsHarnessMaintenanceControlPlaneWithAudit(t *testing.T) {
+	inter := NewIntermediary([]Policy{{
+		Name:  "allow-all",
+		Rules: []Rule{{Action: "*", Resource: "*", Effect: Allow}},
+	}}, newTestAuditLog(t), &mockExecutor{}).WithWorkflowClass(policy.HarnessMaintenance)
+
+	result := inter.Evaluate(Intent{Action: "file_write", Resource: ".xylem/HARNESS.md", AgentID: "a"})
+	if result.Effect != Allow {
+		t.Fatalf("effect: got %q, want %q", result.Effect, Allow)
+	}
+	if !result.Audit {
+		t.Fatal("Audit = false, want true")
+	}
+	if result.RuleMatched != "harness-maintenance.write_control_plane.allow" {
+		t.Fatalf("ruleMatched: got %q", result.RuleMatched)
+	}
+}
+
+func TestSmoke_S1_DeliveryControlPlaneWriteDeniedWithAuditEntry(t *testing.T) {
+	exec := &mockExecutor{}
+	al := newTestAuditLog(t)
+	inter := NewIntermediary([]Policy{{
+		Name:  "allow-all",
+		Rules: []Rule{{Action: "*", Resource: "*", Effect: Allow}},
+	}}, al, exec).WithWorkflowClass(policy.Delivery)
+
+	effect, err := inter.Submit(context.Background(), Intent{
+		Action:        "file_write",
+		Resource:      ".xylem/HARNESS.md",
+		AgentID:       "vessel-delivery",
+		Justification: "attempt control-plane edit",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, Deny, effect)
+	assert.Equal(t, 0, exec.calls())
+
+	entries, readErr := al.Entries()
+	require.NoError(t, readErr)
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	assert.Equal(t, Deny, entry.Decision)
+	assert.Equal(t, string(policy.Delivery), entry.WorkflowClass)
+	assert.Equal(t, string(policy.OpWriteControlPlane), entry.Operation)
+	assert.Equal(t, "delivery.write_control_plane.deny", entry.RuleMatched)
+	assert.Equal(t, ".xylem/HARNESS.md", entry.FilePath)
+	assert.Equal(t, "vessel-delivery", entry.VesselID)
+	assert.False(t, entry.Audit)
+}
+
+func TestSmoke_S2_HarnessMaintenanceControlPlaneWriteAllowedWithAuditEntry(t *testing.T) {
+	exec := &mockExecutor{}
+	al := newTestAuditLog(t)
+	inter := NewIntermediary([]Policy{{
+		Name:  "allow-all",
+		Rules: []Rule{{Action: "*", Resource: "*", Effect: Allow}},
+	}}, al, exec).WithWorkflowClass(policy.HarnessMaintenance)
+
+	effect, err := inter.Submit(context.Background(), Intent{
+		Action:        "file_write",
+		Resource:      ".xylem/HARNESS.md",
+		AgentID:       "vessel-maintenance",
+		Justification: "update harness instructions",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, Allow, effect)
+	assert.Equal(t, 1, exec.calls())
+
+	entries, readErr := al.Entries()
+	require.NoError(t, readErr)
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	assert.Equal(t, Allow, entry.Decision)
+	assert.Equal(t, string(policy.HarnessMaintenance), entry.WorkflowClass)
+	assert.Equal(t, string(policy.OpWriteControlPlane), entry.Operation)
+	assert.Equal(t, "harness-maintenance.write_control_plane.allow", entry.RuleMatched)
+	assert.Equal(t, ".xylem/HARNESS.md", entry.FilePath)
+	assert.Equal(t, "vessel-maintenance", entry.VesselID)
+	assert.True(t, entry.Audit)
+}
+
+func TestEvaluate_UserRulesCannotLoosenClassMatrix(t *testing.T) {
+	inter := NewIntermediary([]Policy{{
+		Name:  "allow-all",
+		Rules: []Rule{{Action: "*", Resource: "*", Effect: Allow}},
+	}}, newTestAuditLog(t), &mockExecutor{}).WithWorkflowClass(policy.Delivery)
+
+	result := inter.Evaluate(Intent{Action: "file_write", Resource: ".xylem.yml", AgentID: "a"})
+	if result.Effect != Deny {
+		t.Fatalf("effect: got %q, want %q", result.Effect, Deny)
+	}
+	if result.MatchedRule != nil {
+		t.Fatalf("MatchedRule = %#v, want nil because matrix denial should happen before glob rules", result.MatchedRule)
+	}
+}
+
+func TestSmoke_S3_UserGlobRulesCannotLoosenWorkflowClassMatrix(t *testing.T) {
+	exec := &mockExecutor{}
+	al := newTestAuditLog(t)
+	inter := NewIntermediary([]Policy{{
+		Name:  "allow-all",
+		Rules: []Rule{{Action: "*", Resource: "*", Effect: Allow}},
+	}}, al, exec).WithWorkflowClass(policy.Delivery)
+
+	effect, err := inter.Submit(context.Background(), Intent{
+		Action:        "file_write",
+		Resource:      ".xylem/HARNESS.md",
+		AgentID:       "vessel-tighten-only",
+		Justification: "user policy must not bypass class matrix",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, Deny, effect)
+	assert.Equal(t, 0, exec.calls())
+
+	entries, readErr := al.Entries()
+	require.NoError(t, readErr)
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	assert.Equal(t, Deny, entry.Decision)
+	assert.Equal(t, "delivery.write_control_plane.deny", entry.RuleMatched)
+	assert.Equal(t, string(policy.Delivery), entry.WorkflowClass)
+}
+
+func TestSubmit_AuditEntryIncludesWorkflowClassOperationAndPath(t *testing.T) {
+	al := newTestAuditLog(t)
+	inter := NewIntermediary([]Policy{{
+		Name:  "allow-all",
+		Rules: []Rule{{Action: "*", Resource: "*", Effect: Allow}},
+	}}, al, &mockExecutor{}).WithWorkflowClass(policy.HarnessMaintenance)
+
+	_, err := inter.Submit(context.Background(), Intent{
+		Action:   "file_write",
+		Resource: ".xylem/HARNESS.md",
+		AgentID:  "vessel-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries, err := al.Entries()
+	if err != nil {
+		t.Fatalf("read audit: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries: got %d, want 1", len(entries))
+	}
+	entry := entries[0]
+	if entry.WorkflowClass != string(policy.HarnessMaintenance) {
+		t.Fatalf("WorkflowClass = %q", entry.WorkflowClass)
+	}
+	if entry.Operation != string(policy.OpWriteControlPlane) {
+		t.Fatalf("Operation = %q", entry.Operation)
+	}
+	if entry.RuleMatched != "harness-maintenance.write_control_plane.allow" {
+		t.Fatalf("RuleMatched = %q", entry.RuleMatched)
+	}
+	if entry.FilePath != ".xylem/HARNESS.md" {
+		t.Fatalf("FilePath = %q", entry.FilePath)
+	}
+	if entry.VesselID != "vessel-1" {
+		t.Fatalf("VesselID = %q", entry.VesselID)
+	}
+	if !entry.Audit {
+		t.Fatal("Audit = false, want true")
 	}
 }
 

--- a/cli/internal/policy/policy.go
+++ b/cli/internal/policy/policy.go
@@ -1,0 +1,170 @@
+package policy
+
+import "path/filepath"
+
+// Class is the workflow policy class.
+type Class string
+
+const (
+	Delivery           Class = "delivery"
+	HarnessMaintenance Class = "harness-maintenance"
+	Ops                Class = "ops"
+)
+
+// Mode controls whether policy violations are warnings or hard failures.
+type Mode string
+
+const (
+	ModeWarn    Mode = "warn"
+	ModeEnforce Mode = "enforce"
+)
+
+// Operation is a class-matrix operation.
+type Operation string
+
+const (
+	OpWriteControlPlane   Operation = "write_control_plane"
+	OpCommitDefaultBranch Operation = "commit_default_branch"
+	OpPushBranch          Operation = "push_branch"
+	OpCreatePR            Operation = "create_pr"
+	OpMergePR             Operation = "merge_pr"
+	OpReloadDaemon        Operation = "reload_daemon"
+	OpReadSecrets         Operation = "read_secrets"
+)
+
+// Decision is the result of evaluating a workflow class against an operation.
+type Decision struct {
+	Allowed bool
+	Rule    string
+	Audit   bool
+}
+
+// NormalizeClass returns a valid class, defaulting to delivery.
+func NormalizeClass(value string) Class {
+	switch Class(value) {
+	case Delivery, HarnessMaintenance, Ops:
+		return Class(value)
+	default:
+		return Delivery
+	}
+}
+
+// Valid reports whether the class is recognized.
+func (c Class) Valid() bool {
+	switch c {
+	case Delivery, HarnessMaintenance, Ops:
+		return true
+	default:
+		return false
+	}
+}
+
+// NormalizeMode returns a valid policy mode, defaulting to enforce.
+func NormalizeMode(value string) Mode {
+	switch Mode(value) {
+	case ModeWarn, ModeEnforce:
+		return Mode(value)
+	default:
+		return ModeEnforce
+	}
+}
+
+// Valid reports whether the mode is recognized.
+func (m Mode) Valid() bool {
+	switch m {
+	case ModeWarn, ModeEnforce:
+		return true
+	default:
+		return false
+	}
+}
+
+// Evaluate applies the authoritative workflow-class matrix.
+func Evaluate(class Class, operation Operation) Decision {
+	class = NormalizeClass(string(class))
+	switch operation {
+	case "":
+		return Decision{Allowed: true}
+	case OpWriteControlPlane:
+		switch class {
+		case HarnessMaintenance:
+			return Decision{Allowed: true, Rule: "harness-maintenance.write_control_plane.allow", Audit: true}
+		case Delivery:
+			return Decision{Rule: "delivery.write_control_plane.deny"}
+		case Ops:
+			return Decision{Rule: "ops.write_control_plane.deny"}
+		}
+	case OpCommitDefaultBranch:
+		return Decision{Rule: "policy.class.no-main-commits"}
+	case OpPushBranch:
+		return Decision{Allowed: true, Rule: string(class) + ".push_branch.allow"}
+	case OpCreatePR:
+		return Decision{Allowed: true, Rule: string(class) + ".create_pr.allow"}
+	case OpMergePR:
+		if class == Ops {
+			return Decision{Allowed: true, Rule: "ops.merge_pr.allow"}
+		}
+		return Decision{Rule: string(class) + ".merge_pr.deny"}
+	case OpReloadDaemon:
+		if class == Ops {
+			return Decision{Allowed: true, Rule: "ops.reload_daemon.allow"}
+		}
+		return Decision{Rule: string(class) + ".reload_daemon.deny"}
+	case OpReadSecrets:
+		return Decision{Rule: string(class) + ".read_secrets.deny"}
+	}
+	return Decision{Allowed: true}
+}
+
+// OperationFromActionResource maps an intermediary action/resource pair to a
+// workflow-class matrix operation.
+func OperationFromActionResource(action, resource string) Operation {
+	switch action {
+	case "file_write":
+		if IsControlPlanePath(resource) {
+			return OpWriteControlPlane
+		}
+	case "git_push":
+		return OpPushBranch
+	case "pr_create":
+		return OpCreatePR
+	case "merge_pr", "pr_merge":
+		return OpMergePR
+	case "daemon_reload":
+		return OpReloadDaemon
+	case "file_read":
+		if IsSecretPath(resource) {
+			return OpReadSecrets
+		}
+	}
+	return ""
+}
+
+// IsControlPlanePath reports whether a path belongs to xylem's control plane.
+func IsControlPlanePath(path string) bool {
+	switch path {
+	case ".xylem/HARNESS.md", ".xylem.yml":
+		return true
+	}
+	if matched, err := filepath.Match(".xylem/workflows/*", path); err == nil && matched {
+		return true
+	}
+	if matched, err := filepath.Match(".xylem/prompts/*/*.md", path); err == nil && matched {
+		return true
+	}
+	return false
+}
+
+// IsSecretPath reports whether a path targets a secrets surface.
+func IsSecretPath(path string) bool {
+	switch {
+	case path == ".env", filepath.Base(path) == ".env", filepath.Base(path) == ".env.local":
+		return true
+	case filepath.Base(path) == ".netrc":
+		return true
+	case path == "~/.aws", path == "~/.ssh", path == "~/.gnupg", path == "~/.docker/config.json":
+		return true
+	default:
+		return false
+	}
+}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/orchestrator"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
@@ -659,7 +660,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if wErr := os.WriteFile(filepath.Join(phasesDir, p.Name+".command"), []byte(rendered), 0o644); wErr != nil {
 					log.Printf("warn: write command file: %v", wErr)
 				}
-				if policyErr := r.enforcePhasePolicy(vessel, p, rendered, ""); policyErr != nil {
+				if policyErr := r.enforcePhasePolicy(ctx, vessel, sk, p, worktreePath, rendered, ""); policyErr != nil {
 					finishCurrentPhaseSpan(policyErr)
 					log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
 					vessel.FailedPhase = p.Name
@@ -721,7 +722,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if wErr := os.WriteFile(promptPath, []byte(rendered), 0o644); wErr != nil {
 					log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
 				}
-				if policyErr := r.enforcePhasePolicy(vessel, p, "", promptTemplate); policyErr != nil {
+				if policyErr := r.enforcePhasePolicy(ctx, vessel, sk, p, worktreePath, "", promptTemplate); policyErr != nil {
 					finishCurrentPhaseSpan(policyErr)
 					log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
 					vessel.FailedPhase = p.Name
@@ -1947,7 +1948,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if wErr := os.WriteFile(filepath.Join(phasesDir, p.Name+".command"), []byte(rendered), 0o644); wErr != nil {
 				log.Printf("warn: write command file: %v", wErr)
 			}
-			if policyErr := r.enforcePhasePolicy(vessel, p, rendered, ""); policyErr != nil {
+			if policyErr := r.enforcePhasePolicy(ctx, vessel, wf, p, worktreePath, rendered, ""); policyErr != nil {
 				finishCurrentPhaseSpan(policyErr)
 				log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
 				vessel.FailedPhase = p.Name
@@ -2008,7 +2009,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if wErr := os.WriteFile(promptPath, []byte(rendered), 0o644); wErr != nil {
 				log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
 			}
-			if policyErr := r.enforcePhasePolicy(vessel, p, "", promptTemplate); policyErr != nil {
+			if policyErr := r.enforcePhasePolicy(ctx, vessel, wf, p, worktreePath, "", promptTemplate); policyErr != nil {
 				finishCurrentPhaseSpan(policyErr)
 				log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
 				vessel.FailedPhase = p.Name
@@ -2585,18 +2586,22 @@ func phaseActionType(p *workflow.Phase) string {
 	return "phase_execute"
 }
 
-func (r *Runner) enforcePhasePolicy(vessel queue.Vessel, p workflow.Phase, renderedCommand, renderedPrompt string) error {
+func (r *Runner) enforcePhasePolicy(ctx context.Context, vessel queue.Vessel, sk *workflow.Workflow, p workflow.Phase, worktreePath, renderedCommand, renderedPrompt string) error {
+	workflowClass := policy.Delivery
+	if sk != nil {
+		workflowClass = policy.NormalizeClass(sk.Class)
+	}
+	if err := r.guardDefaultBranchPush(ctx, vessel, p, workflowClass, worktreePath, renderedCommand, renderedPrompt); err != nil {
+		return err
+	}
 	if r.Intermediary == nil {
 		return nil
 	}
 
+	inter := r.Intermediary.WithWorkflowClass(workflowClass)
 	for _, intent := range r.phasePolicyIntents(vessel, p, renderedCommand, renderedPrompt) {
-		result := r.Intermediary.Evaluate(intent)
-		entry := intermediary.AuditEntry{
-			Intent:    intent,
-			Decision:  result.Effect,
-			Timestamp: time.Now().UTC(),
-		}
+		result := inter.Evaluate(intent)
+		entry := r.policyAuditEntry(vessel, workflowClass, intent, result, "")
 		if result.Effect != intermediary.Allow {
 			entry.Error = result.Reason
 		}
@@ -2604,6 +2609,10 @@ func (r *Runner) enforcePhasePolicy(vessel queue.Vessel, p workflow.Phase, rende
 			return fmt.Errorf("record audit evidence: %w", err)
 		}
 		if result.Effect != intermediary.Allow {
+			if r.Config != nil && r.Config.HarnessPolicyMode() == policy.ModeWarn {
+				log.Printf("%sphase %q policy warning: %v", vesselLabel(vessel), p.Name, formatPolicyDecisionError(p.Name, intent, result))
+				continue
+			}
 			return formatPolicyDecisionError(p.Name, intent, result)
 		}
 	}
@@ -2689,6 +2698,77 @@ func phaseIntentMetadata(vessel queue.Vessel, p workflow.Phase, classifiedFrom s
 	return metadata
 }
 
+func (r *Runner) policyAuditEntry(vessel queue.Vessel, workflowClass policy.Class, intent intermediary.Intent, result intermediary.PolicyResult, filePath string) intermediary.AuditEntry {
+	entry := intermediary.AuditEntry{
+		Intent:        intent,
+		Decision:      result.Effect,
+		Timestamp:     time.Now().UTC(),
+		Audit:         result.Audit,
+		WorkflowClass: string(workflowClass),
+		Operation:     result.Operation,
+		RuleMatched:   result.RuleMatched,
+		VesselID:      vessel.ID,
+	}
+	if filePath != "" {
+		entry.FilePath = filePath
+	} else if intent.Action == "file_write" {
+		entry.FilePath = intent.Resource
+	}
+	return entry
+}
+
+func (r *Runner) guardDefaultBranchPush(ctx context.Context, vessel queue.Vessel, p workflow.Phase, workflowClass policy.Class, worktreePath, renderedCommand, renderedPrompt string) error {
+	if workflowClass != policy.HarnessMaintenance {
+		return nil
+	}
+	branch := extractGitPushResource(renderedCommand)
+	if branch == "*" {
+		branch = extractGitPushResource(renderedPrompt)
+	}
+	if branch == "*" || strings.TrimSpace(branch) == "" {
+		return nil
+	}
+
+	defaultBranch := ""
+	if r.Config != nil {
+		defaultBranch = strings.TrimSpace(r.Config.DefaultBranch)
+	}
+	if defaultBranch == "" && strings.TrimSpace(worktreePath) != "" {
+		detected, err := r.detectDefaultBranchAtPath(ctx, worktreePath)
+		if err == nil {
+			defaultBranch = detected
+		}
+	}
+	if defaultBranch == "" || branch != defaultBranch {
+		return nil
+	}
+
+	result := intermediary.PolicyResult{
+		Effect:      intermediary.Deny,
+		Reason:      `matched workflow class rule "policy.class.no-main-commits"`,
+		Operation:   string(policy.OpCommitDefaultBranch),
+		RuleMatched: "policy.class.no-main-commits",
+	}
+	intent := intermediary.Intent{
+		Action:        "git_push",
+		Resource:      branch,
+		AgentID:       vessel.ID,
+		Justification: fmt.Sprintf("phase %q may push to %s", p.Name, branch),
+		Metadata:      phaseIntentMetadata(vessel, p, "command"),
+	}
+	entry := r.policyAuditEntry(vessel, workflowClass, intent, result, "")
+	entry.Error = result.Reason
+	if err := r.appendAuditEntry(entry); err != nil {
+		return fmt.Errorf("record audit evidence: %w", err)
+	}
+	err := formatPolicyDecisionError(p.Name, intent, result)
+	if r.Config != nil && r.Config.HarnessPolicyMode() == policy.ModeWarn {
+		log.Printf("%sphase %q policy warning: %v", vesselLabel(vessel), p.Name, err)
+		return nil
+	}
+	return err
+}
+
 func formatPolicyDecisionError(phaseName string, intent intermediary.Intent, result intermediary.PolicyResult) error {
 	qualifier := ""
 	if intent.Action != "" && intent.Action != "phase_execute" && intent.Action != "external_command" {
@@ -2756,7 +2836,7 @@ func extractGitPushResource(rendered string) string {
 			if strings.HasPrefix(token, "-") {
 				continue
 			}
-			positional = append(positional, token)
+			positional = append(positional, normalizeGitPushTarget(token))
 			if len(positional) == 2 {
 				return positional[1]
 			}
@@ -2764,6 +2844,22 @@ func extractGitPushResource(rendered string) string {
 		return "*"
 	}
 	return "*"
+}
+
+func normalizeGitPushTarget(token string) string {
+	token = strings.Trim(strings.TrimSpace(token), "\"'")
+	if token == "" {
+		return "*"
+	}
+	token = strings.TrimPrefix(token, "+")
+	if idx := strings.LastIndex(token, ":"); idx >= 0 {
+		token = token[idx+1:]
+	}
+	token = strings.TrimPrefix(token, "refs/heads/")
+	if token == "" {
+		return "*"
+	}
+	return token
 }
 
 func extractRepoFlag(rendered, fallback string) string {
@@ -2863,12 +2959,18 @@ func (r *Runner) verifyProtectedSurfaces(vessel queue.Vessel, p workflow.Phase, 
 	}
 
 	violations := surface.Compare(before, after)
-	policy, err := r.workflowProtectedWritePolicy(vessel, violations)
+	workflowClass := policy.Delivery
+	if strings.TrimSpace(vessel.Workflow) != "" {
+		if sk, loadErr := r.loadWorkflow(vessel.Workflow); loadErr == nil {
+			workflowClass = policy.NormalizeClass(sk.Class)
+		}
+	}
+	policyCfg, err := r.workflowProtectedWritePolicy(vessel, violations)
 	if err != nil {
 		return fmt.Errorf("resolve protected surface policy: %w", err)
 	}
-	violations = filterAdditiveProtectedSurfaceViolations(violations, policy.allowAdditive)
-	violations = filterCanonicalProtectedSurfaceViolations(vessel, p, violations, policy.allowCanonical)
+	violations = filterAdditiveProtectedSurfaceViolations(violations, policyCfg.allowAdditive)
+	violations = filterCanonicalProtectedSurfaceViolations(vessel, p, violations, policyCfg.allowCanonical)
 
 	// Source-root alignment filter: drop modification violations where the
 	// after-hash matches the canonical source root's current hash for that
@@ -2906,13 +3008,86 @@ func (r *Runner) verifyProtectedSurfaces(vessel queue.Vessel, p workflow.Phase, 
 		}
 	}
 
+	allowedControlPlane := make(map[string]intermediary.PolicyResult)
+	deniedControlPlane := make(map[string]intermediary.PolicyResult)
+	if len(violations) > 0 {
+		inter := r.Intermediary
+		if inter != nil {
+			inter = inter.WithWorkflowClass(workflowClass)
+		}
+		filtered := make([]surface.Violation, 0, len(violations))
+		for _, violation := range violations {
+			if !policy.IsControlPlanePath(violation.Path) {
+				filtered = append(filtered, violation)
+				continue
+			}
+			intent := intermediary.Intent{
+				Action:        "file_write",
+				Resource:      violation.Path,
+				AgentID:       vessel.ID,
+				Justification: fmt.Sprintf("verify protected surfaces after phase %q", p.Name),
+				Metadata: map[string]string{
+					"phase":    p.Name,
+					"before":   violation.Before,
+					"after":    violation.After,
+					"source":   vessel.Source,
+					"workflow": vessel.Workflow,
+				},
+			}
+			result := intermediary.PolicyResult{
+				Effect:      intermediary.Deny,
+				Reason:      `matched workflow class rule "delivery.write_control_plane.deny"`,
+				Operation:   string(policy.OpWriteControlPlane),
+				RuleMatched: string(workflowClass) + ".write_control_plane.deny",
+			}
+			if inter != nil {
+				result = inter.Evaluate(intent)
+			} else {
+				decision := policy.Evaluate(workflowClass, policy.OpWriteControlPlane)
+				result.Reason = fmt.Sprintf("matched workflow class rule %q", decision.Rule)
+				result.RuleMatched = decision.Rule
+				result.Audit = decision.Audit
+				if decision.Allowed {
+					result.Effect = intermediary.Allow
+				}
+			}
+			if result.Effect == intermediary.Allow {
+				allowedControlPlane[violation.Path] = result
+				continue
+			}
+			deniedControlPlane[violation.Path] = result
+			filtered = append(filtered, violation)
+		}
+		violations = filtered
+	}
+	for path, result := range allowedControlPlane {
+		entry := r.policyAuditEntry(vessel, workflowClass, intermediary.Intent{
+			Action:        "file_write",
+			Resource:      path,
+			AgentID:       vessel.ID,
+			Justification: fmt.Sprintf("verify protected surfaces after phase %q", p.Name),
+			Metadata: map[string]string{
+				"phase":    p.Name,
+				"source":   vessel.Source,
+				"workflow": vessel.Workflow,
+			},
+		}, result, path)
+		if err := r.appendAuditEntry(entry); err != nil {
+			return fmt.Errorf("record audit evidence: %w", err)
+		}
+	}
+
 	if len(violations) == 0 {
 		return nil
 	}
 
 	errMsg := fmt.Sprintf("phase %q violated protected surfaces: %s", p.Name, formatViolations(violations))
-	if err := r.recordProtectedSurfaceViolations(vessel, p, errMsg, violations); err != nil {
+	if err := r.recordProtectedSurfaceViolations(vessel, workflowClass, p, errMsg, violations, deniedControlPlane); err != nil {
 		return fmt.Errorf("%s (record audit evidence: %w)", errMsg, err)
+	}
+	if r.Config != nil && r.Config.HarnessPolicyMode() == policy.ModeWarn {
+		log.Printf("%sphase %q policy warning: %s", vesselLabel(vessel), p.Name, errMsg)
+		return nil
 	}
 	if err := r.restoreDeletedProtectedSurfaces(context.Background(), worktreePath, violations); err != nil {
 		log.Printf("%sphase %q protected surface self-heal failed: %v", vesselLabel(vessel), p.Name, err)
@@ -3301,26 +3476,30 @@ func (r *Runner) detectDefaultBranchAtPath(ctx context.Context, worktreePath str
 	return "", fmt.Errorf("could not detect default branch from origin")
 }
 
-func (r *Runner) recordProtectedSurfaceViolations(vessel queue.Vessel, p workflow.Phase, errMsg string, violations []surface.Violation) error {
+func (r *Runner) recordProtectedSurfaceViolations(vessel queue.Vessel, workflowClass policy.Class, p workflow.Phase, errMsg string, violations []surface.Violation, decisions map[string]intermediary.PolicyResult) error {
 	for _, violation := range violations {
-		if err := r.appendAuditEntry(intermediary.AuditEntry{
-			Intent: intermediary.Intent{
-				Action:        "file_write",
-				Resource:      violation.Path,
-				AgentID:       vessel.ID,
-				Justification: fmt.Sprintf("verify protected surfaces after phase %q", p.Name),
-				Metadata: map[string]string{
-					"phase":    p.Name,
-					"before":   violation.Before,
-					"after":    violation.After,
-					"source":   vessel.Source,
-					"workflow": vessel.Workflow,
-				},
+		intent := intermediary.Intent{
+			Action:        "file_write",
+			Resource:      violation.Path,
+			AgentID:       vessel.ID,
+			Justification: fmt.Sprintf("verify protected surfaces after phase %q", p.Name),
+			Metadata: map[string]string{
+				"phase":    p.Name,
+				"before":   violation.Before,
+				"after":    violation.After,
+				"source":   vessel.Source,
+				"workflow": vessel.Workflow,
 			},
-			Decision:  intermediary.Deny,
-			Timestamp: time.Now().UTC(),
-			Error:     errMsg,
-		}); err != nil {
+		}
+		result, ok := decisions[violation.Path]
+		if !ok {
+			result = intermediary.PolicyResult{
+				Effect: intermediary.Deny,
+			}
+		}
+		entry := r.policyAuditEntry(vessel, workflowClass, intent, result, violation.Path)
+		entry.Error = errMsg
+		if err := r.appendAuditEntry(entry); err != nil {
 			return fmt.Errorf("append surface violation audit for %s: %w", violation.Path, err)
 		}
 	}

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
+	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/surface"
@@ -229,6 +231,43 @@ func TestProp_BudgetExceededIsMonotonic(t *testing.T) {
 			if exceeded && !tracker.BudgetExceeded() {
 				t.Fatal("BudgetExceeded reverted to false")
 			}
+		}
+	})
+}
+
+func TestProp_DefaultBranchPushGuardMatchesClassAndTarget(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		class := rapid.SampledFrom([]policy.Class{policy.Delivery, policy.HarnessMaintenance, policy.Ops}).Draw(t, "class")
+		target := rapid.SampledFrom([]string{"main", "feature-1", "release"}).Draw(t, "target")
+
+		dir, err := os.MkdirTemp("", "runner-push-guard-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(dir)
+
+		cfg := makeTestConfig(dir, 1)
+		cfg.DefaultBranch = "main"
+		cfg.StateDir = filepath.Join(dir, ".xylem-state")
+		if err := os.MkdirAll(cfg.StateDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+
+		r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{path: dir}, &mockCmdRunner{})
+		r.AuditLog = intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+
+		err = r.enforcePhasePolicy(context.Background(), queue.Vessel{
+			ID:       "issue-1",
+			Source:   "github-issue",
+			Workflow: "wf",
+		}, &workflow.Workflow{
+			Name:  "wf",
+			Class: string(class),
+		}, workflow.Phase{Name: "publish", Type: "command"}, dir, "git push origin "+target, "")
+
+		wantErr := class == policy.HarnessMaintenance && target == "main"
+		if (err != nil) != wantErr {
+			t.Fatalf("enforcePhasePolicy() error = %v, want error=%t for class=%q target=%q", err, wantErr, class, target)
 		}
 	})
 }

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/surface"
@@ -455,8 +456,18 @@ func TestBuildCommand(t *testing.T) {
 	}
 }
 
+type testWorkflowOptions struct {
+	class                         string
+	allowAdditiveProtectedWrites  bool
+	allowCanonicalProtectedWrites bool
+}
+
 // writeWorkflowFile creates a workflow YAML and its prompt files in the given dir.
 func writeWorkflowFile(t *testing.T, dir, name string, phases []testPhase) {
+	writeWorkflowFileWithOptions(t, dir, name, testWorkflowOptions{}, phases)
+}
+
+func writeWorkflowFileWithOptions(t *testing.T, dir, name string, opts testWorkflowOptions, phases []testPhase) {
 	t.Helper()
 	workflowDir := filepath.Join(dir, ".xylem", "workflows")
 	os.MkdirAll(workflowDir, 0o755)
@@ -494,7 +505,19 @@ func writeWorkflowFile(t *testing.T, dir, name string, phases []testPhase) {
 		}
 	}
 
-	workflowContent := fmt.Sprintf("name: %s\nphases:\n%s", name, phaseYAML.String())
+	var workflowHeader strings.Builder
+	fmt.Fprintf(&workflowHeader, "name: %s\n", name)
+	if opts.class != "" {
+		fmt.Fprintf(&workflowHeader, "class: %s\n", opts.class)
+	}
+	if opts.allowAdditiveProtectedWrites {
+		workflowHeader.WriteString("allow_additive_protected_writes: true\n")
+	}
+	if opts.allowCanonicalProtectedWrites {
+		workflowHeader.WriteString("allow_canonical_protected_writes: true\n")
+	}
+	workflowHeader.WriteString("phases:\n")
+	workflowContent := workflowHeader.String() + phaseYAML.String()
 	os.WriteFile(filepath.Join(workflowDir, name+".yaml"), []byte(workflowContent), 0o644)
 }
 
@@ -857,6 +880,25 @@ func TestPhasePolicyIntents_ClassifiesHighRiskCommandActions(t *testing.T) {
 	assert.Equal(t, "pr_create", intents[3].Action)
 	assert.Equal(t, "owner/repo", intents[3].Resource)
 	assert.Equal(t, "command", intents[1].Metadata["classified_from"])
+}
+
+func TestPhasePolicyIntents_ExtractsRefspecTargetBranch(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	r := New(cfg, nil, nil, nil)
+	vessel := queue.Vessel{
+		ID:       "issue-1",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Meta:     map[string]string{"config_source": "github"},
+	}
+	phaseDef := workflow.Phase{Name: "publish", Type: "command"}
+
+	intents := r.phasePolicyIntents(vessel, phaseDef, `git push origin HEAD:refs/heads/main`, "")
+	require.Len(t, intents, 2)
+
+	assert.Equal(t, "git_push", intents[1].Action)
+	assert.Equal(t, "main", intents[1].Resource)
 }
 
 func TestPhasePolicyIntents_ClassifiesHighRiskPromptActions(t *testing.T) {
@@ -6142,12 +6184,39 @@ func TestSmoke_S21_SurfacePostVerificationAllowsReferencedCanonicalProtectedWrit
 }
 
 func TestSmoke_S23_AuditLogRecordsDeniedCanonicalProtectedWriteWithoutIssuePathReference(t *testing.T) {
-	r, auditLog, worktreeDir, protectedPath, before := setupCanonicalProtectedWriteSmokeTest(t)
+	repoRoot := t.TempDir()
+	withTestWorkingDir(t, repoRoot)
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".xylem", "workflows"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".xylem", "prompts", "doctor"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".xylem", "prompts", "doctor", "analyze.md"), []byte("analyze"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".xylem", "workflows", "doctor.yaml"), []byte(`name: doctor
+class: delivery
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/doctor/analyze.md
+    max_turns: 1
+`), 0o644))
+
+	worktreeDir := filepath.Join(repoRoot, "worktree")
+	protectedPath := filepath.Join(worktreeDir, ".xylem", "workflows", "doctor.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(protectedPath), 0o755))
+	require.NoError(t, os.WriteFile(protectedPath, []byte("name: doctor\nphases: []\n"), 0o644))
+
+	cfg := makeTestConfig(repoRoot, 1)
+	cfg.StateDir = filepath.Join(repoRoot, ".xylem-state")
+	require.NoError(t, os.MkdirAll(cfg.StateDir, 0o755))
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	r := New(cfg, queue.New(filepath.Join(repoRoot, "queue.jsonl")), &mockWorktree{path: worktreeDir}, &mockCmdRunner{})
+	r.AuditLog = auditLog
+
+	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), worktreeDir)
+	require.NoError(t, err)
+	require.True(t, ok)
 
 	modifiedContents := "name: doctor\nupdated: true\n"
 	require.NoError(t, os.WriteFile(protectedPath, []byte(modifiedContents), 0o644))
 
-	err := r.verifyProtectedSurfaces(
+	err = r.verifyProtectedSurfaces(
 		queue.Vessel{
 			ID:       "issue-canonical-denied",
 			Source:   "github-issue",
@@ -6170,6 +6239,187 @@ func TestSmoke_S23_AuditLogRecordsDeniedCanonicalProtectedWriteWithoutIssuePathR
 	assert.Equal(t, "file_write", entries[0].Intent.Action)
 	assert.Equal(t, ".xylem/workflows/doctor.yaml", entries[0].Intent.Resource)
 	assert.Equal(t, intermediary.Deny, entries[0].Decision)
+	assert.Equal(t, string(policy.Delivery), entries[0].WorkflowClass)
+	assert.Equal(t, "write_control_plane", entries[0].Operation)
+	assert.Equal(t, "delivery.write_control_plane.deny", entries[0].RuleMatched)
+}
+
+func TestSmoke_WorkflowClassHarnessMaintenanceProtectedWriteAllowedWithAudit(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem-state")
+	require.NoError(t, os.MkdirAll(cfg.StateDir, 0o755))
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{path: dir}, &mockCmdRunner{})
+	r.AuditLog = auditLog
+
+	withTestWorkingDir(t, dir)
+	writeWorkflowFileWithOptions(t, dir, "implement-harness", testWorkflowOptions{class: string(policy.HarnessMaintenance)}, []testPhase{
+		{name: "implement", promptContent: "Update harness", maxTurns: 1},
+	})
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".xylem"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem", "HARNESS.md"), []byte("before\n"), 0o644))
+
+	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), dir)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem", "HARNESS.md"), []byte("after\n"), 0o644))
+
+	err = r.verifyProtectedSurfaces(queue.Vessel{
+		ID:       "issue-allow",
+		Source:   "github-issue",
+		Workflow: "implement-harness",
+	}, workflow.Phase{Name: "implement"}, dir, before)
+	require.NoError(t, err)
+
+	entries, err := auditLog.Entries()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, intermediary.Allow, entries[0].Decision)
+	assert.Equal(t, string(policy.HarnessMaintenance), entries[0].WorkflowClass)
+	assert.Equal(t, "write_control_plane", entries[0].Operation)
+	assert.Equal(t, ".xylem/HARNESS.md", entries[0].FilePath)
+	assert.True(t, entries[0].Audit)
+}
+
+func TestSmoke_S4_HarnessMaintenancePushToDefaultBranchDeniedAtRunnerLayer(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem-state")
+	cfg.DefaultBranch = "main"
+	require.NoError(t, os.MkdirAll(cfg.StateDir, 0o755))
+
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{path: dir}, &mockCmdRunner{})
+	r.AuditLog = auditLog
+
+	err := r.enforcePhasePolicy(context.Background(), queue.Vessel{
+		ID:       "issue-push",
+		Source:   "github-issue",
+		Workflow: "implement-harness",
+	}, &workflow.Workflow{
+		Name:  "implement-harness",
+		Class: string(policy.HarnessMaintenance),
+	}, workflow.Phase{Name: "publish", Type: "command"}, dir, "git push origin main", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "denied by policy")
+
+	entries, readErr := auditLog.Entries()
+	require.NoError(t, readErr)
+	require.Len(t, entries, 1)
+	assert.Equal(t, intermediary.Deny, entries[0].Decision)
+	assert.Equal(t, "commit_default_branch", entries[0].Operation)
+	assert.Equal(t, "policy.class.no-main-commits", entries[0].RuleMatched)
+	assert.Equal(t, string(policy.HarnessMaintenance), entries[0].WorkflowClass)
+}
+
+func TestSmoke_HarnessMaintenancePushRefspecToDefaultBranchDeniedAtRunnerLayer(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem-state")
+	cfg.DefaultBranch = "main"
+	require.NoError(t, os.MkdirAll(cfg.StateDir, 0o755))
+
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{path: dir}, &mockCmdRunner{})
+	r.AuditLog = auditLog
+
+	err := r.enforcePhasePolicy(context.Background(), queue.Vessel{
+		ID:       "issue-push-refspec",
+		Source:   "github-issue",
+		Workflow: "implement-harness",
+	}, &workflow.Workflow{
+		Name:  "implement-harness",
+		Class: string(policy.HarnessMaintenance),
+	}, workflow.Phase{Name: "publish", Type: "command"}, dir, "git push origin HEAD:refs/heads/main", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "denied by policy")
+
+	entries, readErr := auditLog.Entries()
+	require.NoError(t, readErr)
+	require.Len(t, entries, 1)
+	assert.Equal(t, intermediary.Deny, entries[0].Decision)
+	assert.Equal(t, "main", entries[0].Intent.Resource)
+	assert.Equal(t, "commit_default_branch", entries[0].Operation)
+	assert.Equal(t, "policy.class.no-main-commits", entries[0].RuleMatched)
+	assert.Equal(t, string(policy.HarnessMaintenance), entries[0].WorkflowClass)
+}
+
+func TestSmoke_S5_WarnModeLogsProtectedWriteViolationWithoutFailing(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem-state")
+	cfg.Harness.Policy.Mode = string(policy.ModeWarn)
+	require.NoError(t, os.MkdirAll(cfg.StateDir, 0o755))
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{path: dir}, &mockCmdRunner{})
+	r.AuditLog = auditLog
+
+	withTestWorkingDir(t, dir)
+	writeWorkflowFileWithOptions(t, dir, "delivery-write", testWorkflowOptions{class: string(policy.Delivery)}, []testPhase{
+		{name: "implement", promptContent: "Update harness", maxTurns: 1},
+	})
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".xylem"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem", "HARNESS.md"), []byte("before\n"), 0o644))
+
+	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), dir)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem", "HARNESS.md"), []byte("after\n"), 0o644))
+
+	err = r.verifyProtectedSurfaces(queue.Vessel{
+		ID:       "issue-warn",
+		Source:   "github-issue",
+		Workflow: "delivery-write",
+	}, workflow.Phase{Name: "implement"}, dir, before)
+	require.NoError(t, err)
+
+	entries, readErr := auditLog.Entries()
+	require.NoError(t, readErr)
+	require.Len(t, entries, 1)
+	assert.Equal(t, intermediary.Deny, entries[0].Decision)
+	assert.Equal(t, "write_control_plane", entries[0].Operation)
+	assert.Equal(t, "delivery.write_control_plane.deny", entries[0].RuleMatched)
+}
+
+func TestSmoke_S6_EnforceModeFailsProtectedWriteViolation(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem-state")
+	cfg.Harness.Policy.Mode = string(policy.ModeEnforce)
+	require.NoError(t, os.MkdirAll(cfg.StateDir, 0o755))
+
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{path: dir}, &mockCmdRunner{})
+	r.AuditLog = auditLog
+
+	withTestWorkingDir(t, dir)
+	writeWorkflowFileWithOptions(t, dir, "delivery-write", testWorkflowOptions{class: string(policy.Delivery)}, []testPhase{
+		{name: "implement", promptContent: "Update harness", maxTurns: 1},
+	})
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".xylem"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem", "HARNESS.md"), []byte("before\n"), 0o644))
+
+	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), dir)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem", "HARNESS.md"), []byte("after\n"), 0o644))
+
+	err = r.verifyProtectedSurfaces(queue.Vessel{
+		ID:       "issue-enforce",
+		Source:   "github-issue",
+		Workflow: "delivery-write",
+	}, workflow.Phase{Name: "implement"}, dir, before)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "violated protected surfaces")
+
+	entries, readErr := auditLog.Entries()
+	require.NoError(t, readErr)
+	require.Len(t, entries, 1)
+	assert.Equal(t, intermediary.Deny, entries[0].Decision)
+	assert.Equal(t, string(policy.Delivery), entries[0].WorkflowClass)
+	assert.Equal(t, "write_control_plane", entries[0].Operation)
+	assert.Equal(t, "delivery.write_control_plane.deny", entries[0].RuleMatched)
 }
 
 func TestSmoke_S23_AuditLogRecordsDeniedAdditiveProtectedWriteWithoutWorkflowOptIn(t *testing.T) {

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"gopkg.in/yaml.v3"
 )
 
@@ -21,6 +22,7 @@ var validPhaseName = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 type Workflow struct {
 	Name                          string  `yaml:"name"`
 	Description                   string  `yaml:"description,omitempty"`
+	Class                         string  `yaml:"class,omitempty"`
 	LLM                           *string `yaml:"llm,omitempty"`
 	Model                         *string `yaml:"model,omitempty"`
 	AllowAdditiveProtectedWrites  bool    `yaml:"allow_additive_protected_writes,omitempty"`
@@ -152,6 +154,8 @@ func Load(path string) (*Workflow, error) {
 		return nil, fmt.Errorf("parse workflow yaml %q: %w", path, err)
 	}
 
+	s.normalizeClass()
+
 	if err := s.Validate(path); err != nil {
 		return nil, fmt.Errorf("validate workflow %q: %w", path, err)
 	}
@@ -164,6 +168,8 @@ func Load(path string) (*Workflow, error) {
 // filename. Prompt file paths are resolved relative to the current working
 // directory (repo root).
 func (s *Workflow) Validate(workflowFilePath string) error {
+	s.normalizeClass()
+
 	if s.Name == "" {
 		return fmt.Errorf(`"name" is required`)
 	}
@@ -179,6 +185,18 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 
 	if err := validateLLM(s.LLM, "workflow"); err != nil {
 		return err
+	}
+	if !policy.NormalizeClass(s.Class).Valid() || s.Class != string(policy.NormalizeClass(s.Class)) {
+		return fmt.Errorf("workflow class %q is invalid; must be delivery, harness-maintenance, or ops", s.Class)
+	}
+	switch policy.Class(s.Class) {
+	case policy.Delivery, policy.Ops:
+		if s.AllowAdditiveProtectedWrites {
+			return fmt.Errorf("workflow class %q must not set allow_additive_protected_writes", s.Class)
+		}
+		if s.AllowCanonicalProtectedWrites {
+			return fmt.Errorf("workflow class %q must not set allow_canonical_protected_writes", s.Class)
+		}
 	}
 
 	// Collect all phase names upfront for dependency reference validation.
@@ -263,6 +281,20 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 	}
 
 	return nil
+}
+
+func (s *Workflow) normalizeClass() {
+	if strings.TrimSpace(s.Class) != "" {
+		if policy.Class(s.Class).Valid() {
+			s.Class = string(policy.Class(s.Class))
+		}
+		return
+	}
+	if s.AllowAdditiveProtectedWrites || s.AllowCanonicalProtectedWrites {
+		s.Class = string(policy.HarnessMaintenance)
+		return
+	}
+	s.Class = string(policy.Delivery)
 }
 
 // HasDependencies returns true if any phase declares explicit depends_on.

--- a/cli/internal/workflow/workflow_prop_test.go
+++ b/cli/internal/workflow/workflow_prop_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"pgregory.net/rapid"
 )
 
@@ -76,6 +77,27 @@ func TestPropValidateGateAllowsEmptyEvidenceLevel(t *testing.T) {
 		})
 		if err != nil {
 			t.Fatalf("validateGate() error = %v for empty level", err)
+		}
+	})
+}
+
+func TestPropNormalizeClassMigratesLegacyProtectedWriteFlags(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		allowAdditive := rapid.Bool().Draw(t, "allowAdditive")
+		allowCanonical := rapid.Bool().Draw(t, "allowCanonical")
+		wf := &Workflow{
+			AllowAdditiveProtectedWrites:  allowAdditive,
+			AllowCanonicalProtectedWrites: allowCanonical,
+		}
+
+		wf.normalizeClass()
+
+		want := policy.Delivery
+		if allowAdditive || allowCanonical {
+			want = policy.HarnessMaintenance
+		}
+		if wf.Class != string(want) {
+			t.Fatalf("normalizeClass() = %q, want %q", wf.Class, want)
 		}
 	})
 }

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -221,6 +222,76 @@ phases:
 	got, err := Load(path)
 	require.NoError(t, err)
 	assert.True(t, got.AllowAdditiveProtectedWrites)
+}
+
+func TestLoadWorkflowClassDefaultsToDelivery(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, string(policy.Delivery), got.Class)
+}
+
+func TestLoadWorkflowMigratesLegacyProtectedWriteFlagsToHarnessMaintenance(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+allow_canonical_protected_writes: true
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, string(policy.HarnessMaintenance), got.Class)
+}
+
+func TestLoadWorkflowRejectsInvalidClass(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+class: unsupported
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`)
+
+	_, err := Load(path)
+	requireErrorContains(t, err, `workflow class "unsupported" is invalid`)
+}
+
+func TestLoadWorkflowRejectsProtectedWriteFlagsForDelivery(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+class: delivery
+allow_canonical_protected_writes: true
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`)
+
+	_, err := Load(path)
+	requireErrorContains(t, err, `workflow class "delivery" must not set allow_canonical_protected_writes`)
 }
 
 func TestLoadWorkflowAllowCanonicalProtectedWrites(t *testing.T) {


### PR DESCRIPTION
## Summary
Implements [issue #235](https://github.com/nicholls-inc/xylem/issues/235) by threading workflow classes through workflow loading, intermediary evaluation, runner phase enforcement, protected-surface verification, and the git push path. The change also extends `.xylem/audit.jsonl` entries with workflow class, operation, matched rule, file path, vessel ID, and audit markers, and adds `harness.policy.mode` warn/enforce handling for the rollout path.

## Smoke scenarios covered
- S1 — Delivery control-plane write denied with audit entry
- S2 — Harness-maintenance control-plane write allowed with audit entry
- S3 — User glob rules cannot loosen workflow class matrix
- S4 — Harness-maintenance push to default branch denied at runner layer
- S5 — Warn mode logs protected-write violation without failing
- S6 — Enforce mode fails protected-write violation

## Changes summary
- **Added:** `cli/internal/policy/policy.go`
- **Modified:** `cli/internal/config/config.go`, `cli/internal/config/config_test.go`, `cli/internal/intermediary/intermediary.go`, `cli/internal/intermediary/intermediary_prop_test.go`, `cli/internal/intermediary/intermediary_test.go`, `cli/internal/runner/runner.go`, `cli/internal/runner/runner_prop_test.go`, `cli/internal/runner/runner_test.go`, `cli/internal/workflow/workflow.go`, `cli/internal/workflow/workflow_prop_test.go`, `cli/internal/workflow/workflow_test.go`
- **Key types/functions:** `policy.Class`, `policy.Mode`, `policy.Operation`, `policy.Evaluate`, `policy.OperationFromActionResource`, `config.HarnessPolicyMode`, `workflow.Workflow.Class`, `(*Intermediary).WithWorkflowClass`, `AuditEntry`, `PolicyResult`, `(*Runner).enforcePhasePolicy`, `(*Runner).guardDefaultBranchPush`, `(*Runner).policyAuditEntry`, `normalizeGitPushTarget`

## Test plan
- `cd cli && goimports -w . && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`
- `cd cli && go vet ./... && go build ./cmd/xylem && go test ./...`

Fixes #235