### PR TITLE
feat: parameterize PR validation and auto-merge workflows via config

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -149,10 +149,19 @@ observability:
   insecure: true
   sample_rate: 1.0
 
+validation:
+  format: "goimports -l ./cli/..."
+  lint: "go vet ./cli/..."
+  build: "go build ./cli/cmd/xylem"
+  test: "go test ./cli/..."
+
 daemon:
   auto_upgrade: true
   auto_merge: true
   auto_merge_repo: nicholls-inc/xylem
+  auto_merge_labels: [ready-to-merge, harness-impl]
+  auto_merge_branch_pattern: "^(feat|fix|chore)/issue-\\d+"
+  auto_merge_reviewer: "copilot-pull-request-reviewer"
 
 concurrency: 3
 max_turns: 80

--- a/.xylem/workflows/fix-pr-checks.yaml
+++ b/.xylem/workflows/fix-pr-checks.yaml
@@ -15,7 +15,12 @@ phases:
     model: gpt-5.4
     gate:
       type: command
-      run: "cd cli && goimports -l . | grep -c . | xargs test 0 -eq && go vet ./... && go build ./cmd/xylem && go test ./..."
+      run: |
+        set -e
+        {{ if .Validation.Format }}{{ .Validation.Format }}{{ end }}
+        {{ if .Validation.Lint }}{{ .Validation.Lint }}{{ end }}
+        {{ if .Validation.Build }}{{ .Validation.Build }}{{ end }}
+        {{ if .Validation.Test }}{{ .Validation.Test }}{{ end }}
       retries: 3
   - name: push
     prompt_file: .xylem/prompts/fix-pr-checks/push.md

--- a/.xylem/workflows/merge-pr.yaml
+++ b/.xylem/workflows/merge-pr.yaml
@@ -15,4 +15,4 @@ phases:
     # attempted to bypass protection but hit the same mergeability gate when
     # a PR was behind main or had pending CI, producing exit status 1 and
     # blocking further merge-pr vessels. --auto correctly waits.
-    run: "gh pr merge {{.Issue.Number}} --repo nicholls-inc/xylem --squash --delete-branch --auto"
+    run: "gh pr merge {{.Issue.Number}} --repo {{.Repo.Slug}} --squash --delete-branch --auto"

--- a/.xylem/workflows/resolve-conflicts.yaml
+++ b/.xylem/workflows/resolve-conflicts.yaml
@@ -15,7 +15,15 @@ phases:
     model: gpt-5.4
     gate:
       type: command
-      run: "git fetch origin main && test \"$(git branch --show-current)\" = \"$(gh pr view {{.Issue.Number}} --json headRefName --jq '.headRefName')\" && git merge-base --is-ancestor origin/main HEAD && cd cli && go vet ./... && go build ./cmd/xylem && go test ./..."
+      run: |
+        set -e
+        git fetch origin {{ .Repo.DefaultBranch }}
+        test "$(git branch --show-current)" = "$(gh pr view {{ .Issue.Number }} --repo {{ .Repo.Slug }} --json headRefName --jq '.headRefName')"
+        git merge-base --is-ancestor origin/{{ .Repo.DefaultBranch }} HEAD
+        {{ if .Validation.Format }}{{ .Validation.Format }}{{ end }}
+        {{ if .Validation.Lint }}{{ .Validation.Lint }}{{ end }}
+        {{ if .Validation.Build }}{{ .Validation.Build }}{{ end }}
+        {{ if .Validation.Test }}{{ .Validation.Test }}{{ end }}
       retries: 2
   - name: push
     prompt_file: .xylem/prompts/resolve-conflicts/push.md

--- a/cli/cmd/xylem/automerge.go
+++ b/cli/cmd/xylem/automerge.go
@@ -9,24 +9,35 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 )
 
-// xylemBranchPattern matches branch names created by xylem vessels.
-// Examples: feat/issue-42-42, fix/issue-99-99, feat/issue-60-60-runner-context
-var xylemBranchPattern = regexp.MustCompile(`^(feat|fix|chore)/issue-\d+`)
+type autoMergeSettings struct {
+	repo                     string
+	labels                   []string
+	branchPattern            *regexp.Regexp
+	branchPatternRaw         string
+	reviewer                 string
+	conflictResolutionLabels []string
+}
 
-// copilotReviewerLogin is the GitHub bot that performs automated code review.
-const copilotReviewerLogin = "copilot-pull-request-reviewer"
-
-const (
-	harnessImplLabel  = "harness-impl"
-	readyToMergeLabel = "ready-to-merge"
-)
-
-// conflictResolutionLabels are the labels that trigger the resolve-conflicts
-// workflow via the conflict-resolution github-pr source. Auto-merge adds
-// these to any CONFLICTING xylem PR so the workflow picks it up.
-var conflictResolutionLabels = []string{"needs-conflict-resolution", harnessImplLabel}
+func newAutoMergeSettings(dc config.DaemonConfig) (autoMergeSettings, error) {
+	pattern := dc.EffectiveAutoMergeBranchPattern()
+	compiled, err := regexp.Compile(pattern)
+	if err != nil {
+		return autoMergeSettings{}, fmt.Errorf("compile auto-merge branch pattern %q: %w", pattern, err)
+	}
+	labels := dc.EffectiveAutoMergeLabels()
+	return autoMergeSettings{
+		repo:                     strings.TrimSpace(dc.AutoMergeRepo),
+		labels:                   labels,
+		branchPattern:            compiled,
+		branchPatternRaw:         pattern,
+		reviewer:                 dc.EffectiveAutoMergeReviewer(),
+		conflictResolutionLabels: append([]string{"needs-conflict-resolution"}, labels...),
+	}, nil
+}
 
 // isBenignGhWarning reports whether a gh CLI error is a non-fatal warning
 // that should not block the intended operation. The most common case is the
@@ -100,6 +111,15 @@ func (p prSummary) hasLabel(name string) bool {
 	return false
 }
 
+func (p prSummary) hasLabels(names ...string) bool {
+	for _, name := range names {
+		if !p.hasLabel(name) {
+			return false
+		}
+	}
+	return true
+}
+
 // autoMergeAction describes what the daemon should do with a PR this cycle.
 type autoMergeAction int
 
@@ -129,8 +149,8 @@ const (
 // 8. Auto-merge already enabled → wait for GitHub
 // 9. No copilot review requested or submitted → request review, then enable auto-merge
 // 10. Otherwise enable auto-merge and let branch protection enforce review
-func decideAutoMergeAction(pr prSummary) autoMergeAction {
-	if !isMergeReadyXylemPR(pr) {
+func decideAutoMergeAction(pr prSummary, settings autoMergeSettings) autoMergeAction {
+	if !isMergeReadyPR(pr, settings) {
 		return actionSkip
 	}
 	if pr.State != "OPEN" && pr.State != "" {
@@ -141,7 +161,7 @@ func decideAutoMergeAction(pr prSummary) autoMergeAction {
 		// If the PR already has the labels that trigger resolve-conflicts
 		// workflow, just wait — the workflow is (or will be) processing it.
 		// Otherwise, add the labels so the workflow picks it up.
-		if pr.hasLabel("needs-conflict-resolution") && pr.hasLabel(harnessImplLabel) {
+		if pr.hasLabels(settings.conflictResolutionLabels...) {
 			return actionWaitForMergeable
 		}
 		return actionRouteConflict
@@ -159,32 +179,31 @@ func decideAutoMergeAction(pr prSummary) autoMergeAction {
 	if autoMergeEnabled(pr) {
 		return actionWaitForAutoMerge
 	}
-	if !copilotReviewRequestedOrSubmitted(pr) {
+	if settings.reviewer != "" && !reviewRequestedOrSubmitted(pr, settings.reviewer) {
 		return actionRequestReview
 	}
 	return actionEnableAutoMerge
 }
 
-func isMergeReadyXylemPR(pr prSummary) bool {
-	return xylemBranchPattern.MatchString(pr.HeadRefName) &&
-		pr.hasLabel(readyToMergeLabel) &&
-		pr.hasLabel(harnessImplLabel)
+func isMergeReadyPR(pr prSummary, settings autoMergeSettings) bool {
+	return settings.branchPattern.MatchString(pr.HeadRefName) &&
+		pr.hasLabels(settings.labels...)
 }
 
 func autoMergeEnabled(pr prSummary) bool {
 	return pr.AutoMergeRequest != nil
 }
 
-// copilotReviewRequestedOrSubmitted returns true if copilot has either been
-// requested as a reviewer or has already submitted a review.
-func copilotReviewRequestedOrSubmitted(pr prSummary) bool {
+// reviewRequestedOrSubmitted returns true if the configured reviewer has either
+// been requested as a reviewer or has already submitted a review.
+func reviewRequestedOrSubmitted(pr prSummary, reviewer string) bool {
 	for _, r := range pr.ReviewRequests {
-		if r.Login == copilotReviewerLogin {
+		if r.Login == reviewer {
 			return true
 		}
 	}
 	for _, r := range pr.LatestReviews {
-		if r.Author.Login == copilotReviewerLogin {
+		if r.Author.Login == reviewer {
 			return true
 		}
 	}
@@ -216,9 +235,15 @@ func allChecksGreen(pr prSummary) bool {
 // review cycle and (2) enable GitHub auto-merge when the PR is otherwise
 // merge-ready.
 //
-// Repo is the GitHub repo slug (e.g., "owner/name"). If empty, gh uses the
+// The repo slug comes from daemon.auto_merge_repo. If empty, gh uses the
 // current directory's origin remote.
-func autoMergeXylemPRs(ctx context.Context, repo string) {
+func autoMergeXylemPRs(ctx context.Context, dc config.DaemonConfig) {
+	settings, err := newAutoMergeSettings(dc)
+	if err != nil {
+		slog.Error("daemon auto-merge disabled by invalid configuration", "error", err)
+		return
+	}
+	repo := settings.repo
 	prs, err := listOpenPRsFn(ctx, repo)
 	if err != nil {
 		slog.Error("daemon auto-merge failed to list PRs", "repo", repo, "error", err)
@@ -226,12 +251,12 @@ func autoMergeXylemPRs(ctx context.Context, repo string) {
 	}
 
 	for _, pr := range prs {
-		action := decideAutoMergeAction(pr)
+		action := decideAutoMergeAction(pr, settings)
 		switch action {
 		case actionSkip:
 			continue
 		case actionRequestReview:
-			if err := requestCopilotReviewFn(ctx, repo, pr.Number); err != nil {
+			if err := requestCopilotReviewFn(ctx, repo, pr.Number, settings.reviewer); err != nil {
 				if isBenignGhWarning(err) {
 					slog.Info("daemon auto-merge requested copilot review with gh warning ignored",
 						"repo", repo,
@@ -242,7 +267,7 @@ func autoMergeXylemPRs(ctx context.Context, repo string) {
 					slog.Warn("daemon auto-merge skipping copilot review request; reviewer is not a collaborator",
 						"repo", repo,
 						"pr", pr.Number,
-						"reviewer", copilotReviewerLogin,
+						"reviewer", settings.reviewer,
 						"error", err)
 				} else {
 					slog.Warn("daemon auto-merge request review failed; enabling auto-merge anyway",
@@ -268,7 +293,7 @@ func autoMergeXylemPRs(ctx context.Context, repo string) {
 				"pr", pr.Number,
 				"head_ref", pr.HeadRefName)
 		case actionRouteConflict:
-			if err := addPRLabelsFn(ctx, repo, pr.Number, conflictResolutionLabels); err != nil {
+			if err := addPRLabelsFn(ctx, repo, pr.Number, settings.conflictResolutionLabels); err != nil {
 				if isBenignGhWarning(err) {
 					slog.Info("daemon auto-merge routed PR to resolve-conflicts workflow with gh warning ignored",
 						"repo", repo,
@@ -372,15 +397,18 @@ func addPRLabels(ctx context.Context, repo string, number int, labels []string) 
 	return nil
 }
 
-// requestCopilotReview adds copilot-pull-request-reviewer as a reviewer on
-// the given PR. Uses the GitHub REST API directly (not `gh pr edit`) so we
+// requestCopilotReview adds the configured reviewer as a reviewer on the given
+// PR. Uses the GitHub REST API directly (not `gh pr edit`) so we
 // avoid the GraphQL Projects-deprecation warning that `gh pr edit` emits
 // alongside a non-zero exit code even when the underlying operation succeeds.
-func requestCopilotReview(ctx context.Context, repo string, number int) error {
+func requestCopilotReview(ctx context.Context, repo string, number int, reviewer string) error {
 	if repo == "" {
 		return fmt.Errorf("requestCopilotReview: repo slug required")
 	}
-	body, err := json.Marshal(map[string][]string{"reviewers": {copilotReviewerLogin}})
+	if strings.TrimSpace(reviewer) == "" {
+		return fmt.Errorf("requestCopilotReview: reviewer required")
+	}
+	body, err := json.Marshal(map[string][]string{"reviewers": {reviewer}})
 	if err != nil {
 		return fmt.Errorf("marshal reviewer payload: %w", err)
 	}

--- a/cli/cmd/xylem/automerge_prop_test.go
+++ b/cli/cmd/xylem/automerge_prop_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestPropDecideAutoMergeActionMatchesMergeReadiness(t *testing.T) {
+	settings := xylemAutoMergeSettings(t)
 	rapid.Check(t, func(t *rapid.T) {
 		hasReadyLabel := rapid.Bool().Draw(t, "hasReadyLabel")
 		hasHarnessLabel := rapid.Bool().Draw(t, "hasHarnessLabel")
@@ -23,12 +24,12 @@ func TestPropDecideAutoMergeActionMatchesMergeReadiness(t *testing.T) {
 		if hasReadyLabel {
 			labels = append(labels, struct {
 				Name string `json:"name"`
-			}{Name: readyToMergeLabel})
+			}{Name: "ready-to-merge"})
 		}
 		if hasHarnessLabel {
 			labels = append(labels, struct {
 				Name string `json:"name"`
-			}{Name: harnessImplLabel})
+			}{Name: "harness-impl"})
 		}
 
 		pr := prSummary{
@@ -48,13 +49,14 @@ func TestPropDecideAutoMergeActionMatchesMergeReadiness(t *testing.T) {
 			want = actionRequestReview
 		}
 
-		if got := decideAutoMergeAction(pr); got != want {
+		if got := decideAutoMergeAction(pr, settings); got != want {
 			t.Fatalf("decideAutoMergeAction(%+v) = %v, want %v", pr, got, want)
 		}
 	})
 }
 
 func TestPropDecideAutoMergeActionWaitsWhenAutoMergeAlreadyEnabled(t *testing.T) {
+	settings := xylemAutoMergeSettings(t)
 	rapid.Check(t, func(t *rapid.T) {
 		reviewDecision := rapid.SampledFrom([]string{"", "REVIEW_REQUIRED", "APPROVED"}).Draw(t, "reviewDecision")
 		withReviewRequest := rapid.Bool().Draw(t, "withReviewRequest")
@@ -68,7 +70,7 @@ func TestPropDecideAutoMergeActionWaitsWhenAutoMergeAlreadyEnabled(t *testing.T)
 			AutoMergeRequest: &struct{}{},
 			Labels: []struct {
 				Name string `json:"name"`
-			}{{Name: readyToMergeLabel}, {Name: harnessImplLabel}},
+			}{{Name: "ready-to-merge"}, {Name: "harness-impl"}},
 			StatusCheckRollup: []struct {
 				Conclusion string `json:"conclusion"`
 				Status     string `json:"status"`
@@ -77,7 +79,7 @@ func TestPropDecideAutoMergeActionWaitsWhenAutoMergeAlreadyEnabled(t *testing.T)
 		if withReviewRequest {
 			pr.ReviewRequests = append(pr.ReviewRequests, struct {
 				Login string `json:"login"`
-			}{Login: copilotReviewerLogin})
+			}{Login: settings.reviewer})
 		}
 		if withLatestReview {
 			pr.LatestReviews = append(pr.LatestReviews, struct {
@@ -88,12 +90,12 @@ func TestPropDecideAutoMergeActionWaitsWhenAutoMergeAlreadyEnabled(t *testing.T)
 			}{
 				Author: struct {
 					Login string `json:"login"`
-				}{Login: copilotReviewerLogin},
+				}{Login: settings.reviewer},
 				State: "COMMENTED",
 			})
 		}
 
-		if got := decideAutoMergeAction(pr); got != actionWaitForAutoMerge {
+		if got := decideAutoMergeAction(pr, settings); got != actionWaitForAutoMerge {
 			t.Fatalf("expected wait-for-auto-merge, got %v for %+v", got, pr)
 		}
 	})

--- a/cli/cmd/xylem/automerge_test.go
+++ b/cli/cmd/xylem/automerge_test.go
@@ -5,9 +5,23 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func xylemAutoMergeSettings(t *testing.T) autoMergeSettings {
+	t.Helper()
+
+	settings, err := newAutoMergeSettings(config.DaemonConfig{
+		AutoMergeRepo:          "nicholls-inc/xylem",
+		AutoMergeLabels:        []string{"ready-to-merge", "harness-impl"},
+		AutoMergeBranchPattern: `^(feat|fix|chore)/issue-\d+`,
+		AutoMergeReviewer:      "copilot-pull-request-reviewer",
+	})
+	require.NoError(t, err)
+	return settings
+}
 
 func TestIsBenignGhWarning(t *testing.T) {
 	tests := []struct {
@@ -84,13 +98,13 @@ func TestPRSummary_HasLabel(t *testing.T) {
 	pr := prSummary{
 		Labels: []struct {
 			Name string `json:"name"`
-		}{{Name: "needs-conflict-resolution"}, {Name: harnessImplLabel}},
+		}{{Name: "needs-conflict-resolution"}, {Name: "harness-impl"}},
 	}
 	if !pr.hasLabel("needs-conflict-resolution") {
 		t.Error("hasLabel('needs-conflict-resolution') = false, want true")
 	}
-	if !pr.hasLabel(harnessImplLabel) {
-		t.Errorf("hasLabel(%q) = false, want true", harnessImplLabel)
+	if !pr.hasLabel("harness-impl") {
+		t.Errorf("hasLabel(%q) = false, want true", "harness-impl")
 	}
 	if pr.hasLabel("nonexistent") {
 		t.Error("hasLabel('nonexistent') = true, want false")
@@ -98,6 +112,7 @@ func TestPRSummary_HasLabel(t *testing.T) {
 }
 
 func TestXylemBranchPattern(t *testing.T) {
+	settings := xylemAutoMergeSettings(t)
 	tests := []struct {
 		branch string
 		want   bool
@@ -114,12 +129,38 @@ func TestXylemBranchPattern(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.branch, func(t *testing.T) {
-			got := xylemBranchPattern.MatchString(tt.branch)
+			got := settings.branchPattern.MatchString(tt.branch)
 			if got != tt.want {
-				t.Errorf("xylemBranchPattern.MatchString(%q) = %v, want %v", tt.branch, got, tt.want)
+				t.Errorf("branchPattern.MatchString(%q) = %v, want %v", tt.branch, got, tt.want)
 			}
 		})
 	}
+}
+
+func TestNewAutoMergeSettingsDefaults(t *testing.T) {
+	settings, err := newAutoMergeSettings(config.DaemonConfig{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ready-to-merge"}, settings.labels)
+	assert.Equal(t, ".*", settings.branchPatternRaw)
+	assert.Equal(t, "", settings.reviewer)
+	assert.Equal(t, []string{"needs-conflict-resolution", "ready-to-merge"}, settings.conflictResolutionLabels)
+	assert.True(t, settings.branchPattern.MatchString("any/branch"))
+}
+
+func TestNewAutoMergeSettingsCustomizesLabelsPatternAndReviewer(t *testing.T) {
+	settings, err := newAutoMergeSettings(config.DaemonConfig{
+		AutoMergeRepo:          "owner/repo",
+		AutoMergeLabels:        []string{"merge-ready", "bot-authored"},
+		AutoMergeBranchPattern: "^release/",
+		AutoMergeReviewer:      "copilot-bot",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "owner/repo", settings.repo)
+	assert.Equal(t, []string{"merge-ready", "bot-authored"}, settings.labels)
+	assert.Equal(t, "copilot-bot", settings.reviewer)
+	assert.Equal(t, []string{"needs-conflict-resolution", "merge-ready", "bot-authored"}, settings.conflictResolutionLabels)
+	assert.True(t, settings.branchPattern.MatchString("release/1.2"))
+	assert.False(t, settings.branchPattern.MatchString("feat/issue-1-1"))
 }
 
 func TestAllChecksGreen(t *testing.T) {
@@ -158,13 +199,14 @@ func TestAllChecksGreen(t *testing.T) {
 }
 
 func TestDecideAutoMergeAction(t *testing.T) {
+	settings := xylemAutoMergeSettings(t)
 	greenChecks := []struct {
 		Conclusion string `json:"conclusion"`
 		Status     string `json:"status"`
 	}{{Conclusion: "SUCCESS", Status: "COMPLETED"}}
 	mergeReadyLabels := []struct {
 		Name string `json:"name"`
-	}{{Name: readyToMergeLabel}, {Name: harnessImplLabel}}
+	}{{Name: "ready-to-merge"}, {Name: "harness-impl"}}
 	copilotReviewed := []struct {
 		Author struct {
 			Login string `json:"login"`
@@ -173,7 +215,7 @@ func TestDecideAutoMergeAction(t *testing.T) {
 	}{{
 		Author: struct {
 			Login string `json:"login"`
-		}{Login: copilotReviewerLogin},
+		}{Login: settings.reviewer},
 		State: "APPROVED",
 	}}
 
@@ -195,7 +237,7 @@ func TestDecideAutoMergeAction(t *testing.T) {
 				Mergeable:   "MERGEABLE",
 				Labels: []struct {
 					Name string `json:"name"`
-				}{{Name: harnessImplLabel}},
+				}{{Name: "harness-impl"}},
 			},
 			want: actionSkip,
 		},
@@ -215,7 +257,7 @@ func TestDecideAutoMergeAction(t *testing.T) {
 				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "CONFLICTING",
 				Labels: []struct {
 					Name string `json:"name"`
-				}{{Name: "needs-conflict-resolution"}, {Name: readyToMergeLabel}, {Name: harnessImplLabel}},
+				}{{Name: "needs-conflict-resolution"}, {Name: "ready-to-merge"}, {Name: "harness-impl"}},
 			},
 			want: actionWaitForMergeable,
 		},
@@ -259,7 +301,7 @@ func TestDecideAutoMergeAction(t *testing.T) {
 				Labels: mergeReadyLabels, StatusCheckRollup: greenChecks, ReviewDecision: "REVIEW_REQUIRED",
 				ReviewRequests: []struct {
 					Login string `json:"login"`
-				}{{Login: copilotReviewerLogin}},
+				}{{Login: settings.reviewer}},
 			},
 			want: actionEnableAutoMerge,
 		},
@@ -288,14 +330,15 @@ func TestDecideAutoMergeAction(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := decideAutoMergeAction(tt.pr); got != tt.want {
+			if got := decideAutoMergeAction(tt.pr, settings); got != tt.want {
 				t.Errorf("decideAutoMergeAction() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestSmoke_S1_AutoMergeContinuesWhenCopilotReviewerIsNotCollaborator(t *testing.T) {
+func TestSmoke_S8_AutoMergeContinuesWhenConfiguredReviewerIsNotCollaborator(t *testing.T) {
+	settings := xylemAutoMergeSettings(t)
 	origListOpenPRsFn := listOpenPRsFn
 	origRequestCopilotReviewFn := requestCopilotReviewFn
 	origAddPRLabelsFn := addPRLabelsFn
@@ -315,13 +358,13 @@ func TestSmoke_S1_AutoMergeContinuesWhenCopilotReviewerIsNotCollaborator(t *test
 		ReviewDecision: "REVIEW_REQUIRED",
 		Labels: []struct {
 			Name string `json:"name"`
-		}{{Name: readyToMergeLabel}, {Name: harnessImplLabel}},
+		}{{Name: "ready-to-merge"}, {Name: "harness-impl"}},
 		StatusCheckRollup: []struct {
 			Conclusion string `json:"conclusion"`
 			Status     string `json:"status"`
 		}{{Conclusion: "SUCCESS", Status: "COMPLETED"}},
 	}
-	require.Equal(t, actionRequestReview, decideAutoMergeAction(mergeReadyPR))
+	require.Equal(t, actionRequestReview, decideAutoMergeAction(mergeReadyPR, settings))
 
 	listCalls := 0
 	listOpenPRsFn = func(context.Context, string) ([]prSummary, error) {
@@ -338,10 +381,11 @@ func TestSmoke_S1_AutoMergeContinuesWhenCopilotReviewerIsNotCollaborator(t *test
 	}
 
 	reviewCalls := 0
-	requestCopilotReviewFn = func(_ context.Context, repo string, number int) error {
+	requestCopilotReviewFn = func(_ context.Context, repo string, number int, reviewer string) error {
 		reviewCalls++
 		assert.Equal(t, "nicholls-inc/xylem", repo)
 		assert.Equal(t, 42, number)
+		assert.Equal(t, settings.reviewer, reviewer)
 		return errors.New(`exit status 1: {"message":"Reviews may only be requested from collaborators"}`)
 	}
 
@@ -363,7 +407,12 @@ func TestSmoke_S1_AutoMergeContinuesWhenCopilotReviewerIsNotCollaborator(t *test
 		return nil
 	}
 
-	autoMergeXylemPRs(context.Background(), "nicholls-inc/xylem")
+	autoMergeXylemPRs(context.Background(), config.DaemonConfig{
+		AutoMergeRepo:          settings.repo,
+		AutoMergeLabels:        append([]string(nil), settings.labels...),
+		AutoMergeBranchPattern: settings.branchPatternRaw,
+		AutoMergeReviewer:      settings.reviewer,
+	})
 
 	assert.Equal(t, 1, listCalls)
 	assert.Equal(t, 1, reviewCalls)

--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -113,7 +113,7 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		// harness PRs, then enable GitHub auto-merge once checks are green
 		// and the PR is mergeable.
 		if cfg.Daemon.AutoMerge {
-			autoMergeXylemPRs(ctx, cfg.Daemon.AutoMergeRepo)
+			autoMergeXylemPRs(ctx, cfg.Daemon)
 		}
 	}
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -73,6 +74,7 @@ type Config struct {
 	LLMRouting    LLMRoutingConfig          `yaml:"llm_routing,omitempty"`
 	Claude        ClaudeConfig              `yaml:"claude"`
 	Copilot       CopilotConfig             `yaml:"copilot,omitempty"`
+	Validation    ValidationConfig          `yaml:"validation,omitempty"`
 	Daemon        DaemonConfig              `yaml:"daemon,omitempty"`
 	Harness       HarnessConfig             `yaml:"harness,omitempty"`
 	Observability ObservabilityConfig       `yaml:"observability,omitempty"`
@@ -174,6 +176,13 @@ type CopilotConfig struct {
 	Env          map[string]string `yaml:"env,omitempty"`
 }
 
+type ValidationConfig struct {
+	Format string `yaml:"format,omitempty"`
+	Lint   string `yaml:"lint,omitempty"`
+	Build  string `yaml:"build,omitempty"`
+	Test   string `yaml:"test,omitempty"`
+}
+
 type DaemonConfig struct {
 	ScanInterval  string `yaml:"scan_interval,omitempty"`
 	DrainInterval string `yaml:"drain_interval,omitempty"`
@@ -190,6 +199,15 @@ type DaemonConfig struct {
 	// AutoMergeRepo is the GitHub repo slug (owner/name) for auto-merge.
 	// If empty, gh CLI uses the current directory's origin remote.
 	AutoMergeRepo string `yaml:"auto_merge_repo,omitempty"`
+	// AutoMergeLabels are the labels a PR must carry before the daemon treats
+	// it as merge-ready. Defaults to ["ready-to-merge"].
+	AutoMergeLabels []string `yaml:"auto_merge_labels,omitempty"`
+	// AutoMergeBranchPattern filters which PR head refs the daemon manages.
+	// Defaults to ".*".
+	AutoMergeBranchPattern string `yaml:"auto_merge_branch_pattern,omitempty"`
+	// AutoMergeReviewer is the GitHub login to request before enabling
+	// auto-merge. Defaults to empty, which skips reviewer requests.
+	AutoMergeReviewer string `yaml:"auto_merge_reviewer,omitempty"`
 }
 
 type HarnessConfig struct {
@@ -353,6 +371,16 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("daemon.drain_interval must be a valid duration: %w", err)
 		}
 	}
+	if strings.TrimSpace(c.Daemon.AutoMergeBranchPattern) != "" {
+		if _, err := regexp.Compile(strings.TrimSpace(c.Daemon.AutoMergeBranchPattern)); err != nil {
+			return fmt.Errorf("daemon.auto_merge_branch_pattern must be a valid regexp: %w", err)
+		}
+	}
+	for i, label := range c.Daemon.AutoMergeLabels {
+		if strings.TrimSpace(label) == "" {
+			return fmt.Errorf("daemon.auto_merge_labels[%d] must be non-empty", i)
+		}
+	}
 
 	// Validate sources
 	for name, src := range c.Sources {
@@ -433,8 +461,51 @@ func (c *Config) Validate() error {
 	if err := c.validateProviders(); err != nil {
 		return err
 	}
+	if err := c.validateWorkflowRequirements(); err != nil {
+		return err
+	}
 
 	return nil
+}
+
+func (c Config) ValidationConfigured() bool {
+	return !c.Validation.IsEmpty()
+}
+
+func (v ValidationConfig) IsEmpty() bool {
+	return strings.TrimSpace(v.Format) == "" &&
+		strings.TrimSpace(v.Lint) == "" &&
+		strings.TrimSpace(v.Build) == "" &&
+		strings.TrimSpace(v.Test) == ""
+}
+
+func (d DaemonConfig) EffectiveAutoMergeLabels() []string {
+	if len(d.AutoMergeLabels) == 0 {
+		return []string{"ready-to-merge"}
+	}
+	labels := make([]string, 0, len(d.AutoMergeLabels))
+	for _, label := range d.AutoMergeLabels {
+		trimmed := strings.TrimSpace(label)
+		if trimmed == "" {
+			continue
+		}
+		labels = append(labels, trimmed)
+	}
+	if len(labels) == 0 {
+		return []string{"ready-to-merge"}
+	}
+	return labels
+}
+
+func (d DaemonConfig) EffectiveAutoMergeBranchPattern() string {
+	if trimmed := strings.TrimSpace(d.AutoMergeBranchPattern); trimmed != "" {
+		return trimmed
+	}
+	return ".*"
+}
+
+func (d DaemonConfig) EffectiveAutoMergeReviewer() string {
+	return strings.TrimSpace(d.AutoMergeReviewer)
 }
 
 // CleanupAfterDuration returns the parsed cleanup_after duration, defaulting to
@@ -661,6 +732,43 @@ func (c *Config) validateCost() error {
 		return fmt.Errorf("cost.budget.max_tokens must be non-negative")
 	}
 	return nil
+}
+
+func (c *Config) validateWorkflowRequirements() error {
+	if c.ValidationConfigured() {
+		return nil
+	}
+	required := []string{"fix-pr-checks", "resolve-conflicts"}
+	active := make([]string, 0, len(required))
+	for _, workflowName := range required {
+		if c.workflowActive(workflowName) {
+			active = append(active, workflowName)
+		}
+	}
+	if len(active) == 0 {
+		return nil
+	}
+	sort.Strings(active)
+	return fmt.Errorf("validation: at least one of format, lint, build, or test must be set when workflows are active: %s", strings.Join(active, ", "))
+}
+
+func (c *Config) workflowActive(name string) bool {
+	for _, task := range c.Tasks {
+		if strings.TrimSpace(task.Workflow) == name {
+			return true
+		}
+	}
+	for _, src := range c.Sources {
+		if strings.TrimSpace(src.Workflow) == name {
+			return true
+		}
+		for _, task := range src.Tasks {
+			if strings.TrimSpace(task.Workflow) == name {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // validateProviderDefaultModels ensures every active LLM provider has a

--- a/cli/internal/config/config_prop_test.go
+++ b/cli/internal/config/config_prop_test.go
@@ -212,6 +212,53 @@ func TestPropNormalizeLegacyProvidersPreservesDefaultTierModels(t *testing.T) {
 	})
 }
 
+func TestPropValidationRequirementAcceptsAnyNonEmptyValidationCommand(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := validConfig()
+		cfg.Sources = map[string]SourceConfig{
+			"github": {
+				Type: "github",
+				Repo: "owner/name",
+				Tasks: map[string]Task{
+					"fix-checks": {Labels: []string{"ci"}, Workflow: "fix-pr-checks"},
+				},
+			},
+		}
+		commands := []*string{
+			&cfg.Validation.Format,
+			&cfg.Validation.Lint,
+			&cfg.Validation.Build,
+			&cfg.Validation.Test,
+		}
+		idx := rapid.IntRange(0, len(commands)-1).Draw(t, "command-index")
+		*commands[idx] = rapid.StringMatching(`[a-z0-9 ./_-]{4,32}`).Draw(t, "command")
+
+		if err := cfg.validateWorkflowRequirements(); err != nil {
+			t.Fatalf("validateWorkflowRequirements() error = %v", err)
+		}
+	})
+}
+
+func TestPropEffectiveAutoMergeLabelsNeverReturnsBlank(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		size := rapid.IntRange(0, 6).Draw(t, "size")
+		labels := make([]string, 0, size)
+		for i := 0; i < size; i++ {
+			labels = append(labels, rapid.SampledFrom([]string{"ready-to-merge", "harness-impl", " ci ", "   "}).Draw(t, fmt.Sprintf("label-%d", i)))
+		}
+
+		got := (DaemonConfig{AutoMergeLabels: labels}).EffectiveAutoMergeLabels()
+		if len(got) == 0 {
+			t.Fatal("EffectiveAutoMergeLabels() returned no labels")
+		}
+		for _, label := range got {
+			if strings.TrimSpace(label) == "" {
+				t.Fatalf("EffectiveAutoMergeLabels() returned blank label in %#v", got)
+			}
+		}
+	})
+}
+
 func containsString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -2397,6 +2397,7 @@ concurrency: 2
 max_turns: 50
 timeout: "30m"
 claude:
+  command: "claude"
   default_model: "claude-sonnet-4-6"
 `)
 
@@ -2413,6 +2414,113 @@ claude:
 	assert.True(t, task.On.PRHeadUpdated)
 	assert.Equal(t, "10m", task.On.Debounce)
 	assert.Equal(t, "review-pr", task.Workflow)
+}
+
+func TestSmoke_S1_LoadsValidationAndAutoMergeConfig(t *testing.T) {
+	t.Parallel()
+
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-checks:
+        labels: [ci]
+        workflow: fix-pr-checks
+validation:
+  format: "fmt ./..."
+  lint: "vet ./..."
+  build: "build ./..."
+  test: "test ./..."
+daemon:
+  auto_merge: true
+  auto_merge_repo: owner/name
+  auto_merge_labels: [ready-to-merge, harness-impl]
+  auto_merge_branch_pattern: "^feat/"
+  auto_merge_reviewer: "copilot-bot"
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "fmt ./...", cfg.Validation.Format)
+	assert.Equal(t, "vet ./...", cfg.Validation.Lint)
+	assert.Equal(t, "build ./...", cfg.Validation.Build)
+	assert.Equal(t, "test ./...", cfg.Validation.Test)
+	assert.Equal(t, []string{"ready-to-merge", "harness-impl"}, cfg.Daemon.AutoMergeLabels)
+	assert.Equal(t, "^feat/", cfg.Daemon.AutoMergeBranchPattern)
+	assert.Equal(t, "copilot-bot", cfg.Daemon.AutoMergeReviewer)
+}
+
+func TestSmoke_S2_RejectsEmptyValidationForActivePRValidationWorkflows(t *testing.T) {
+	t.Parallel()
+
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-checks:
+        labels: [ci]
+        workflow: fix-pr-checks
+      resolve-conflicts:
+        labels: [merge]
+        workflow: resolve-conflicts
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validation: at least one of format, lint, build, or test must be set")
+	assert.Contains(t, err.Error(), "fix-pr-checks")
+	assert.Contains(t, err.Error(), "resolve-conflicts")
+}
+
+func TestSmoke_S3_AllowsPartialValidationForActivePRValidationWorkflow(t *testing.T) {
+	t.Parallel()
+
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix-checks:
+        labels: [ci]
+        workflow: fix-pr-checks
+validation:
+  test: "go test ./..."
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "go test ./...", cfg.Validation.Test)
+}
+
+func TestValidateRejectsInvalidAutoMergeBranchPattern(t *testing.T) {
+	cfg := validConfig()
+	cfg.Daemon.AutoMergeBranchPattern = "("
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daemon.auto_merge_branch_pattern")
 }
 
 func TestSourceTimeoutValid(t *testing.T) {

--- a/cli/internal/phase/phase.go
+++ b/cli/internal/phase/phase.go
@@ -22,6 +22,9 @@ type TemplateData struct {
 	PreviousOutputs map[string]string // phase name → output text
 	GateResult      string            // most recent gate command output
 	Vessel          VesselData
+	Repo            RepoData
+	Source          SourceData
+	Validation      ValidationData
 }
 
 // IssueData describes the issue being worked on.
@@ -43,6 +46,26 @@ type PhaseData struct {
 type VesselData struct {
 	ID     string
 	Source string
+}
+
+// RepoData describes repository-level template metadata for the vessel.
+type RepoData struct {
+	Slug          string
+	DefaultBranch string
+}
+
+// SourceData describes the configured source that produced the vessel.
+type SourceData struct {
+	Name string
+	Repo string
+}
+
+// ValidationData describes optional repo-specific validation commands.
+type ValidationData struct {
+	Format string
+	Lint   string
+	Build  string
+	Test   string
 }
 
 // TruncateOutput truncates s to maxLen characters, appending a suffix if truncated.

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -590,19 +590,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			phaseStart := r.runtimeNow()
 
 			// Build template data
-			td := phase.TemplateData{
-				Issue: issueData,
-				Phase: phase.PhaseData{
-					Name:  p.Name,
-					Index: i,
-				},
-				PreviousOutputs: previousOutputs,
-				GateResult:      gateResult,
-				Vessel: phase.VesselData{
-					ID:     vessel.ID,
-					Source: vessel.Source,
-				},
-			}
+			td := r.buildTemplateData(vessel, issueData, p.Name, i, previousOutputs, gateResult)
 
 			var output []byte
 			var runErr error
@@ -1880,19 +1868,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		log.Printf("%sphase %q starting (orchestrated)", vesselLabel(vessel), p.Name)
 		phaseStart := r.runtimeNow()
 
-		td := phase.TemplateData{
-			Issue: issueData,
-			Phase: phase.PhaseData{
-				Name:  p.Name,
-				Index: phaseIdx,
-			},
-			PreviousOutputs: previousOutputs,
-			GateResult:      gateResult,
-			Vessel: phase.VesselData{
-				ID:     vessel.ID,
-				Source: vessel.Source,
-			},
-		}
+		td := r.buildTemplateData(vessel, issueData, p.Name, phaseIdx, previousOutputs, gateResult)
 
 		var output []byte
 		var runErr error
@@ -3517,6 +3493,52 @@ func (r *Runner) resolveRepo(vessel queue.Vessel) string {
 		return s.Repo
 	default:
 		return ""
+	}
+}
+
+func (r *Runner) resolveDefaultBranch() string {
+	if r.Config != nil && strings.TrimSpace(r.Config.DefaultBranch) != "" {
+		return strings.TrimSpace(r.Config.DefaultBranch)
+	}
+	return "main"
+}
+
+func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueData, phaseName string, phaseIndex int, previousOutputs map[string]string, gateResult string) phase.TemplateData {
+	sourceName := vessel.Source
+	if configSource := r.sourceConfigNameFromMeta(vessel); configSource != "" {
+		sourceName = configSource
+	}
+	repoSlug := strings.TrimSpace(r.resolveRepo(vessel))
+	validation := phase.ValidationData{}
+	if r.Config != nil {
+		validation = phase.ValidationData{
+			Format: strings.TrimSpace(r.Config.Validation.Format),
+			Lint:   strings.TrimSpace(r.Config.Validation.Lint),
+			Build:  strings.TrimSpace(r.Config.Validation.Build),
+			Test:   strings.TrimSpace(r.Config.Validation.Test),
+		}
+	}
+	return phase.TemplateData{
+		Issue: issueData,
+		Phase: phase.PhaseData{
+			Name:  phaseName,
+			Index: phaseIndex,
+		},
+		PreviousOutputs: previousOutputs,
+		GateResult:      gateResult,
+		Vessel: phase.VesselData{
+			ID:     vessel.ID,
+			Source: vessel.Source,
+		},
+		Repo: phase.RepoData{
+			Slug:          repoSlug,
+			DefaultBranch: r.resolveDefaultBranch(),
+		},
+		Source: phase.SourceData{
+			Name: sourceName,
+			Repo: repoSlug,
+		},
+		Validation: validation,
 	}
 }
 

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -4849,6 +4849,46 @@ func TestResolveRepoPrefersConfigSource(t *testing.T) {
 	}
 }
 
+func TestSmoke_S4_BuildTemplateDataExposesRepoAndValidation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.DefaultBranch = "trunk"
+	cfg.Validation = config.ValidationConfig{
+		Format: "fmt ./...",
+		Lint:   "lint ./...",
+		Build:  "build ./...",
+		Test:   "test ./...",
+	}
+	cfg.Sources["harness-merge"] = config.SourceConfig{
+		Type: "github-pr",
+		Repo: "owner/config-repo",
+		Tasks: map[string]config.Task{
+			"merge-ready": {Labels: []string{"ready"}, Workflow: "merge-pr"},
+		},
+	}
+	r := &Runner{
+		Config: cfg,
+		Sources: map[string]source.Source{
+			"github-pr":     &source.GitHubPR{Repo: "owner/runtime-repo"},
+			"harness-merge": &source.GitHubPR{Repo: "owner/config-repo"},
+		},
+	}
+
+	vessel := queue.Vessel{
+		ID:     "pr-42",
+		Source: "github-pr",
+		Meta:   map[string]string{"config_source": "harness-merge"},
+	}
+	td := r.buildTemplateData(vessel, phase.IssueData{Number: 42}, "merge", 0, nil, "")
+
+	rendered, err := renderCommandTemplate("merge", "command", "gh pr merge {{.Issue.Number}} --repo {{.Repo.Slug}} && echo {{.Source.Name}} {{.Source.Repo}} {{.Repo.DefaultBranch}} {{.Validation.Format}} {{.Validation.Lint}} {{.Validation.Build}} {{.Validation.Test}}", td)
+	require.NoError(t, err)
+	assert.Contains(t, rendered, "gh pr merge 42 --repo owner/config-repo")
+	assert.Contains(t, rendered, "echo harness-merge owner/config-repo trunk fmt ./... lint ./... build ./... test ./...")
+}
+
 func TestResolveSourcePrefersConfigSource(t *testing.T) {
 	primary := &source.Scheduled{Repo: "owner/primary-repo"}
 	fallback := &source.Scheduled{Repo: "owner/fallback-repo"}

--- a/cli/internal/workflow/merge_pr_workflow_test.go
+++ b/cli/internal/workflow/merge_pr_workflow_test.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestSmoke_S1_MergePRWorkflowUsesAutoFlag(t *testing.T) {
+func TestSmoke_S7_MergePRWorkflowUsesRepoSlugAndAutoFlag(t *testing.T) {
 	t.Parallel()
 
 	_, file, _, ok := runtime.Caller(0)
@@ -35,4 +35,6 @@ func TestSmoke_S1_MergePRWorkflowUsesAutoFlag(t *testing.T) {
 	assert.Equal(t, "command", mergePhase.Type)
 	assert.Contains(t, mergePhase.Run, "--auto")
 	assert.NotContains(t, mergePhase.Run, "--admin")
+	assert.Contains(t, mergePhase.Run, "{{.Repo.Slug}}")
+	assert.NotContains(t, mergePhase.Run, "nicholls-inc/xylem")
 }

--- a/cli/internal/workflow/pr_validation_workflow_test.go
+++ b/cli/internal/workflow/pr_validation_workflow_test.go
@@ -1,0 +1,54 @@
+package workflow
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSmoke_S5_FixPRChecksWorkflowUsesValidationTemplateCommands(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := checkedInWorkflowPath(t, "fix-pr-checks.yaml")
+	data, err := os.ReadFile(workflowPath)
+	require.NoError(t, err, "ReadFile(%q)", workflowPath)
+
+	var wf Workflow
+	require.NoError(t, yaml.Unmarshal(data, &wf), "yaml.Unmarshal(%q)", workflowPath)
+
+	fixPhase := findPhaseByName(t, wf.Phases, "fix")
+	require.NotNil(t, fixPhase.Gate, "workflow %q missing fix gate", wf.Name)
+	assert.Equal(t, "command", fixPhase.Gate.Type)
+	assert.Contains(t, fixPhase.Gate.Run, "set -e")
+	assert.Contains(t, fixPhase.Gate.Run, "{{ .Validation.Format }}")
+	assert.Contains(t, fixPhase.Gate.Run, "{{ .Validation.Lint }}")
+	assert.Contains(t, fixPhase.Gate.Run, "{{ .Validation.Build }}")
+	assert.Contains(t, fixPhase.Gate.Run, "{{ .Validation.Test }}")
+	assert.NotContains(t, fixPhase.Gate.Run, "go build ./cmd/xylem")
+}
+
+func TestSmoke_S6_ResolveConflictsWorkflowUsesRepoAndValidationTemplates(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := checkedInWorkflowPath(t, "resolve-conflicts.yaml")
+	data, err := os.ReadFile(workflowPath)
+	require.NoError(t, err, "ReadFile(%q)", workflowPath)
+
+	var wf Workflow
+	require.NoError(t, yaml.Unmarshal(data, &wf), "yaml.Unmarshal(%q)", workflowPath)
+
+	resolvePhase := findPhaseByName(t, wf.Phases, "resolve")
+	require.NotNil(t, resolvePhase.Gate, "workflow %q missing resolve gate", wf.Name)
+	assert.Equal(t, "command", resolvePhase.Gate.Type)
+	assert.Contains(t, resolvePhase.Gate.Run, "{{ .Repo.Slug }}")
+	assert.Contains(t, resolvePhase.Gate.Run, "{{ .Repo.DefaultBranch }}")
+	assert.Contains(t, resolvePhase.Gate.Run, "{{ .Validation.Format }}")
+	assert.Contains(t, resolvePhase.Gate.Run, "{{ .Validation.Lint }}")
+	assert.Contains(t, resolvePhase.Gate.Run, "{{ .Validation.Build }}")
+	assert.Contains(t, resolvePhase.Gate.Run, "{{ .Validation.Test }}")
+	assert.NotContains(t, resolvePhase.Gate.Run, "go build ./cmd/xylem")
+	assert.NotContains(t, resolvePhase.Gate.Run, "--repo nicholls-inc/xylem")
+}


### PR DESCRIPTION
## Summary

Implements https://github.com/nicholls-inc/xylem/issues/237 by moving fix-pr-checks, resolve-conflicts, merge-pr, and daemon auto-merge behavior off xylem-specific hard-coded commands and repo assumptions and onto config-backed validation and repo metadata.

## Smoke scenarios covered

- S1 — LoadsValidationAndAutoMergeConfig
- S2 — RejectsEmptyValidationForActivePRValidationWorkflows
- S3 — AllowsPartialValidationForActivePRValidationWorkflow
- S4 — BuildTemplateDataExposesRepoAndValidation
- S5 — FixPRChecksWorkflowUsesValidationTemplateCommands
- S6 — ResolveConflictsWorkflowUsesRepoAndValidationTemplates
- S7 — MergePRWorkflowUsesRepoSlugAndAutoFlag
- S8 — AutoMergeContinuesWhenConfiguredReviewerIsNotCollaborator

## Changes summary

### Files added

- `cli/internal/workflow/pr_validation_workflow_test.go`

### Files modified

- `.xylem.yml`
- `.xylem/workflows/fix-pr-checks.yaml`
- `.xylem/workflows/merge-pr.yaml`
- `.xylem/workflows/resolve-conflicts.yaml`
- `cli/cmd/xylem/automerge.go`
- `cli/cmd/xylem/automerge_prop_test.go`
- `cli/cmd/xylem/automerge_test.go`
- `cli/cmd/xylem/daemon.go`
- `cli/internal/config/config.go`
- `cli/internal/config/config_prop_test.go`
- `cli/internal/config/config_test.go`
- `cli/internal/phase/phase.go`
- `cli/internal/runner/runner.go`
- `cli/internal/runner/runner_test.go`
- `cli/internal/workflow/merge_pr_workflow_test.go`

### Key types and functions

- Added `config.ValidationConfig` and `Config.ValidationConfigured()` / `ValidationConfig.IsEmpty()`.
- Added daemon config helpers `DaemonConfig.EffectiveAutoMergeLabels()`, `EffectiveAutoMergeBranchPattern()`, and `EffectiveAutoMergeReviewer()`.
- Added workflow-aware config validation via `Config.validateWorkflowRequirements()`.
- Extended `phase.TemplateData` with `RepoData` and `ValidationData` in `cli/internal/phase/phase.go`.
- Threaded `.Repo` and `.Validation` through `Runner.buildTemplateData()` in `cli/internal/runner/runner.go`.
- Reworked auto-merge settings in `cli/cmd/xylem/automerge.go` via `autoMergeSettings` and `newAutoMergeSettings()` so labels, branch pattern, reviewer, and repo slug come from config.
- Parameterized checked-in workflow YAML for validation gates and merge repo slug.

## Test plan

- `cd cli && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`
- Post-rebase rerun: `cd cli && go vet ./... && go build ./cmd/xylem && go test ./...`

Fixes #237