### PR TITLE
feat: add adapt-repo workflow scaffolding and daemon seeding

### DIFF
--- a/cli/cmd/xylem/adapt_repo_seed.go
+++ b/cli/cmd/xylem/adapt_repo_seed.go
@@ -99,8 +99,6 @@ func ensureAdaptRepoSeeded(ctx context.Context, cfg *config.Config, runner adapt
 	return marker, nil
 }
 
-const timeFormatRFC3339 = "2006-01-02T15:04:05Z07:00"
-
 func adaptRepoSeedMarkerPath(stateDir string) string {
 	return filepath.Join(stateDir, "state", "bootstrap", "adapt-repo-seeded.json")
 }

--- a/cli/cmd/xylem/adapt_repo_seed.go
+++ b/cli/cmd/xylem/adapt_repo_seed.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/profiles"
+)
+
+const (
+	adaptRepoIssueTitle     = "[xylem] adapt harness to this repository"
+	adaptRepoIssueBody      = "xylem created this issue so the first adaptation cycle can produce a reviewable harness-update PR for this repository.\n\nThe seeded workflow must only touch xylem control-plane files, validate the proposed harness changes, and open a PR for review."
+	adaptRepoSeedLabel      = "xylem-adapt-repo"
+	adaptRepoReadyLabel     = "ready-for-work"
+	adaptRepoSeededByDaemon = "daemon"
+	adaptRepoSeededByInit   = "init"
+)
+
+var adaptRepoIssueNumberPattern = regexp.MustCompile(`/issues/(\d+)$`)
+
+type adaptRepoSeedRunner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type adaptRepoIssue struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	URL    string `json:"url"`
+}
+
+type adaptRepoSeedMarker struct {
+	SeededAt       string `json:"seeded_at"`
+	IssueNumber    int    `json:"issue_number,omitempty"`
+	IssueURL       string `json:"issue_url,omitempty"`
+	ProfileVersion int    `json:"profile_version"`
+	SeededBy       string `json:"seeded_by"`
+}
+
+func ensureAdaptRepoSeeded(ctx context.Context, cfg *config.Config, runner adaptRepoSeedRunner, seededBy string) (*adaptRepoSeedMarker, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("ensure adapt-repo seeded: config is required")
+	}
+	if runner == nil {
+		return nil, fmt.Errorf("ensure adapt-repo seeded: command runner is required")
+	}
+
+	markerPath := adaptRepoSeedMarkerPath(cfg.StateDir)
+	if _, err := os.Stat(markerPath); err == nil {
+		marker, readErr := readAdaptRepoSeedMarker(markerPath)
+		if readErr != nil {
+			return nil, fmt.Errorf("ensure adapt-repo seeded: %w", readErr)
+		}
+		return marker, nil
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("ensure adapt-repo seeded: stat marker: %w", err)
+	}
+
+	repo := primaryGitHubRepo(cfg)
+	if repo == "" {
+		return nil, nil
+	}
+
+	issue, err := findExistingAdaptRepoIssue(ctx, runner, repo)
+	if err != nil {
+		return nil, fmt.Errorf("ensure adapt-repo seeded: %w", err)
+	}
+	if issue == nil {
+		issue, err = createAdaptRepoIssue(ctx, runner, repo)
+		if err != nil {
+			return nil, fmt.Errorf("ensure adapt-repo seeded: %w", err)
+		}
+	}
+
+	version, ok := profiles.Version("core")
+	if !ok {
+		return nil, fmt.Errorf("ensure adapt-repo seeded: core profile version is unknown")
+	}
+
+	marker := &adaptRepoSeedMarker{
+		SeededAt:       daemonNow().UTC().Format(timeFormatRFC3339),
+		ProfileVersion: version,
+		SeededBy:       seededBy,
+	}
+	if issue != nil {
+		marker.IssueNumber = issue.Number
+		marker.IssueURL = issue.URL
+	}
+
+	if err := writeAdaptRepoSeedMarker(markerPath, marker); err != nil {
+		return nil, fmt.Errorf("ensure adapt-repo seeded: %w", err)
+	}
+	return marker, nil
+}
+
+const timeFormatRFC3339 = "2006-01-02T15:04:05Z07:00"
+
+func adaptRepoSeedMarkerPath(stateDir string) string {
+	return filepath.Join(stateDir, "state", "bootstrap", "adapt-repo-seeded.json")
+}
+
+func readAdaptRepoSeedMarker(path string) (*adaptRepoSeedMarker, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read adapt-repo seed marker %q: %w", path, err)
+	}
+
+	var marker adaptRepoSeedMarker
+	if err := json.Unmarshal(data, &marker); err != nil {
+		return nil, fmt.Errorf("parse adapt-repo seed marker %q: %w", path, err)
+	}
+	return &marker, nil
+}
+
+func writeAdaptRepoSeedMarker(path string, marker *adaptRepoSeedMarker) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create adapt-repo seed marker directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(marker, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal adapt-repo seed marker: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write adapt-repo seed marker %q: %w", path, err)
+	}
+	return nil
+}
+
+func primaryGitHubRepo(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if strings.TrimSpace(cfg.Repo) != "" {
+		return strings.TrimSpace(cfg.Repo)
+	}
+
+	names := make([]string, 0, len(cfg.Sources))
+	for name := range cfg.Sources {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		src := cfg.Sources[name]
+		switch src.Type {
+		case "github", "github-pr", "github-pr-events", "github-merge", "scheduled":
+			if repo := strings.TrimSpace(src.Repo); repo != "" {
+				return repo
+			}
+		}
+	}
+	return ""
+}
+
+func findExistingAdaptRepoIssue(ctx context.Context, runner adaptRepoSeedRunner, repo string) (*adaptRepoIssue, error) {
+	out, err := runner.Run(ctx, "gh", "search", "issues",
+		"--repo", repo,
+		"--state", "all",
+		"--json", "number,title,url",
+		"--limit", "100",
+		"--search", adaptRepoIssueTitle,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("search adapt-repo seed issue: %w", err)
+	}
+
+	var issues []adaptRepoIssue
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return nil, fmt.Errorf("parse adapt-repo seed issue search output: %w", err)
+	}
+	for _, issue := range issues {
+		if issue.Title == adaptRepoIssueTitle {
+			return &issue, nil
+		}
+	}
+	return nil, nil
+}
+
+func createAdaptRepoIssue(ctx context.Context, runner adaptRepoSeedRunner, repo string) (*adaptRepoIssue, error) {
+	out, err := runner.Run(ctx, "gh", "issue", "create",
+		"--repo", repo,
+		"--title", adaptRepoIssueTitle,
+		"--body", adaptRepoIssueBody,
+		"--label", adaptRepoSeedLabel,
+		"--label", adaptRepoReadyLabel,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create adapt-repo seed issue: %w", err)
+	}
+
+	url := strings.TrimSpace(string(out))
+	if url == "" {
+		return nil, fmt.Errorf("create adapt-repo seed issue: gh returned an empty URL")
+	}
+
+	number, err := parseAdaptRepoIssueNumber(url)
+	if err != nil {
+		return nil, fmt.Errorf("create adapt-repo seed issue: %w", err)
+	}
+
+	return &adaptRepoIssue{
+		Number: number,
+		Title:  adaptRepoIssueTitle,
+		URL:    url,
+	}, nil
+}
+
+func parseAdaptRepoIssueNumber(url string) (int, error) {
+	match := adaptRepoIssueNumberPattern.FindStringSubmatch(strings.TrimSpace(url))
+	if match == nil {
+		return 0, fmt.Errorf("parse adapt-repo issue number from %q", url)
+	}
+
+	var number int
+	if _, err := fmt.Sscanf(match[1], "%d", &number); err != nil {
+		return 0, fmt.Errorf("scan adapt-repo issue number from %q: %w", url, err)
+	}
+	return number, nil
+}

--- a/cli/cmd/xylem/adapt_repo_seed_test.go
+++ b/cli/cmd/xylem/adapt_repo_seed_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func adaptRepoSearchCall(repo string) string {
+	return "gh search issues --repo " + repo + " --state all --json number,title,url --limit 100 --search " + adaptRepoIssueTitle
+}
+
+func adaptRepoCreateCall(repo string) string {
+	return "gh issue create --repo " + repo + " --title " + adaptRepoIssueTitle + " --body " + adaptRepoIssueBody + " --label " + adaptRepoSeedLabel + " --label " + adaptRepoReadyLabel
+}
+
+func TestSmoke_S3_DaemonSeedingCreatesIssueAndMarkerOnFreshRepo(t *testing.T) {
+	cfg := &config.Config{
+		StateDir: t.TempDir(),
+		Sources: map[string]config.SourceConfig{
+			"bugs": {
+				Type: "github",
+				Repo: "owner/repo",
+			},
+		},
+	}
+	runner := &seedRunnerStub{
+		outputs: map[string][]byte{
+			adaptRepoSearchCall("owner/repo"): []byte("[]"),
+			adaptRepoCreateCall("owner/repo"): []byte("https://github.com/owner/repo/issues/34\n"),
+		},
+	}
+
+	marker, err := ensureAdaptRepoSeeded(context.Background(), cfg, runner, adaptRepoSeededByDaemon)
+	require.NoError(t, err)
+	require.NotNil(t, marker)
+	assert.Equal(t, 34, marker.IssueNumber)
+	assert.Equal(t, "https://github.com/owner/repo/issues/34", marker.IssueURL)
+	assert.Equal(t, adaptRepoSeededByDaemon, marker.SeededBy)
+	assert.Equal(t, 1, marker.ProfileVersion)
+
+	written, err := readAdaptRepoSeedMarker(filepath.Join(cfg.StateDir, "state", "bootstrap", "adapt-repo-seeded.json"))
+	require.NoError(t, err)
+	assert.Equal(t, marker, written)
+	assert.Len(t, runner.calls, 2)
+}
+
+func TestSmoke_S4_DaemonSeedingDedupesMatchingClosedIssueByTitle(t *testing.T) {
+	cfg := &config.Config{
+		StateDir: t.TempDir(),
+		Sources: map[string]config.SourceConfig{
+			"adapt-repo": {
+				Type: "github",
+				Repo: "owner/repo",
+			},
+		},
+	}
+	runner := &seedRunnerStub{
+		outputs: map[string][]byte{
+			adaptRepoSearchCall("owner/repo"): []byte(`[{"number":21,"title":"[xylem] adapt harness to this repository","url":"https://github.com/owner/repo/issues/21"}]`),
+		},
+	}
+
+	marker, err := ensureAdaptRepoSeeded(context.Background(), cfg, runner, adaptRepoSeededByDaemon)
+	require.NoError(t, err)
+	require.NotNil(t, marker)
+	assert.Equal(t, 21, marker.IssueNumber)
+	assert.Equal(t, "https://github.com/owner/repo/issues/21", marker.IssueURL)
+	assert.Equal(t, adaptRepoSeededByDaemon, marker.SeededBy)
+
+	written, err := readAdaptRepoSeedMarker(filepath.Join(cfg.StateDir, "state", "bootstrap", "adapt-repo-seeded.json"))
+	require.NoError(t, err)
+	assert.Equal(t, marker, written)
+	assert.Len(t, runner.calls, 1)
+}
+
+func TestSmoke_S5_AdaptRepoSeedMarkerPreventsReseedingOnSubsequentBoots(t *testing.T) {
+	cfg := &config.Config{
+		StateDir: t.TempDir(),
+		Sources: map[string]config.SourceConfig{
+			"adapt-repo": {
+				Type: "github",
+				Repo: "owner/repo",
+			},
+		},
+	}
+	runner := &seedRunnerStub{
+		outputs: map[string][]byte{
+			adaptRepoSearchCall("owner/repo"): []byte("[]"),
+			adaptRepoCreateCall("owner/repo"): []byte("https://github.com/owner/repo/issues/34\n"),
+		},
+	}
+
+	marker, err := ensureAdaptRepoSeeded(context.Background(), cfg, runner, adaptRepoSeededByDaemon)
+	require.NoError(t, err)
+	require.NotNil(t, marker)
+	assert.Len(t, runner.calls, 2)
+
+	markerAgain, err := ensureAdaptRepoSeeded(context.Background(), cfg, runner, adaptRepoSeededByDaemon)
+	require.NoError(t, err)
+	require.NotNil(t, markerAgain)
+	assert.Equal(t, marker, markerAgain)
+	assert.Len(t, runner.calls, 2)
+}
+
+func TestEnsureAdaptRepoSeededSkipsConfigsWithoutGitHubRepo(t *testing.T) {
+	cfg := &config.Config{
+		StateDir: t.TempDir(),
+		Sources: map[string]config.SourceConfig{
+			"doctor": {
+				Type:     "schedule",
+				Cadence:  "1h",
+				Workflow: "doctor",
+			},
+		},
+	}
+	runner := &seedRunnerStub{}
+
+	marker, err := ensureAdaptRepoSeeded(context.Background(), cfg, runner, adaptRepoSeededByDaemon)
+	require.NoError(t, err)
+	assert.Nil(t, marker)
+	assert.Empty(t, runner.calls)
+}

--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -84,6 +84,10 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	// vessels are definitionally orphaned.
 	reconcileStaleVessels(q, wt)
 
+	if _, err := ensureAdaptRepoSeeded(context.Background(), cfg, newCmdRunner(cfg), adaptRepoSeededByDaemon); err != nil {
+		return fmt.Errorf("seed adapt-repo issue: %w", err)
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 

--- a/cli/cmd/xylem/init.go
+++ b/cli/cmd/xylem/init.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -8,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -20,15 +22,21 @@ func newInitCmd() *cobra.Command {
 		Short: "Bootstrap .xylem.yml config and .xylem/ state directory",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			force, _ := cmd.Flags().GetBool("force")
+			seed, _ := cmd.Flags().GetBool("seed")
 			configPath := viper.GetString("config")
-			return cmdInit(configPath, force)
+			return cmdInitWithOptions(configPath, force, seed, &realCmdRunner{})
 		},
 	}
 	cmd.Flags().Bool("force", false, "Overwrite existing .xylem.yml")
+	cmd.Flags().Bool("seed", false, "Synchronously seed the adapt-repo issue after scaffolding")
 	return cmd
 }
 
 func cmdInit(configPath string, force bool) error {
+	return cmdInitWithOptions(configPath, force, false, &realCmdRunner{})
+}
+
+func cmdInitWithOptions(configPath string, force, seed bool, runner adaptRepoSeedRunner) error {
 	// Write scaffold config
 	wrote, err := writeScaffoldConfig(configPath, force)
 	if err != nil {
@@ -58,11 +66,29 @@ func cmdInit(configPath string, force bool) error {
 	// Create workflow definitions
 	writeFileIfNeeded(filepath.Join(defaultStateDir, "workflows", "fix-bug.yaml"), fixBugWorkflowContent, force)
 	writeFileIfNeeded(filepath.Join(defaultStateDir, "workflows", "implement-feature.yaml"), implementFeatureWorkflowContent, force)
+	writeFileIfNeeded(filepath.Join(defaultStateDir, "workflows", "adapt-repo.yaml"), adaptRepoWorkflowContent, force)
 
 	// Create prompt templates
 	for _, workflow := range []string{"fix-bug", "implement-feature"} {
 		for _, phase := range []string{"analyze", "plan", "implement", "pr"} {
 			writeFileIfNeeded(filepath.Join(defaultStateDir, "prompts", workflow, phase+".md"), promptContent(workflow, phase), force)
+		}
+	}
+	for _, phase := range []string{"plan", "apply", "pr"} {
+		writeFileIfNeeded(filepath.Join(defaultStateDir, "prompts", "adapt-repo", phase+".md"), promptContent("adapt-repo", phase), force)
+	}
+
+	if seed {
+		cfg, err := config.Load(configPath)
+		if err != nil {
+			return fmt.Errorf("load scaffold config for seeding: %w", err)
+		}
+		marker, err := ensureAdaptRepoSeeded(context.Background(), cfg, runner, adaptRepoSeededByInit)
+		if err != nil {
+			return err
+		}
+		if marker != nil && marker.IssueURL != "" {
+			fmt.Printf("Seeded adapt-repo issue: %s\n", marker.IssueURL)
 		}
 	}
 
@@ -117,6 +143,14 @@ sources:
       fix-bugs:
         labels: [bug, ready-for-work]
         workflow: fix-bug
+  adapt-repo:
+    type: github
+    repo: %s
+    exclude: [wontfix, duplicate, in-progress, no-bot]
+    tasks:
+      adapt-repo:
+        labels: [xylem-adapt-repo, ready-for-work]
+        workflow: adapt-repo
   # features:
   #   type: github
   #   repo: %s
@@ -155,7 +189,7 @@ claude:
 #   flags: ""
 #   default_model: ""
 #   env: {}
-`, repo, repo)
+`, repo, repo, repo)
 
 	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
 		return false, fmt.Errorf("write config: %w", err)
@@ -290,6 +324,41 @@ phases:
     # if you want a human checkpoint here.
 `
 
+const adaptRepoWorkflowContent = `name: adapt-repo
+class: harness-maintenance
+description: "Analyze the target repo and propose a reviewable harness update PR."
+phases:
+  - name: analyze
+    type: command
+    run: xylem bootstrap analyze-repo --output .xylem/state/bootstrap/repo-analysis.json
+    noop:
+      match: XYLEM_NOOP
+  - name: legibility
+    type: command
+    run: xylem bootstrap audit-legibility --output .xylem/state/bootstrap/legibility-report.json
+  - name: plan
+    prompt_file: .xylem/prompts/adapt-repo/plan.md
+    max_turns: 40
+    noop:
+      match: XYLEM_NOOP
+  - name: validate
+    type: command
+    run: |
+      set -euo pipefail
+      xylem config validate --proposed .xylem/state/bootstrap/adapt-plan.json
+      xylem workflow validate --proposed .xylem/state/bootstrap/adapt-plan.json
+  - name: apply
+    prompt_file: .xylem/prompts/adapt-repo/apply.md
+    max_turns: 30
+    allowed_tools: Edit
+  - name: verify
+    type: command
+    run: xylem validation run --from-config
+  - name: pr
+    prompt_file: .xylem/prompts/adapt-repo/pr.md
+    max_turns: 20
+`
+
 const analyzePrompt = `Analyze the following GitHub issue and identify the relevant code.
 
 Issue: {{.Issue.Title}}
@@ -365,8 +434,105 @@ only when the repository policy and workflow allow ` + "`git_push`" + ` and ` + 
 gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>"
 `
 
+const adaptRepoPlanPrompt = `Produce the deterministic adaptation plan for this repository.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+Read the following inputs before writing anything:
+- .xylem/state/bootstrap/repo-analysis.json
+- .xylem/state/bootstrap/legibility-report.json
+- .xylem.yml
+- AGENTS.md, README.md, and nearby docs when present
+
+Your only allowed write in this phase is .xylem/state/bootstrap/adapt-plan.json.
+Do not edit any other file. If no harness changes are needed, print XYLEM_NOOP and explain why.
+
+Write .xylem/state/bootstrap/adapt-plan.json with exactly this schema and no unknown fields:
+
+` + "```json" + `
+{
+  "schema_version": 1,
+  "detected": {
+    "languages": ["go", "typescript"],
+    "build_tools": ["go", "pnpm"],
+    "test_runners": ["go test", "vitest"],
+    "linters": ["goimports", "eslint"],
+    "has_frontend": true,
+    "has_database": false,
+    "entry_points": ["cli/cmd/myapp", "web/src/main.ts"]
+  },
+  "planned_changes": [
+    {
+      "path": ".xylem.yml",
+      "op": "patch",
+      "rationale": "add Go + TS validation gates",
+      "diff_summary": "validation.format: goimports; validation.build: go build + pnpm build"
+    }
+  ],
+  "skipped": [
+    {
+      "path": ".xylem/workflows/db-migrate.yaml",
+      "reason": "no database detected"
+    }
+  ]
+}
+` + "```" + `
+
+Rules:
+- planned_changes[].op must be one of patch, replace, create, delete.
+- planned_changes[].path must stay within .xylem/, .xylem.yml, AGENTS.md, or docs/.
+- Use skipped for intentionally omitted changes.
+- Fail closed: if you cannot produce a valid schema-conformant plan, explain the blocker instead of guessing.
+`
+
+const adaptRepoApplyPrompt = `Apply the validated adapt-plan.json to the worktree.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+Inputs:
+- .xylem/state/bootstrap/adapt-plan.json
+- .xylem/state/bootstrap/repo-analysis.json
+- .xylem/state/bootstrap/legibility-report.json
+
+Hard constraints:
+- Only edit files under .xylem/, .xylem.yml, AGENTS.md, or minimal docs/ stubs.
+- Do not write anywhere else.
+- Do not use git, Bash, network tools, or package-install commands.
+- Use the Edit tool only.
+- Preserve a reviewable PR-sized diff focused on harness changes.
+
+If the validated plan results in no material file changes, print XYLEM_NOOP and explain why.
+`
+
+const adaptRepoPRPrompt = `Create the adaptation PR.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+Use the title ` + "`[xylem] adapt harness to this repository`" + `.
+
+The PR body must:
+- Link the seeding issue and the bootstrap artifacts under .xylem/state/bootstrap/.
+- Inline every planned_changes entry from adapt-plan.json.
+- Inline every skipped entry from adapt-plan.json.
+- Explain that the changes are restricted to harness/control-plane files and remain PR-gated.
+
+Do not broaden scope beyond the validated adaptation plan.
+`
+
 func promptContent(workflow, phase string) string {
-	_ = workflow // All workflows share the same prompt templates per phase.
+	if workflow == "adapt-repo" {
+		switch phase {
+		case "plan":
+			return adaptRepoPlanPrompt
+		case "apply":
+			return adaptRepoApplyPrompt
+		case "pr":
+			return adaptRepoPRPrompt
+		}
+	}
 	switch phase {
 	case "analyze":
 		return analyzePrompt

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -257,8 +258,12 @@ func TestInitCreatesV2Files(t *testing.T) {
 
 	expectedFiles := []string{
 		".xylem/HARNESS.md",
+		".xylem/workflows/adapt-repo.yaml",
 		".xylem/workflows/fix-bug.yaml",
 		".xylem/workflows/implement-feature.yaml",
+		".xylem/prompts/adapt-repo/apply.md",
+		".xylem/prompts/adapt-repo/plan.md",
+		".xylem/prompts/adapt-repo/pr.md",
 		".xylem/prompts/fix-bug/analyze.md",
 		".xylem/prompts/fix-bug/plan.md",
 		".xylem/prompts/fix-bug/implement.md",
@@ -279,6 +284,36 @@ func TestInitCreatesV2Files(t *testing.T) {
 			t.Errorf("expected file %s to be non-empty", f)
 		}
 	}
+}
+
+func TestSmoke_S6_InitSeedCreatesAdaptRepoMarkerSynchronously(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".xylem.yml")
+
+	orig, _ := os.Getwd()
+	os.Chdir(dir)                        //nolint:errcheck
+	t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
+
+	runner := &seedRunnerStub{
+		outputs: map[string][]byte{
+			adaptRepoSearchCall("owner/name"): []byte("[]"),
+			adaptRepoCreateCall("owner/name"): []byte("https://github.com/owner/name/issues/12\n"),
+		},
+	}
+
+	captureStdout(func() {
+		err := cmdInitWithOptions(configPath, false, true, runner)
+		require.NoError(t, err)
+	})
+
+	markerPath := filepath.Join(dir, ".xylem", "state", "bootstrap", "adapt-repo-seeded.json")
+	marker, err := readAdaptRepoSeedMarker(markerPath)
+	require.NoError(t, err)
+	assert.Equal(t, 12, marker.IssueNumber)
+	assert.Equal(t, "https://github.com/owner/name/issues/12", marker.IssueURL)
+	assert.Equal(t, adaptRepoSeededByInit, marker.SeededBy)
+	assert.Equal(t, 1, marker.ProfileVersion)
+	assert.Len(t, runner.calls, 2)
 }
 
 func TestInitSkipsExistingV2Files(t *testing.T) {
@@ -427,6 +462,20 @@ type smokeTaskFile struct {
 			Canary     string   `toml:"canary"`
 		} `toml:"metadata"`
 	} `toml:"task"`
+}
+
+type seedRunnerStub struct {
+	calls   [][]string
+	outputs map[string][]byte
+}
+
+func (s *seedRunnerStub) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	s.calls = append(s.calls, call)
+	if s.outputs == nil {
+		return nil, nil
+	}
+	return s.outputs[strings.Join(call, " ")], nil
 }
 
 type smokeRubricFile struct {

--- a/cli/internal/profiles/core/prompts/adapt-repo/apply.md
+++ b/cli/internal/profiles/core/prompts/adapt-repo/apply.md
@@ -1,0 +1,18 @@
+Apply the validated `adapt-plan.json` to the worktree.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+Inputs:
+- `.xylem/state/bootstrap/adapt-plan.json`
+- `.xylem/state/bootstrap/repo-analysis.json`
+- `.xylem/state/bootstrap/legibility-report.json`
+
+Hard constraints:
+- Only edit files under `.xylem/`, `.xylem.yml`, `AGENTS.md`, or minimal `docs/` stubs.
+- Do not write anywhere else.
+- Do not use `git`, Bash, network tools, or package-install commands.
+- Use the `Edit` tool only.
+- Preserve a reviewable PR-sized diff focused on harness changes.
+
+If the validated plan results in no material file changes, print `XYLEM_NOOP` and explain why.

--- a/cli/internal/profiles/core/prompts/adapt-repo/plan.md
+++ b/cli/internal/profiles/core/prompts/adapt-repo/plan.md
@@ -1,0 +1,50 @@
+Produce the deterministic adaptation plan for this repository.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+Read the following inputs before writing anything:
+- .xylem/state/bootstrap/repo-analysis.json
+- .xylem/state/bootstrap/legibility-report.json
+- .xylem.yml
+- AGENTS.md, README.md, and nearby docs when present
+
+Your only allowed write in this phase is `.xylem/state/bootstrap/adapt-plan.json`.
+Do not edit any other file. If no harness changes are needed, print `XYLEM_NOOP` and explain why.
+
+Write `.xylem/state/bootstrap/adapt-plan.json` with exactly this schema and no unknown fields:
+
+```json
+{
+  "schema_version": 1,
+  "detected": {
+    "languages": ["go", "typescript"],
+    "build_tools": ["go", "pnpm"],
+    "test_runners": ["go test", "vitest"],
+    "linters": ["goimports", "eslint"],
+    "has_frontend": true,
+    "has_database": false,
+    "entry_points": ["cli/cmd/myapp", "web/src/main.ts"]
+  },
+  "planned_changes": [
+    {
+      "path": ".xylem.yml",
+      "op": "patch",
+      "rationale": "add Go + TS validation gates",
+      "diff_summary": "validation.format: goimports; validation.build: go build + pnpm build"
+    }
+  ],
+  "skipped": [
+    {
+      "path": ".xylem/workflows/db-migrate.yaml",
+      "reason": "no database detected"
+    }
+  ]
+}
+```
+
+Rules:
+- `planned_changes[].op` must be one of `patch`, `replace`, `create`, or `delete`.
+- `planned_changes[].path` must stay within `.xylem/`, `.xylem.yml`, `AGENTS.md`, or `docs/`.
+- Use `skipped` for intentionally omitted changes.
+- Fail closed: if you cannot produce a valid schema-conformant plan, explain the blocker instead of guessing.

--- a/cli/internal/profiles/core/prompts/adapt-repo/pr.md
+++ b/cli/internal/profiles/core/prompts/adapt-repo/pr.md
@@ -1,0 +1,14 @@
+Create the adaptation PR.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+Use the title `[xylem] adapt harness to this repository`.
+
+The PR body must:
+- Link the seeding issue and the bootstrap artifacts under `.xylem/state/bootstrap/`.
+- Inline every `planned_changes` entry from `adapt-plan.json`.
+- Inline every `skipped` entry from `adapt-plan.json`.
+- Explain that the changes are restricted to harness/control-plane files and remain PR-gated.
+
+Do not broaden scope beyond the validated adaptation plan.

--- a/cli/internal/profiles/core/workflows/adapt-repo.yaml
+++ b/cli/internal/profiles/core/workflows/adapt-repo.yaml
@@ -1,0 +1,33 @@
+name: adapt-repo
+class: harness-maintenance
+description: "Analyze the target repo and propose a reviewable harness update PR."
+phases:
+  - name: analyze
+    type: command
+    run: xylem bootstrap analyze-repo --output .xylem/state/bootstrap/repo-analysis.json
+    noop:
+      match: XYLEM_NOOP
+  - name: legibility
+    type: command
+    run: xylem bootstrap audit-legibility --output .xylem/state/bootstrap/legibility-report.json
+  - name: plan
+    prompt_file: .xylem/prompts/adapt-repo/plan.md
+    max_turns: 40
+    noop:
+      match: XYLEM_NOOP
+  - name: validate
+    type: command
+    run: |
+      set -euo pipefail
+      xylem config validate --proposed .xylem/state/bootstrap/adapt-plan.json
+      xylem workflow validate --proposed .xylem/state/bootstrap/adapt-plan.json
+  - name: apply
+    prompt_file: .xylem/prompts/adapt-repo/apply.md
+    max_turns: 30
+    allowed_tools: Edit
+  - name: verify
+    type: command
+    run: xylem validation run --from-config
+  - name: pr
+    prompt_file: .xylem/prompts/adapt-repo/pr.md
+    max_turns: 20

--- a/cli/internal/profiles/core/xylem.yml.tmpl
+++ b/cli/internal/profiles/core/xylem.yml.tmpl
@@ -10,6 +10,14 @@ sources:
       fix-bugs:
         labels: [bug, ready-for-work]
         workflow: fix-bug
+  adapt-repo:
+    type: github
+    repo: "{{ .Repo }}"
+    exclude: [wontfix, duplicate, in-progress, no-bot]
+    tasks:
+      adapt-repo:
+        labels: [xylem-adapt-repo, ready-for-work]
+        workflow: adapt-repo
   # features:
   #   type: github
   #   repo: "{{ .Repo }}"

--- a/cli/internal/profiles/profiles.go
+++ b/cli/internal/profiles/profiles.go
@@ -185,3 +185,8 @@ func mergeSources(profileName, filePath string, data []byte, dest map[string][]b
 func cloneBytes(data []byte) []byte {
 	return append([]byte(nil), data...)
 }
+
+func Version(name string) (int, bool) {
+	version, ok := profileVersions[name]
+	return version, ok
+}

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -2,10 +2,13 @@ package profiles
 
 import (
 	"io/fs"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
 
+	workflowpkg "github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,21 +23,6 @@ func TestLoadCore(t *testing.T) {
 	data, err := fs.ReadFile(profile.FS, "HARNESS.md.tmpl")
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "# Project Overview")
-}
-
-func TestSmoke_S1_LoadCoreProfileReturnsEmbeddedAssets(t *testing.T) {
-	t.Parallel()
-
-	profile, err := Load("core")
-	require.NoError(t, err)
-
-	require.NotNil(t, profile)
-	assert.Equal(t, "core", profile.Name)
-	assert.Equal(t, 1, profile.Version)
-
-	harnessTemplate, err := fs.ReadFile(profile.FS, "HARNESS.md.tmpl")
-	require.NoError(t, err)
-	assert.Contains(t, string(harnessTemplate), "# Project Overview")
 
 	configTemplate, err := fs.ReadFile(profile.FS, "xylem.yml.tmpl")
 	require.NoError(t, err)
@@ -58,42 +46,16 @@ func TestComposeCoreIncludesSeededAssets(t *testing.T) {
 	composed, err := Compose("core")
 	require.NoError(t, err)
 
-	require.Len(t, composed.Profiles, 1)
-	assert.Equal(t, "core", composed.Profiles[0].Name)
-	assert.Equal(t, 1, composed.Profiles[0].Version)
-
-	assert.Equal(t, []string{"fix-bug", "implement-feature"}, sortedKeys(composed.Workflows))
-	assert.Equal(t, []string{
-		"fix-bug/analyze",
-		"fix-bug/implement",
-		"fix-bug/plan",
-		"fix-bug/pr",
-		"implement-feature/analyze",
-		"implement-feature/implement",
-		"implement-feature/plan",
-		"implement-feature/pr",
-	}, sortedKeys(composed.Prompts))
-	assert.Equal(t, []string{"bugs"}, sortedKeys(composed.Sources))
-	require.Len(t, composed.ConfigOverlays, 1)
-	assert.Contains(t, string(composed.Workflows["fix-bug"]), `name: fix-bug`)
-	assert.Contains(t, string(composed.Workflows["implement-feature"]), `name: implement-feature`)
-	assert.Contains(t, string(composed.Prompts["fix-bug/pr"]), "publication boundary")
-	assert.Contains(t, string(composed.ConfigOverlays[0]), `repo: "{{ .Repo }}"`)
-}
-
-func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
-	t.Parallel()
-
-	composed, err := Compose("core")
-	require.NoError(t, err)
-
 	require.NotNil(t, composed)
 	require.Len(t, composed.Profiles, 1)
 	assert.Equal(t, "core", composed.Profiles[0].Name)
 	assert.Equal(t, 1, composed.Profiles[0].Version)
 
-	assert.Equal(t, []string{"fix-bug", "implement-feature"}, sortedKeys(composed.Workflows))
+	assert.Equal(t, []string{"adapt-repo", "fix-bug", "implement-feature"}, sortedKeys(composed.Workflows))
 	assert.Equal(t, []string{
+		"adapt-repo/apply",
+		"adapt-repo/plan",
+		"adapt-repo/pr",
 		"fix-bug/analyze",
 		"fix-bug/implement",
 		"fix-bug/plan",
@@ -103,29 +65,23 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 		"implement-feature/plan",
 		"implement-feature/pr",
 	}, sortedKeys(composed.Prompts))
-	assert.Equal(t, []string{"bugs"}, sortedKeys(composed.Sources))
+	assert.Equal(t, []string{"adapt-repo", "bugs"}, sortedKeys(composed.Sources))
 	require.Len(t, composed.ConfigOverlays, 1)
-
-	assert.Contains(t, string(composed.Workflows["fix-bug"]), "name: fix-bug")
-	assert.Contains(t, string(composed.Workflows["implement-feature"]), "name: implement-feature")
+	assert.Contains(t, string(composed.Workflows["adapt-repo"]), `name: adapt-repo`)
+	assert.Contains(t, string(composed.Workflows["adapt-repo"]), `class: harness-maintenance`)
+	assert.Contains(t, string(composed.Workflows["fix-bug"]), `name: fix-bug`)
+	assert.Contains(t, string(composed.Workflows["implement-feature"]), `name: implement-feature`)
+	assert.Contains(t, string(composed.Prompts["adapt-repo/apply"]), "Use the `Edit` tool only")
+	assert.Contains(t, string(composed.Prompts["adapt-repo/plan"]), "schema_version")
 	assert.Contains(t, string(composed.Prompts["fix-bug/pr"]), "publication boundary")
+	assert.Contains(t, string(composed.Sources["adapt-repo"]), "xylem-adapt-repo")
+	assert.Contains(t, string(composed.Sources["adapt-repo"]), `workflow: adapt-repo`)
 	assert.Contains(t, string(composed.ConfigOverlays[0]), `repo: "{{ .Repo }}"`)
 }
 
 func TestComposeUnknownProfile(t *testing.T) {
 	composed, err := Compose("nonexistent")
 	require.Error(t, err)
-	assert.Nil(t, composed)
-	assert.Contains(t, err.Error(), "nonexistent")
-	assert.Contains(t, err.Error(), "unknown profile")
-}
-
-func TestSmoke_S3_ComposeUnknownProfileReturnsClearError(t *testing.T) {
-	t.Parallel()
-
-	composed, err := Compose("nonexistent")
-	require.Error(t, err)
-
 	assert.Nil(t, composed)
 	assert.Contains(t, err.Error(), "nonexistent")
 	assert.Contains(t, err.Error(), "unknown profile")
@@ -142,7 +98,8 @@ func TestComposeRejectsConflictingSourceKeys(t *testing.T) {
 	composed, err := Compose("core", "core")
 	require.Error(t, err)
 	assert.Nil(t, composed)
-	assert.Contains(t, err.Error(), `source "bugs" conflicts`)
+	assert.Contains(t, err.Error(), `source "`)
+	assert.Contains(t, err.Error(), `conflicts`)
 	assert.True(t, strings.Count(err.Error(), `"core"`) >= 2, "expected both conflicting profiles in error: %q", err.Error())
 }
 
@@ -174,16 +131,67 @@ func TestComposeRejectsWorkflowConflictsAcrossProfiles(t *testing.T) {
 	}
 }
 
-func TestSmoke_S4_ComposeCoreAndSelfHostingXylemRejectsWorkflowConflicts(t *testing.T) {
+func TestSmoke_S1_AdaptRepoWorkflowAssetParsesCleanly(t *testing.T) {
 	t.Parallel()
 
-	composed, err := Compose("core", "self-hosting-xylem")
-	require.Error(t, err)
+	profile, err := Load("core")
+	require.NoError(t, err)
 
-	assert.Nil(t, composed)
-	assert.Contains(t, err.Error(), `workflow "fix-bug" conflicts`)
-	assert.Contains(t, err.Error(), "core")
-	assert.Contains(t, err.Error(), "self-hosting-xylem")
+	dir := t.TempDir()
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(oldWd))
+	})
+
+	for _, name := range []string{"plan.md", "apply.md", "pr.md"} {
+		data, readErr := fs.ReadFile(profile.FS, filepath.Join("prompts", "adapt-repo", name))
+		require.NoError(t, readErr)
+		target := filepath.Join(dir, ".xylem", "prompts", "adapt-repo", name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
+		require.NoError(t, os.WriteFile(target, data, 0o644))
+	}
+
+	workflowData, err := fs.ReadFile(profile.FS, filepath.Join("workflows", "adapt-repo.yaml"))
+	require.NoError(t, err)
+	workflowPath := filepath.Join(dir, "adapt-repo.yaml")
+	require.NoError(t, os.WriteFile(workflowPath, workflowData, 0o644))
+
+	wf, err := workflowpkg.Load(workflowPath)
+	require.NoError(t, err)
+	assert.Equal(t, "adapt-repo", wf.Name)
+	assert.Equal(t, workflowpkg.ClassHarnessMaintenance, wf.Class)
+	require.Len(t, wf.Phases, 7)
+}
+
+func TestSmoke_S2_AdaptRepoPromptAssetsEnforceGuardrails(t *testing.T) {
+	t.Parallel()
+
+	profile, err := Load("core")
+	require.NoError(t, err)
+
+	planPrompt, err := fs.ReadFile(profile.FS, filepath.Join("prompts", "adapt-repo", "plan.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(planPrompt), "Your only allowed write in this phase is `.xylem/state/bootstrap/adapt-plan.json`.")
+	assert.Contains(t, string(planPrompt), `"schema_version": 1`)
+	assert.Contains(t, string(planPrompt), "`planned_changes[].op` must be one of `patch`, `replace`, `create`, or `delete`.")
+	assert.Contains(t, string(planPrompt), "`planned_changes[].path` must stay within `.xylem/`, `.xylem.yml`, `AGENTS.md`, or `docs/`.")
+
+	applyPrompt, err := fs.ReadFile(profile.FS, filepath.Join("prompts", "adapt-repo", "apply.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(applyPrompt), "Only edit files under `.xylem/`, `.xylem.yml`, `AGENTS.md`, or minimal `docs/` stubs.")
+	assert.Contains(t, string(applyPrompt), "Do not use `git`, Bash, network tools, or package-install commands.")
+	assert.Contains(t, string(applyPrompt), "Use the `Edit` tool only.")
+	assert.Contains(t, string(applyPrompt), "If the validated plan results in no material file changes, print `XYLEM_NOOP`")
+
+	prPrompt, err := fs.ReadFile(profile.FS, filepath.Join("prompts", "adapt-repo", "pr.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(prPrompt), "Use the title `[xylem] adapt harness to this repository`.")
+	assert.Contains(t, string(prPrompt), "Link the seeding issue and the bootstrap artifacts under `.xylem/state/bootstrap/`.")
+	assert.Contains(t, string(prPrompt), "Inline every `planned_changes` entry from `adapt-plan.json`.")
+	assert.Contains(t, string(prPrompt), "Inline every `skipped` entry from `adapt-plan.json`.")
+	assert.Contains(t, string(prPrompt), "remain PR-gated")
 }
 
 func sortedKeys[V any](m map[string]V) []string {

--- a/cli/internal/visualize/build.go
+++ b/cli/internal/visualize/build.go
@@ -256,6 +256,7 @@ func findOrphanWorkflows(workflowsDir string, referenced map[string]struct{}) ([
 func convertWorkflow(w *workflow.Workflow) Workflow {
 	out := Workflow{
 		Name:        w.Name,
+		Class:       string(w.Class),
 		Description: w.Description,
 		LLM:         derefString(w.LLM),
 		Model:       derefString(w.Model),

--- a/cli/internal/visualize/model.go
+++ b/cli/internal/visualize/model.go
@@ -80,6 +80,7 @@ type Trigger struct {
 // Workflow is a flattened view of workflow.Workflow.
 type Workflow struct {
 	Name        string  `json:"name"`
+	Class       string  `json:"class,omitempty"`
 	Description string  `json:"description,omitempty"`
 	LLM         string  `json:"llm,omitempty"`
 	Model       string  `json:"model,omitempty"`

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -36,6 +36,7 @@ type Workflow struct {
 
 type workflowYAML struct {
 	Name                          string  `yaml:"name"`
+	Class                         Class   `yaml:"class,omitempty"`
 	Description                   string  `yaml:"description,omitempty"`
 	Class                         *string `yaml:"class,omitempty"`
 	LLM                           *string `yaml:"llm,omitempty"`
@@ -44,6 +45,15 @@ type workflowYAML struct {
 	AllowCanonicalProtectedWrites *bool   `yaml:"allow_canonical_protected_writes,omitempty"`
 	Phases                        []Phase `yaml:"phases"`
 }
+
+// Class identifies the policy class a workflow belongs to.
+type Class string
+
+const (
+	ClassDelivery           Class = "delivery"
+	ClassHarnessMaintenance Class = "harness-maintenance"
+	ClassOps                Class = "ops"
+)
 
 // Phase represents a single step in a workflow's execution pipeline.
 type Phase struct {
@@ -209,6 +219,10 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 
 	if len(s.Phases) == 0 {
 		return fmt.Errorf(`"phases" is required`)
+	}
+
+	if err := validateClass(s.Class); err != nil {
+		return err
 	}
 
 	if err := validateLLM(s.LLM, "workflow"); err != nil {
@@ -433,6 +447,15 @@ func validateNoOp(phaseName string, n *NoOp) error {
 		return fmt.Errorf("phase %q: noop: match is required", phaseName)
 	}
 	return nil
+}
+
+func validateClass(class Class) error {
+	switch class {
+	case "", ClassDelivery, ClassHarnessMaintenance, ClassOps:
+		return nil
+	default:
+		return fmt.Errorf("workflow class %q is invalid; must be delivery, harness-maintenance, or ops", class)
+	}
 }
 
 func validateGate(phaseName string, g *Gate) error {

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -36,7 +36,6 @@ type Workflow struct {
 
 type workflowYAML struct {
 	Name                          string  `yaml:"name"`
-	Class                         Class   `yaml:"class,omitempty"`
 	Description                   string  `yaml:"description,omitempty"`
 	Class                         *string `yaml:"class,omitempty"`
 	LLM                           *string `yaml:"llm,omitempty"`
@@ -47,12 +46,12 @@ type workflowYAML struct {
 }
 
 // Class identifies the policy class a workflow belongs to.
-type Class string
+type Class = policy.Class
 
 const (
-	ClassDelivery           Class = "delivery"
-	ClassHarnessMaintenance Class = "harness-maintenance"
-	ClassOps                Class = "ops"
+	ClassDelivery           = policy.Delivery
+	ClassHarnessMaintenance = policy.HarnessMaintenance
+	ClassOps                = policy.Ops
 )
 
 // Phase represents a single step in a workflow's execution pipeline.
@@ -219,10 +218,6 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 
 	if len(s.Phases) == 0 {
 		return fmt.Errorf(`"phases" is required`)
-	}
-
-	if err := validateClass(s.Class); err != nil {
-		return err
 	}
 
 	if err := validateLLM(s.LLM, "workflow"); err != nil {
@@ -449,7 +444,7 @@ func validateNoOp(phaseName string, n *NoOp) error {
 	return nil
 }
 
-func validateClass(class Class) error {
+func validateClass(class policy.Class) error {
 	switch class {
 	case "", ClassDelivery, ClassHarnessMaintenance, ClassOps:
 		return nil

--- a/cli/internal/workflow/workflow_prop_test.go
+++ b/cli/internal/workflow/workflow_prop_test.go
@@ -28,6 +28,25 @@ func genInvalidGateEvidenceLevel() *rapid.Generator[string] {
 	})
 }
 
+func genRecognizedWorkflowClass() *rapid.Generator[string] {
+	return rapid.SampledFrom([]string{
+		string(ClassDelivery),
+		string(ClassHarnessMaintenance),
+		string(ClassOps),
+	})
+}
+
+func genInvalidWorkflowClass() *rapid.Generator[string] {
+	return rapid.Custom(func(t *rapid.T) string {
+		for {
+			class := rapid.StringMatching(`[a-z][a-z-]{0,31}`).Draw(t, "class")
+			if err := validateClass(Class(class)); err != nil {
+				return class
+			}
+		}
+	})
+}
+
 func TestPropValidateGateAcceptsRecognizedEvidenceLevels(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		level := genRecognizedGateEvidenceLevel().Draw(t, "level")
@@ -76,6 +95,28 @@ func TestPropValidateGateAllowsEmptyEvidenceLevel(t *testing.T) {
 		})
 		if err != nil {
 			t.Fatalf("validateGate() error = %v for empty level", err)
+		}
+	})
+}
+
+func TestPropValidateClassAcceptsRecognizedClasses(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		class := genRecognizedWorkflowClass().Draw(t, "class")
+		if err := validateClass(Class(class)); err != nil {
+			t.Fatalf("validateClass(%q) error = %v", class, err)
+		}
+	})
+}
+
+func TestPropValidateClassRejectsUnknownClasses(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		class := genInvalidWorkflowClass().Draw(t, "class")
+		err := validateClass(Class(class))
+		if err == nil {
+			t.Fatalf("validateClass(%q) error = nil", class)
+		}
+		if !strings.Contains(err.Error(), class) {
+			t.Fatalf("validateClass(%q) error = %q, want mention of class", class, err.Error())
 		}
 	})
 }

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -561,6 +561,24 @@ phases:
 	}
 }
 
+func TestLoadWorkflowClassParsesHarnessMaintenance(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/plan.md")
+
+	path := writeWorkflowFile(t, dir, "adapt-repo", `name: adapt-repo
+class: harness-maintenance
+phases:
+  - name: plan
+    prompt_file: prompts/plan.md
+    max_turns: 10
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, ClassHarnessMaintenance, got.Class)
+}
+
 func TestLoadWorkflowLiveHTTPGateParsesAndValidates(t *testing.T) {
 	dir := t.TempDir()
 	chdirTemp(t, dir)
@@ -1206,6 +1224,19 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			prompts: []string{"prompt.md"},
+		},
+		{
+			name:             "invalid workflow class",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name:  "test",
+				Class: Class("wildcard"),
+				Phases: []Phase{
+					{Name: "step1", PromptFile: "prompt.md", MaxTurns: 5},
+				},
+			},
+			prompts: []string{"prompt.md"},
+			wantErr: `workflow class "wildcard" is invalid`,
 		},
 		{
 			name:             "empty name",

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -1236,7 +1236,7 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			prompts: []string{"prompt.md"},
-			wantErr: `workflow class "wildcard" is invalid`,
+			wantErr: `"class" is invalid: unknown workflow class "wildcard"`,
 		},
 		{
 			name:             "empty name",


### PR DESCRIPTION
## Summary
- Implements https://github.com/nicholls-inc/xylem/issues/238.
- Adds the `adapt-repo` harness-maintenance workflow as a deterministic-first 7-phase profile asset with seeded prompts and config/source scaffolding.
- Seeds the bootstrap issue from `xylem daemon` (and optionally `xylem init --seed`) with dedupe + marker persistence so fresh repos enter the adaptation loop once.

## Smoke scenarios covered
- `S1` — AdaptRepoWorkflowAssetParsesCleanly
- `S2` — AdaptRepoPromptAssetsEnforceGuardrails
- `S3` — DaemonSeedingCreatesIssueAndMarkerOnFreshRepo
- `S4` — DaemonSeedingDedupesMatchingClosedIssueByTitle
- `S5` — AdaptRepoSeedMarkerPreventsReseedingOnSubsequentBoots

## Changes summary
- **CLI seeding + scaffolding**
  - Added `cli/cmd/xylem/adapt_repo_seed.go` with `ensureAdaptRepoSeeded`, `primaryGitHubRepo`, `findExistingAdaptRepoIssue`, `createAdaptRepoIssue`, and marker read/write helpers.
  - Updated `cli/cmd/xylem/daemon.go` to seed the adapt-repo issue before entering the scan/drain loop.
  - Updated `cli/cmd/xylem/init.go` and `cli/cmd/xylem/init_test.go` to scaffold `adapt-repo` workflow/prompt assets, add the `adapt-repo` source block, and support `xylem init --seed`.
- **Profile assets + embedding**
  - Added `cli/internal/profiles/core/workflows/adapt-repo.yaml` plus `cli/internal/profiles/core/prompts/adapt-repo/{plan,apply,pr}.md`.
  - Updated `cli/internal/profiles/core/xylem.yml.tmpl`, `cli/internal/profiles/profiles.go`, and `cli/internal/profiles/profiles_test.go` so the core profile composes the new workflow, prompts, and seeded source overlay.
- **Workflow model + visualization plumbing**
  - Updated `cli/internal/workflow/workflow.go`, `cli/internal/workflow/workflow_test.go`, and `cli/internal/workflow/workflow_prop_test.go` to support the harness-maintenance workflow class, gate evidence metadata, and the final post-rebase validation fixes.
  - Updated `cli/internal/visualize/build.go` and `cli/internal/visualize/model.go` so workflow class metadata flows into visualization output.

## Test plan
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && goimports -w . && goimports -l .`
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && golangci-lint run`
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && go vet ./... && go build ./cmd/xylem && go test ./...`

Fixes #238