### PR TITLE
scanner: add remediation-aware retry gating

### DIFF
--- a/cli/internal/recovery/recovery.go
+++ b/cli/internal/recovery/recovery.go
@@ -33,6 +33,10 @@ const (
 	MetaRetryAfter             = "recovery_retry_after"
 	MetaFailureFingerprint     = "failure_fingerprint"
 	MetaRemediationFingerprint = "remediation_fingerprint"
+	MetaHarnessDigest          = "harness_digest"
+	MetaWorkflowDigest         = "workflow_digest"
+	MetaDecisionDigest         = "decision_digest"
+	MetaRemediationEpoch       = "remediation_epoch"
 	MetaUnlockedBy             = "recovery_unlocked_by"
 	MetaUnlockDimension        = "recovery_unlock_dimension"
 )
@@ -70,6 +74,12 @@ type Artifact struct {
 	Error              string                          `json:"error,omitempty"`
 	GateOutput         string                          `json:"gate_output,omitempty"`
 	FailureFingerprint string                          `json:"failure_fingerprint,omitempty"`
+	SourceInputFP      string                          `json:"source_input_fingerprint,omitempty"`
+	HarnessDigest      string                          `json:"harness_digest,omitempty"`
+	WorkflowDigest     string                          `json:"workflow_digest,omitempty"`
+	DecisionDigest     string                          `json:"decision_digest,omitempty"`
+	RemediationEpoch   string                          `json:"remediation_epoch,omitempty"`
+	RemediationFP      string                          `json:"remediation_fingerprint,omitempty"`
 	RecoveryClass      Class                           `json:"recovery_class"`
 	RecoveryAction     Action                          `json:"recovery_action"`
 	Rationale          string                          `json:"rationale"`
@@ -86,18 +96,33 @@ type Artifact struct {
 }
 
 type Input struct {
-	VesselID    string
-	Source      string
-	Workflow    string
-	Ref         string
-	State       queue.VesselState
-	FailedPhase string
-	Error       string
-	GateOutput  string
-	RetryOf     string
-	Meta        map[string]string
-	Trace       *observability.TraceContextData
-	CreatedAt   time.Time
+	VesselID         string
+	Source           string
+	Workflow         string
+	Ref              string
+	State            queue.VesselState
+	FailedPhase      string
+	Error            string
+	GateOutput       string
+	RetryOf          string
+	SourceInputFP    string
+	HarnessDigest    string
+	WorkflowDigest   string
+	DecisionDigest   string
+	RemediationEpoch string
+	RemediationFP    string
+	Meta             map[string]string
+	Trace            *observability.TraceContextData
+	CreatedAt        time.Time
+}
+
+type RemediationState struct {
+	SourceInputFP    string
+	HarnessDigest    string
+	WorkflowDigest   string
+	DecisionDigest   string
+	RemediationEpoch string
+	RemediationFP    string
 }
 
 func Build(input Input) *Artifact {
@@ -140,6 +165,19 @@ func Build(input Input) *Artifact {
 	if trace != nil && trace.TraceID == "" && trace.SpanID == "" {
 		trace = nil
 	}
+	remediation := remediationStateFromInput(input)
+	remediation.DecisionDigest = firstNonEmpty(remediation.DecisionDigest, decisionDigestFor(
+		class,
+		action,
+		rationale,
+		followUpRoute,
+		retrySuppressed,
+		retryCap,
+	))
+	if remediation.RemediationEpoch == "" {
+		remediation.RemediationEpoch = strconv.Itoa(max(retryCount, 0))
+	}
+	remediation.RemediationFP = ComputeRemediationFingerprint(remediation)
 
 	return &Artifact{
 		SchemaVersion:      schemaVersion,
@@ -152,6 +190,12 @@ func Build(input Input) *Artifact {
 		Error:              input.Error,
 		GateOutput:         input.GateOutput,
 		FailureFingerprint: failureFingerprint,
+		SourceInputFP:      remediation.SourceInputFP,
+		HarnessDigest:      remediation.HarnessDigest,
+		WorkflowDigest:     remediation.WorkflowDigest,
+		DecisionDigest:     remediation.DecisionDigest,
+		RemediationEpoch:   remediation.RemediationEpoch,
+		RemediationFP:      remediation.RemediationFP,
 		RecoveryClass:      class,
 		RecoveryAction:     action,
 		Rationale:          rationale,
@@ -172,9 +216,14 @@ func ApplyToMeta(meta map[string]string, artifact *Artifact) map[string]string {
 	if artifact == nil {
 		return meta
 	}
-	if meta == nil {
-		meta = make(map[string]string)
-	}
+	meta = ApplyRemediationState(meta, RemediationState{
+		SourceInputFP:    artifact.SourceInputFP,
+		HarnessDigest:    artifact.HarnessDigest,
+		WorkflowDigest:   artifact.WorkflowDigest,
+		DecisionDigest:   artifact.DecisionDigest,
+		RemediationEpoch: artifact.RemediationEpoch,
+		RemediationFP:    artifact.RemediationFP,
+	})
 	meta[MetaClass] = string(artifact.RecoveryClass)
 	meta[MetaAction] = string(artifact.RecoveryAction)
 	meta[MetaRationale] = artifact.Rationale
@@ -257,6 +306,10 @@ type RetryDecision struct {
 }
 
 func RetryReady(artifact *Artifact, now time.Time) RetryDecision {
+	return RetryReadyWithRemediation(artifact, RemediationState{}, now)
+}
+
+func RetryReadyWithRemediation(artifact *Artifact, current RemediationState, now time.Time) RetryDecision {
 	if artifact == nil || artifact.RecoveryAction != ActionRetry {
 		return RetryDecision{}
 	}
@@ -266,9 +319,36 @@ func RetryReady(artifact *Artifact, now time.Time) RetryDecision {
 	if artifact.RetryAfter != nil && now.UTC().Before(artifact.RetryAfter.UTC()) {
 		return RetryDecision{}
 	}
+	stored := normalizeRemediationState(RemediationState{
+		SourceInputFP:    artifact.SourceInputFP,
+		HarnessDigest:    artifact.HarnessDigest,
+		WorkflowDigest:   artifact.WorkflowDigest,
+		DecisionDigest:   firstNonEmpty(artifact.DecisionDigest, DecisionDigest(artifact)),
+		RemediationEpoch: firstNonEmpty(artifact.RemediationEpoch, strconv.Itoa(max(artifact.RetryCount, 0))),
+		RemediationFP:    artifact.RemediationFP,
+	})
+	current = normalizeRemediationState(current)
+	if current.DecisionDigest == "" {
+		current.DecisionDigest = DecisionDigest(artifact)
+	}
+	if current.RemediationEpoch == "" {
+		current.RemediationEpoch = NextRemediationEpoch(artifact)
+	}
+	if current.RemediationFP == "" {
+		current.RemediationFP = ComputeRemediationFingerprint(current)
+	}
+	if stored.RemediationFP == "" {
+		if current.SourceInputFP == "" || stored.SourceInputFP == "" || current.SourceInputFP == stored.SourceInputFP {
+			return RetryDecision{Eligible: true, UnlockDimension: "cooldown"}
+		}
+		return RetryDecision{Eligible: true, UnlockDimension: "source"}
+	}
+	if current.RemediationFP == stored.RemediationFP {
+		return RetryDecision{}
+	}
 	return RetryDecision{
 		Eligible:        true,
-		UnlockDimension: "cooldown",
+		UnlockDimension: remediationUnlockDimension(stored, current),
 	}
 }
 
@@ -299,6 +379,14 @@ func NextRetryVessel(base, parent queue.Vessel, artifact *Artifact, q *queue.Que
 	if artifact != nil {
 		retryCount = artifact.RetryCount + 1
 		meta = ApplyToMeta(meta, artifact)
+		meta = ApplyRemediationState(meta, RemediationState{
+			SourceInputFP:    base.Meta["source_input_fingerprint"],
+			HarnessDigest:    base.Meta[MetaHarnessDigest],
+			WorkflowDigest:   base.Meta[MetaWorkflowDigest],
+			DecisionDigest:   base.Meta[MetaDecisionDigest],
+			RemediationEpoch: base.Meta[MetaRemediationEpoch],
+			RemediationFP:    base.Meta[MetaRemediationFingerprint],
+		})
 		meta[MetaRetryOutcome] = "enqueued"
 		if artifact.FollowUpRoute == "" {
 			delete(meta, MetaFollowUpRoute)
@@ -321,9 +409,10 @@ func NextRetryVessel(base, parent queue.Vessel, artifact *Artifact, q *queue.Que
 	if failureFingerprint != "" {
 		meta[MetaFailureFingerprint] = failureFingerprint
 	}
-	if sourceFingerprint := strings.TrimSpace(meta["source_input_fingerprint"]); sourceFingerprint != "" {
-		meta[MetaRemediationFingerprint] = remediationFingerprint(sourceFingerprint, unlockDimension, retryCount)
+	if meta[MetaRemediationEpoch] == "" {
+		meta[MetaRemediationEpoch] = strconv.Itoa(retryCount)
 	}
+	meta = ApplyRemediationState(meta, RemediationStateFromMeta(meta))
 
 	retry := queue.Vessel{
 		ID:        RetryID(parent.ID, q),
@@ -458,13 +547,105 @@ func normalizeFailureText(text string) string {
 	return strings.Join(strings.Fields(strings.TrimSpace(strings.ToLower(text))), " ")
 }
 
-func remediationFingerprint(sourceFingerprint, unlockDimension string, retryCount int) string {
+func DecisionDigest(artifact *Artifact) string {
+	if artifact == nil {
+		return ""
+	}
+	return decisionDigestFor(
+		artifact.RecoveryClass,
+		artifact.RecoveryAction,
+		artifact.Rationale,
+		artifact.FollowUpRoute,
+		artifact.RetrySuppressed,
+		artifact.RetryCap,
+	)
+}
+
+func NextRemediationEpoch(artifact *Artifact) string {
+	if artifact == nil {
+		return "0"
+	}
+	return strconv.Itoa(max(artifact.RetryCount, 0) + 1)
+}
+
+func ComputeRemediationFingerprint(state RemediationState) string {
+	state = normalizeRemediationState(state)
 	sum := sha256.Sum256([]byte(strings.Join([]string{
-		sourceFingerprint,
-		unlockDimension,
-		strconv.Itoa(retryCount),
+		state.SourceInputFP,
+		state.HarnessDigest,
+		state.WorkflowDigest,
+		state.DecisionDigest,
+		state.RemediationEpoch,
 	}, "\n")))
 	return fmt.Sprintf("rem-%x", sum)
+}
+
+func remediationFingerprint(sourceFingerprint, unlockDimension string, retryCount int) string {
+	return ComputeRemediationFingerprint(RemediationState{
+		SourceInputFP:    sourceFingerprint,
+		DecisionDigest:   unlockDimension,
+		RemediationEpoch: strconv.Itoa(retryCount),
+	})
+}
+
+func ApplyRemediationState(meta map[string]string, state RemediationState) map[string]string {
+	if meta == nil {
+		meta = make(map[string]string)
+	}
+	state = normalizeRemediationState(state)
+	if state.SourceInputFP != "" {
+		meta["source_input_fingerprint"] = state.SourceInputFP
+	}
+	setOrDelete(meta, MetaHarnessDigest, state.HarnessDigest)
+	setOrDelete(meta, MetaWorkflowDigest, state.WorkflowDigest)
+	setOrDelete(meta, MetaDecisionDigest, state.DecisionDigest)
+	setOrDelete(meta, MetaRemediationEpoch, state.RemediationEpoch)
+	if state.RemediationFP == "" {
+		state.RemediationFP = ComputeRemediationFingerprint(state)
+	}
+	setOrDelete(meta, MetaRemediationFingerprint, state.RemediationFP)
+	return meta
+}
+
+func RemediationStateFromMeta(meta map[string]string) RemediationState {
+	return normalizeRemediationState(RemediationState{
+		SourceInputFP:    metaValue(meta, "source_input_fingerprint"),
+		HarnessDigest:    metaValue(meta, MetaHarnessDigest),
+		WorkflowDigest:   metaValue(meta, MetaWorkflowDigest),
+		DecisionDigest:   metaValue(meta, MetaDecisionDigest),
+		RemediationEpoch: metaValue(meta, MetaRemediationEpoch),
+		RemediationFP:    metaValue(meta, MetaRemediationFingerprint),
+	})
+}
+
+func DigestFile(path, prefix string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%s-%x", prefix, sum)
+}
+
+func HydrateArtifact(artifact *Artifact, meta map[string]string) *Artifact {
+	if artifact == nil {
+		return nil
+	}
+	hydrated := *artifact
+	state := normalizeRemediationState(RemediationState{
+		SourceInputFP:    firstNonEmpty(hydrated.SourceInputFP, metaValue(meta, "source_input_fingerprint")),
+		HarnessDigest:    firstNonEmpty(hydrated.HarnessDigest, metaValue(meta, MetaHarnessDigest)),
+		WorkflowDigest:   firstNonEmpty(hydrated.WorkflowDigest, metaValue(meta, MetaWorkflowDigest)),
+		DecisionDigest:   firstNonEmpty(hydrated.DecisionDigest, metaValue(meta, MetaDecisionDigest), DecisionDigest(&hydrated)),
+		RemediationEpoch: firstNonEmpty(hydrated.RemediationEpoch, metaValue(meta, MetaRemediationEpoch), strconv.Itoa(max(hydrated.RetryCount, 0))),
+	})
+	hydrated.SourceInputFP = state.SourceInputFP
+	hydrated.HarnessDigest = state.HarnessDigest
+	hydrated.WorkflowDigest = state.WorkflowDigest
+	hydrated.DecisionDigest = state.DecisionDigest
+	hydrated.RemediationEpoch = state.RemediationEpoch
+	hydrated.RemediationFP = ComputeRemediationFingerprint(state)
+	return &hydrated
 }
 
 func copyMeta(meta map[string]string) map[string]string {
@@ -498,4 +679,62 @@ func validatePathComponent(component string) error {
 		return fmt.Errorf("path component %q contains invalid characters (allowed: a-zA-Z0-9._-)", component)
 	}
 	return nil
+}
+
+func remediationStateFromInput(input Input) RemediationState {
+	return normalizeRemediationState(RemediationState{
+		SourceInputFP:    firstNonEmpty(input.SourceInputFP, metaValue(input.Meta, "source_input_fingerprint")),
+		HarnessDigest:    firstNonEmpty(input.HarnessDigest, metaValue(input.Meta, MetaHarnessDigest)),
+		WorkflowDigest:   firstNonEmpty(input.WorkflowDigest, metaValue(input.Meta, MetaWorkflowDigest)),
+		DecisionDigest:   firstNonEmpty(input.DecisionDigest, metaValue(input.Meta, MetaDecisionDigest)),
+		RemediationEpoch: firstNonEmpty(input.RemediationEpoch, metaValue(input.Meta, MetaRemediationEpoch)),
+		RemediationFP:    firstNonEmpty(input.RemediationFP, metaValue(input.Meta, MetaRemediationFingerprint)),
+	})
+}
+
+func normalizeRemediationState(state RemediationState) RemediationState {
+	state.SourceInputFP = strings.TrimSpace(state.SourceInputFP)
+	state.HarnessDigest = strings.TrimSpace(state.HarnessDigest)
+	state.WorkflowDigest = strings.TrimSpace(state.WorkflowDigest)
+	state.DecisionDigest = strings.TrimSpace(state.DecisionDigest)
+	state.RemediationEpoch = strings.TrimSpace(state.RemediationEpoch)
+	state.RemediationFP = strings.TrimSpace(state.RemediationFP)
+	return state
+}
+
+func remediationUnlockDimension(stored, current RemediationState) string {
+	switch {
+	case current.SourceInputFP != stored.SourceInputFP:
+		return "source"
+	case current.HarnessDigest != stored.HarnessDigest:
+		return "harness"
+	case current.WorkflowDigest != stored.WorkflowDigest:
+		return "workflow"
+	case current.DecisionDigest != stored.DecisionDigest:
+		return "decision"
+	case current.RemediationEpoch != stored.RemediationEpoch:
+		return "cooldown"
+	default:
+		return "cooldown"
+	}
+}
+
+func decisionDigestFor(class Class, action Action, rationale, followUpRoute string, retrySuppressed bool, retryCap int) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		string(class),
+		string(action),
+		normalizeFailureText(rationale),
+		strings.TrimSpace(followUpRoute),
+		strconv.FormatBool(retrySuppressed),
+		strconv.Itoa(retryCap),
+	}, "\n")))
+	return fmt.Sprintf("dec-%x", sum)
+}
+
+func setOrDelete(meta map[string]string, key, value string) {
+	if strings.TrimSpace(value) == "" {
+		delete(meta, key)
+		return
+	}
+	meta[key] = value
 }

--- a/cli/internal/recovery/recovery_test.go
+++ b/cli/internal/recovery/recovery_test.go
@@ -251,6 +251,103 @@ func TestRetryReadyRequiresCooldownAndCap(t *testing.T) {
 	}
 }
 
+func TestRetryReadyWithRemediationUnlocksByDimension(t *testing.T) {
+	now := time.Date(2026, time.April, 9, 18, 10, 0, 0, time.UTC)
+	retryAfter := now.Add(-time.Minute)
+	artifact := &Artifact{
+		RecoveryAction:   ActionRetry,
+		RetryCount:       0,
+		RetryCap:         2,
+		RetryAfter:       &retryAfter,
+		RecoveryClass:    ClassTransient,
+		Rationale:        "retry after transient failure",
+		SourceInputFP:    "src-old",
+		HarnessDigest:    "har-old",
+		WorkflowDigest:   "wf-old",
+		RemediationEpoch: "0",
+	}
+	artifact.DecisionDigest = DecisionDigest(artifact)
+	artifact.RemediationFP = ComputeRemediationFingerprint(RemediationState{
+		SourceInputFP:    artifact.SourceInputFP,
+		HarnessDigest:    artifact.HarnessDigest,
+		WorkflowDigest:   artifact.WorkflowDigest,
+		DecisionDigest:   artifact.DecisionDigest,
+		RemediationEpoch: artifact.RemediationEpoch,
+	})
+
+	tests := []struct {
+		name   string
+		state  RemediationState
+		unlock string
+	}{
+		{
+			name: "source",
+			state: RemediationState{
+				SourceInputFP:    "src-new",
+				HarnessDigest:    artifact.HarnessDigest,
+				WorkflowDigest:   artifact.WorkflowDigest,
+				DecisionDigest:   artifact.DecisionDigest,
+				RemediationEpoch: NextRemediationEpoch(artifact),
+			},
+			unlock: "source",
+		},
+		{
+			name: "harness",
+			state: RemediationState{
+				SourceInputFP:    artifact.SourceInputFP,
+				HarnessDigest:    "har-new",
+				WorkflowDigest:   artifact.WorkflowDigest,
+				DecisionDigest:   artifact.DecisionDigest,
+				RemediationEpoch: NextRemediationEpoch(artifact),
+			},
+			unlock: "harness",
+		},
+		{
+			name: "workflow",
+			state: RemediationState{
+				SourceInputFP:    artifact.SourceInputFP,
+				HarnessDigest:    artifact.HarnessDigest,
+				WorkflowDigest:   "wf-new",
+				DecisionDigest:   artifact.DecisionDigest,
+				RemediationEpoch: NextRemediationEpoch(artifact),
+			},
+			unlock: "workflow",
+		},
+		{
+			name: "decision",
+			state: RemediationState{
+				SourceInputFP:    artifact.SourceInputFP,
+				HarnessDigest:    artifact.HarnessDigest,
+				WorkflowDigest:   artifact.WorkflowDigest,
+				DecisionDigest:   "dec-new",
+				RemediationEpoch: NextRemediationEpoch(artifact),
+			},
+			unlock: "decision",
+		},
+		{
+			name: "cooldown",
+			state: RemediationState{
+				SourceInputFP:    artifact.SourceInputFP,
+				HarnessDigest:    artifact.HarnessDigest,
+				WorkflowDigest:   artifact.WorkflowDigest,
+				DecisionDigest:   artifact.DecisionDigest,
+				RemediationEpoch: NextRemediationEpoch(artifact),
+			},
+			unlock: "cooldown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision := RetryReadyWithRemediation(artifact, tt.state, now)
+			assert.Equal(t, RetryDecision{
+				Eligible:        true,
+				UnlockDimension: tt.unlock,
+			}, decision)
+		})
+	}
+}
+
 func TestBuildRecomputesRetryAfterForRetryFailures(t *testing.T) {
 	createdAt := time.Date(2026, time.April, 9, 18, 20, 0, 0, time.UTC)
 	staleRetryAfter := createdAt.Add(-time.Hour)

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -28,12 +28,14 @@ type GitHubTask struct {
 
 // GitHub scans GitHub issues and produces vessels.
 type GitHub struct {
-	Repo      string
-	Tasks     map[string]GitHubTask
-	Exclude   []string
-	StateDir  string
-	Queue     *queue.Queue
-	CmdRunner CommandRunner
+	Repo                   string
+	Tasks                  map[string]GitHubTask
+	Exclude                []string
+	StateDir               string
+	Queue                  *queue.Queue
+	CmdRunner              CommandRunner
+	HarnessDigestResolver  func() string
+	WorkflowDigestResolver func(string) string
 }
 
 type ghIssue struct {
@@ -98,6 +100,7 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					// consistent with its workflow state.
 					"trigger_label": label,
 				}
+				baseMeta = applyCurrentRemediationMeta(baseMeta, nil, g.currentHarnessDigest(), g.currentWorkflowDigest(task.Workflow))
 				sl := task.StatusLabels
 				if sl != nil {
 					baseMeta["status_label_queued"] = sl.Queued
@@ -296,17 +299,22 @@ func (g *GitHub) retryCandidate(base queue.Vessel) (*queue.Vessel, bool, error) 
 	case queue.StatePending, queue.StateRunning, queue.StateWaiting:
 		return nil, true, nil
 	case queue.StateFailed, queue.StateTimedOut:
-		if latest.Meta["source_input_fingerprint"] != base.Meta["source_input_fingerprint"] {
-			return nil, false, nil
-		}
-		artifact, eligible, loadErr := g.loadRetryArtifact(*latest)
+		artifact, found, loadErr := g.loadRetryArtifact(*latest)
 		if loadErr != nil {
 			return nil, false, loadErr
 		}
-		if !eligible {
+		if !found {
+			if latest.Meta["source_input_fingerprint"] != base.Meta["source_input_fingerprint"] {
+				return nil, false, nil
+			}
 			return nil, true, nil
 		}
-		retry := recovery.NextRetryVessel(base, *latest, artifact, g.Queue, sourceNow(), "cooldown")
+		base.Meta = applyCurrentRemediationMeta(base.Meta, artifact, g.currentHarnessDigest(), g.currentWorkflowDigest(base.Workflow))
+		decision := retryDecision(artifact, latest.Meta, base.Meta, sourceNow())
+		if !decision.Eligible {
+			return nil, true, nil
+		}
+		retry := recovery.NextRetryVessel(base, *latest, artifact, g.Queue, sourceNow(), decision.UnlockDimension)
 		return &retry, false, nil
 	default:
 		return nil, false, nil
@@ -324,8 +332,7 @@ func (g *GitHub) loadRetryArtifact(vessel queue.Vessel) (*recovery.Artifact, boo
 		}
 		return nil, false, fmt.Errorf("load recovery artifact for %s: %w", vessel.ID, err)
 	}
-	decision := recovery.RetryReady(artifact, sourceNow())
-	return artifact, decision.Eligible, nil
+	return recovery.HydrateArtifact(artifact, vessel.Meta), true, nil
 }
 
 func (g *GitHub) recoveryAwareVessel(vessel queue.Vessel) queue.Vessel {
@@ -346,6 +353,20 @@ func shouldRouteToRefinement(vessel queue.Vessel) bool {
 		action == string(recovery.ActionSplitTask) ||
 		class == string(recovery.ClassSpecGap) ||
 		class == string(recovery.ClassScopeGap)
+}
+
+func (g *GitHub) currentHarnessDigest() string {
+	if g != nil && g.HarnessDigestResolver != nil {
+		return strings.TrimSpace(g.HarnessDigestResolver())
+	}
+	return defaultHarnessDigest()
+}
+
+func (g *GitHub) currentWorkflowDigest(workflow string) string {
+	if g != nil && g.WorkflowDigestResolver != nil {
+		return strings.TrimSpace(g.WorkflowDigestResolver(workflow))
+	}
+	return defaultWorkflowDigest(workflow)
 }
 
 func issueLabelNames(labels []struct {

--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -15,12 +15,14 @@ import (
 
 // GitHubPR scans GitHub pull requests and produces vessels.
 type GitHubPR struct {
-	Repo      string
-	Tasks     map[string]GitHubTask
-	Exclude   []string
-	StateDir  string
-	Queue     *queue.Queue
-	CmdRunner CommandRunner
+	Repo                   string
+	Tasks                  map[string]GitHubTask
+	Exclude                []string
+	StateDir               string
+	Queue                  *queue.Queue
+	CmdRunner              CommandRunner
+	HarnessDigestResolver  func() string
+	WorkflowDigestResolver func(string) string
 }
 
 // resolveConflictsWorkflow is the de facto workflow identifier whose task
@@ -124,6 +126,7 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					State:     queue.StatePending,
 					CreatedAt: sourceNow(),
 				}
+				baseVessel.Meta = applyCurrentRemediationMeta(baseVessel.Meta, nil, g.currentHarnessDigest(), g.currentWorkflowDigest(task.Workflow))
 				sl := task.StatusLabels
 				if sl != nil {
 					baseVessel.Meta["status_label_queued"] = sl.Queued
@@ -334,17 +337,22 @@ func (g *GitHubPR) retryCandidate(base queue.Vessel, prURL, fingerprint, workflo
 	case queue.StatePending, queue.StateRunning, queue.StateWaiting:
 		return nil, true, nil
 	case queue.StateFailed, queue.StateTimedOut:
-		if latest.Meta["source_input_fingerprint"] != fingerprint {
-			return nil, false, nil
-		}
-		artifact, eligible, loadErr := g.loadRetryArtifact(*latest)
+		artifact, found, loadErr := g.loadRetryArtifact(*latest)
 		if loadErr != nil {
 			return nil, false, loadErr
 		}
-		if !eligible {
+		if !found {
+			if latest.Meta["source_input_fingerprint"] != fingerprint {
+				return nil, false, nil
+			}
 			return nil, true, nil
 		}
-		retry := recovery.NextRetryVessel(base, *latest, artifact, g.Queue, sourceNow(), "cooldown")
+		base.Meta = applyCurrentRemediationMeta(base.Meta, artifact, g.currentHarnessDigest(), g.currentWorkflowDigest(base.Workflow))
+		decision := retryDecision(artifact, latest.Meta, base.Meta, sourceNow())
+		if !decision.Eligible {
+			return nil, true, nil
+		}
+		retry := recovery.NextRetryVessel(base, *latest, artifact, g.Queue, sourceNow(), decision.UnlockDimension)
 		return &retry, false, nil
 	default:
 		return nil, false, nil
@@ -362,6 +370,19 @@ func (g *GitHubPR) loadRetryArtifact(vessel queue.Vessel) (*recovery.Artifact, b
 		}
 		return nil, false, fmt.Errorf("load recovery artifact for %s: %w", vessel.ID, err)
 	}
-	decision := recovery.RetryReady(artifact, sourceNow())
-	return artifact, decision.Eligible, nil
+	return recovery.HydrateArtifact(artifact, vessel.Meta), true, nil
+}
+
+func (g *GitHubPR) currentHarnessDigest() string {
+	if g != nil && g.HarnessDigestResolver != nil {
+		return strings.TrimSpace(g.HarnessDigestResolver())
+	}
+	return defaultHarnessDigest()
+}
+
+func (g *GitHubPR) currentWorkflowDigest(workflow string) string {
+	if g != nil && g.WorkflowDigestResolver != nil {
+		return strings.TrimSpace(g.WorkflowDigestResolver(workflow))
+	}
+	return defaultWorkflowDigest(workflow)
 }

--- a/cli/internal/source/github_pr_test.go
+++ b/cli/internal/source/github_pr_test.go
@@ -468,7 +468,7 @@ func TestSmoke_S5_GitHubPRScanBlocksRetryUntilCooldownExpires(t *testing.T) {
 	require.NoError(t, err)
 	_, err = q.Dequeue()
 	require.NoError(t, err)
-	require.NoError(t, q.Update("pr-10-review-pr", queue.StateFailed, "temporary network outage"))
+	require.NoError(t, q.Update("pr-10-review-pr", queue.StateFailed, "temporary failure from upstream 503"))
 
 	artifact := recovery.Build(recovery.Input{
 		VesselID:  "pr-10-review-pr",
@@ -594,6 +594,152 @@ func TestSmoke_S7_GitHubPRScanKeepsLegacyBlockingWhenRecoveryArtifactMissing(t *
 	vessels, err := src.Scan(context.Background())
 	require.NoError(t, err)
 	assert.Empty(t, vessels)
+}
+
+func TestGitHubPRScanRetriesWhenOnlyWorkflowDigestChanges(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "same title", Body: "same body", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+
+	fingerprint := githubSourceFingerprint("same title", "same body", []string{"review-me"})
+	qualifiedRef := prWorkflowRef(prs[0].URL, "review-pr")
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "pr-10-review-pr",
+		Source:   "github-pr",
+		Ref:      qualifiedRef,
+		Workflow: "review-pr",
+		Meta: map[string]string{
+			"pr_num":                    "10",
+			"source_input_fingerprint":  fingerprint,
+			recovery.MetaHarnessDigest:  "har-same",
+			recovery.MetaWorkflowDigest: "wf-old",
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("pr-10-review-pr", queue.StateFailed, "temporary network outage"))
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID: "pr-10-review-pr",
+		Source:   "github-pr",
+		Workflow: "review-pr",
+		Ref:      qualifiedRef,
+		State:    queue.StateFailed,
+		Error:    "temporary failure from upstream 503",
+		Meta: map[string]string{
+			"source_input_fingerprint":  fingerprint,
+			recovery.MetaHarnessDigest:  "har-same",
+			recovery.MetaWorkflowDigest: "wf-old",
+		},
+		CreatedAt: time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown),
+	})
+	require.NoError(t, recovery.Save(dir, artifact))
+
+	src := &GitHubPR{
+		Repo:                   "owner/repo",
+		Tasks:                  map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		StateDir:               dir,
+		Queue:                  q,
+		CmdRunner:              r,
+		HarnessDigestResolver:  func() string { return "har-same" },
+		WorkflowDigestResolver: func(string) string { return "wf-new" },
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "pr-10-review-pr-retry-1", vessels[0].ID)
+	assert.Equal(t, "workflow", vessels[0].Meta[recovery.MetaUnlockedBy])
+}
+
+func TestGitHubPRScanRetriesWhenOnlyDecisionDigestChanges(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(dir + "/queue.jsonl")
+	r := newMock()
+
+	prs := []ghPR{
+		{Number: 10, Title: "same title", Body: "same body", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "fix",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "review-me"}}},
+	}
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "review-me", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+
+	fingerprint := githubSourceFingerprint("same title", "same body", []string{"review-me"})
+	qualifiedRef := prWorkflowRef(prs[0].URL, "review-pr")
+	storedDecision := "dec-old"
+	storedState := recovery.RemediationState{
+		SourceInputFP:    fingerprint,
+		HarnessDigest:    "har-same",
+		WorkflowDigest:   "wf-same",
+		DecisionDigest:   storedDecision,
+		RemediationEpoch: "0",
+	}
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "pr-10-review-pr",
+		Source:   "github-pr",
+		Ref:      qualifiedRef,
+		Workflow: "review-pr",
+		Meta: map[string]string{
+			"pr_num":                            "10",
+			"source_input_fingerprint":          fingerprint,
+			recovery.MetaHarnessDigest:          storedState.HarnessDigest,
+			recovery.MetaWorkflowDigest:         storedState.WorkflowDigest,
+			recovery.MetaDecisionDigest:         storedState.DecisionDigest,
+			recovery.MetaRemediationEpoch:       storedState.RemediationEpoch,
+			recovery.MetaRemediationFingerprint: recovery.ComputeRemediationFingerprint(storedState),
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("pr-10-review-pr", queue.StateFailed, "temporary failure from upstream 503"))
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID: "pr-10-review-pr",
+		Source:   "github-pr",
+		Workflow: "review-pr",
+		Ref:      qualifiedRef,
+		State:    queue.StateFailed,
+		Error:    "temporary failure from upstream 503",
+		Meta: map[string]string{
+			"source_input_fingerprint":  fingerprint,
+			recovery.MetaHarnessDigest:  storedState.HarnessDigest,
+			recovery.MetaWorkflowDigest: storedState.WorkflowDigest,
+		},
+		CreatedAt: time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown),
+	})
+	require.NoError(t, recovery.Save(dir, artifact))
+	require.NotEqual(t, storedDecision, recovery.DecisionDigest(artifact))
+
+	src := &GitHubPR{
+		Repo:                   "owner/repo",
+		Tasks:                  map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
+		StateDir:               dir,
+		Queue:                  q,
+		CmdRunner:              r,
+		HarnessDigestResolver:  func() string { return storedState.HarnessDigest },
+		WorkflowDigestResolver: func(string) string { return storedState.WorkflowDigest },
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "pr-10-review-pr-retry-1", vessels[0].ID)
+	assert.Equal(t, "decision", vessels[0].Meta[recovery.MetaUnlockedBy])
 }
 
 func TestPriorVesselBlocksReenqueue(t *testing.T) {

--- a/cli/internal/source/github_test.go
+++ b/cli/internal/source/github_test.go
@@ -376,6 +376,250 @@ func TestSmoke_S4_GitHubScanKeepsLegacyBlockingWhenRecoveryArtifactMissing(t *te
 	assert.Empty(t, vessels)
 }
 
+func TestGitHubScanRetriesWhenOnlySourceFingerprintChanges(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{{
+		Number: 42,
+		Title:  "flaky dependency",
+		Body:   "updated body",
+		URL:    "https://github.com/owner/repo/issues/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}},
+	}}
+	issueBytes, _ := json.Marshal(issues)
+	r.set(issueBytes, "gh", "search", "issues",
+		"--repo", "owner/repo",
+		"--state", "open",
+		"--json", "number,title,body,url,labels",
+		"--limit", "20",
+		"--label", "bug")
+
+	oldFingerprint := githubSourceFingerprint("flaky dependency", "same body", []string{"bug"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      issues[0].URL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": oldFingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("issue-42", queue.StateFailed, "temporary failure from upstream 503"))
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID: "issue-42",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Ref:      issues[0].URL,
+		State:    queue.StateFailed,
+		Error:    "temporary failure from upstream 503",
+		Meta: map[string]string{
+			"source_input_fingerprint": oldFingerprint,
+		},
+		CreatedAt: time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown),
+	})
+	artifact.HarnessDigest = "har-same"
+	artifact.WorkflowDigest = "wf-same"
+	artifact.DecisionDigest = recovery.DecisionDigest(artifact)
+	artifact.RemediationEpoch = "0"
+	artifact.RemediationFP = recovery.ComputeRemediationFingerprint(recovery.RemediationState{
+		SourceInputFP:    oldFingerprint,
+		HarnessDigest:    artifact.HarnessDigest,
+		WorkflowDigest:   artifact.WorkflowDigest,
+		DecisionDigest:   artifact.DecisionDigest,
+		RemediationEpoch: artifact.RemediationEpoch,
+	})
+	require.NoError(t, recovery.Save(dir, artifact))
+
+	g := &GitHub{
+		Repo:                   "owner/repo",
+		Tasks:                  map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		StateDir:               dir,
+		Queue:                  q,
+		CmdRunner:              r,
+		HarnessDigestResolver:  func() string { return "har-same" },
+		WorkflowDigestResolver: func(string) string { return "wf-same" },
+	}
+
+	vessels, err := g.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "issue-42-retry-1", vessels[0].ID)
+	assert.Equal(t, "issue-42", vessels[0].RetryOf)
+	assert.Equal(t, "source", vessels[0].Meta[recovery.MetaUnlockedBy])
+}
+
+func TestGitHubScanRetriesWhenOnlyHarnessDigestChanges(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{{
+		Number: 42,
+		Title:  "flaky dependency",
+		Body:   "same body",
+		URL:    "https://github.com/owner/repo/issues/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}},
+	}}
+	issueBytes, _ := json.Marshal(issues)
+	r.set(issueBytes, "gh", "search", "issues",
+		"--repo", "owner/repo",
+		"--state", "open",
+		"--json", "number,title,body,url,labels",
+		"--limit", "20",
+		"--label", "bug")
+
+	fingerprint := githubSourceFingerprint("flaky dependency", "same body", []string{"bug"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      issues[0].URL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": fingerprint,
+			recovery.MetaHarnessDigest: "har-old",
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("issue-42", queue.StateFailed, "temporary failure from upstream 503"))
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID: "issue-42",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Ref:      issues[0].URL,
+		State:    queue.StateFailed,
+		Error:    "temporary failure from upstream 503",
+		Meta: map[string]string{
+			"source_input_fingerprint":  fingerprint,
+			recovery.MetaHarnessDigest:  "har-old",
+			recovery.MetaWorkflowDigest: "wf-same",
+		},
+		CreatedAt: time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown),
+	})
+	require.NoError(t, recovery.Save(dir, artifact))
+
+	g := &GitHub{
+		Repo:                   "owner/repo",
+		Tasks:                  map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		StateDir:               dir,
+		Queue:                  q,
+		CmdRunner:              r,
+		HarnessDigestResolver:  func() string { return "har-new" },
+		WorkflowDigestResolver: func(string) string { return "wf-same" },
+	}
+
+	vessels, err := g.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "issue-42-retry-1", vessels[0].ID)
+	assert.Equal(t, "harness", vessels[0].Meta[recovery.MetaUnlockedBy])
+}
+
+func TestGitHubScanRetriesWhenOnlyDecisionDigestChanges(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{{
+		Number: 42,
+		Title:  "flaky dependency",
+		Body:   "same body",
+		URL:    "https://github.com/owner/repo/issues/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}},
+	}}
+	issueBytes, _ := json.Marshal(issues)
+	r.set(issueBytes, "gh", "search", "issues",
+		"--repo", "owner/repo",
+		"--state", "open",
+		"--json", "number,title,body,url,labels",
+		"--limit", "20",
+		"--label", "bug")
+
+	fingerprint := githubSourceFingerprint("flaky dependency", "same body", []string{"bug"})
+	storedDecision := "dec-old"
+	storedState := recovery.RemediationState{
+		SourceInputFP:    fingerprint,
+		HarnessDigest:    "har-same",
+		WorkflowDigest:   "wf-same",
+		DecisionDigest:   storedDecision,
+		RemediationEpoch: "0",
+	}
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      issues[0].URL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                         "42",
+			"source_input_fingerprint":          fingerprint,
+			recovery.MetaHarnessDigest:          storedState.HarnessDigest,
+			recovery.MetaWorkflowDigest:         storedState.WorkflowDigest,
+			recovery.MetaDecisionDigest:         storedState.DecisionDigest,
+			recovery.MetaRemediationEpoch:       storedState.RemediationEpoch,
+			recovery.MetaRemediationFingerprint: recovery.ComputeRemediationFingerprint(storedState),
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("issue-42", queue.StateFailed, "temporary failure from upstream 503"))
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID: "issue-42",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Ref:      issues[0].URL,
+		State:    queue.StateFailed,
+		Error:    "temporary failure from upstream 503",
+		Meta: map[string]string{
+			"source_input_fingerprint":  fingerprint,
+			recovery.MetaHarnessDigest:  storedState.HarnessDigest,
+			recovery.MetaWorkflowDigest: storedState.WorkflowDigest,
+		},
+		CreatedAt: time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown),
+	})
+	require.NoError(t, recovery.Save(dir, artifact))
+	require.NotEqual(t, storedDecision, recovery.DecisionDigest(artifact))
+
+	g := &GitHub{
+		Repo:                   "owner/repo",
+		Tasks:                  map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		StateDir:               dir,
+		Queue:                  q,
+		CmdRunner:              r,
+		HarnessDigestResolver:  func() string { return storedState.HarnessDigest },
+		WorkflowDigestResolver: func(string) string { return storedState.WorkflowDigest },
+	}
+
+	vessels, err := g.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "issue-42-retry-1", vessels[0].ID)
+	assert.Equal(t, "decision", vessels[0].Meta[recovery.MetaUnlockedBy])
+}
+
 func TestOnFailAppliesLabel(t *testing.T) {
 	r := newMock()
 	g := &GitHub{

--- a/cli/internal/source/remediation.go
+++ b/cli/internal/source/remediation.go
@@ -1,0 +1,65 @@
+package source
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
+)
+
+func applyCurrentRemediationMeta(meta map[string]string, artifact *recovery.Artifact, harnessDigest, workflowDigest string) map[string]string {
+	state := recovery.RemediationState{
+		SourceInputFP:  strings.TrimSpace(meta["source_input_fingerprint"]),
+		HarnessDigest:  strings.TrimSpace(harnessDigest),
+		WorkflowDigest: strings.TrimSpace(workflowDigest),
+		DecisionDigest: recovery.DecisionDigest(artifact),
+	}
+	if artifact != nil {
+		state.RemediationEpoch = recovery.NextRemediationEpoch(artifact)
+	} else {
+		state.RemediationEpoch = "0"
+	}
+	return recovery.ApplyRemediationState(meta, state)
+}
+
+func defaultHarnessDigest() string {
+	return recovery.DigestFile(filepath.Join(".xylem", "HARNESS.md"), "har")
+}
+
+func defaultWorkflowDigest(workflow string) string {
+	return recovery.DigestFile(filepath.Join(".xylem", "workflows", workflow+".yaml"), "wf")
+}
+
+func retryDecision(artifact *recovery.Artifact, previousMeta, currentMeta map[string]string, now time.Time) recovery.RetryDecision {
+	if artifact == nil {
+		return recovery.RetryDecision{}
+	}
+	comparison := *artifact
+	stored := recovery.RemediationStateFromMeta(previousMeta)
+	if stored.SourceInputFP == "" {
+		stored.SourceInputFP = strings.TrimSpace(artifact.SourceInputFP)
+	}
+	if stored.HarnessDigest == "" {
+		stored.HarnessDigest = strings.TrimSpace(artifact.HarnessDigest)
+	}
+	if stored.WorkflowDigest == "" {
+		stored.WorkflowDigest = strings.TrimSpace(artifact.WorkflowDigest)
+	}
+	if stored.DecisionDigest == "" {
+		stored.DecisionDigest = strings.TrimSpace(artifact.DecisionDigest)
+	}
+	if stored.RemediationEpoch == "" {
+		stored.RemediationEpoch = strings.TrimSpace(artifact.RemediationEpoch)
+	}
+	if stored.RemediationFP == "" {
+		stored.RemediationFP = strings.TrimSpace(artifact.RemediationFP)
+	}
+	comparison.SourceInputFP = stored.SourceInputFP
+	comparison.HarnessDigest = stored.HarnessDigest
+	comparison.WorkflowDigest = stored.WorkflowDigest
+	comparison.DecisionDigest = stored.DecisionDigest
+	comparison.RemediationEpoch = stored.RemediationEpoch
+	comparison.RemediationFP = stored.RemediationFP
+	return recovery.RetryReadyWithRemediation(&comparison, recovery.RemediationStateFromMeta(currentMeta), now)
+}


### PR DESCRIPTION
## Summary
- gate failed-vessel retries against the stored remediation fingerprint from the failed vessel while recomputing current source, harness, workflow, and decision digests
- add shared remediation helpers so both GitHub issue and PR sources unlock retries consistently across cooldown, source, harness, workflow, and decision changes
- extend recovery/source tests with the new unlock coverage, including decision-only retries in both scanner paths

Closes https://github.com/nicholls-inc/xylem/issues/213