### PR TITLE
feat: auto-admin-merge green harness PRs from the daemon

### DIFF
--- a/.xylem/HARNESS.md
+++ b/.xylem/HARNESS.md
@@ -79,3 +79,13 @@ CI runs, in order: `goimports -l .`, `go vet`, `golangci-lint`, `go build`, `go 
 - **git** — must be on PATH (worktree operations)
 - **claude** — Claude Code CLI, for session execution
 - **gh** — GitHub CLI, authenticated. Required only for `github` source scanning.
+
+# Harness PR auto-admin-merge contract
+
+For self-hosted `harness-impl` pull requests, the daemon and the checked-in
+`merge-pr` workflow share the same contract:
+
+- Only PRs on xylem-managed issue branches with the required merge labels are eligible.
+- The `no-auto-admin-merge` label is an immediate opt-out and leaves the PR for manual handling.
+- Auto-admin-merge only fires when the PR is `MERGEABLE`, CI is fully green, there is no active `CHANGES_REQUESTED` review state, and all review threads are resolved.
+- Non-`harness-impl` or otherwise human-authored PRs remain outside this path and still require normal manual merge decisions.

--- a/.xylem/prompts/merge-pr/check.md
+++ b/.xylem/prompts/merge-pr/check.md
@@ -1,4 +1,4 @@
-Verify that the following pull request is ready to merge.
+Verify that the following pull request is safe for xylem's automatic admin-merge path.
 
 Issue: {{.Issue.Title}}
 URL: {{.Issue.URL}}
@@ -10,18 +10,26 @@ PR Number: {{.Issue.Number}}
 
 Run all of the following checks and report each result:
 
-1. **CI status** -- Run `gh pr checks {{.Issue.Number}}` and confirm every required check has passed. If any check is failing or pending, record which ones.
+1. **Eligibility** -- Run `gh pr view {{.Issue.Number}} --json state,labels --jq '{state: .state, labels: [.labels[].name]}'` and confirm:
+   - the PR is still `OPEN`
+   - it still has the `harness-impl` label
+   - it does **not** have the `no-auto-admin-merge` label
 
-2. **Review state** -- Run `gh pr view {{.Issue.Number}} --json reviews --jq '.reviews[] | {state: .state, author: .author.login}'` and check for any `CHANGES_REQUESTED` reviews that have not been followed by an `APPROVED` review from the same author.
+2. **CI status** -- Run `gh pr checks {{.Issue.Number}}` and confirm every required check has passed. If any check is failing or pending, record which ones.
 
-3. **Mergeable state** -- Run `gh pr view {{.Issue.Number}} --json mergeable --jq '.mergeable'` and confirm the value is `MERGEABLE`.
+3. **Review state** -- Run `gh pr view {{.Issue.Number}} --json reviewDecision,reviewThreads,reviews` and confirm:
+   - `reviewDecision` is **not** `CHANGES_REQUESTED`
+   - every review thread is resolved (`isResolved == true`)
+   - there is no outstanding review signal that should block an admin merge
+
+4. **Mergeable state** -- Run `gh pr view {{.Issue.Number}} --json mergeable --jq '.mergeable'` and confirm the value is `MERGEABLE`.
 
 ## Decision
 
-If ANY check fails, output the exact standalone line:
+If ANY check fails, or the PR is already merged/closed, or the PR has the `no-auto-admin-merge` label, output the exact standalone line:
 
 XYLEM_NOOP
 
 Then explain which checks failed and why the PR cannot be merged yet.
 
-If ALL checks pass, confirm the PR is ready to merge and summarize the passing results.
+If ALL checks pass, confirm the PR is ready for admin merge and summarize the passing results.

--- a/.xylem/workflows/merge-pr.yaml
+++ b/.xylem/workflows/merge-pr.yaml
@@ -8,11 +8,9 @@ phases:
       match: XYLEM_NOOP
   - name: merge
     type: command
-    # Use --auto so GitHub queues the merge for when required checks pass and
-    # review requirements are met, rather than failing immediately with
-    # "Pull request is not mergeable: the merge commit cannot be cleanly
-    # created" when checks are still pending. The previous --admin flag
-    # attempted to bypass protection but hit the same mergeability gate when
-    # a PR was behind main or had pending CI, producing exit status 1 and
-    # blocking further merge-pr vessels. --auto correctly waits.
-    run: "gh pr merge {{.Issue.Number}} --repo {{.Repo.Slug}} --squash --delete-branch --auto"
+    # The check phase enforces xylem's deterministic safety contract
+    # (trusted harness PR, green CI, mergeable, no unresolved review threads,
+    # no opt-out label). At that point the desired behavior is an immediate
+    # admin merge rather than a queued GitHub auto-merge that can still wait
+    # on admin-only protections.
+    run: "gh pr merge {{.Issue.Number}} --repo {{.Repo.Slug}} --squash --delete-branch --admin"

--- a/cli/cmd/xylem/automerge.go
+++ b/cli/cmd/xylem/automerge.go
@@ -19,6 +19,7 @@ type autoMergeSettings struct {
 	branchPattern            *regexp.Regexp
 	branchPatternRaw         string
 	reviewer                 string
+	optOutLabel              string
 	conflictResolutionLabels []string
 }
 
@@ -35,6 +36,7 @@ func newAutoMergeSettings(dc config.DaemonConfig) (autoMergeSettings, error) {
 		branchPattern:            compiled,
 		branchPatternRaw:         pattern,
 		reviewer:                 dc.EffectiveAutoMergeReviewer(),
+		optOutLabel:              dc.EffectiveAutoAdminMergeOptOutLabel(),
 		conflictResolutionLabels: append([]string{"needs-conflict-resolution"}, labels...),
 	}, nil
 }
@@ -67,7 +69,7 @@ func isBenignGhWarning(err error) bool {
 // pair: the reviewer will not spontaneously become a collaborator, so
 // retrying on every drain tick only spams the log. Callers should treat
 // this as "review cannot be requested from this bot; continue with
-// auto-merge and let branch protection wait for some other approval".
+// admin-merge safety checks instead".
 func isReviewerNotCollaborator(err error) bool {
 	if err == nil {
 		return false
@@ -96,6 +98,9 @@ type prSummary struct {
 		} `json:"author"`
 		State string `json:"state"`
 	} `json:"latestReviews"`
+	ReviewThreads []struct {
+		IsResolved bool `json:"isResolved"`
+	} `json:"reviewThreads"`
 	Labels []struct {
 		Name string `json:"name"`
 	} `json:"labels"`
@@ -124,14 +129,15 @@ func (p prSummary) hasLabels(names ...string) bool {
 type autoMergeAction int
 
 const (
-	actionSkip             autoMergeAction = iota // not a merge-ready xylem PR, or skip for other reasons
-	actionRequestReview                           // request copilot review, then enable auto-merge
-	actionWaitForChecks                           // CI still running
-	actionWaitForMergeable                        // unknown mergeable state (github computing)
-	actionRouteConflict                           // conflicts — add labels so resolve-conflicts workflow picks it up
-	actionAddressReview                           // changes requested; another workflow handles
-	actionEnableAutoMerge                         // enable GitHub auto-merge
-	actionWaitForAutoMerge                        // auto-merge already enabled; wait for GitHub
+	actionSkip                 autoMergeAction = iota // not a merge-ready xylem PR, or skip for other reasons
+	actionRequestReview                               // request copilot review, then continue with admin merge
+	actionWaitForChecks                               // CI still running
+	actionWaitForMergeable                            // unknown mergeable state (github computing)
+	actionRouteConflict                               // conflicts — add labels so resolve-conflicts workflow picks it up
+	actionAddressReview                               // changes requested; another workflow handles
+	actionWaitForReviewThreads                        // unresolved review threads remain
+	actionBlockedOptOut                               // explicit no-auto-admin-merge label
+	actionAdminMerge                                  // merge immediately with admin bypass
 )
 
 // decideAutoMergeAction returns the action to take for a given PR. It does
@@ -146,15 +152,19 @@ const (
 // 5. Unknown mergeable state → wait (github computing)
 // 6. CI failing/running → wait (fix-pr-checks handles failures)
 // 7. Changes requested → wait (respond-to-pr-review handles)
-// 8. Auto-merge already enabled → wait for GitHub
-// 9. No copilot review requested or submitted → request review, then enable auto-merge
-// 10. Otherwise enable auto-merge and let branch protection enforce review
+// 8. Explicit no-auto-admin-merge label → stay blocked
+// 9. Unresolved review threads → wait
+// 10. No copilot review requested or submitted → request review, then admin-merge
+// 11. Otherwise admin-merge immediately
 func decideAutoMergeAction(pr prSummary, settings autoMergeSettings) autoMergeAction {
 	if !isMergeReadyPR(pr, settings) {
 		return actionSkip
 	}
 	if pr.State != "OPEN" && pr.State != "" {
 		return actionSkip
+	}
+	if pr.hasLabel(settings.optOutLabel) {
+		return actionBlockedOptOut
 	}
 	// Mergeable state: MERGEABLE / CONFLICTING / UNKNOWN
 	if pr.Mergeable == "CONFLICTING" {
@@ -176,13 +186,13 @@ func decideAutoMergeAction(pr prSummary, settings autoMergeSettings) autoMergeAc
 	if pr.ReviewDecision == "CHANGES_REQUESTED" {
 		return actionAddressReview
 	}
-	if autoMergeEnabled(pr) {
-		return actionWaitForAutoMerge
+	if hasUnresolvedReviewThreads(pr) {
+		return actionWaitForReviewThreads
 	}
 	if settings.reviewer != "" && !reviewRequestedOrSubmitted(pr, settings.reviewer) {
 		return actionRequestReview
 	}
-	return actionEnableAutoMerge
+	return actionAdminMerge
 }
 
 func isMergeReadyPR(pr prSummary, settings autoMergeSettings) bool {
@@ -190,8 +200,13 @@ func isMergeReadyPR(pr prSummary, settings autoMergeSettings) bool {
 		pr.hasLabels(settings.labels...)
 }
 
-func autoMergeEnabled(pr prSummary) bool {
-	return pr.AutoMergeRequest != nil
+func hasUnresolvedReviewThreads(pr prSummary) bool {
+	for _, thread := range pr.ReviewThreads {
+		if !thread.IsResolved {
+			return true
+		}
+	}
+	return false
 }
 
 // reviewRequestedOrSubmitted returns true if the configured reviewer has either
@@ -232,8 +247,8 @@ func allChecksGreen(pr prSummary) bool {
 // The existing `respond-to-pr-review`, `fix-pr-checks`, and
 // `resolve-conflicts` workflows handle the intermediate steps via the
 // `github-pr-events` source, so auto-merge only needs to (1) kick off the
-// review cycle and (2) enable GitHub auto-merge when the PR is otherwise
-// merge-ready.
+// review cycle and (2) admin-merge trusted harness PRs once deterministic
+// merge safety checks pass.
 //
 // The repo slug comes from daemon.auto_merge_repo. If empty, gh uses the
 // current directory's origin remote.
@@ -251,6 +266,18 @@ func autoMergeXylemPRs(ctx context.Context, dc config.DaemonConfig) {
 	}
 
 	for _, pr := range prs {
+		if !isMergeReadyPR(pr, settings) {
+			continue
+		}
+		detailedPR, err := getPRSummaryFn(ctx, repo, pr.Number)
+		if err != nil {
+			slog.Error("daemon auto-merge failed to inspect PR",
+				"repo", repo,
+				"pr", pr.Number,
+				"error", err)
+			continue
+		}
+		pr = detailedPR
 		action := decideAutoMergeAction(pr, settings)
 		switch action {
 		case actionSkip:
@@ -270,7 +297,7 @@ func autoMergeXylemPRs(ctx context.Context, dc config.DaemonConfig) {
 						"reviewer", settings.reviewer,
 						"error", err)
 				} else {
-					slog.Warn("daemon auto-merge request review failed; enabling auto-merge anyway",
+					slog.Warn("daemon auto-merge request review failed; continuing with admin-merge attempt",
 						"repo", repo,
 						"pr", pr.Number,
 						"error", err)
@@ -281,14 +308,14 @@ func autoMergeXylemPRs(ctx context.Context, dc config.DaemonConfig) {
 					"pr", pr.Number,
 					"head_ref", pr.HeadRefName)
 			}
-			if err := enableAutoMergePRFn(ctx, repo, pr.Number); err != nil {
-				slog.Error("daemon auto-merge failed to enable auto-merge",
+			if err := adminMergePRFn(ctx, repo, pr.Number); err != nil {
+				slog.Error("daemon auto-merge failed to admin-merge PR",
 					"repo", repo,
 					"pr", pr.Number,
 					"error", err)
 				continue
 			}
-			slog.Info("daemon auto-merge enabled auto-merge",
+			slog.Info("daemon auto-merge merged PR with admin bypass",
 				"repo", repo,
 				"pr", pr.Number,
 				"head_ref", pr.HeadRefName)
@@ -321,50 +348,74 @@ func autoMergeXylemPRs(ctx context.Context, dc config.DaemonConfig) {
 			slog.Info("daemon auto-merge waiting for review follow-up",
 				"repo", repo,
 				"pr", pr.Number)
-		case actionEnableAutoMerge:
-			if err := enableAutoMergePRFn(ctx, repo, pr.Number); err != nil {
-				slog.Error("daemon auto-merge failed to enable auto-merge",
+		case actionWaitForReviewThreads:
+			slog.Info("daemon auto-merge waiting for unresolved review threads",
+				"repo", repo,
+				"pr", pr.Number)
+		case actionBlockedOptOut:
+			slog.Info("daemon auto-merge blocked by opt-out label",
+				"repo", repo,
+				"pr", pr.Number,
+				"label", settings.optOutLabel)
+		case actionAdminMerge:
+			if err := adminMergePRFn(ctx, repo, pr.Number); err != nil {
+				slog.Error("daemon auto-merge failed to admin-merge PR",
 					"repo", repo,
 					"pr", pr.Number,
 					"error", err)
 				continue
 			}
-			slog.Info("daemon auto-merge enabled auto-merge",
+			slog.Info("daemon auto-merge merged PR with admin bypass",
 				"repo", repo,
 				"pr", pr.Number,
 				"head_ref", pr.HeadRefName)
-		case actionWaitForAutoMerge:
-			slog.Info("daemon auto-merge waiting for GitHub auto-merge",
-				"repo", repo,
-				"pr", pr.Number)
 		}
 	}
 }
 
 var (
 	listOpenPRsFn          = listOpenPRs
+	getPRSummaryFn         = getPRSummary
 	requestCopilotReviewFn = requestCopilotReview
 	addPRLabelsFn          = addPRLabels
-	enableAutoMergePRFn    = enableAutoMergePR
+	adminMergePRFn         = adminMergePR
 )
 
 func listOpenPRs(ctx context.Context, repo string) ([]prSummary, error) {
-	args := []string{"pr", "list", "--state", "open", "--json",
-		"number,headRefName,mergeable,state,reviewDecision,autoMergeRequest,statusCheckRollup,reviewRequests,latestReviews,labels",
-		"--limit", "50"}
+	args := []string{"pr", "list", "--state", "open", "--json", "number,headRefName,state,labels", "--limit", "50"}
 	if repo != "" {
 		args = append(args, "--repo", repo)
 	}
 	cmd := exec.CommandContext(ctx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("gh pr list: %w", err)
 	}
 	var prs []prSummary
 	if err := json.Unmarshal(out, &prs); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode gh pr list output: %w", err)
 	}
 	return prs, nil
+}
+
+func getPRSummary(ctx context.Context, repo string, number int) (prSummary, error) {
+	args := []string{
+		"pr", "view", strconv.Itoa(number),
+		"--json", "number,headRefName,mergeable,state,reviewDecision,autoMergeRequest,statusCheckRollup,reviewRequests,latestReviews,reviewThreads,labels",
+	}
+	if repo != "" {
+		args = append(args, "--repo", repo)
+	}
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return prSummary{}, fmt.Errorf("gh pr view %d: %w", number, err)
+	}
+	var pr prSummary
+	if err := json.Unmarshal(out, &pr); err != nil {
+		return prSummary{}, fmt.Errorf("decode gh pr view output for %d: %w", number, err)
+	}
+	return pr, nil
 }
 
 // addPRLabels adds the given labels to a PR via the GitHub REST API.
@@ -427,8 +478,8 @@ func requestCopilotReview(ctx context.Context, repo string, number int, reviewer
 	return nil
 }
 
-func enableAutoMergePR(ctx context.Context, repo string, number int) error {
-	args := []string{"pr", "merge", "--auto", "--squash", "--delete-branch"}
+func adminMergePR(ctx context.Context, repo string, number int) error {
+	args := []string{"pr", "merge", "--admin", "--squash", "--delete-branch"}
 	if repo != "" {
 		args = append(args, "--repo", repo)
 	}

--- a/cli/cmd/xylem/automerge_prop_test.go
+++ b/cli/cmd/xylem/automerge_prop_test.go
@@ -55,19 +55,17 @@ func TestPropDecideAutoMergeActionMatchesMergeReadiness(t *testing.T) {
 	})
 }
 
-func TestPropDecideAutoMergeActionWaitsWhenAutoMergeAlreadyEnabled(t *testing.T) {
+func TestPropDecideAutoMergeActionAdminMergesWithReviewerEvidence(t *testing.T) {
 	settings := xylemAutoMergeSettings(t)
 	rapid.Check(t, func(t *rapid.T) {
 		reviewDecision := rapid.SampledFrom([]string{"", "REVIEW_REQUIRED", "APPROVED"}).Draw(t, "reviewDecision")
-		withReviewRequest := rapid.Bool().Draw(t, "withReviewRequest")
-		withLatestReview := rapid.Bool().Draw(t, "withLatestReview")
+		reviewEvidence := rapid.SampledFrom([]string{"request", "latest-review"}).Draw(t, "reviewEvidence")
 
 		pr := prSummary{
-			HeadRefName:      "feat/issue-42-42",
-			State:            "OPEN",
-			Mergeable:        "MERGEABLE",
-			ReviewDecision:   reviewDecision,
-			AutoMergeRequest: &struct{}{},
+			HeadRefName:    "feat/issue-42-42",
+			State:          "OPEN",
+			Mergeable:      "MERGEABLE",
+			ReviewDecision: reviewDecision,
 			Labels: []struct {
 				Name string `json:"name"`
 			}{{Name: "ready-to-merge"}, {Name: "harness-impl"}},
@@ -75,13 +73,16 @@ func TestPropDecideAutoMergeActionWaitsWhenAutoMergeAlreadyEnabled(t *testing.T)
 				Conclusion string `json:"conclusion"`
 				Status     string `json:"status"`
 			}{{Conclusion: "SUCCESS", Status: "COMPLETED"}},
+			ReviewThreads: []struct {
+				IsResolved bool `json:"isResolved"`
+			}{{IsResolved: true}},
 		}
-		if withReviewRequest {
-			pr.ReviewRequests = append(pr.ReviewRequests, struct {
+		switch reviewEvidence {
+		case "request":
+			pr.ReviewRequests = []struct {
 				Login string `json:"login"`
-			}{Login: settings.reviewer})
-		}
-		if withLatestReview {
+			}{{Login: settings.reviewer}}
+		case "latest-review":
 			pr.LatestReviews = append(pr.LatestReviews, struct {
 				Author struct {
 					Login string `json:"login"`
@@ -93,10 +94,39 @@ func TestPropDecideAutoMergeActionWaitsWhenAutoMergeAlreadyEnabled(t *testing.T)
 				}{Login: settings.reviewer},
 				State: "COMMENTED",
 			})
+		default:
+			t.Fatalf("unexpected review evidence %q", reviewEvidence)
 		}
 
-		if got := decideAutoMergeAction(pr, settings); got != actionWaitForAutoMerge {
-			t.Fatalf("expected wait-for-auto-merge, got %v for %+v", got, pr)
+		if got := decideAutoMergeAction(pr, settings); got != actionAdminMerge {
+			t.Fatalf("expected admin-merge, got %v for %+v", got, pr)
+		}
+	})
+}
+
+func TestPropDecideAutoMergeActionOptOutLabelAlwaysBlocks(t *testing.T) {
+	settings := xylemAutoMergeSettings(t)
+	rapid.Check(t, func(t *rapid.T) {
+		resolved := rapid.Bool().Draw(t, "resolved")
+		pr := prSummary{
+			HeadRefName:    "feat/issue-42-42",
+			State:          "OPEN",
+			Mergeable:      "MERGEABLE",
+			ReviewDecision: "APPROVED",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "ready-to-merge"}, {Name: "harness-impl"}, {Name: settings.optOutLabel}},
+			StatusCheckRollup: []struct {
+				Conclusion string `json:"conclusion"`
+				Status     string `json:"status"`
+			}{{Conclusion: "SUCCESS", Status: "COMPLETED"}},
+			ReviewThreads: []struct {
+				IsResolved bool `json:"isResolved"`
+			}{{IsResolved: resolved}},
+		}
+
+		if got := decideAutoMergeAction(pr, settings); got != actionBlockedOptOut {
+			t.Fatalf("expected opt-out block, got %v for %+v", got, pr)
 		}
 	})
 }

--- a/cli/cmd/xylem/automerge_test.go
+++ b/cli/cmd/xylem/automerge_test.go
@@ -143,6 +143,7 @@ func TestNewAutoMergeSettingsDefaults(t *testing.T) {
 	assert.Equal(t, []string{"ready-to-merge"}, settings.labels)
 	assert.Equal(t, ".*", settings.branchPatternRaw)
 	assert.Equal(t, "", settings.reviewer)
+	assert.Equal(t, "no-auto-admin-merge", settings.optOutLabel)
 	assert.Equal(t, []string{"needs-conflict-resolution", "ready-to-merge"}, settings.conflictResolutionLabels)
 	assert.True(t, settings.branchPattern.MatchString("any/branch"))
 }
@@ -158,9 +159,35 @@ func TestNewAutoMergeSettingsCustomizesLabelsPatternAndReviewer(t *testing.T) {
 	assert.Equal(t, "owner/repo", settings.repo)
 	assert.Equal(t, []string{"merge-ready", "bot-authored"}, settings.labels)
 	assert.Equal(t, "copilot-bot", settings.reviewer)
+	assert.Equal(t, "no-auto-admin-merge", settings.optOutLabel)
 	assert.Equal(t, []string{"needs-conflict-resolution", "merge-ready", "bot-authored"}, settings.conflictResolutionLabels)
 	assert.True(t, settings.branchPattern.MatchString("release/1.2"))
 	assert.False(t, settings.branchPattern.MatchString("feat/issue-1-1"))
+}
+
+func TestHasUnresolvedReviewThreads(t *testing.T) {
+	tests := []struct {
+		name    string
+		threads []struct {
+			IsResolved bool `json:"isResolved"`
+		}
+		want bool
+	}{
+		{name: "no threads", want: false},
+		{name: "all resolved", threads: []struct {
+			IsResolved bool `json:"isResolved"`
+		}{{IsResolved: true}, {IsResolved: true}}, want: false},
+		{name: "unresolved present", threads: []struct {
+			IsResolved bool `json:"isResolved"`
+		}{{IsResolved: true}, {IsResolved: false}}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pr := prSummary{ReviewThreads: tt.threads}
+			assert.Equal(t, tt.want, hasUnresolvedReviewThreads(pr))
+		})
+	}
 }
 
 func TestAllChecksGreen(t *testing.T) {
@@ -242,6 +269,17 @@ func TestDecideAutoMergeAction(t *testing.T) {
 			want: actionSkip,
 		},
 		{
+			name: "xylem PR with opt-out label stays blocked",
+			pr: prSummary{
+				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "MERGEABLE",
+				Labels: []struct {
+					Name string `json:"name"`
+				}{{Name: "ready-to-merge"}, {Name: "harness-impl"}, {Name: settings.optOutLabel}},
+				StatusCheckRollup: greenChecks,
+			},
+			want: actionBlockedOptOut,
+		},
+		{
 			name: "xylem PR with conflicts and no conflict labels is routed to resolve-conflicts",
 			pr: prSummary{
 				HeadRefName: "feat/issue-1-1",
@@ -287,6 +325,17 @@ func TestDecideAutoMergeAction(t *testing.T) {
 			want: actionAddressReview,
 		},
 		{
+			name: "xylem PR with unresolved review threads waits",
+			pr: prSummary{
+				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "MERGEABLE",
+				Labels: mergeReadyLabels, StatusCheckRollup: greenChecks, ReviewDecision: "REVIEW_REQUIRED",
+				ReviewThreads: []struct {
+					IsResolved bool `json:"isResolved"`
+				}{{IsResolved: false}},
+			},
+			want: actionWaitForReviewThreads,
+		},
+		{
 			name: "xylem PR without review requests asks for copilot review first",
 			pr: prSummary{
 				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "MERGEABLE",
@@ -295,7 +344,7 @@ func TestDecideAutoMergeAction(t *testing.T) {
 			want: actionRequestReview,
 		},
 		{
-			name: "xylem PR with copilot requested enables auto-merge",
+			name: "xylem PR with copilot requested admin-merges",
 			pr: prSummary{
 				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "MERGEABLE",
 				Labels: mergeReadyLabels, StatusCheckRollup: greenChecks, ReviewDecision: "REVIEW_REQUIRED",
@@ -303,29 +352,29 @@ func TestDecideAutoMergeAction(t *testing.T) {
 					Login string `json:"login"`
 				}{{Login: settings.reviewer}},
 			},
-			want: actionEnableAutoMerge,
+			want: actionAdminMerge,
 		},
 		{
-			name: "xylem PR approved + green + mergeable enables auto-merge",
+			name: "xylem PR approved + green + mergeable admin-merges",
 			pr: prSummary{
 				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "MERGEABLE",
 				Labels: mergeReadyLabels, StatusCheckRollup: greenChecks, ReviewDecision: "APPROVED",
 				LatestReviews: copilotReviewed,
 			},
-			want: actionEnableAutoMerge,
+			want: actionAdminMerge,
 		},
 		{
-			name: "xylem PR with auto-merge already enabled waits",
+			name: "closed xylem PR is skipped",
 			pr: prSummary{
 				HeadRefName:       "feat/issue-1-1",
-				State:             "OPEN",
+				State:             "CLOSED",
 				Mergeable:         "MERGEABLE",
-				ReviewDecision:    "REVIEW_REQUIRED",
-				AutoMergeRequest:  &struct{}{},
+				ReviewDecision:    "APPROVED",
 				Labels:            mergeReadyLabels,
 				StatusCheckRollup: greenChecks,
+				LatestReviews:     copilotReviewed,
 			},
-			want: actionWaitForAutoMerge,
+			want: actionSkip,
 		},
 	}
 	for _, tt := range tests {
@@ -340,14 +389,16 @@ func TestDecideAutoMergeAction(t *testing.T) {
 func TestSmoke_S8_AutoMergeContinuesWhenConfiguredReviewerIsNotCollaborator(t *testing.T) {
 	settings := xylemAutoMergeSettings(t)
 	origListOpenPRsFn := listOpenPRsFn
+	origGetPRSummaryFn := getPRSummaryFn
 	origRequestCopilotReviewFn := requestCopilotReviewFn
 	origAddPRLabelsFn := addPRLabelsFn
-	origEnableAutoMergePRFn := enableAutoMergePRFn
+	origAdminMergePRFn := adminMergePRFn
 	t.Cleanup(func() {
 		listOpenPRsFn = origListOpenPRsFn
+		getPRSummaryFn = origGetPRSummaryFn
 		requestCopilotReviewFn = origRequestCopilotReviewFn
 		addPRLabelsFn = origAddPRLabelsFn
-		enableAutoMergePRFn = origEnableAutoMergePRFn
+		adminMergePRFn = origAdminMergePRFn
 	})
 
 	mergeReadyPR := prSummary{
@@ -370,14 +421,14 @@ func TestSmoke_S8_AutoMergeContinuesWhenConfiguredReviewerIsNotCollaborator(t *t
 	listOpenPRsFn = func(context.Context, string) ([]prSummary, error) {
 		listCalls++
 		return []prSummary{{
-			Number:            mergeReadyPR.Number,
-			HeadRefName:       mergeReadyPR.HeadRefName,
-			Mergeable:         mergeReadyPR.Mergeable,
-			State:             mergeReadyPR.State,
-			ReviewDecision:    mergeReadyPR.ReviewDecision,
-			Labels:            mergeReadyPR.Labels,
-			StatusCheckRollup: mergeReadyPR.StatusCheckRollup,
+			Number:      mergeReadyPR.Number,
+			HeadRefName: mergeReadyPR.HeadRefName,
+			State:       mergeReadyPR.State,
+			Labels:      mergeReadyPR.Labels,
 		}}, nil
+	}
+	getPRSummaryFn = func(context.Context, string, int) (prSummary, error) {
+		return mergeReadyPR, nil
 	}
 
 	reviewCalls := 0
@@ -395,9 +446,9 @@ func TestSmoke_S8_AutoMergeContinuesWhenConfiguredReviewerIsNotCollaborator(t *t
 		return nil
 	}
 
-	enableCalls := 0
-	enableAutoMergePRFn = func(_ context.Context, repo string, number int) error {
-		enableCalls++
+	adminMergeCalls := 0
+	adminMergePRFn = func(_ context.Context, repo string, number int) error {
+		adminMergeCalls++
 		if repo != "nicholls-inc/xylem" {
 			t.Fatalf("repo = %q, want nicholls-inc/xylem", repo)
 		}
@@ -417,5 +468,80 @@ func TestSmoke_S8_AutoMergeContinuesWhenConfiguredReviewerIsNotCollaborator(t *t
 	assert.Equal(t, 1, listCalls)
 	assert.Equal(t, 1, reviewCalls)
 	assert.Equal(t, 0, labelCalls)
-	assert.Equal(t, 1, enableCalls)
+	assert.Equal(t, 1, adminMergeCalls)
+}
+
+func TestSmoke_S9_AutoAdminMergeWithinOneDaemonTick(t *testing.T) {
+	settings := xylemAutoMergeSettings(t)
+	origListOpenPRsFn := listOpenPRsFn
+	origGetPRSummaryFn := getPRSummaryFn
+	origRequestCopilotReviewFn := requestCopilotReviewFn
+	origAddPRLabelsFn := addPRLabelsFn
+	origAdminMergePRFn := adminMergePRFn
+	t.Cleanup(func() {
+		listOpenPRsFn = origListOpenPRsFn
+		getPRSummaryFn = origGetPRSummaryFn
+		requestCopilotReviewFn = origRequestCopilotReviewFn
+		addPRLabelsFn = origAddPRLabelsFn
+		adminMergePRFn = origAdminMergePRFn
+	})
+
+	mergeReadyPR := prSummary{
+		Number:         77,
+		HeadRefName:    "feat/issue-77-77",
+		Mergeable:      "MERGEABLE",
+		State:          "OPEN",
+		ReviewDecision: "APPROVED",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "ready-to-merge"}, {Name: "harness-impl"}},
+		StatusCheckRollup: []struct {
+			Conclusion string `json:"conclusion"`
+			Status     string `json:"status"`
+		}{{Conclusion: "SUCCESS", Status: "COMPLETED"}},
+		ReviewThreads: []struct {
+			IsResolved bool `json:"isResolved"`
+		}{{IsResolved: true}},
+	}
+
+	listOpenPRsFn = func(context.Context, string) ([]prSummary, error) {
+		return []prSummary{{
+			Number:      mergeReadyPR.Number,
+			HeadRefName: mergeReadyPR.HeadRefName,
+			State:       mergeReadyPR.State,
+			Labels:      mergeReadyPR.Labels,
+		}}, nil
+	}
+	getPRSummaryFn = func(context.Context, string, int) (prSummary, error) {
+		return mergeReadyPR, nil
+	}
+
+	reviewCalls := 0
+	requestCopilotReviewFn = func(context.Context, string, int, string) error {
+		reviewCalls++
+		return nil
+	}
+	labelCalls := 0
+	addPRLabelsFn = func(context.Context, string, int, []string) error {
+		labelCalls++
+		return nil
+	}
+	adminMergeCalls := 0
+	adminMergePRFn = func(_ context.Context, repo string, number int) error {
+		adminMergeCalls++
+		assert.Equal(t, settings.repo, repo)
+		assert.Equal(t, mergeReadyPR.Number, number)
+		return nil
+	}
+
+	autoMergeXylemPRs(context.Background(), config.DaemonConfig{
+		AutoMergeRepo:          settings.repo,
+		AutoMergeLabels:        append([]string(nil), settings.labels...),
+		AutoMergeBranchPattern: settings.branchPatternRaw,
+		AutoMergeReviewer:      settings.reviewer,
+	})
+
+	assert.Equal(t, 1, adminMergeCalls)
+	assert.Equal(t, 1, reviewCalls)
+	assert.Equal(t, 0, labelCalls)
 }

--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -114,8 +114,8 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		drainRunner.CheckWaitingVessels(ctx)
 		drainRunner.CheckHungVessels(ctx)
 		// Auto-merge: best-effort request copilot review on merge-ready
-		// harness PRs, then enable GitHub auto-merge once checks are green
-		// and the PR is mergeable.
+		// harness PRs, then admin-merge once deterministic safety checks
+		// are green.
 		if cfg.Daemon.AutoMerge {
 			autoMergeXylemPRs(ctx, cfg.Daemon)
 		}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -19,6 +19,7 @@ const minTimeout = 30 * time.Second
 
 const DefaultAuditLogPath = "audit.jsonl"
 const DefaultLLMRoutingTier = "med"
+const DefaultAutoAdminMergeOptOutLabel = "no-auto-admin-merge"
 
 // DefaultProtectedSurfaces is the default list of paths that xylem's
 // runtime verifier treats as off-limits to vessel modifications.
@@ -191,10 +192,10 @@ type DaemonConfig struct {
 	// auto_upgrade check while the loop is running. Only meaningful when
 	// AutoUpgrade is true. Defaults to 5m. Accepts any Go duration string.
 	UpgradeInterval string `yaml:"upgrade_interval,omitempty"`
-	// AutoMerge enables the automatic copilot review cycle + GitHub
-	// auto-merge for merge-ready xylem-authored PRs. The daemon only acts
-	// on PRs labeled ready-to-merge + harness-impl whose branches match
-	// feat/issue-*, fix/issue-*, or chore/issue-*.
+	// AutoMerge enables the daemon's automatic reviewer-request +
+	// admin-merge loop for merge-ready harness PRs. Only PRs matching the
+	// configured labels and branch pattern are eligible, and the
+	// no-auto-admin-merge label always opts a PR out.
 	AutoMerge bool `yaml:"auto_merge,omitempty"`
 	// AutoMergeRepo is the GitHub repo slug (owner/name) for auto-merge.
 	// If empty, gh CLI uses the current directory's origin remote.
@@ -506,6 +507,10 @@ func (d DaemonConfig) EffectiveAutoMergeBranchPattern() string {
 
 func (d DaemonConfig) EffectiveAutoMergeReviewer() string {
 	return strings.TrimSpace(d.AutoMergeReviewer)
+}
+
+func (d DaemonConfig) EffectiveAutoAdminMergeOptOutLabel() string {
+	return DefaultAutoAdminMergeOptOutLabel
 }
 
 // CleanupAfterDuration returns the parsed cleanup_after duration, defaulting to

--- a/cli/internal/dtu/dtu_prop_test.go
+++ b/cli/internal/dtu/dtu_prop_test.go
@@ -106,3 +106,77 @@ func TestPropRepositoryAutoMergeRespectsCheckStates(t *testing.T) {
 		}
 	})
 }
+
+func TestPropRepositoryAdminMergeBypassesCheckStates(t *testing.T) {
+	t.Parallel()
+
+	checkStates := []CheckState{
+		CheckStatePending,
+		CheckStateSuccess,
+		CheckStateFailure,
+		CheckStateCancelled,
+		CheckStateSkipped,
+	}
+
+	rapid.Check(t, func(t *rapid.T) {
+		deleteHeadBranch := rapid.Bool().Draw(t, "delete_head_branch")
+		checkCount := rapid.IntRange(0, 5).Draw(t, "check_count")
+
+		checks := make([]Check, 0, checkCount)
+		for i := 0; i < checkCount; i++ {
+			state := rapid.SampledFrom(checkStates).Draw(t, fmt.Sprintf("check_state_%d", i))
+			checks = append(checks, Check{
+				ID:    int64(i + 1),
+				Name:  fmt.Sprintf("check-%d", i),
+				State: state,
+			})
+		}
+
+		repo := &Repository{
+			Owner:         "owner",
+			Name:          "repo",
+			DefaultBranch: "main",
+			Branches: []Branch{
+				{Name: "main", SHA: "1111111111111111111111111111111111111111"},
+				{Name: "feature/merge-me", SHA: "deadbeefcafebabe"},
+			},
+			PullRequests: []PullRequest{{
+				Number:     8,
+				Title:      "Admin merge me",
+				State:      PullRequestStateOpen,
+				BaseBranch: "main",
+				HeadBranch: "feature/merge-me",
+				HeadSHA:    "feedfacecafebeef",
+				Checks:     checks,
+			}},
+		}
+
+		if err := repo.MergePullRequest(8, MergePullRequestOptions{DeleteHeadBranch: deleteHeadBranch, AdminMerge: true}); err != nil {
+			t.Fatalf("MergePullRequest() error = %v", err)
+		}
+
+		pr := repo.PullRequestByNumber(8)
+		if pr == nil {
+			t.Fatal("PullRequestByNumber() = nil")
+			return
+		}
+		if pr.State != PullRequestStateMerged || !pr.Merged {
+			t.Fatalf("merged pull request = %#v, want merged state", pr)
+		}
+		if pr.AutoMergeEnabled || pr.AutoMergeDeleteBranch {
+			t.Fatalf("merged pull request flags = %#v, want cleared auto-merge flags", pr)
+		}
+		if branch := repo.BranchByName("main"); branch == nil || branch.SHA != pr.HeadSHA {
+			t.Fatalf("main branch = %#v, want SHA %q", branch, pr.HeadSHA)
+		}
+		if deleteHeadBranch {
+			if branch := repo.BranchByName(pr.HeadBranch); branch != nil {
+				t.Fatalf("head branch = %#v, want deleted", branch)
+			}
+		} else {
+			if branch := repo.BranchByName(pr.HeadBranch); branch == nil || branch.SHA != pr.HeadSHA {
+				t.Fatalf("head branch = %#v, want retained at SHA %q", branch, pr.HeadSHA)
+			}
+		}
+	})
+}

--- a/cli/internal/dtu/dtu_test.go
+++ b/cli/internal/dtu/dtu_test.go
@@ -512,6 +512,50 @@ func TestRepositoryMergePullRequestDeletesHeadBranchAndUpsertsBase(t *testing.T)
 	}
 }
 
+func TestRepositoryAdminMergeBypassesQueuedChecks(t *testing.T) {
+	t.Parallel()
+
+	repo := &Repository{
+		Owner:         "owner",
+		Name:          "repo",
+		DefaultBranch: "main",
+		Branches: []Branch{
+			{Name: "main", SHA: "1111111111111111111111111111111111111111"},
+			{Name: "feature/merge-me", SHA: "deadbeefcafebabe"},
+		},
+		PullRequests: []PullRequest{{
+			Number:     10,
+			Title:      "Admin merge me",
+			State:      PullRequestStateOpen,
+			BaseBranch: "main",
+			HeadBranch: "feature/merge-me",
+			HeadSHA:    "feedfacecafebeef",
+			Checks:     []Check{{ID: 1, Name: "ci", State: CheckStatePending}},
+		}},
+	}
+
+	if err := repo.MergePullRequest(10, MergePullRequestOptions{DeleteHeadBranch: true, AdminMerge: true}); err != nil {
+		t.Fatalf("MergePullRequest() error = %v", err)
+	}
+
+	pr := repo.PullRequestByNumber(10)
+	if pr == nil {
+		t.Fatal("PullRequestByNumber() = nil")
+	}
+	if pr.State != PullRequestStateMerged || !pr.Merged {
+		t.Fatalf("pull request = %#v, want merged state", pr)
+	}
+	if pr.AutoMergeEnabled || pr.AutoMergeDeleteBranch {
+		t.Fatalf("pull request auto-merge flags = %#v, want cleared", pr)
+	}
+	if branch := repo.BranchByName("main"); branch == nil || branch.SHA != pr.HeadSHA {
+		t.Fatalf("main branch = %#v, want SHA %q", branch, pr.HeadSHA)
+	}
+	if branch := repo.BranchByName(pr.HeadBranch); branch != nil {
+		t.Fatalf("head branch = %#v, want deleted after admin merge", branch)
+	}
+}
+
 func TestRepositoryMergePullRequestQueuesAutoMergeUntilChecksPass(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/dtu/types.go
+++ b/cli/internal/dtu/types.go
@@ -405,11 +405,13 @@ func (r *Repository) DeleteBranch(name string) bool {
 type MergePullRequestOptions struct {
 	DeleteHeadBranch bool
 	AutoMerge        bool
+	AdminMerge       bool
 }
 
 // MergePullRequest updates pull-request and git-visible state to reflect a merge.
 // When auto-merge is requested and merge-blocking checks are still present, the
-// pull request remains open with auto-merge enabled until checks pass.
+// pull request remains open with auto-merge enabled until checks pass. Admin
+// merges bypass the queued-auto-merge path and merge immediately.
 func (r *Repository) MergePullRequest(number int, opts MergePullRequestOptions) error {
 	if r == nil {
 		return fmt.Errorf("repository must not be nil")
@@ -432,7 +434,7 @@ func (r *Repository) MergePullRequest(number int, opts MergePullRequestOptions) 
 		return fmt.Errorf("pull request %d: head SHA is required", number)
 	}
 
-	if opts.AutoMerge {
+	if opts.AutoMerge && !opts.AdminMerge {
 		pr.AutoMergeEnabled = true
 		pr.AutoMergeDeleteBranch = opts.DeleteHeadBranch
 		if pr.HasBlockingMergeChecks() {
@@ -535,12 +537,16 @@ type PullRequest struct {
 	Merged                bool             `yaml:"merged,omitempty" json:"merged,omitempty"`
 	AutoMergeEnabled      bool             `yaml:"auto_merge_enabled,omitempty" json:"auto_merge_enabled,omitempty"`
 	AutoMergeDeleteBranch bool             `yaml:"auto_merge_delete_branch,omitempty" json:"auto_merge_delete_branch,omitempty"`
+	Mergeable             string           `yaml:"mergeable,omitempty" json:"mergeable,omitempty"`
+	ReviewDecision        string           `yaml:"review_decision,omitempty" json:"review_decision,omitempty"`
 	Labels                []string         `yaml:"labels,omitempty" json:"labels,omitempty"`
 	BaseBranch            string           `yaml:"base_branch" json:"base_branch"`
 	HeadBranch            string           `yaml:"head_branch" json:"head_branch"`
 	HeadSHA               string           `yaml:"head_sha" json:"head_sha"`
 	Comments              []Comment        `yaml:"comments,omitempty" json:"comments,omitempty"`
 	Reviews               []Review         `yaml:"reviews,omitempty" json:"reviews,omitempty"`
+	ReviewRequests        []string         `yaml:"review_requests,omitempty" json:"review_requests,omitempty"`
+	ReviewThreads         []ReviewThread   `yaml:"review_threads,omitempty" json:"review_threads,omitempty"`
 	Checks                []Check          `yaml:"checks,omitempty" json:"checks,omitempty"`
 }
 
@@ -574,6 +580,11 @@ type Review struct {
 	Author string      `yaml:"author,omitempty" json:"author,omitempty"`
 	State  ReviewState `yaml:"state,omitempty" json:"state,omitempty"`
 	Body   string      `yaml:"body,omitempty" json:"body,omitempty"`
+}
+
+// ReviewThread describes a pull request review thread.
+type ReviewThread struct {
+	IsResolved bool `yaml:"is_resolved,omitempty" json:"is_resolved,omitempty"`
 }
 
 // Check describes a pull request check run.

--- a/cli/internal/dtushim/shim.go
+++ b/cli/internal/dtushim/shim.go
@@ -1352,6 +1352,7 @@ func runGHPRMerge(_ context.Context, store *dtu.Store, args []string, stderr io.
 		return repo.MergePullRequest(number, dtu.MergePullRequestOptions{
 			DeleteHeadBranch: opts.deleteBranch,
 			AutoMerge:        opts.autoMerge,
+			AdminMerge:       opts.adminMerge,
 		})
 	})
 	if err != nil {
@@ -1435,6 +1436,7 @@ type ghOptions struct {
 	limit        int
 	deleteBranch bool
 	autoMerge    bool
+	adminMerge   bool
 	addLabels    []string
 	removeLabels []string
 }
@@ -1514,6 +1516,8 @@ func parseGHFlags(args []string) (ghOptions, error) {
 			opts.deleteBranch = true
 		case "--auto":
 			opts.autoMerge = true
+		case "--admin":
+			opts.adminMerge = true
 		case "--add-label":
 			value, next, err := requireValue(args, i, args[i])
 			if err != nil {
@@ -1593,10 +1597,30 @@ func encodePR(state *dtu.State, repo *dtu.Repository, pr dtu.PullRequest, fields
 			out[field] = prURL(state, repo, pr)
 		case "labels":
 			out[field] = encodeLabels(pr.Labels)
+		case "state":
+			out[field] = prState(pr)
 		case "headRefName":
 			out[field] = pr.HeadBranch
 		case "headRefOid":
 			out[field] = pr.HeadSHA
+		case "mergeable":
+			out[field] = prMergeable(pr)
+		case "reviewDecision":
+			out[field] = prReviewDecision(pr)
+		case "autoMergeRequest":
+			if pr.AutoMergeEnabled {
+				out[field] = map[string]any{}
+			} else {
+				out[field] = nil
+			}
+		case "statusCheckRollup":
+			out[field] = encodeStatusCheckRollup(pr.Checks)
+		case "reviewRequests":
+			out[field] = encodeReviewRequests(pr.ReviewRequests)
+		case "latestReviews":
+			out[field] = encodeLatestReviews(pr.Reviews)
+		case "reviewThreads":
+			out[field] = encodeReviewThreads(pr.ReviewThreads)
 		case "mergeCommit":
 			out[field] = map[string]any{"oid": pr.HeadSHA}
 		}
@@ -1646,6 +1670,66 @@ func ghCheckState(state dtu.CheckState) string {
 	default:
 		return "PENDING"
 	}
+}
+
+func prState(pr dtu.PullRequest) string {
+	if pr.State != "" {
+		return strings.ToUpper(string(pr.State))
+	}
+	return "OPEN"
+}
+
+func prMergeable(pr dtu.PullRequest) string {
+	if trimmed := strings.TrimSpace(pr.Mergeable); trimmed != "" {
+		return trimmed
+	}
+	return "MERGEABLE"
+}
+
+func prReviewDecision(pr dtu.PullRequest) string {
+	return strings.TrimSpace(pr.ReviewDecision)
+}
+
+func encodeStatusCheckRollup(checks []dtu.Check) []map[string]string {
+	out := make([]map[string]string, 0, len(checks))
+	for _, check := range checks {
+		status := "COMPLETED"
+		if check.State == dtu.CheckStatePending {
+			status = "IN_PROGRESS"
+		}
+		out = append(out, map[string]string{
+			"conclusion": ghCheckState(check.State),
+			"status":     status,
+		})
+	}
+	return out
+}
+
+func encodeReviewRequests(requests []string) []map[string]string {
+	out := make([]map[string]string, 0, len(requests))
+	for _, request := range requests {
+		out = append(out, map[string]string{"login": request})
+	}
+	return out
+}
+
+func encodeLatestReviews(reviews []dtu.Review) []map[string]any {
+	out := make([]map[string]any, 0, len(reviews))
+	for _, review := range reviews {
+		out = append(out, map[string]any{
+			"author": map[string]string{"login": review.Author},
+			"state":  string(review.State),
+		})
+	}
+	return out
+}
+
+func encodeReviewThreads(threads []dtu.ReviewThread) []map[string]any {
+	out := make([]map[string]any, 0, len(threads))
+	for _, thread := range threads {
+		out = append(out, map[string]any{"isResolved": thread.IsResolved})
+	}
+	return out
 }
 
 func matchesPRState(pr dtu.PullRequest, want string) bool {

--- a/cli/internal/dtushim/shim_test.go
+++ b/cli/internal/dtushim/shim_test.go
@@ -145,6 +145,10 @@ func TestExecuteGHPRSurfacesUsedByXylem(t *testing.T) {
 	t.Parallel()
 
 	state := sampleState()
+	state.Repositories[0].PullRequests[0].Mergeable = "MERGEABLE"
+	state.Repositories[0].PullRequests[0].ReviewDecision = "APPROVED"
+	state.Repositories[0].PullRequests[0].ReviewRequests = []string{"copilot-pull-request-reviewer"}
+	state.Repositories[0].PullRequests[0].ReviewThreads = []dtu.ReviewThread{{IsResolved: true}, {IsResolved: false}}
 	store, stateDir := testStore(t, state)
 	env := envForStore(store, stateDir, state.UniverseID)
 
@@ -164,6 +168,28 @@ func TestExecuteGHPRSurfacesUsedByXylem(t *testing.T) {
 	}
 	if strings.TrimSpace(viewOut.String()) != "abc12345deadbeef" {
 		t.Fatalf("pr view output = %q", viewOut.String())
+	}
+
+	var richViewOut, richViewErr bytes.Buffer
+	code = Execute(context.Background(), "gh", []string{
+		"pr", "view", "10", "--repo", "owner/repo",
+		"--json", "state,mergeable,reviewDecision,statusCheckRollup,reviewRequests,reviewThreads",
+	}, nil, &richViewOut, &richViewErr, env)
+	if code != 0 {
+		t.Fatalf("pr view rich code = %d, stderr = %q", code, richViewErr.String())
+	}
+	rich := richViewOut.String()
+	for _, want := range []string{
+		`"state":"OPEN"`,
+		`"mergeable":"MERGEABLE"`,
+		`"reviewDecision":"APPROVED"`,
+		`"login":"copilot-pull-request-reviewer"`,
+		`"isResolved":false`,
+		`"status":"COMPLETED"`,
+	} {
+		if !strings.Contains(rich, want) {
+			t.Fatalf("rich pr view output = %s, want substring %q", rich, want)
+		}
 	}
 
 	var checksOut, checksErr bytes.Buffer
@@ -264,6 +290,45 @@ func TestExecuteGHPRMergeUpdatesStateAndGitVisibility(t *testing.T) {
 	if strings.Contains(headOut.String(), "fix/issue-1-bug-one") {
 		t.Fatalf("git ls-remote head output = %q, want deleted head branch to disappear", headOut.String())
 	}
+}
+
+func TestExecuteGHPRAdminMergeBypassesPendingChecks(t *testing.T) {
+	t.Parallel()
+
+	state := sampleState()
+	state.Repositories[0].Branches = []dtu.Branch{
+		{Name: "main", SHA: "1111111111111111111111111111111111111111"},
+		{Name: "fix/issue-1-bug-one", SHA: "abc12345deadbeef"},
+	}
+	store, stateDir := testStore(t, state)
+	env := envForStore(store, stateDir, state.UniverseID)
+
+	var mergeOut, mergeErr bytes.Buffer
+	code := Execute(
+		context.Background(),
+		"gh",
+		[]string{"pr", "merge", "10", "--repo", "owner/repo", "--delete-branch", "--squash", "--admin"},
+		nil,
+		&mergeOut,
+		&mergeErr,
+		env,
+	)
+	require.Zero(t, code, "stderr = %q", mergeErr.String())
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	repo := loaded.RepositoryBySlug("owner/repo")
+	require.NotNil(t, repo)
+	pr := repo.PullRequestByNumber(10)
+	require.NotNil(t, pr)
+	assert.Equal(t, dtu.PullRequestStateMerged, pr.State)
+	assert.True(t, pr.Merged)
+	assert.False(t, pr.AutoMergeEnabled)
+	assert.False(t, pr.AutoMergeDeleteBranch)
+	main := repo.BranchByName("main")
+	require.NotNil(t, main)
+	assert.Equal(t, pr.HeadSHA, main.SHA)
+	assert.Nil(t, repo.BranchByName(pr.HeadBranch))
 }
 
 func TestSmoke_S2_GHPRMergeWithAutoQueuesUntilChecksPass(t *testing.T) {

--- a/cli/internal/workflow/merge_pr_workflow_test.go
+++ b/cli/internal/workflow/merge_pr_workflow_test.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestSmoke_S7_MergePRWorkflowUsesRepoSlugAndAutoFlag(t *testing.T) {
+func TestSmoke_S7_MergePRWorkflowUsesRepoSlugAndAdminFlag(t *testing.T) {
 	t.Parallel()
 
 	_, file, _, ok := runtime.Caller(0)
@@ -33,8 +33,8 @@ func TestSmoke_S7_MergePRWorkflowUsesRepoSlugAndAutoFlag(t *testing.T) {
 	}
 	require.NotNil(t, mergePhase, "workflow %q missing merge phase", wf.Name)
 	assert.Equal(t, "command", mergePhase.Type)
-	assert.Contains(t, mergePhase.Run, "--auto")
-	assert.NotContains(t, mergePhase.Run, "--admin")
+	assert.Contains(t, mergePhase.Run, "--admin")
+	assert.NotContains(t, mergePhase.Run, "--auto")
 	assert.Contains(t, mergePhase.Run, "{{.Repo.Slug}}")
 	assert.NotContains(t, mergePhase.Run, "nicholls-inc/xylem")
 }


### PR DESCRIPTION
## Summary

Implements [#244](https://github.com/nicholls-inc/xylem/issues/244) by switching the harness PR merge path from queued GitHub auto-merge to deterministic admin-merge once all daemon gates are green.

## Smoke scenarios covered

- S7 — MergePRWorkflowUsesRepoSlugAndAdminFlag
- S8 — AutoMergeContinuesWhenConfiguredReviewerIsNotCollaborator
- S9 — AutoAdminMergeWithinOneDaemonTick

## Changes summary

- **Modified workflow/docs:** `.xylem/workflows/merge-pr.yaml`, `.xylem/prompts/merge-pr/check.md`, and `.xylem/HARNESS.md` now document and enforce the admin-merge contract for trusted `harness-impl` PRs, including `no-auto-admin-merge` opt-out handling and resolved-thread requirements.
- **Modified daemon/config path:** `cli/cmd/xylem/automerge.go`, `cli/cmd/xylem/daemon.go`, and `cli/internal/config/config.go` add the richer PR snapshot, `autoMergeSettings`, `decideAutoMergeAction`, unresolved review-thread gating, opt-out label handling, reviewer-request fallthrough, and direct admin merge execution.
- **Modified DTU/shim model:** `cli/internal/dtu/types.go`, `cli/internal/dtu/dtu_test.go`, `cli/internal/dtu/dtu_prop_test.go`, `cli/internal/dtushim/shim.go`, and `cli/internal/dtushim/shim_test.go` add admin-merge semantics plus `gh pr view`/`gh pr merge` coverage for review threads and admin bypass behavior.
- **Modified regression tests:** `cli/cmd/xylem/automerge_test.go`, `cli/cmd/xylem/automerge_prop_test.go`, and `cli/internal/workflow/merge_pr_workflow_test.go` cover the new decision logic, smoke cases, and workflow command shape.

## Test plan

- `cd cli && goimports -w .`
- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #244