### PR TITLE
daemon: add deterministic self-monitoring for stalled vessels and idle backlog

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/daemonhealth"
 	"github.com/nicholls-inc/xylem/cli/internal/dtu"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
@@ -91,8 +92,47 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	startedAt := daemonNow()
+	lastActivityAt := startedAt
+	lastUpgradeAt := startedAt
+	idleThreshold := 5 * time.Minute
+	if cfg.Daemon.StallMonitor.ScannerIdleThreshold != "" {
+		if parsed, err := time.ParseDuration(cfg.Daemon.StallMonitor.ScannerIdleThreshold); err == nil {
+			idleThreshold = parsed
+		}
+	}
+	var backlogCount int
+	var stallChecks []daemonhealth.Check
+	scanRunner := newCmdRunner(cfg)
 	scan := func(ctx context.Context) (scanner.ScanResult, error) {
-		return runScan(ctx, cfg, q)
+		s := scanner.New(cfg, q, scanRunner)
+		result, err := s.Scan(ctx)
+		if err != nil {
+			return result, err
+		}
+		if result.Added > 0 {
+			lastActivityAt = daemonNow()
+			backlogCount = 0
+			return result, nil
+		}
+		if !daemonQueueIdle(q) {
+			backlogCount = 0
+			return result, nil
+		}
+		count, err := s.BacklogCount(ctx)
+		if err != nil {
+			slog.Warn("daemon backlog check failed", "error", err)
+			backlogCount = 0
+			return result, nil
+		}
+		backlogCount = count
+		if count > 0 {
+			idleFor := daemonNow().Sub(lastActivityAt)
+			if idleFor > idleThreshold {
+				slog.Warn("daemon idle with backlog", "count", count, "idle_for", idleFor)
+			}
+		}
+		return result, nil
 	}
 	cmdRunner := newCmdRunner(cfg)
 	drainRunner, cleanupDrainRunner := buildDrainRunner(cfg, q, wt, cmdRunner)
@@ -111,6 +151,8 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		return drainRunner.Drain(ctx)
 	}
 	check := func(ctx context.Context) {
+		findings := drainRunner.CheckStalledVessels(ctx)
+		stallChecks = daemonChecksFromFindings(findings, daemonNow())
 		drainRunner.CheckWaitingVessels(ctx)
 		drainRunner.CheckHungVessels(ctx)
 		// Auto-merge: best-effort request copilot review on merge-ready
@@ -121,7 +163,32 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		}
 	}
 
-	commandErr = daemonLoop(ctx, q, drainRunner, scan, drain, check, upgrade, scanInterval, drainInterval, upgradeInterval)
+	tickHook := func(now time.Time, state daemonTickState) {
+		if !state.LastUpgrade.IsZero() {
+			lastUpgradeAt = state.LastUpgrade
+		}
+		counts := daemonQueueCounts(q)
+		if counts.pending > 0 || counts.running > 0 || counts.waiting > 0 || state.InFlight > 0 {
+			lastActivityAt = now
+		}
+		checks := append([]daemonhealth.Check(nil), stallChecks...)
+		if check := daemonBacklogHealthCheck(now, lastActivityAt, idleThreshold, backlogCount, counts); check != nil {
+			checks = append(checks, *check)
+		}
+		snapshot := daemonhealth.Snapshot{
+			PID:           os.Getpid(),
+			StartedAt:     startedAt.UTC(),
+			UpdatedAt:     now.UTC(),
+			Binary:        buildInfo(),
+			LastUpgradeAt: lastUpgradeAt.UTC(),
+			Checks:        checks,
+		}
+		if err := daemonhealth.Save(cfg.StateDir, snapshot); err != nil {
+			slog.Warn("daemon save health failed", "error", err)
+		}
+	}
+
+	commandErr = daemonLoop(ctx, q, drainRunner, scan, drain, check, upgrade, tickHook, scanInterval, drainInterval, upgradeInterval)
 	return commandErr
 }
 
@@ -170,12 +237,19 @@ type inFlightTracker interface {
 // checkFunc runs periodic vessel health checks (waiting vessel label checks,
 // hung vessel timeouts). May be nil if no checks are needed.
 type checkFunc func(ctx context.Context)
+type tickFunc func(now time.Time, state daemonTickState)
 
 // upgradeFunc runs a self-upgrade attempt. If it succeeds with a binary
 // change, it calls exec() and never returns. If it returns, either the
 // binary was unchanged or the upgrade failed; the daemon continues normally.
 // May be nil to disable periodic upgrades.
 type upgradeFunc func()
+
+type daemonTickState struct {
+	LastUpgrade time.Time
+	InFlight    int
+	Draining    bool
+}
 
 // defaultUpgradeInterval is how often the daemon checks for a new binary.
 // Five minutes balances fast activation of newly-merged fixes against
@@ -216,7 +290,7 @@ const upgradeOverdueMultiplier = 3
 //     Once in_flight reaches zero, the normal path fires.
 //
 // Pass nil/zero upgrade/upgradeInterval to disable.
-func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, scan scanFunc, drain drainFunc, check checkFunc, upgrade upgradeFunc, scanInterval, drainInterval, upgradeInterval time.Duration) error {
+func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, scan scanFunc, drain drainFunc, check checkFunc, upgrade upgradeFunc, tick tickFunc, scanInterval, drainInterval, upgradeInterval time.Duration) error {
 	tickInterval := scanInterval
 	if drainInterval < tickInterval {
 		tickInterval = drainInterval
@@ -283,6 +357,7 @@ func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, sc
 		upgradeOverdue := upgradeReady && upgradeElapsed >= upgradeInterval*time.Duration(upgradeOverdueMultiplier)
 		inFlight := trackerInFlightCount(tracker)
 		drainIdle := atomic.LoadInt32(&draining) == 0
+		drainingNow := !drainIdle
 
 		if upgradePending && drainIdle && inFlight == 0 {
 			// Normal path: daemon is fully idle and upgrade is due.
@@ -328,6 +403,13 @@ func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, sc
 		}
 
 		logTickSummary(q)
+		if tick != nil {
+			tick(now, daemonTickState{
+				LastUpgrade: lastUpgrade,
+				InFlight:    inFlight,
+				Draining:    drainingNow,
+			})
+		}
 
 		select {
 		case <-ctx.Done():
@@ -406,6 +488,68 @@ func logTickSummary(q *queue.Queue) {
 		"running", counts[queue.StateRunning],
 		"completed", counts[queue.StateCompleted],
 		"failed", counts[queue.StateFailed])
+}
+
+type daemonQueueSnapshot struct {
+	pending int
+	running int
+	waiting int
+}
+
+func daemonQueueCounts(q *queue.Queue) daemonQueueSnapshot {
+	vessels, err := q.List()
+	if err != nil {
+		return daemonQueueSnapshot{}
+	}
+	var snapshot daemonQueueSnapshot
+	for _, vessel := range vessels {
+		switch vessel.State {
+		case queue.StatePending:
+			snapshot.pending++
+		case queue.StateRunning:
+			snapshot.running++
+		case queue.StateWaiting:
+			snapshot.waiting++
+		}
+	}
+	return snapshot
+}
+
+func daemonQueueIdle(q *queue.Queue) bool {
+	counts := daemonQueueCounts(q)
+	return counts.pending == 0 && counts.running == 0
+}
+
+func daemonChecksFromFindings(findings []runner.StallFinding, now time.Time) []daemonhealth.Check {
+	checks := make([]daemonhealth.Check, 0, len(findings))
+	for _, finding := range findings {
+		level := daemonhealth.LevelCritical
+		if finding.Level == "warning" {
+			level = daemonhealth.LevelWarning
+		}
+		checks = append(checks, daemonhealth.Check{
+			Code:      finding.Code,
+			Level:     level,
+			Message:   finding.Message,
+			UpdatedAt: now.UTC(),
+		})
+	}
+	return checks
+}
+
+func daemonBacklogHealthCheck(now, lastActivityAt time.Time, idleThreshold time.Duration, backlogCount int, counts daemonQueueSnapshot) *daemonhealth.Check {
+	if backlogCount == 0 || counts.pending != 0 || counts.running != 0 {
+		return nil
+	}
+	if now.Sub(lastActivityAt) <= idleThreshold {
+		return nil
+	}
+	return &daemonhealth.Check{
+		Code:      "idle_with_backlog",
+		Level:     daemonhealth.LevelWarning,
+		Message:   fmt.Sprintf("Daemon idle with %d backlog items on GitHub", backlogCount),
+		UpdatedAt: now.UTC(),
+	}
 }
 
 // reconcileStaleVessels transitions ALL running vessels to timed_out. The

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -189,6 +190,14 @@ func (daemonNoopRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, e
 	return []byte("[]"), nil
 }
 
+type daemonBacklogRunner struct {
+	output []byte
+}
+
+func (r daemonBacklogRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return r.output, nil
+}
+
 func TestDaemonLoopScheduledSourceRunsSingleTick(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{
@@ -229,7 +238,7 @@ func TestDaemonLoopScheduledSourceRunsSingleTick(t *testing.T) {
 		return runner.DrainResult{Launched: 1, Completed: 1}, nil
 	}
 
-	if err := daemonLoop(ctx, q, tracker, scan, drain, nil, nil, 10*time.Millisecond, 10*time.Millisecond, 0); err != nil {
+	if err := daemonLoop(ctx, q, tracker, scan, drain, nil, nil, nil, 10*time.Millisecond, 10*time.Millisecond, 0); err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
 
@@ -240,6 +249,43 @@ func TestDaemonLoopScheduledSourceRunsSingleTick(t *testing.T) {
 	if len(completed) != 1 {
 		t.Fatalf("len(completed) = %d, want 1", len(completed))
 	}
+}
+
+func TestSmoke_S2_DaemonIdleWithBacklogWarningFires(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		StateDir: dir,
+		Sources: map[string]config.SourceConfig{
+			"issues": {
+				Type:    "github",
+				Repo:    "owner/repo",
+				Exclude: []string{"wontfix"},
+				Tasks: map[string]config.Task{
+					"bugs": {
+						Labels:   []string{"bug"},
+						Workflow: "fix-bug",
+					},
+				},
+			},
+		},
+	}
+	issues := []map[string]any{
+		{"number": 1, "title": "one", "body": "", "url": "https://github.com/owner/repo/issues/1", "labels": []map[string]string{{"name": "bug"}}},
+		{"number": 2, "title": "two", "body": "", "url": "https://github.com/owner/repo/issues/2", "labels": []map[string]string{{"name": "bug"}}},
+		{"number": 3, "title": "three", "body": "", "url": "https://github.com/owner/repo/issues/3", "labels": []map[string]string{{"name": "bug"}}},
+	}
+	output, err := json.Marshal(issues)
+	require.NoError(t, err)
+
+	s := scanner.New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), daemonBacklogRunner{output: output})
+	count, err := s.BacklogCount(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 3, count)
+
+	check := daemonBacklogHealthCheck(time.Now().UTC(), time.Now().UTC().Add(-10*time.Minute), 5*time.Minute, count, daemonQueueSnapshot{})
+	require.NotNil(t, check)
+	assert.Equal(t, "idle_with_backlog", check.Code)
+	assert.Equal(t, "Daemon idle with 3 backlog items on GitHub", check.Message)
 }
 
 type trackerStub struct {
@@ -307,7 +353,7 @@ func TestDaemonShutdown(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, nil, time.Hour, time.Hour, 0)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, nil, nil, time.Hour, time.Hour, 0)
 	if err != nil {
 		t.Fatalf("expected nil error on shutdown, got: %v", err)
 	}
@@ -354,7 +400,7 @@ func TestSmoke_S3_DaemonTickDrainsScheduledVessel(t *testing.T) {
 
 	err := daemonLoop(ctx, q, nil, func(ctx context.Context) (scanner.ScanResult, error) {
 		return runScan(ctx, cfg, q)
-	}, drain, nil, nil, time.Millisecond, time.Millisecond, 0)
+	}, drain, nil, nil, nil, time.Millisecond, time.Millisecond, 0)
 	require.NoError(t, err)
 
 	vessels, err := q.List()
@@ -428,7 +474,7 @@ func TestDaemonLoopPeriodicUpgradeFiresAtDrainEnd(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, upgrade, time.Hour, 2*time.Millisecond, time.Millisecond)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, upgrade, nil, time.Hour, 2*time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -450,7 +496,7 @@ func TestDaemonLoopPeriodicUpgradeRespectsInterval(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, upgrade, time.Hour, 2*time.Millisecond, 10*time.Second)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, upgrade, nil, time.Hour, 2*time.Millisecond, 10*time.Second)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -470,7 +516,7 @@ func TestDaemonLoopPeriodicUpgradeNilDisables(t *testing.T) {
 	defer cancel()
 
 	// Passing nil upgrade should not panic even with a non-zero interval.
-	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, nil, time.Hour, 2*time.Millisecond, 10*time.Millisecond)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, nil, nil, time.Hour, 2*time.Millisecond, 10*time.Millisecond)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -509,7 +555,7 @@ func TestDaemonLoopUpgradeWaitsForDrainCompletion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, nil, noopScan, slowDrain, nil, upgrade, time.Hour, time.Millisecond, time.Millisecond)
+	err := daemonLoop(ctx, q, nil, noopScan, slowDrain, nil, upgrade, nil, time.Hour, time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -537,7 +583,7 @@ func TestSmoke_S35_DaemonLoopAllowsNewDrainTicksWhileVesselsRemainInFlight(t *te
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, nil, time.Hour, 10*time.Millisecond, 0)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, nil, nil, time.Hour, 10*time.Millisecond, 0)
 	require.NoError(t, err)
 
 	assert.GreaterOrEqual(t, drainCalls.Load(), int32(2))
@@ -571,7 +617,7 @@ func TestSmoke_S36_DaemonLoopUpgradeWaitsForTrackerIdle(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, time.Hour, 10*time.Millisecond, time.Millisecond)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, time.Hour, 10*time.Millisecond, time.Millisecond)
 	require.NoError(t, err)
 
 	assert.NotZero(t, upgradeSeen.Load())
@@ -613,7 +659,7 @@ func TestSmoke_S39_DaemonAutoUpgradeProceedsAfterCancelledVesselDropsInFlight(t 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, time.Hour, 10*time.Millisecond, time.Millisecond)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, time.Hour, 10*time.Millisecond, time.Millisecond)
 	require.NoError(t, err)
 
 	select {
@@ -671,7 +717,7 @@ func TestDaemonLoopUpgradeOverduePausesDrainToCreateIdleWindow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, time.Hour, 5*time.Millisecond, 5*time.Millisecond)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, time.Hour, 5*time.Millisecond, 5*time.Millisecond)
 	require.NoError(t, err)
 
 	// Upgrade MUST have fired at least once despite the continuously saturating drain.
@@ -708,7 +754,7 @@ func TestDaemonLoopUpgradeOverdueDoesNotFireUnderNormalConditions(t *testing.T) 
 	defer cancel()
 
 	// upgradeInterval=2ms; over 100ms, normal path should fire many times.
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, time.Hour, 2*time.Millisecond, 2*time.Millisecond)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, time.Hour, 2*time.Millisecond, 2*time.Millisecond)
 	require.NoError(t, err)
 
 	assert.GreaterOrEqual(t, upgradeSeen.Load(), int32(5),
@@ -794,7 +840,7 @@ func TestDaemonNonBlockingDrain(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	err := daemonLoop(ctx, q, nil, noopScan, slowDrain, nil, nil, time.Hour, time.Millisecond, 0)
+	err := daemonLoop(ctx, q, nil, noopScan, slowDrain, nil, nil, nil, time.Hour, time.Millisecond, 0)
 	elapsed := time.Since(start)
 
 	if err != nil {

--- a/cli/cmd/xylem/exec.go
+++ b/cli/cmd/xylem/exec.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
 )
 
 // maxStderrBytes is the maximum amount of stderr captured from a phase subprocess.
@@ -165,6 +166,14 @@ func (r *realCmdRunner) RunProcessWithEnv(ctx context.Context, dir string, extra
 }
 
 func (r *realCmdRunner) RunPhase(ctx context.Context, dir string, stdin io.Reader, name string, args ...string) ([]byte, error) {
+	return r.runPhaseInternal(ctx, dir, stdin, nil, name, args...)
+}
+
+func (r *realCmdRunner) RunPhaseObserved(ctx context.Context, dir string, stdin io.Reader, observer runner.PhaseProcessObserver, name string, args ...string) ([]byte, error) {
+	return r.runPhaseInternal(ctx, dir, stdin, observer, name, args...)
+}
+
+func (r *realCmdRunner) runPhaseInternal(ctx context.Context, dir string, stdin io.Reader, observer runner.PhaseProcessObserver, name string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
 	cmd.Stdin = stdin
@@ -175,7 +184,14 @@ func (r *realCmdRunner) RunPhase(ctx context.Context, dir string, stdin io.Reade
 	cmd.Stdout = &stdout
 	cmd.Stderr = stderr
 
-	err := cmd.Run()
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	if observer != nil && cmd.Process != nil {
+		observer.ProcessStarted(cmd.Process.Pid)
+		defer observer.ProcessExited(cmd.Process.Pid)
+	}
+	err := cmd.Wait()
 	if err != nil && stderr.Len() > 0 {
 		return stdout.Bytes(), fmt.Errorf("%w\nstderr: %s", err, stderr.String())
 	}

--- a/cli/cmd/xylem/status.go
+++ b/cli/cmd/xylem/status.go
@@ -2,15 +2,19 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/daemonhealth"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
 )
@@ -76,6 +80,10 @@ func cmdStatus(cfg *config.Config, q *queue.Queue, jsonMode bool, stateFilter st
 		}
 	}
 	fleet := runner.AnalyzeFleetStatus(vessels, summaries)
+	daemonSnapshot, daemonErr := loadDaemonSnapshot(cfg)
+	if daemonErr != nil {
+		return daemonErr
+	}
 
 	if jsonMode {
 		enc := json.NewEncoder(os.Stdout)
@@ -84,6 +92,16 @@ func cmdStatus(cfg *config.Config, q *queue.Queue, jsonMode bool, stateFilter st
 		return nil
 	}
 
+	counts := map[queue.VesselState]int{}
+	for _, j := range vessels {
+		counts[j.State]++
+	}
+
+	fmt.Printf("Queue: %d running, %d pending, %d completed, %d failed, %d cancelled, %d waiting, %d timed_out\n",
+		counts[queue.StateRunning], counts[queue.StatePending], counts[queue.StateCompleted],
+		counts[queue.StateFailed], counts[queue.StateCancelled], counts[queue.StateWaiting],
+		counts[queue.StateTimedOut])
+	renderDaemonHealth(daemonSnapshot)
 	if len(vessels) == 0 {
 		fmt.Println("No vessels in queue.")
 		return nil
@@ -94,9 +112,7 @@ func cmdStatus(cfg *config.Config, q *queue.Queue, jsonMode bool, stateFilter st
 	fmt.Printf("%-14s  %-14s  %-20s  %-10s  %-10s  %-12s  %-42s  %-12s  %s\n",
 		"----", "------", "-----", "-----", "------", "----", "----", "-------", "--------")
 
-	counts := map[queue.VesselState]int{}
 	for i, j := range vessels {
-		counts[j.State]++
 		started := "—"
 		duration := "—"
 		if j.StartedAt != nil {
@@ -116,12 +132,7 @@ func cmdStatus(cfg *config.Config, q *queue.Queue, jsonMode bool, stateFilter st
 			j.ID, j.Source, wf, string(j.State), rows[i].Health, formatSummaryCost(summaries[j.ID]), info, started, duration)
 	}
 
-	fmt.Printf("\nSummary: %d pending, %d running, %d completed, %d failed, %d cancelled, %d waiting, %d timed_out\n",
-		counts[queue.StatePending], counts[queue.StateRunning],
-		counts[queue.StateCompleted], counts[queue.StateFailed],
-		counts[queue.StateCancelled], counts[queue.StateWaiting],
-		counts[queue.StateTimedOut])
-	fmt.Printf("Health: %d healthy, %d degraded, %d unhealthy\n",
+	fmt.Printf("\nHealth: %d healthy, %d degraded, %d unhealthy\n",
 		fleet.Healthy, fleet.Degraded, fleet.Unhealthy)
 	if len(fleet.Patterns) > 0 {
 		fmt.Printf("Patterns: %s\n", runner.FormatFleetPatterns(fleet.Patterns))
@@ -189,4 +200,76 @@ func pauseMarkerPath(cfg *config.Config) string {
 func isPaused(cfg *config.Config) bool {
 	_, err := os.Stat(pauseMarkerPath(cfg))
 	return err == nil
+}
+
+func loadDaemonSnapshot(cfg *config.Config) (*daemonhealth.Snapshot, error) {
+	if cfg == nil || cfg.StateDir == "" {
+		return nil, nil
+	}
+	snapshot, err := daemonhealth.Load(cfg.StateDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("load daemon health: %w", err)
+	}
+	return snapshot, nil
+}
+
+func renderDaemonHealth(snapshot *daemonhealth.Snapshot) {
+	if snapshot == nil {
+		return
+	}
+	fmt.Println("Health:")
+	if daemonProcessAlive(snapshot.PID) {
+		fmt.Printf("  %s Daemon alive (pid=%d, uptime=%s)\n", daemonHealthIcon(daemonhealth.LevelOK), snapshot.PID, time.Since(snapshot.StartedAt).Round(time.Second))
+	} else {
+		fmt.Printf("  %s Daemon not running (pid=%d, last heartbeat=%s)\n", daemonHealthIcon(daemonhealth.LevelCritical), snapshot.PID, snapshot.UpdatedAt.UTC().Format("15:04:05"))
+	}
+	if !snapshot.LastUpgradeAt.IsZero() {
+		fmt.Printf("  %s Auto-upgrade current (binary=%s, last=%s)\n", daemonHealthIcon(daemonhealth.LevelOK), snapshot.Binary, snapshot.LastUpgradeAt.UTC().Format("15:04:05"))
+	}
+	checks := append([]daemonhealth.Check(nil), snapshot.Checks...)
+	sort.Slice(checks, func(i, j int) bool {
+		if checks[i].Level == checks[j].Level {
+			return checks[i].Code < checks[j].Code
+		}
+		return daemonLevelRank(checks[i].Level) > daemonLevelRank(checks[j].Level)
+	})
+	for _, check := range checks {
+		fmt.Printf("  %s %s\n", daemonHealthIcon(check.Level), check.Message)
+	}
+}
+
+func daemonProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+func daemonHealthIcon(level daemonhealth.Level) string {
+	switch level {
+	case daemonhealth.LevelCritical:
+		return "✗"
+	case daemonhealth.LevelWarning:
+		return "⚠"
+	default:
+		return "✓"
+	}
+}
+
+func daemonLevelRank(level daemonhealth.Level) int {
+	switch level {
+	case daemonhealth.LevelCritical:
+		return 3
+	case daemonhealth.LevelWarning:
+		return 2
+	default:
+		return 1
+	}
 }

--- a/cli/cmd/xylem/status_test.go
+++ b/cli/cmd/xylem/status_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/daemonhealth"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
 
@@ -74,11 +75,53 @@ func TestStatusTable(t *testing.T) {
 	if !strings.Contains(out, "completed") {
 		t.Errorf("expected 'completed' state in output, got: %s", out)
 	}
-	if !strings.Contains(out, "Summary:") {
-		t.Errorf("expected summary line, got: %s", out)
+	if !strings.Contains(out, "Queue:") {
+		t.Errorf("expected queue line, got: %s", out)
 	}
 	if !strings.Contains(out, "Info") {
 		t.Errorf("expected Info column header, got: %s", out)
+	}
+}
+
+func TestStatusShowsDaemonHealth(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	err := daemonhealth.Save(filepath.Join(dir, ".xylem"), daemonhealth.Snapshot{
+		PID:           os.Getpid(),
+		StartedAt:     now.Add(-2 * time.Hour),
+		UpdatedAt:     now,
+		Binary:        "f366e79d",
+		LastUpgradeAt: now.Add(-15 * time.Minute),
+		Checks: []daemonhealth.Check{
+			{
+				Code:      "idle_with_backlog",
+				Level:     daemonhealth.LevelWarning,
+				Message:   "Daemon idle with 4 backlog items on GitHub",
+				UpdatedAt: now,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("save daemon health: %v", err)
+	}
+
+	var statusErr error
+	out := captureStdout(func() { statusErr = cmdStatus(testStatusConfig(dir), q, false, "") })
+	if statusErr != nil {
+		t.Fatalf("unexpected error: %v", statusErr)
+	}
+	if !strings.Contains(out, "Health:") {
+		t.Fatalf("expected health section, got: %s", out)
+	}
+	if !strings.Contains(out, "Daemon alive") {
+		t.Fatalf("expected daemon alive line, got: %s", out)
+	}
+	if !strings.Contains(out, "Auto-upgrade current") {
+		t.Fatalf("expected auto-upgrade line, got: %s", out)
+	}
+	if !strings.Contains(out, "Daemon idle with 4 backlog items on GitHub") {
+		t.Fatalf("expected backlog warning, got: %s", out)
 	}
 }
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -184,9 +184,10 @@ type ValidationConfig struct {
 }
 
 type DaemonConfig struct {
-	ScanInterval  string `yaml:"scan_interval,omitempty"`
-	DrainInterval string `yaml:"drain_interval,omitempty"`
-	AutoUpgrade   bool   `yaml:"auto_upgrade,omitempty"`
+	ScanInterval  string             `yaml:"scan_interval,omitempty"`
+	DrainInterval string             `yaml:"drain_interval,omitempty"`
+	StallMonitor  StallMonitorConfig `yaml:"stall_monitor,omitempty"`
+	AutoUpgrade   bool               `yaml:"auto_upgrade,omitempty"`
 	// UpgradeInterval controls how often the daemon re-runs the
 	// auto_upgrade check while the loop is running. Only meaningful when
 	// AutoUpgrade is true. Defaults to 5m. Accepts any Go duration string.
@@ -208,6 +209,12 @@ type DaemonConfig struct {
 	// AutoMergeReviewer is the GitHub login to request before enabling
 	// auto-merge. Defaults to empty, which skips reviewer requests.
 	AutoMergeReviewer string `yaml:"auto_merge_reviewer,omitempty"`
+}
+
+type StallMonitorConfig struct {
+	PhaseStallThreshold  string `yaml:"phase_stall_threshold,omitempty"`
+	ScannerIdleThreshold string `yaml:"scanner_idle_threshold,omitempty"`
+	OrphanCheckEnabled   bool   `yaml:"orphan_check_enabled,omitempty"`
 }
 
 type HarnessConfig struct {
@@ -278,6 +285,11 @@ func Load(path string) (*Config, error) {
 		Daemon: DaemonConfig{
 			ScanInterval:  "60s",
 			DrainInterval: "30s",
+			StallMonitor: StallMonitorConfig{
+				PhaseStallThreshold:  "10m",
+				ScannerIdleThreshold: "5m",
+				OrphanCheckEnabled:   true,
+			},
 		},
 	}
 
@@ -369,6 +381,16 @@ func (c *Config) Validate() error {
 	if c.Daemon.DrainInterval != "" {
 		if _, err := time.ParseDuration(c.Daemon.DrainInterval); err != nil {
 			return fmt.Errorf("daemon.drain_interval must be a valid duration: %w", err)
+		}
+	}
+	if c.Daemon.StallMonitor.PhaseStallThreshold != "" {
+		if _, err := time.ParseDuration(c.Daemon.StallMonitor.PhaseStallThreshold); err != nil {
+			return fmt.Errorf("daemon.stall_monitor.phase_stall_threshold must be a valid duration: %w", err)
+		}
+	}
+	if c.Daemon.StallMonitor.ScannerIdleThreshold != "" {
+		if _, err := time.ParseDuration(c.Daemon.StallMonitor.ScannerIdleThreshold); err != nil {
+			return fmt.Errorf("daemon.stall_monitor.scanner_idle_threshold must be a valid duration: %w", err)
 		}
 	}
 	if strings.TrimSpace(c.Daemon.AutoMergeBranchPattern) != "" {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -179,6 +179,15 @@ claude:
 	if cfg.Daemon.DrainInterval != "30s" {
 		t.Fatalf("Daemon.DrainInterval = %q, want 30s", cfg.Daemon.DrainInterval)
 	}
+	if cfg.Daemon.StallMonitor.PhaseStallThreshold != "10m" {
+		t.Fatalf("Daemon.StallMonitor.PhaseStallThreshold = %q, want 10m", cfg.Daemon.StallMonitor.PhaseStallThreshold)
+	}
+	if cfg.Daemon.StallMonitor.ScannerIdleThreshold != "5m" {
+		t.Fatalf("Daemon.StallMonitor.ScannerIdleThreshold = %q, want 5m", cfg.Daemon.StallMonitor.ScannerIdleThreshold)
+	}
+	if !cfg.Daemon.StallMonitor.OrphanCheckEnabled {
+		t.Fatal("Daemon.StallMonitor.OrphanCheckEnabled = false, want true")
+	}
 
 	// Legacy config should be normalized into Sources
 	if len(cfg.Sources) != 1 {
@@ -246,6 +255,12 @@ func TestValidateScheduleSource(t *testing.T) {
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
+}
+
+func TestValidateRejectsInvalidPhaseStallThreshold(t *testing.T) {
+	cfg := validConfig()
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "not-a-duration"
+	requireErrorContains(t, cfg.Validate(), "daemon.stall_monitor.phase_stall_threshold")
 }
 
 func TestValidateScheduleSourceRejectsMalformedCadence(t *testing.T) {

--- a/cli/internal/daemonhealth/daemonhealth.go
+++ b/cli/internal/daemonhealth/daemonhealth.go
@@ -1,0 +1,69 @@
+package daemonhealth
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const fileName = "daemon-health.json"
+
+type Level string
+
+const (
+	LevelOK       Level = "ok"
+	LevelWarning  Level = "warning"
+	LevelCritical Level = "critical"
+)
+
+type Check struct {
+	Code      string    `json:"code"`
+	Level     Level     `json:"level"`
+	Message   string    `json:"message"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type Snapshot struct {
+	PID           int       `json:"pid"`
+	StartedAt     time.Time `json:"started_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+	Binary        string    `json:"binary,omitempty"`
+	LastUpgradeAt time.Time `json:"last_upgrade_at,omitempty"`
+	Checks        []Check   `json:"checks,omitempty"`
+}
+
+func Path(stateDir string) string {
+	return filepath.Join(stateDir, "state", fileName)
+}
+
+func Save(stateDir string, snapshot Snapshot) error {
+	path := Path(stateDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("save daemon health: create dir: %w", err)
+	}
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("save daemon health: marshal: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("save daemon health: write: %w", err)
+	}
+	return nil
+}
+
+func Load(stateDir string) (*Snapshot, error) {
+	data, err := os.ReadFile(Path(stateDir))
+	if err != nil {
+		return nil, fmt.Errorf("load daemon health: read: %w", err)
+	}
+	var snapshot Snapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return nil, fmt.Errorf("load daemon health: unmarshal: %w", err)
+	}
+	if snapshot.Checks == nil {
+		snapshot.Checks = []Check{}
+	}
+	return &snapshot, nil
+}

--- a/cli/internal/dtu/scenario_daemon_test.go
+++ b/cli/internal/dtu/scenario_daemon_test.go
@@ -2,13 +2,19 @@ package dtu_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	dtu "github.com/nicholls-inc/xylem/cli/internal/dtu"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
 	"github.com/nicholls-inc/xylem/cli/internal/scanner"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // reconcileStaleVesselsForTest replicates the daemon's stale-vessel
@@ -189,4 +195,50 @@ func TestScenarioDaemonRecovery(t *testing.T) {
 	if len(events) == 0 {
 		t.Fatal("no DTU events recorded")
 	}
+}
+
+func TestSmoke_S4_DeterministicPhaseStallRecovery(t *testing.T) {
+	env := newScenarioEnv(t, "issue-daemon-recovery.yaml")
+	defer withWorkingDir(t, env.repoDir)()
+
+	cfg := baseScenarioConfig(env.stateDir)
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "10m"
+	cfg.Daemon.StallMonitor.OrphanCheckEnabled = false
+
+	now, err := dtu.RuntimeNow()
+	require.NoError(t, err)
+	enqueued, err := env.queue.Enqueue(queue.Vessel{
+		ID:        "stall-1",
+		Source:    "manual",
+		Workflow:  "fix-bug",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	})
+	require.NoError(t, err)
+	require.True(t, enqueued)
+	vessel, err := env.queue.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, vessel)
+
+	outputPath := filepath.Join(env.stateDir, "phases", vessel.ID, "analyze.output")
+	require.NoError(t, os.MkdirAll(filepath.Dir(outputPath), 0o755))
+	require.NoError(t, os.WriteFile(outputPath, []byte(""), 0o644))
+	old := now.Add(-11 * time.Minute)
+	require.NoError(t, os.Chtimes(outputPath, old, old))
+	require.NoError(t, env.queue.UpdateVessel(*vessel))
+
+	r := runner.New(cfg, env.queue, nil, env.cmdRunner)
+	findings := r.CheckStalledVessels(context.Background())
+	require.Len(t, findings, 1)
+	assert.Equal(t, "phase_stalled", findings[0].Code)
+	assert.Equal(t, "analyze", findings[0].Phase)
+
+	updated, err := env.queue.FindByID(vessel.ID)
+	require.NoError(t, err)
+	assert.Equal(t, queue.StateTimedOut, updated.State)
+	assert.Contains(t, updated.Error, "phase stalled: no output for")
+	require.NotNil(t, updated.EndedAt)
+
+	events := readEvents(t, env.store)
+	assert.NotEmpty(t, events)
 }

--- a/cli/internal/runner/monitor_prop_test.go
+++ b/cli/internal/runner/monitor_prop_test.go
@@ -1,0 +1,74 @@
+package runner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"pgregory.net/rapid"
+)
+
+func TestProp_LatestPhaseActivityReturnsNewestOutput(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		dir, err := os.MkdirTemp("", "monitor-prop-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(dir)
+		cfg := makeTestConfig(dir, 1)
+		cfg.StateDir = filepath.Join(dir, ".xylem")
+		r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{}, &mockCmdRunner{})
+
+		vesselID := rapid.StringMatching(`[a-z0-9-]{1,16}`).Draw(t, "vesselID")
+		phaseCount := rapid.IntRange(1, 8).Draw(t, "phaseCount")
+		phasesDir := filepath.Join(cfg.StateDir, "phases", vesselID)
+		if err := os.MkdirAll(phasesDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", phasesDir, err)
+		}
+
+		base := time.Unix(1_700_000_000, 0).UTC()
+		var (
+			wantPhase string
+			wantTime  time.Time
+		)
+		for i := range phaseCount {
+			phaseName := fmt.Sprintf("phase_%d", i)
+			offsetSeconds := rapid.IntRange(0, 10_000).Draw(t, fmt.Sprintf("offset-%d", i))
+			modTime := base.Add(time.Duration(offsetSeconds+i*10_001) * time.Second)
+			outputPath := filepath.Join(phasesDir, phaseName+".output")
+			if err := os.WriteFile(outputPath, []byte(phaseName), 0o644); err != nil {
+				t.Fatalf("WriteFile(%q): %v", outputPath, err)
+			}
+			if err := os.Chtimes(outputPath, modTime, modTime); err != nil {
+				t.Fatalf("Chtimes(%q): %v", outputPath, err)
+			}
+			if wantPhase == "" || modTime.After(wantTime) {
+				wantPhase = phaseName
+				wantTime = modTime
+			}
+		}
+
+		ignoredPath := filepath.Join(phasesDir, "ignored.txt")
+		ignoredTime := wantTime.Add(24 * time.Hour)
+		if err := os.WriteFile(ignoredPath, []byte("ignore me"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%q): %v", ignoredPath, err)
+		}
+		if err := os.Chtimes(ignoredPath, ignoredTime, ignoredTime); err != nil {
+			t.Fatalf("Chtimes(%q): %v", ignoredPath, err)
+		}
+
+		gotPhase, gotTime, err := r.latestPhaseActivity(vesselID)
+		if err != nil {
+			t.Fatalf("latestPhaseActivity(%q) error = %v", vesselID, err)
+		}
+		if gotPhase != wantPhase {
+			t.Fatalf("latestPhaseActivity(%q) phase = %q, want %q", vesselID, gotPhase, wantPhase)
+		}
+		if !gotTime.Equal(wantTime) {
+			t.Fatalf("latestPhaseActivity(%q) time = %s, want %s", vesselID, gotTime, wantTime)
+		}
+	})
+}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -15,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
@@ -44,6 +46,15 @@ type CommandRunner interface {
 	RunOutput(ctx context.Context, name string, args ...string) ([]byte, error)
 	RunProcess(ctx context.Context, dir string, name string, args ...string) error
 	RunPhase(ctx context.Context, dir string, stdin io.Reader, name string, args ...string) ([]byte, error)
+}
+
+type PhaseProcessObserver interface {
+	ProcessStarted(pid int)
+	ProcessExited(pid int)
+}
+
+type PhaseProcessRunner interface {
+	RunPhaseObserved(ctx context.Context, dir string, stdin io.Reader, observer PhaseProcessObserver, name string, args ...string) ([]byte, error)
 }
 
 // WorktreeManager abstracts worktree lifecycle for testing.
@@ -103,6 +114,23 @@ type Runner struct {
 
 	resultMu sync.Mutex
 	result   DrainResult
+
+	processMu sync.Mutex
+	processes map[string]trackedProcess
+}
+
+type trackedProcess struct {
+	PID       int
+	PhaseName string
+	Exited    bool
+}
+
+type StallFinding struct {
+	Code     string
+	Level    string
+	VesselID string
+	Phase    string
+	Message  string
 }
 
 // New creates a Runner.
@@ -112,12 +140,13 @@ func New(cfg *config.Config, q *queue.Queue, wt WorktreeManager, r CommandRunner
 		concurrency = cfg.Concurrency
 	}
 	return &Runner{
-		Config:   cfg,
-		Queue:    q,
-		Worktree: wt,
-		Runner:   r,
-		LiveGate: gate.NewLiveVerifier(),
-		sem:      make(chan struct{}, concurrency),
+		Config:    cfg,
+		Queue:     q,
+		Worktree:  wt,
+		Runner:    r,
+		LiveGate:  gate.NewLiveVerifier(),
+		sem:       make(chan struct{}, concurrency),
+		processes: make(map[string]trackedProcess),
 	}
 }
 
@@ -473,6 +502,8 @@ func (r *Runner) CheckWaitingVessels(ctx context.Context) {
 }
 
 func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome string) {
+	defer r.clearTrackedProcess(vessel.ID)
+
 	// Look up source for this vessel
 	src := r.resolveSourceForVessel(vessel)
 
@@ -677,6 +708,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					}
 					return "failed"
 				}
+				outputPath := filepath.Join(phasesDir, p.Name+".output")
+				if touchErr := r.touchPhaseActivity(outputPath); touchErr != nil {
+					log.Printf("warn: touch phase activity %s: %v", outputPath, touchErr)
+				}
 				cmdOut, cmdErr := gate.RunCommand(ctx, r.Runner, worktreePath, rendered)
 				output = []byte(cmdOut)
 				runErr = cmdErr
@@ -745,7 +780,11 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if phaseStdin != nil {
 					stdinContent = rendered
 				}
-				output, runErr = r.runPhaseWithRateLimitRetry(ctx, worktreePath, stdinContent, cmd, args)
+				outputPath := filepath.Join(phasesDir, p.Name+".output")
+				if touchErr := r.touchPhaseActivity(outputPath); touchErr != nil {
+					log.Printf("warn: touch phase activity %s: %v", outputPath, touchErr)
+				}
+				output, runErr = r.runPhaseWithRateLimitRetry(ctx, vessel.ID, p.Name, worktreePath, stdinContent, cmd, args)
 			}
 
 			if r.vesselCancelled(ctx, vessel.ID) {
@@ -1078,7 +1117,11 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 		return "failed"
 	}
 
-	output, runErr := r.runPhaseWithRateLimitRetry(ctx, worktreePath, prompt, cmd, args)
+	outputPath := filepath.Join(r.Config.StateDir, "phases", vessel.ID, "prompt.output")
+	if touchErr := r.touchPhaseActivity(outputPath); touchErr != nil {
+		log.Printf("warn: touch phase activity %s: %v", outputPath, touchErr)
+	}
+	output, runErr := r.runPhaseWithRateLimitRetry(ctx, vessel.ID, "prompt", worktreePath, prompt, cmd, args)
 	phaseDuration := r.runtimeSince(phaseStartedAt)
 	if r.vesselCancelled(ctx, vessel.ID) {
 		return r.cancelVessel(vessel, worktreePath, vrs, nil)
@@ -1852,6 +1895,9 @@ type gateExecutionResult struct {
 // gate evaluation and retries. It returns the outcome without mutating the
 // vessel's queue state directly (the caller handles that).
 func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *workflow.Workflow, phaseIdx int, previousOutputs map[string]string, issueData phase.IssueData, harnessContent, worktreePath string, src source.Source, vrs *vesselRunState, enforceBudget bool) singlePhaseResult {
+	if vessel.Meta != nil {
+		vessel.Meta = maps.Clone(vessel.Meta)
+	}
 	p := wf.Phases[phaseIdx]
 	gateResult := ""
 	gateRetries := 0
@@ -1953,6 +1999,10 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				}
 				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
 			}
+			outputPath := filepath.Join(phasesDir, p.Name+".output")
+			if touchErr := r.touchPhaseActivity(outputPath); touchErr != nil {
+				log.Printf("warn: touch phase activity %s: %v", outputPath, touchErr)
+			}
 			cmdOut, cmdErr := gate.RunCommand(ctx, r.Runner, worktreePath, rendered)
 			output = []byte(cmdOut)
 			runErr = cmdErr
@@ -2020,7 +2070,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if phaseStdin != nil {
 				stdinContent = rendered
 			}
-			output, runErr = r.runPhaseWithRateLimitRetry(ctx, worktreePath, stdinContent, cmd, args)
+			outputPath := filepath.Join(phasesDir, p.Name+".output")
+			if touchErr := r.touchPhaseActivity(outputPath); touchErr != nil {
+				log.Printf("warn: touch phase activity %s: %v", outputPath, touchErr)
+			}
+			output, runErr = r.runPhaseWithRateLimitRetry(ctx, vessel.ID, p.Name, worktreePath, stdinContent, cmd, args)
 		}
 
 		if r.vesselCancelled(ctx, vessel.ID) {
@@ -3457,6 +3511,142 @@ func (r *Runner) rebuildPreviousOutputs(vesselID string, sk *workflow.Workflow) 
 	return outputs
 }
 
+func (r *Runner) touchPhaseActivity(path string) error {
+	now := r.runtimeNow()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create activity dir: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE, 0o644)
+	if err != nil {
+		return fmt.Errorf("open activity file: %w", err)
+	}
+	if closeErr := f.Close(); closeErr != nil {
+		return fmt.Errorf("close activity file: %w", closeErr)
+	}
+	if err := os.Chtimes(path, now, now); err != nil {
+		return fmt.Errorf("update activity mtime: %w", err)
+	}
+	return nil
+}
+
+func (r *Runner) latestPhaseActivity(vesselID string) (string, time.Time, error) {
+	phasesDir := filepath.Join(r.Config.StateDir, "phases", vesselID)
+	entries, err := os.ReadDir(phasesDir)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	var (
+		latestPhase string
+		latestTime  time.Time
+	)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".output") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return "", time.Time{}, err
+		}
+		if latestPhase == "" || info.ModTime().After(latestTime) {
+			latestPhase = strings.TrimSuffix(entry.Name(), ".output")
+			latestTime = info.ModTime()
+		}
+	}
+	if latestPhase == "" {
+		return "", time.Time{}, os.ErrNotExist
+	}
+	return latestPhase, latestTime, nil
+}
+
+func (r *Runner) markProcessStarted(vesselID, phaseName string, pid int) {
+	r.processMu.Lock()
+	defer r.processMu.Unlock()
+	r.processes[vesselID] = trackedProcess{PID: pid, PhaseName: phaseName}
+}
+
+func (r *Runner) markProcessExited(vesselID string, pid int) {
+	r.processMu.Lock()
+	defer r.processMu.Unlock()
+	current, ok := r.processes[vesselID]
+	if !ok || current.PID != pid {
+		return
+	}
+	current.Exited = true
+	r.processes[vesselID] = current
+}
+
+func (r *Runner) clearTrackedProcess(vesselID string) {
+	r.processMu.Lock()
+	defer r.processMu.Unlock()
+	delete(r.processes, vesselID)
+}
+
+func (r *Runner) trackedProcess(vesselID string) (trackedProcess, bool) {
+	r.processMu.Lock()
+	defer r.processMu.Unlock()
+	proc, ok := r.processes[vesselID]
+	return proc, ok
+}
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil
+}
+
+func stopProcess(pid int, sleep func(context.Context, time.Duration) error) error {
+	if pid <= 0 {
+		return nil
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find process %d: %w", pid, err)
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("sigterm process %d: %w", pid, err)
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if !processAlive(pid) {
+			return nil
+		}
+		if sleep != nil {
+			if err := sleep(context.Background(), 250*time.Millisecond); err != nil {
+				break
+			}
+		} else {
+			time.Sleep(250 * time.Millisecond)
+		}
+	}
+	if !processAlive(pid) {
+		return nil
+	}
+	if err := proc.Signal(syscall.SIGKILL); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("sigkill process %d: %w", pid, err)
+	}
+	return nil
+}
+
+type vesselProcessObserver struct {
+	r         *Runner
+	vesselID  string
+	phaseName string
+}
+
+func (o vesselProcessObserver) ProcessStarted(pid int) {
+	o.r.markProcessStarted(o.vesselID, o.phaseName, pid)
+}
+
+func (o vesselProcessObserver) ProcessExited(pid int) {
+	o.r.markProcessExited(o.vesselID, pid)
+}
+
 func (r *Runner) parseIssueNum(vessel queue.Vessel) int {
 	if vessel.Meta == nil {
 		return 0
@@ -3654,6 +3844,100 @@ func (r *Runner) CheckHungVessels(ctx context.Context) {
 	}
 }
 
+func (r *Runner) CheckStalledVessels(ctx context.Context) []StallFinding {
+	threshold := r.Config.Daemon.StallMonitor.PhaseStallThreshold
+	if threshold == "" {
+		return nil
+	}
+	stallThreshold, err := time.ParseDuration(threshold)
+	if err != nil {
+		log.Printf("warn: parse phase stall threshold: %v", err)
+		return nil
+	}
+
+	running, err := r.Queue.ListByState(queue.StateRunning)
+	if err != nil {
+		log.Printf("warn: list running vessels for stall check: %v", err)
+		return nil
+	}
+
+	findings := make([]StallFinding, 0)
+	for _, vessel := range running {
+		if r.Config.Daemon.StallMonitor.OrphanCheckEnabled {
+			proc, ok := r.trackedProcess(vessel.ID)
+			if ok && (proc.Exited || !processAlive(proc.PID)) {
+				msg := "vessel orphaned (no live subprocess)"
+				log.Printf("warn: %s for vessel %s", msg, vessel.ID)
+				if r.timeoutRunningVessel(ctx, vessel, msg) {
+					findings = append(findings, StallFinding{
+						Code:     "orphaned_subprocess",
+						Level:    "critical",
+						VesselID: vessel.ID,
+						Message:  msg,
+					})
+				}
+				continue
+			}
+		}
+
+		phaseName, modifiedAt, err := r.latestPhaseActivity(vessel.ID)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				log.Printf("warn: inspect phase activity for vessel %s: %v", vessel.ID, err)
+			}
+			continue
+		}
+		staleFor := r.runtimeSince(modifiedAt)
+		if staleFor <= stallThreshold {
+			continue
+		}
+
+		if proc, ok := r.trackedProcess(vessel.ID); ok && !proc.Exited && processAlive(proc.PID) {
+			if err := stopProcess(proc.PID, r.runtimeSleep); err != nil {
+				log.Printf("warn: stop stalled process for vessel %s: %v", vessel.ID, err)
+			}
+		}
+		msg := fmt.Sprintf("phase stalled: no output for %s", staleFor.Truncate(time.Second))
+		log.Printf("warn: %s for vessel %s (phase=%s)", msg, vessel.ID, phaseName)
+		if r.timeoutRunningVessel(ctx, vessel, msg) {
+			findings = append(findings, StallFinding{
+				Code:     "phase_stalled",
+				Level:    "critical",
+				VesselID: vessel.ID,
+				Phase:    phaseName,
+				Message:  fmt.Sprintf("Vessel %s phase-stalled (%s no output on %s)", vessel.ID, staleFor.Truncate(time.Second), phaseName),
+			})
+		}
+	}
+	return findings
+}
+
+func (r *Runner) timeoutRunningVessel(ctx context.Context, vessel queue.Vessel, errMsg string) bool {
+	r.clearTrackedProcess(vessel.ID)
+	if updateErr := r.Queue.Update(vessel.ID, queue.StateTimedOut, errMsg); updateErr != nil {
+		log.Printf("warn: failed to update vessel %s to timed_out: %v", vessel.ID, updateErr)
+		return false
+	}
+
+	timeoutSpan := r.startWaitTransitionSpan(ctx, vessel, "timed_out", waitedDuration(vessel.StartedAt, r.runtimeNow()))
+	vrs := newVesselRunState(r.Config, vessel, r.runtimeNow())
+	vrs.setTraceContext(observability.TraceContextFromContext(timeoutSpan.Context()))
+	r.annotateRecoveryMetadata(vessel.ID, queue.StateTimedOut, errMsg, traceContextPointer(vrs.trace))
+	src := r.resolveSourceForVessel(vessel)
+	if err := src.OnTimedOut(ctx, vessel); err != nil {
+		log.Printf("warn: OnTimedOut hook for vessel %s: %v", vessel.ID, err)
+	}
+	r.persistRunArtifacts(vessel, string(queue.StateTimedOut), vrs, nil, r.runtimeNow())
+	if r.Tracer != nil {
+		if current, findErr := r.Queue.FindByID(vessel.ID); findErr == nil && current != nil {
+			timeoutSpan.AddAttributes(observability.RecoveryAttributes(recoveryAttributesFromMeta(current.Meta)))
+		}
+	}
+	r.finishWaitTransitionSpan(timeoutSpan, nil)
+	r.removeWorktree(ctx, vessel.WorktreePath, vessel.ID)
+	return true
+}
+
 func (r *Runner) runtimeNow() time.Time {
 	now, err := dtu.RuntimeNow()
 	if err != nil {
@@ -3740,14 +4024,26 @@ func isRateLimitError(err error) bool {
 // stdinContent is re-wrapped in a fresh strings.Reader for each attempt;
 // pass "" for nil stdin.
 func (r *Runner) runPhaseWithRateLimitRetry(
-	ctx context.Context, dir, stdinContent, cmd string, args []string,
+	ctx context.Context, vesselID, phaseName, dir, stdinContent, cmd string, args []string,
 ) ([]byte, error) {
 	for attempt := 0; attempt <= rateLimitMaxRetries; attempt++ {
 		var stdin io.Reader
 		if stdinContent != "" {
 			stdin = strings.NewReader(stdinContent)
 		}
-		output, err := r.Runner.RunPhase(ctx, dir, stdin, cmd, args...)
+		var (
+			output []byte
+			err    error
+		)
+		if observedRunner, ok := r.Runner.(PhaseProcessRunner); ok {
+			output, err = observedRunner.RunPhaseObserved(ctx, dir, stdin, vesselProcessObserver{
+				r:         r,
+				vesselID:  vesselID,
+				phaseName: phaseName,
+			}, cmd, args...)
+		} else {
+			output, err = r.Runner.RunPhase(ctx, dir, stdin, cmd, args...)
+		}
 		if err == nil || !isRateLimitError(err) {
 			return output, err
 		}

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -7243,6 +7243,135 @@ func TestCheckHungVesselsWritesTraceableSummary(t *testing.T) {
 	assert.Equal(t, timeoutSpan.SpanContext().SpanID().String(), summary.Trace.SpanID)
 }
 
+func TestSmoke_S1_PhaseStalledVesselTimesOut(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "10m"
+	cfg.Daemon.StallMonitor.OrphanCheckEnabled = false
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:        "stall-1",
+		Source:    "manual",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	})
+	vessel, _ := q.Dequeue()
+	require.NotNil(t, vessel)
+
+	outputPath := filepath.Join(cfg.StateDir, "phases", vessel.ID, "analyze.output")
+	require.NoError(t, os.MkdirAll(filepath.Dir(outputPath), 0o755))
+	require.NoError(t, os.WriteFile(outputPath, []byte(""), 0o644))
+	old := now.Add(-11 * time.Minute)
+	require.NoError(t, os.Chtimes(outputPath, old, old))
+	require.NoError(t, q.UpdateVessel(*vessel))
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	findings := r.CheckStalledVessels(context.Background())
+	require.Len(t, findings, 1)
+	assert.Equal(t, "phase_stalled", findings[0].Code)
+	assert.Equal(t, "analyze", findings[0].Phase)
+
+	updated, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	assert.Equal(t, queue.StateTimedOut, updated.State)
+	assert.Contains(t, updated.Error, "phase stalled: no output for")
+}
+
+func TestSmoke_S3_OrphanedRunningVesselTimesOut(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "10m"
+	cfg.Daemon.StallMonitor.OrphanCheckEnabled = true
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:        "orphan-1",
+		Source:    "manual",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	})
+	vessel, _ := q.Dequeue()
+	require.NotNil(t, vessel)
+	require.NoError(t, q.UpdateVessel(*vessel))
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	r.markProcessStarted(vessel.ID, "analyze", os.Getpid())
+	r.markProcessExited(vessel.ID, os.Getpid())
+	findings := r.CheckStalledVessels(context.Background())
+	require.Len(t, findings, 1)
+	assert.Equal(t, "orphaned_subprocess", findings[0].Code)
+
+	updated, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	assert.Equal(t, queue.StateTimedOut, updated.State)
+	assert.Equal(t, "vessel orphaned (no live subprocess)", updated.Error)
+}
+
+func TestTimeoutRunningVesselReturnsFalseWhenStateAlreadyChanged(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:        "transition-1",
+		Source:    "manual",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	})
+	vessel, _ := q.Dequeue()
+	require.NotNil(t, vessel)
+	require.NoError(t, q.Update(vessel.ID, queue.StateCompleted, ""))
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	ok := r.timeoutRunningVessel(context.Background(), *vessel, "phase stalled: no output for 11m0s")
+	assert.False(t, ok)
+
+	updated, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	assert.Equal(t, queue.StateCompleted, updated.State)
+	assert.Empty(t, updated.Error)
+}
+
+func TestCheckStalledVesselsDoesNotTimeoutUntrackedRecentPhase(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "10m"
+	cfg.Daemon.StallMonitor.OrphanCheckEnabled = true
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:        "command-1",
+		Source:    "manual",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	})
+	vessel, _ := q.Dequeue()
+	require.NotNil(t, vessel)
+
+	outputPath := filepath.Join(cfg.StateDir, "phases", vessel.ID, "analyze.output")
+	require.NoError(t, os.MkdirAll(filepath.Dir(outputPath), 0o755))
+	require.NoError(t, os.WriteFile(outputPath, []byte("still running"), 0o644))
+	require.NoError(t, os.Chtimes(outputPath, now, now))
+	require.NoError(t, q.UpdateVessel(*vessel))
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	findings := r.CheckStalledVessels(context.Background())
+	require.Empty(t, findings)
+
+	updated, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	assert.Equal(t, queue.StateRunning, updated.State)
+}
+
 func TestSmoke_S9_NilTracerSkipsAllSpanCreationWithoutPanicking(t *testing.T) {
 	cmdRunner := &mockCmdRunner{
 		phaseOutputs: map[string][]byte{

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -114,6 +114,23 @@ func (s *Scanner) budgetGate() budgetGate {
 	return cost.NewBudgetGate(s.Config.VesselBudget())
 }
 
+// BacklogCount reports how many items currently match backlog-aware sources.
+func (s *Scanner) BacklogCount(ctx context.Context) (int, error) {
+	total := 0
+	for _, entry := range s.buildSources() {
+		backlogSource, ok := entry.src.(source.BacklogSource)
+		if !ok {
+			continue
+		}
+		count, err := backlogSource.BacklogCount(ctx)
+		if err != nil {
+			return total, err
+		}
+		total += count
+	}
+	return total, nil
+}
+
 type sourceEntry struct {
 	src        source.Source
 	configName string

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -154,6 +154,43 @@ func TestScanFindsIssues(t *testing.T) {
 	}
 }
 
+func TestBacklogCountDeduplicatesAndSkipsExcludedIssues(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeConfig(dir)
+	srcCfg := cfg.Sources["github"]
+	srcCfg.Tasks["triage-incidents"] = config.Task{Labels: []string{"incident"}, Workflow: "triage"}
+	cfg.Sources["github"] = srcCfg
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	bugIssues := []ghIssue{
+		{Number: 1, Title: "fix null response", URL: "https://github.com/owner/repo/issues/1", Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}}},
+		{Number: 2, Title: "investigate prod incident", URL: "https://github.com/owner/repo/issues/2", Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}, {Name: "incident"}}},
+		{Number: 3, Title: "skip duplicate backlog item", URL: "https://github.com/owner/repo/issues/3", Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}, {Name: "wontfix"}}},
+	}
+	incidentIssues := []ghIssue{
+		{Number: 2, Title: "investigate prod incident", URL: "https://github.com/owner/repo/issues/2", Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}, {Name: "incident"}}},
+		{Number: 4, Title: "on-call handoff", URL: "https://github.com/owner/repo/issues/4", Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "incident"}}},
+	}
+	r.set(issueJSON(bugIssues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(incidentIssues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "incident")
+
+	s := New(cfg, q, r)
+	count, err := s.BacklogCount(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+}
+
 func TestScanExcludedLabel(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeConfig(dir)

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -151,6 +151,47 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 	return vessels, nil
 }
 
+func (g *GitHub) BacklogCount(ctx context.Context) (int, error) {
+	excludeSet := make(map[string]bool, len(g.Exclude))
+	for _, ex := range g.Exclude {
+		excludeSet[ex] = true
+	}
+
+	seen := make(map[int]struct{})
+	count := 0
+	for _, task := range g.Tasks {
+		for _, label := range task.Labels {
+			args := []string{
+				"search", "issues",
+				"--repo", g.Repo,
+				"--state", "open",
+				"--json", "number,title,body,url,labels",
+				"--limit", "20",
+				"--label", label,
+			}
+
+			out, err := g.CmdRunner.Run(ctx, "gh", args...)
+			if err != nil {
+				return 0, fmt.Errorf("gh search issues: %w", err)
+			}
+
+			var issues []ghIssue
+			if err := json.Unmarshal(out, &issues); err != nil {
+				return 0, fmt.Errorf("parse gh search output: %w", err)
+			}
+
+			for _, issue := range issues {
+				if _, ok := seen[issue.Number]; ok || g.hasExcludedLabel(issue, excludeSet) {
+					continue
+				}
+				seen[issue.Number] = struct{}{}
+				count++
+			}
+		}
+	}
+	return count, nil
+}
+
 func (g *GitHub) OnEnqueue(ctx context.Context, vessel queue.Vessel) error {
 	g.applyIssueLabels(ctx, vessel.Meta["issue_num"],
 		[]string{vessel.Meta["status_label_queued"]}, nil)

--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -143,15 +143,6 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 				if g.hasExcludedLabel(pr, excludeSet) {
 					continue
 				}
-				// resolve-conflicts workflow is only meaningful for PRs in a
-				// CONFLICTING merge state. When GitHub reports MERGEABLE, the
-				// label is stale (conflicts were resolved outside this
-				// workflow, e.g., via manual push or rebase) — strip it so
-				// the next scan does not re-match, breaking what would
-				// otherwise be an infinite enqueue loop. When GitHub reports
-				// UNKNOWN (empty or literal), skip the vessel but preserve
-				// the label so a subsequent scan can re-evaluate once the
-				// merge state has been computed.
 				if task.Workflow == resolveConflictsWorkflow && pr.Mergeable != ghMergeableConflicting {
 					if pr.Mergeable == ghMergeableMergeable {
 						g.stripTaskLabels(ctx, pr.Number, task.Labels)
@@ -178,6 +169,51 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 		}
 	}
 	return vessels, nil
+}
+
+func (g *GitHubPR) BacklogCount(ctx context.Context) (int, error) {
+	excludeSet := make(map[string]bool, len(g.Exclude))
+	for _, ex := range g.Exclude {
+		excludeSet[ex] = true
+	}
+
+	seen := make(map[prWorkflowSeenKey]struct{})
+	count := 0
+	for _, task := range g.Tasks {
+		for _, label := range task.Labels {
+			args := []string{
+				"pr", "list",
+				"--repo", g.Repo,
+				"--state", "open",
+				"--label", label,
+				"--json", "number,title,body,url,labels,headRefName,mergeable",
+				"--limit", "20",
+			}
+
+			out, err := g.CmdRunner.Run(ctx, "gh", args...)
+			if err != nil {
+				return 0, fmt.Errorf("gh pr list: %w", err)
+			}
+
+			var prs []ghPR
+			if err := json.Unmarshal(out, &prs); err != nil {
+				return 0, fmt.Errorf("parse gh pr list output: %w", err)
+			}
+
+			for _, pr := range prs {
+				key := prWorkflowSeenKey{prNum: pr.Number, workflow: task.Workflow}
+				if _, ok := seen[key]; ok || g.hasExcludedLabel(pr, excludeSet) {
+					continue
+				}
+				if task.Workflow == resolveConflictsWorkflow && pr.Mergeable != ghMergeableConflicting {
+					continue
+				}
+				seen[key] = struct{}{}
+				count++
+			}
+		}
+	}
+	return count, nil
 }
 
 func (g *GitHubPR) OnEnqueue(ctx context.Context, vessel queue.Vessel) error {

--- a/cli/internal/source/source.go
+++ b/cli/internal/source/source.go
@@ -140,6 +140,12 @@ type Source interface {
 	BranchName(vessel queue.Vessel) string
 }
 
+// BacklogSource reports how many items currently match this source's scan
+// criteria without enqueueing them.
+type BacklogSource interface {
+	BacklogCount(ctx context.Context) (int, error)
+}
+
 // CommandRunner abstracts subprocess execution for testing.
 type CommandRunner interface {
 	Run(ctx context.Context, name string, args ...string) ([]byte, error)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,6 +103,10 @@ copilot:
 daemon:
   scan_interval: "60s"   # how often the daemon scans for new work
   drain_interval: "30s"  # how often the daemon drains pending vessels
+  stall_monitor:
+    phase_stall_threshold: "10m"   # mark running vessels timed_out after no phase output activity
+    scanner_idle_threshold: "5m"   # warn when queue stays idle while GitHub backlog exists
+    orphan_check_enabled: true      # repair running vessels with no live tracked subprocess
 ```
 
 ## Field reference
@@ -126,6 +130,26 @@ daemon:
 | `harness` | object | see below | No | Agent safety guardrails: protected file surfaces, policy rules, and audit logging. |
 | `observability` | object | see below | No | OpenTelemetry instrumentation settings. |
 | `cost` | object | see below | No | Token budget enforcement settings. |
+
+### `daemon`
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `scan_interval` | string | `"60s"` | No | How often the daemon scans configured sources for new work. Must be a valid Go duration string. |
+| `drain_interval` | string | `"30s"` | No | How often the daemon dequeues pending vessels. Must be a valid Go duration string. |
+| `stall_monitor` | object | see below | No | Deterministic self-monitoring thresholds for phase stalls, idle-with-backlog detection, and orphan repair. |
+| `auto_upgrade` | boolean | `false` | No | Enables periodic self-upgrade checks for the daemon binary. |
+| `upgrade_interval` | string | `"5m"` | No | How often the daemon re-runs auto-upgrade checks while the loop is running. Must be a valid Go duration string. |
+| `auto_merge` | boolean | `false` | No | Enables the merge-ready Copilot review + auto-merge cycle for xylem-authored PRs. |
+| `auto_merge_repo` | string | current repo remote | No | Optional `owner/name` override for auto-merge GitHub operations. |
+
+### `daemon.stall_monitor`
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `phase_stall_threshold` | string | `"10m"` | No | Maximum time since the most recent `*.output` activity for a running vessel before it is marked `timed_out`. Must be a valid Go duration string. |
+| `scanner_idle_threshold` | string | `"5m"` | No | How long the queue may remain idle before xylem warns that GitHub backlog still exists. Must be a valid Go duration string. |
+| `orphan_check_enabled` | boolean | `true` | No | When enabled, the daemon repairs running vessels that have no live tracked subprocess by transitioning them to `timed_out`. |
 
 ### Sources
 


### PR DESCRIPTION
## Summary

Implements https://github.com/nicholls-inc/xylem/issues/207.

This adds deterministic daemon self-monitoring for two failure modes: running vessels that have stalled or lost their tracked subprocess, and scanners that stay idle while GitHub backlog still exists. The daemon now persists heartbeat/check snapshots, surfaces them via `xylem status`, and uses backlog-aware GitHub sources to warn when work is waiting upstream.

## Smoke scenarios covered

- `S1` — `PhaseStalledVesselTimesOut`
- `S2` — `DaemonIdleWithBacklogWarningFires`
- `S3` — `OrphanedRunningVesselTimesOut`
- `S4` — `DeterministicPhaseStallRecovery`

## Changes summary

### Added files

- `cli/internal/daemonhealth/daemonhealth.go` — persisted daemon heartbeat/check snapshot types plus load/save helpers.
- `cli/internal/runner/monitor_prop_test.go` — property coverage for newest phase activity selection.

### Modified files

- `cli/cmd/xylem/daemon.go` — wires stall findings into per-tick health snapshots, tracks idle-with-backlog state, and saves daemon health on each loop tick.
- `cli/cmd/xylem/status.go` and `cli/cmd/xylem/status_test.go` — load/render daemon health alongside queue status output.
- `cli/cmd/xylem/exec.go` — adds observed phase process execution so runner monitoring can track live subprocess state deterministically.
- `cli/internal/config/config.go` and `cli/internal/config/config_test.go` — adds `daemon.stall_monitor` defaults and validation for `phase_stall_threshold`, `scanner_idle_threshold`, and `orphan_check_enabled`.
- `cli/internal/runner/runner.go` and `cli/internal/runner/runner_test.go` — adds deterministic stalled/orphaned vessel checks, returns findings only after successful `timed_out` transitions, and clones vessel metadata before phase execution.
- `cli/internal/scanner/scanner.go` and `cli/internal/scanner/scanner_test.go` — adds scanner backlog aggregation across backlog-aware sources.
- `cli/internal/source/source.go`, `cli/internal/source/github.go`, and `cli/internal/source/github_pr.go` — adds the `BacklogSource` interface plus GitHub/GitHub PR backlog counting.
- `cli/cmd/xylem/daemon_test.go` and `cli/internal/dtu/scenario_daemon_test.go` — adds/renames smoke coverage for idle backlog and deterministic stall recovery.
- `docs/configuration.md` — documents the new daemon stall-monitor settings.

### Key types and functions

- `daemonhealth.Snapshot`, `daemonhealth.Check`, `daemonhealth.Save`, `daemonhealth.Load`
- `daemonLoop(..., tick tickFunc, ...)`, `daemonChecksFromFindings`, `daemonBacklogHealthCheck`, `daemonQueueCounts`
- `runner.PhaseProcessObserver`, `RunPhaseObserved`, `Runner.CheckStalledVessels`, `Runner.timeoutRunningVessel`
- `scanner.Scanner.BacklogCount`, `source.BacklogSource`, `GitHub.BacklogCount`, `GitHubPR.BacklogCount`

## Test plan

- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #207