### PR TITLE
feat: add daemon-driven release-please auto-merge cadence with mature changelog guards

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -133,6 +133,16 @@ sources:
         workflow: sota-gap-analysis
         ref: sota-gap-analysis
 
+  release-please-cut:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "0 10 * * 1,4"
+    timeout: "5m"
+    tasks:
+      cut-release:
+        workflow: cut-release
+        ref: release-please-cut
+
   # Post-merge wave dependency unblocking
   # NOTE: github-merge has no label filtering. The unblock-wave prompt
   # guards with XYLEM_NOOP for non-harness merges.

--- a/.xylem/workflows/cut-release.yaml
+++ b/.xylem/workflows/cut-release.yaml
@@ -1,0 +1,46 @@
+name: cut-release
+description: "Cut mature release-please PRs on a fixed daemon cadence"
+phases:
+  - name: check
+    type: command
+    run: |
+      mkdir -p .xylem/state
+      PR_NUM=$(gh pr list --repo {{.Repo.Slug}} --label "autorelease: pending" --state open --json number --limit 1 | grep -o '"number":[0-9][0-9]*' | head -n 1 | tr -cd '0-9')
+      if [ -z "$PR_NUM" ]; then
+        echo "XYLEM_NOOP: no release PR pending"
+        exit 0
+      fi
+      printf '%s\n' "$PR_NUM" > .xylem/state/release_pr
+    noop:
+      match: XYLEM_NOOP
+  - name: verify
+    type: command
+    run: |
+      PR_NUM=$(cat .xylem/state/release_pr)
+      LABELS_JSON=$(gh pr view "$PR_NUM" --repo {{.Repo.Slug}} --json labels)
+      if printf '%s' "$LABELS_JSON" | grep -q '"name":"block-release"'; then
+        echo "XYLEM_NOOP: block-release label present"
+        exit 0
+      fi
+
+      COMMITS_JSON=$(gh pr view "$PR_NUM" --repo {{.Repo.Slug}} --json commits)
+      COMMITS=$(printf '%s' "$COMMITS_JSON" | grep -o '"oid"' | wc -l | tr -d ' ')
+      if [ "$COMMITS" -lt 5 ]; then
+        echo "XYLEM_NOOP: only $COMMITS commits, below threshold"
+        exit 0
+      fi
+
+      CHECKS_JSON=$(gh pr view "$PR_NUM" --repo {{.Repo.Slug}} --json statusCheckRollup)
+      TOTAL=$(printf '%s' "$CHECKS_JSON" | grep -o '"conclusion"' | wc -l | tr -d ' ')
+      SUCCESS=$(printf '%s' "$CHECKS_JSON" | grep -o '"conclusion":"SUCCESS"' | wc -l | tr -d ' ')
+      if [ "$TOTAL" -eq 0 ] || [ "$TOTAL" -ne "$SUCCESS" ]; then
+        echo "XYLEM_NOOP: release PR checks are not green"
+        exit 0
+      fi
+    noop:
+      match: XYLEM_NOOP
+  - name: merge
+    type: command
+    run: |
+      PR_NUM=$(cat .xylem/state/release_pr)
+      gh pr merge "$PR_NUM" --repo {{.Repo.Slug}} --squash --delete-branch --admin

--- a/cli/internal/cadence/cadence.go
+++ b/cli/internal/cadence/cadence.go
@@ -67,3 +67,91 @@ func (s Spec) FireTime(last *time.Time, now time.Time) (time.Time, bool) {
 	}
 	return time.Time{}, false
 }
+
+// Bucket returns a stable bucket identifier and the enclosing schedule window
+// for a given time. Interval specs use the historical integer bucket index so
+// persisted scheduled-source state remains compatible. Cron specs use the slot
+// start timestamp as the bucket key.
+func (s Spec) Bucket(now time.Time) (int64, time.Time, time.Time, error) {
+	now = now.UTC()
+	if s.interval > 0 {
+		size := s.interval.Nanoseconds()
+		bucket := now.UnixNano() / size
+		startUnix := bucket * size
+		start := time.Unix(0, startUnix).UTC()
+		return bucket, start, start.Add(s.interval), nil
+	}
+	if s.cron == nil {
+		return 0, time.Time{}, time.Time{}, fmt.Errorf("cadence is not initialized")
+	}
+	start, end, err := currentCronWindow(s.cron, now)
+	if err != nil {
+		return 0, time.Time{}, time.Time{}, err
+	}
+	return start.Unix(), start, end, nil
+}
+
+func currentCronWindow(schedule cron.Schedule, now time.Time) (time.Time, time.Time, error) {
+	now = now.UTC().Truncate(time.Minute)
+	if now.IsZero() {
+		return time.Time{}, time.Time{}, fmt.Errorf("current time is required")
+	}
+
+	if cronFiresAt(schedule, now) {
+		end := schedule.Next(now).UTC().Truncate(time.Minute)
+		return now, end, nil
+	}
+
+	end := schedule.Next(now).UTC().Truncate(time.Minute)
+	start, err := previousCronOccurrence(schedule, end)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	return start, end, nil
+}
+
+func cronFiresAt(schedule cron.Schedule, ts time.Time) bool {
+	ts = ts.UTC().Truncate(time.Minute)
+	if ts.Second() != 0 || ts.Nanosecond() != 0 {
+		return false
+	}
+	return schedule.Next(ts.Add(-time.Minute)).UTC().Truncate(time.Minute).Equal(ts)
+}
+
+func previousCronOccurrence(schedule cron.Schedule, next time.Time) (time.Time, error) {
+	next = next.UTC().Truncate(time.Minute)
+	upper := next.Add(-time.Minute)
+	if upper.IsZero() {
+		return time.Time{}, fmt.Errorf("next occurrence is required")
+	}
+
+	lower := upper
+	step := time.Minute
+	const maxLookback = 20 * 366 * 24 * time.Hour
+	for upper.Sub(next.Add(-maxLookback)) > 0 {
+		candidate := upper.Add(-step)
+		if !schedule.Next(candidate).UTC().Truncate(time.Minute).Equal(next) {
+			lower = candidate
+			break
+		}
+		upper = candidate
+		step *= 2
+	}
+	if schedule.Next(lower).UTC().Truncate(time.Minute).Equal(next) {
+		return time.Time{}, fmt.Errorf("could not determine previous cron occurrence before %s", next.Format(time.RFC3339))
+	}
+
+	for upper.Sub(lower) > time.Minute {
+		mid := lower.Add(upper.Sub(lower) / 2).UTC().Truncate(time.Minute)
+		if !mid.Before(upper) {
+			mid = upper.Add(-time.Minute)
+		}
+		if schedule.Next(mid).UTC().Truncate(time.Minute).Equal(next) {
+			upper = mid
+			continue
+		}
+		lower = mid
+	}
+
+	return upper.UTC().Truncate(time.Minute), nil
+}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -1050,23 +1050,12 @@ func validateScheduledSource(name string, src SourceConfig) error {
 	return nil
 }
 
-func parseScheduleValue(value string) (time.Duration, error) {
-	switch strings.TrimSpace(strings.ToLower(value)) {
-	case "@hourly":
-		return time.Hour, nil
-	case "@daily":
-		return 24 * time.Hour, nil
-	case "@weekly":
-		return 7 * 24 * time.Hour, nil
-	}
-	interval, err := time.ParseDuration(value)
+func parseScheduleValue(value string) (string, error) {
+	spec, err := cadence.Parse(value)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
-	if interval <= 0 {
-		return 0, fmt.Errorf("must be greater than 0")
-	}
-	return interval, nil
+	return spec.Raw(), nil
 }
 func validateScheduleSource(name string, src SourceConfig) error {
 	if strings.TrimSpace(src.Workflow) == "" {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1530,6 +1531,28 @@ func TestValidateScheduledSourceValid(t *testing.T) {
 	}
 }
 
+func TestValidateScheduledSourceCronValid(t *testing.T) {
+	cfg := &Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		Claude:      ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]SourceConfig{
+			"release-please-cut": {
+				Type:     "scheduled",
+				Repo:     "owner/name",
+				Schedule: "0 10 * * 1,4",
+				Tasks: map[string]Task{
+					"cut-release": {Workflow: "cut-release", Ref: "release-please-cut"},
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid cron scheduled config, got: %v", err)
+	}
+}
+
 func TestValidateScheduleValid(t *testing.T) {
 	cfg := &Config{
 		Concurrency: 2,
@@ -2050,26 +2073,65 @@ func TestSmoke_S35_HarnessReviewRejectsAbsoluteOutputDir(t *testing.T) {
 }
 
 func TestSmoke_S36_ScheduledSourceLoads(t *testing.T) {
-	cfg := validConfig()
-	cfg.Sources = map[string]SourceConfig{
-		"sota-gap": {
-			Type:     "scheduled",
-			Repo:     "owner/repo",
-			Schedule: "@weekly",
-			Tasks: map[string]Task{
-				"weekly": {Workflow: "sota-gap-analysis", Ref: "sota-gap-analysis"},
-			},
+	tests := []struct {
+		name       string
+		sourceName string
+		taskName   string
+		schedule   string
+		workflow   string
+		ref        string
+	}{
+		{
+			name:       "named cadence",
+			sourceName: "sota-gap",
+			taskName:   "weekly",
+			schedule:   "@weekly",
+			workflow:   "sota-gap-analysis",
+			ref:        "sota-gap-analysis",
+		},
+		{
+			name:       "cron cadence",
+			sourceName: "release-please-cut",
+			taskName:   "cut-release",
+			schedule:   "0 10 * * 1,4",
+			workflow:   "cut-release",
+			ref:        "release-please-cut",
 		},
 	}
 
-	err := cfg.Validate()
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeConfigFile(t, fmt.Sprintf(`sources:
+  %s:
+    type: scheduled
+    repo: owner/repo
+    schedule: %q
+    tasks:
+      %s:
+        workflow: %s
+        ref: %s
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`, tt.sourceName, tt.schedule, tt.taskName, tt.workflow, tt.ref))
 
-	sourceCfg := cfg.Sources["sota-gap"]
-	assert.Equal(t, "scheduled", sourceCfg.Type)
-	assert.Equal(t, "@weekly", sourceCfg.Schedule)
-	assert.Equal(t, "sota-gap-analysis", sourceCfg.Tasks["weekly"].Workflow)
-	assert.Equal(t, "sota-gap-analysis", sourceCfg.Tasks["weekly"].Ref)
+			cfg, err := Load(path)
+			require.NoError(t, err)
+
+			sourceCfg, ok := cfg.Sources[tt.sourceName]
+			require.True(t, ok, "missing source %q", tt.sourceName)
+			taskCfg, ok := sourceCfg.Tasks[tt.taskName]
+			require.True(t, ok, "missing task %q", tt.taskName)
+
+			assert.Equal(t, "scheduled", sourceCfg.Type)
+			assert.Equal(t, tt.schedule, sourceCfg.Schedule)
+			assert.Equal(t, tt.workflow, taskCfg.Workflow)
+			assert.Equal(t, tt.ref, taskCfg.Ref)
+		})
+	}
 }
 
 func TestSmoke_S37_ScheduledSourceAllowsMissingRef(t *testing.T) {

--- a/cli/internal/dtu/dtu_prop_test.go
+++ b/cli/internal/dtu/dtu_prop_test.go
@@ -20,6 +20,7 @@ func TestPropRepositoryAutoMergeRespectsCheckStates(t *testing.T) {
 
 	rapid.Check(t, func(t *rapid.T) {
 		deleteHeadBranch := rapid.Bool().Draw(t, "delete_head_branch")
+		adminMerge := rapid.Bool().Draw(t, "admin_merge")
 		checkCount := rapid.IntRange(0, 5).Draw(t, "check_count")
 
 		checks := make([]Check, 0, checkCount)
@@ -55,7 +56,11 @@ func TestPropRepositoryAutoMergeRespectsCheckStates(t *testing.T) {
 			}},
 		}
 
-		if err := repo.MergePullRequest(7, MergePullRequestOptions{DeleteHeadBranch: deleteHeadBranch, AutoMerge: true}); err != nil {
+		if err := repo.MergePullRequest(7, MergePullRequestOptions{
+			DeleteHeadBranch: deleteHeadBranch,
+			AutoMerge:        true,
+			Admin:            adminMerge,
+		}); err != nil {
 			t.Fatalf("MergePullRequest() error = %v", err)
 		}
 
@@ -68,8 +73,8 @@ func TestPropRepositoryAutoMergeRespectsCheckStates(t *testing.T) {
 			if pr.State != PullRequestStateOpen || pr.Merged {
 				t.Fatalf("queued pull request = %#v, want open queued auto-merge", pr)
 			}
-			if !pr.AutoMergeEnabled || pr.AutoMergeDeleteBranch != deleteHeadBranch {
-				t.Fatalf("queued pull request flags = %#v, want auto-merge enabled with delete=%t", pr, deleteHeadBranch)
+			if !pr.AutoMergeEnabled || pr.AutoMergeDeleteBranch != deleteHeadBranch || pr.AutoMergeAdmin != adminMerge {
+				t.Fatalf("queued pull request flags = %#v, want auto-merge enabled with delete=%t admin=%t", pr, deleteHeadBranch, adminMerge)
 			}
 			if branch := repo.BranchByName("main"); branch == nil || branch.SHA != "1111111111111111111111111111111111111111" {
 				t.Fatalf("main branch = %#v, want original SHA preserved", branch)
@@ -89,8 +94,11 @@ func TestPropRepositoryAutoMergeRespectsCheckStates(t *testing.T) {
 		if pr.State != PullRequestStateMerged || !pr.Merged {
 			t.Fatalf("merged pull request = %#v, want merged state", pr)
 		}
-		if pr.AutoMergeEnabled || pr.AutoMergeDeleteBranch {
+		if pr.AutoMergeEnabled || pr.AutoMergeDeleteBranch || pr.AutoMergeAdmin {
 			t.Fatalf("merged pull request flags = %#v, want cleared auto-merge flags", pr)
+		}
+		if pr.MergedByAdmin != adminMerge {
+			t.Fatalf("MergedByAdmin = %t, want %t", pr.MergedByAdmin, adminMerge)
 		}
 		if branch := repo.BranchByName("main"); branch == nil || branch.SHA != pr.HeadSHA {
 			t.Fatalf("main branch = %#v, want SHA %q", branch, pr.HeadSHA)

--- a/cli/internal/dtu/dtu_test.go
+++ b/cli/internal/dtu/dtu_test.go
@@ -512,6 +512,43 @@ func TestRepositoryMergePullRequestDeletesHeadBranchAndUpsertsBase(t *testing.T)
 	}
 }
 
+func TestRepositoryMergePullRequestMarksAdminMerge(t *testing.T) {
+	t.Parallel()
+
+	repo := &Repository{
+		Owner:         "owner",
+		Name:          "repo",
+		DefaultBranch: "main",
+		Branches: []Branch{
+			{Name: "main", SHA: "1111111111111111111111111111111111111111"},
+			{Name: "release-please--branches--main", SHA: "feedfacecafebeef"},
+		},
+		PullRequests: []PullRequest{{
+			Number:     13,
+			Title:      "Release PR",
+			State:      PullRequestStateOpen,
+			BaseBranch: "main",
+			HeadBranch: "release-please--branches--main",
+			HeadSHA:    "deadc0dedeadc0de",
+		}},
+	}
+
+	if err := repo.MergePullRequest(13, MergePullRequestOptions{DeleteHeadBranch: true, Admin: true}); err != nil {
+		t.Fatalf("MergePullRequest() error = %v", err)
+	}
+
+	pr := repo.PullRequestByNumber(13)
+	if pr == nil {
+		t.Fatal("PullRequestByNumber() = nil")
+	}
+	if pr.State != PullRequestStateMerged || !pr.Merged {
+		t.Fatalf("pull request = %#v, want merged state", pr)
+	}
+	if !pr.MergedByAdmin {
+		t.Fatalf("MergedByAdmin = %t, want true", pr.MergedByAdmin)
+	}
+}
+
 func TestRepositoryMergePullRequestQueuesAutoMergeUntilChecksPass(t *testing.T) {
 	t.Parallel()
 
@@ -545,7 +582,7 @@ func TestRepositoryMergePullRequestQueuesAutoMergeUntilChecksPass(t *testing.T) 
 	if pr.State != PullRequestStateOpen || pr.Merged {
 		t.Fatalf("pull request = %#v, want open queued auto-merge", pr)
 	}
-	if !pr.AutoMergeEnabled || !pr.AutoMergeDeleteBranch {
+	if !pr.AutoMergeEnabled || !pr.AutoMergeDeleteBranch || pr.AutoMergeAdmin {
 		t.Fatalf("pull request auto-merge flags = %#v, want enabled delete-branch queue", pr)
 	}
 	if branch := repo.BranchByName("main"); branch == nil || branch.SHA != "1111111111111111111111111111111111111111" {
@@ -562,8 +599,11 @@ func TestRepositoryMergePullRequestQueuesAutoMergeUntilChecksPass(t *testing.T) 
 	if pr.State != PullRequestStateMerged || !pr.Merged {
 		t.Fatalf("pull request after check success = %#v, want merged state", pr)
 	}
-	if pr.AutoMergeEnabled || pr.AutoMergeDeleteBranch {
+	if pr.AutoMergeEnabled || pr.AutoMergeDeleteBranch || pr.AutoMergeAdmin {
 		t.Fatalf("pull request auto-merge flags after merge = %#v, want cleared", pr)
+	}
+	if pr.MergedByAdmin {
+		t.Fatalf("MergedByAdmin = %t, want false", pr.MergedByAdmin)
 	}
 	if branch := repo.BranchByName("main"); branch == nil || branch.SHA != pr.HeadSHA {
 		t.Fatalf("main branch = %#v, want SHA %q", branch, pr.HeadSHA)
@@ -652,7 +692,7 @@ func TestStoreRecordObservationPRCheckMutationAppliesQueuedAutoMerge(t *testing.
 	if pr.State != PullRequestStateMerged || !pr.Merged {
 		t.Fatalf("pull request = %#v, want merged state", pr)
 	}
-	if pr.AutoMergeEnabled || pr.AutoMergeDeleteBranch {
+	if pr.AutoMergeEnabled || pr.AutoMergeDeleteBranch || pr.AutoMergeAdmin {
 		t.Fatalf("pull request auto-merge flags = %#v, want cleared after merge", pr)
 	}
 	if branch := loadedRepo.BranchByName("main"); branch == nil || branch.SHA != pr.HeadSHA {

--- a/cli/internal/dtu/manifest.go
+++ b/cli/internal/dtu/manifest.go
@@ -217,6 +217,7 @@ func clonePullRequests(in []PullRequest) []PullRequest {
 	for i := range in {
 		out[i] = in[i]
 		out[i].Labels = append([]string(nil), in[i].Labels...)
+		out[i].Commits = append([]PullRequestCommit(nil), in[i].Commits...)
 		out[i].Comments = append([]Comment(nil), in[i].Comments...)
 		out[i].Reviews = append([]Review(nil), in[i].Reviews...)
 		out[i].Checks = append([]Check(nil), in[i].Checks...)

--- a/cli/internal/dtu/scenario_test.go
+++ b/cli/internal/dtu/scenario_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/scanner"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/worktree"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type scenarioPhase struct {
@@ -33,6 +35,7 @@ type scenarioPhase struct {
 	phaseType      string
 	run            string
 	prompt         string
+	noopMatch      string
 	allowedTools   string
 	gateType       string
 	gateRun        string
@@ -133,8 +136,12 @@ func newScenarioEnv(t *testing.T, fixtureName string) *dtuScenarioEnv {
 
 	repoDir := t.TempDir()
 	stateDir := filepath.Join(repoDir, ".xylem")
+	shimDir := filepath.Join(stateDir, "shims")
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(%q): %v", stateDir, err)
+	}
+	if err := os.MkdirAll(shimDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", shimDir, err)
 	}
 
 	manifestPath := scenarioFixturePath(t, fixtureName)
@@ -158,12 +165,20 @@ func newScenarioEnv(t *testing.T, fixtureName string) *dtuScenarioEnv {
 	t.Setenv(dtu.EnvStatePath, store.Path())
 	t.Setenv(dtu.EnvStateDir, stateDir)
 	t.Setenv(dtu.EnvUniverseID, universeID)
+	t.Setenv(dtu.EnvShimDir, shimDir)
+	if err := writeScenarioShimWrappers(shimDir); err != nil {
+		t.Fatalf("writeScenarioShimWrappers(%q): %v", shimDir, err)
+	}
+	pathValue := shimDir + string(os.PathListSeparator) + os.Getenv("PATH")
+	t.Setenv("PATH", pathValue)
 
 	cmdRunner := &dtuScenarioCmdRunner{
 		env: []string{
 			dtu.EnvStatePath + "=" + store.Path(),
 			dtu.EnvStateDir + "=" + stateDir,
 			dtu.EnvUniverseID + "=" + universeID,
+			dtu.EnvShimDir + "=" + shimDir,
+			"PATH=" + pathValue,
 		},
 	}
 
@@ -175,6 +190,46 @@ func newScenarioEnv(t *testing.T, fixtureName string) *dtuScenarioEnv {
 		queue:        queue.New(filepath.Join(stateDir, "queue.jsonl")),
 		cmdRunner:    cmdRunner,
 	}
+}
+
+func writeScenarioShimWrappers(dir string) error {
+	binary, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve test executable: %w", err)
+	}
+	for _, shim := range []string{"gh", "git", "claude", "copilot"} {
+		content := fmt.Sprintf("#!/bin/sh\nGO_WANT_DTU_SCENARIO_SHIM=1 XYLEM_DTU_TEST_SHIM_NAME=%s exec %q -test.run '^TestDTUScenarioShimHelper$' -- \"$@\"\n", shim, binary)
+		if err := os.WriteFile(filepath.Join(dir, shim), []byte(content), 0o755); err != nil {
+			return fmt.Errorf("write shim %q: %w", shim, err)
+		}
+	}
+	return nil
+}
+
+func TestDTUScenarioShimHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_DTU_SCENARIO_SHIM") != "1" {
+		return
+	}
+	shim := strings.TrimSpace(os.Getenv("XYLEM_DTU_TEST_SHIM_NAME"))
+	if shim == "" {
+		fmt.Fprintln(os.Stderr, "missing XYLEM_DTU_TEST_SHIM_NAME")
+		os.Exit(2)
+	}
+
+	args := []string{}
+	for i, arg := range os.Args {
+		if arg == "--" {
+			args = os.Args[i+1:]
+			break
+		}
+	}
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "missing args for shim %s\n", shim)
+		os.Exit(2)
+	}
+
+	code := dtushim.Execute(context.Background(), shim, args, os.Stdin, os.Stdout, os.Stderr, os.Environ())
+	os.Exit(code)
 }
 
 func (r *dtuScenarioCmdRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
@@ -268,6 +323,10 @@ func writeScenarioWorkflow(t *testing.T, repoDir, workflowName string, phases []
 			if phase.allowedTools != "" {
 				fmt.Fprintf(&phaseYAML, "    allowed_tools: %q\n", phase.allowedTools)
 			}
+		}
+		if phase.noopMatch != "" {
+			phaseYAML.WriteString("    noop:\n")
+			fmt.Fprintf(&phaseYAML, "      match: %q\n", phase.noopMatch)
 		}
 
 		switch {
@@ -889,6 +948,154 @@ func TestScenarioGitHubMergeHappyPath(t *testing.T) {
 	if len(claudeInvocations) != 1 || claudeInvocations[0].Shim.Phase != "postmerge" {
 		t.Fatalf("unexpected merge claude invocations: %#v", claudeInvocations)
 	}
+}
+
+func releaseCutScenarioPhases(verifyRun string) []scenarioPhase {
+	return []scenarioPhase{
+		{
+			name:      "check",
+			phaseType: "command",
+			run: `mkdir -p .xylem/state
+printf '3\n' > .xylem/state/release_pr`,
+		},
+		{
+			name:      "verify",
+			phaseType: "command",
+			run:       verifyRun,
+			noopMatch: "XYLEM_NOOP",
+		},
+		{
+			name:      "merge",
+			phaseType: "command",
+			run: `PR_NUM=$(cat .xylem/state/release_pr)
+gh pr merge "$PR_NUM" --repo {{.Repo.Slug}} --squash --delete-branch --admin`,
+		},
+	}
+}
+
+func releaseCutScenarioSource(stateDir string, q *queue.Queue, cmdRunner *dtuScenarioCmdRunner) (*config.Config, *source.Scheduled) {
+	cfg := baseScenarioConfig(stateDir)
+	cfg.Sources = map[string]config.SourceConfig{
+		"release-please-cut": {
+			Type:     "scheduled",
+			Repo:     "owner/repo",
+			Schedule: "0 10 * * 1,4",
+			Tasks: map[string]config.Task{
+				"cut-release": {
+					Workflow: "cut-release",
+					Ref:      "release-please-cut",
+				},
+			},
+		},
+	}
+
+	src := &source.Scheduled{
+		Repo:       "owner/repo",
+		StateDir:   stateDir,
+		ConfigName: "release-please-cut",
+		Schedule:   "0 10 * * 1,4",
+		Queue:      q,
+		Tasks: map[string]source.ScheduledTask{
+			"cut-release": {
+				Workflow: "cut-release",
+				Ref:      "release-please-cut",
+			},
+		},
+	}
+	_ = cmdRunner
+	return cfg, src
+}
+
+func TestSmoke_S1_MatureReleasePRGetsAdminMerged(t *testing.T) {
+	env := newScenarioEnv(t, "release-please-cut-mature.yaml")
+	defer withWorkingDir(t, env.repoDir)()
+
+	writeScenarioWorkflow(t, env.repoDir, "cut-release", releaseCutScenarioPhases(`:`))
+	cfg, src := releaseCutScenarioSource(env.stateDir, env.queue, env.cmdRunner)
+
+	scan := scanner.New(cfg, env.queue, env.cmdRunner)
+	scanResult, err := scan.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, scanResult.Added)
+
+	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
+	drainResult, err := drainer.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, drainResult.Completed)
+
+	loaded, err := env.store.Load()
+	require.NoError(t, err)
+	pr := loaded.RepositoryBySlug("owner/repo").PullRequestByNumber(3)
+	require.NotNil(t, pr)
+	assert.Equal(t, dtu.PullRequestStateMerged, pr.State)
+	assert.True(t, pr.Merged)
+	assert.True(t, pr.MergedByAdmin)
+
+	events := readEvents(t, env.store)
+	mergeCalls := filterShimEvents(events, dtu.EventKindShimInvocation, "gh", []string{"pr", "merge", "3", "--repo", "owner/repo", "--squash", "--delete-branch", "--admin"})
+	assert.Len(t, mergeCalls, 1)
+}
+
+func TestSmoke_S2_BelowCommitThresholdNoops(t *testing.T) {
+	env := newScenarioEnv(t, "release-please-cut-below-threshold.yaml")
+	defer withWorkingDir(t, env.repoDir)()
+
+	writeScenarioWorkflow(t, env.repoDir, "cut-release", releaseCutScenarioPhases(`PR_NUM=$(cat .xylem/state/release_pr)
+gh pr view "$PR_NUM" --repo {{.Repo.Slug}} --json commits >/dev/null
+echo "XYLEM_NOOP: only 4 commits, below threshold"`))
+	cfg, src := releaseCutScenarioSource(env.stateDir, env.queue, env.cmdRunner)
+
+	scan := scanner.New(cfg, env.queue, env.cmdRunner)
+	scanResult, err := scan.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, scanResult.Added)
+
+	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
+	drainResult, err := drainer.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, drainResult.Completed)
+
+	loaded, err := env.store.Load()
+	require.NoError(t, err)
+	pr := loaded.RepositoryBySlug("owner/repo").PullRequestByNumber(3)
+	require.NotNil(t, pr)
+	assert.False(t, pr.Merged)
+	assert.Equal(t, dtu.PullRequestStateOpen, pr.State)
+
+	events := readEvents(t, env.store)
+	mergeCalls := filterShimEvents(events, dtu.EventKindShimInvocation, "gh", []string{"pr", "merge", "3"})
+	assert.Len(t, mergeCalls, 0)
+}
+
+func TestSmoke_S3_BlockReleaseLabelNoops(t *testing.T) {
+	env := newScenarioEnv(t, "release-please-cut-blocked.yaml")
+	defer withWorkingDir(t, env.repoDir)()
+
+	writeScenarioWorkflow(t, env.repoDir, "cut-release", releaseCutScenarioPhases(`PR_NUM=$(cat .xylem/state/release_pr)
+gh pr view "$PR_NUM" --repo {{.Repo.Slug}} --json labels >/dev/null
+echo "XYLEM_NOOP: block-release label present"`))
+	cfg, src := releaseCutScenarioSource(env.stateDir, env.queue, env.cmdRunner)
+
+	scan := scanner.New(cfg, env.queue, env.cmdRunner)
+	scanResult, err := scan.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, scanResult.Added)
+
+	drainer := newDrainRunner(t, cfg, env.queue, env.cmdRunner, env.repoDir, src)
+	drainResult, err := drainer.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, drainResult.Completed)
+
+	loaded, err := env.store.Load()
+	require.NoError(t, err)
+	pr := loaded.RepositoryBySlug("owner/repo").PullRequestByNumber(3)
+	require.NotNil(t, pr)
+	assert.False(t, pr.Merged)
+	assert.Equal(t, dtu.PullRequestStateOpen, pr.State)
+
+	events := readEvents(t, env.store)
+	mergeCalls := filterShimEvents(events, dtu.EventKindShimInvocation, "gh", []string{"pr", "merge", "3"})
+	assert.Len(t, mergeCalls, 0)
 }
 
 func TestScenarioIssueProviderFailureMarksFailed(t *testing.T) {

--- a/cli/internal/dtu/testdata/release-please-cut-below-threshold.yaml
+++ b/cli/internal/dtu/testdata/release-please-cut-below-threshold.yaml
@@ -1,0 +1,34 @@
+metadata:
+  name: release-please-cut-below-threshold
+  scenario: scheduled release cut noops when the release PR is below the commit threshold
+clock:
+  now: 2026-04-06T10:00:00Z
+repositories:
+  - owner: owner
+    name: repo
+    default_branch: main
+    labels:
+      - name: "autorelease: pending"
+      - name: block-release
+    branches:
+      - name: main
+        sha: 1111111111111111111111111111111111111111
+      - name: release-please--branches--main--components--xylem
+        sha: 9999999999999999999999999999999999999999
+    pull_requests:
+      - number: 3
+        title: "chore(main): release 1.2.3"
+        state: open
+        base_branch: main
+        head_branch: release-please--branches--main--components--xylem
+        head_sha: 9999999999999999999999999999999999999999
+        labels: ["autorelease: pending"]
+        commits:
+          - oid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          - oid: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+          - oid: cccccccccccccccccccccccccccccccccccccccc
+          - oid: dddddddddddddddddddddddddddddddddddddddd
+        checks:
+          - id: 1
+            name: ci
+            state: success

--- a/cli/internal/dtu/testdata/release-please-cut-blocked.yaml
+++ b/cli/internal/dtu/testdata/release-please-cut-blocked.yaml
@@ -1,0 +1,35 @@
+metadata:
+  name: release-please-cut-blocked
+  scenario: scheduled release cut noops when the release PR carries block-release
+clock:
+  now: 2026-04-06T10:00:00Z
+repositories:
+  - owner: owner
+    name: repo
+    default_branch: main
+    labels:
+      - name: "autorelease: pending"
+      - name: block-release
+    branches:
+      - name: main
+        sha: 1111111111111111111111111111111111111111
+      - name: release-please--branches--main--components--xylem
+        sha: 9999999999999999999999999999999999999999
+    pull_requests:
+      - number: 3
+        title: "chore(main): release 1.2.3"
+        state: open
+        base_branch: main
+        head_branch: release-please--branches--main--components--xylem
+        head_sha: 9999999999999999999999999999999999999999
+        labels: ["autorelease: pending", "block-release"]
+        commits:
+          - oid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          - oid: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+          - oid: cccccccccccccccccccccccccccccccccccccccc
+          - oid: dddddddddddddddddddddddddddddddddddddddd
+          - oid: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+        checks:
+          - id: 1
+            name: ci
+            state: success

--- a/cli/internal/dtu/testdata/release-please-cut-mature.yaml
+++ b/cli/internal/dtu/testdata/release-please-cut-mature.yaml
@@ -1,0 +1,35 @@
+metadata:
+  name: release-please-cut-mature
+  scenario: scheduled release cut merges a mature release-please PR
+clock:
+  now: 2026-04-06T10:00:00Z
+repositories:
+  - owner: owner
+    name: repo
+    default_branch: main
+    labels:
+      - name: "autorelease: pending"
+      - name: block-release
+    branches:
+      - name: main
+        sha: 1111111111111111111111111111111111111111
+      - name: release-please--branches--main--components--xylem
+        sha: 9999999999999999999999999999999999999999
+    pull_requests:
+      - number: 3
+        title: "chore(main): release 1.2.3"
+        state: open
+        base_branch: main
+        head_branch: release-please--branches--main--components--xylem
+        head_sha: 9999999999999999999999999999999999999999
+        labels: ["autorelease: pending"]
+        commits:
+          - oid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          - oid: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+          - oid: cccccccccccccccccccccccccccccccccccccccc
+          - oid: dddddddddddddddddddddddddddddddddddddddd
+          - oid: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+        checks:
+          - id: 1
+            name: ci
+            state: success

--- a/cli/internal/dtu/types.go
+++ b/cli/internal/dtu/types.go
@@ -405,6 +405,7 @@ func (r *Repository) DeleteBranch(name string) bool {
 type MergePullRequestOptions struct {
 	DeleteHeadBranch bool
 	AutoMerge        bool
+	Admin            bool
 }
 
 // MergePullRequest updates pull-request and git-visible state to reflect a merge.
@@ -435,12 +436,13 @@ func (r *Repository) MergePullRequest(number int, opts MergePullRequestOptions) 
 	if opts.AutoMerge {
 		pr.AutoMergeEnabled = true
 		pr.AutoMergeDeleteBranch = opts.DeleteHeadBranch
+		pr.AutoMergeAdmin = opts.Admin
 		if pr.HasBlockingMergeChecks() {
 			return nil
 		}
 	}
 
-	return r.mergePullRequest(pr, opts.DeleteHeadBranch)
+	return r.mergePullRequest(pr, opts.DeleteHeadBranch, opts.Admin)
 }
 
 // ApplyQueuedAutoMerge finalizes a previously queued auto-merge once checks no
@@ -456,10 +458,10 @@ func (r *Repository) ApplyQueuedAutoMerge(number int) error {
 	if !pr.AutoMergeEnabled || pr.HasBlockingMergeChecks() {
 		return nil
 	}
-	return r.mergePullRequest(pr, pr.AutoMergeDeleteBranch)
+	return r.mergePullRequest(pr, pr.AutoMergeDeleteBranch, pr.AutoMergeAdmin)
 }
 
-func (r *Repository) mergePullRequest(pr *PullRequest, deleteHeadBranch bool) error {
+func (r *Repository) mergePullRequest(pr *PullRequest, deleteHeadBranch bool, mergedByAdmin bool) error {
 	if pr == nil {
 		return fmt.Errorf("pull request must not be nil")
 	}
@@ -479,8 +481,10 @@ func (r *Repository) mergePullRequest(pr *PullRequest, deleteHeadBranch bool) er
 
 	pr.State = PullRequestStateMerged
 	pr.Merged = true
+	pr.MergedByAdmin = mergedByAdmin
 	pr.AutoMergeEnabled = false
 	pr.AutoMergeDeleteBranch = false
+	pr.AutoMergeAdmin = false
 	r.UpsertBranch(Branch{Name: baseBranch, SHA: headSHA})
 
 	if deleteHeadBranch {
@@ -527,21 +531,29 @@ type Issue struct {
 
 // PullRequest describes a GitHub pull request.
 type PullRequest struct {
-	Number                int              `yaml:"number" json:"number"`
-	Title                 string           `yaml:"title" json:"title"`
-	Body                  string           `yaml:"body,omitempty" json:"body,omitempty"`
-	URL                   string           `yaml:"url,omitempty" json:"url,omitempty"`
-	State                 PullRequestState `yaml:"state,omitempty" json:"state,omitempty"`
-	Merged                bool             `yaml:"merged,omitempty" json:"merged,omitempty"`
-	AutoMergeEnabled      bool             `yaml:"auto_merge_enabled,omitempty" json:"auto_merge_enabled,omitempty"`
-	AutoMergeDeleteBranch bool             `yaml:"auto_merge_delete_branch,omitempty" json:"auto_merge_delete_branch,omitempty"`
-	Labels                []string         `yaml:"labels,omitempty" json:"labels,omitempty"`
-	BaseBranch            string           `yaml:"base_branch" json:"base_branch"`
-	HeadBranch            string           `yaml:"head_branch" json:"head_branch"`
-	HeadSHA               string           `yaml:"head_sha" json:"head_sha"`
-	Comments              []Comment        `yaml:"comments,omitempty" json:"comments,omitempty"`
-	Reviews               []Review         `yaml:"reviews,omitempty" json:"reviews,omitempty"`
-	Checks                []Check          `yaml:"checks,omitempty" json:"checks,omitempty"`
+	Number                int                 `yaml:"number" json:"number"`
+	Title                 string              `yaml:"title" json:"title"`
+	Body                  string              `yaml:"body,omitempty" json:"body,omitempty"`
+	URL                   string              `yaml:"url,omitempty" json:"url,omitempty"`
+	State                 PullRequestState    `yaml:"state,omitempty" json:"state,omitempty"`
+	Merged                bool                `yaml:"merged,omitempty" json:"merged,omitempty"`
+	MergedByAdmin         bool                `yaml:"merged_by_admin,omitempty" json:"merged_by_admin,omitempty"`
+	AutoMergeEnabled      bool                `yaml:"auto_merge_enabled,omitempty" json:"auto_merge_enabled,omitempty"`
+	AutoMergeDeleteBranch bool                `yaml:"auto_merge_delete_branch,omitempty" json:"auto_merge_delete_branch,omitempty"`
+	AutoMergeAdmin        bool                `yaml:"auto_merge_admin,omitempty" json:"auto_merge_admin,omitempty"`
+	Labels                []string            `yaml:"labels,omitempty" json:"labels,omitempty"`
+	BaseBranch            string              `yaml:"base_branch" json:"base_branch"`
+	HeadBranch            string              `yaml:"head_branch" json:"head_branch"`
+	HeadSHA               string              `yaml:"head_sha" json:"head_sha"`
+	Commits               []PullRequestCommit `yaml:"commits,omitempty" json:"commits,omitempty"`
+	Comments              []Comment           `yaml:"comments,omitempty" json:"comments,omitempty"`
+	Reviews               []Review            `yaml:"reviews,omitempty" json:"reviews,omitempty"`
+	Checks                []Check             `yaml:"checks,omitempty" json:"checks,omitempty"`
+}
+
+// PullRequestCommit is a minimal commit entry surfaced by gh pr view --json commits.
+type PullRequestCommit struct {
+	OID string `yaml:"oid,omitempty" json:"oid,omitempty"`
 }
 
 // HasBlockingMergeChecks reports whether any check still prevents a queued

--- a/cli/internal/dtushim/shim.go
+++ b/cli/internal/dtushim/shim.go
@@ -1352,6 +1352,7 @@ func runGHPRMerge(_ context.Context, store *dtu.Store, args []string, stderr io.
 		return repo.MergePullRequest(number, dtu.MergePullRequestOptions{
 			DeleteHeadBranch: opts.deleteBranch,
 			AutoMerge:        opts.autoMerge,
+			Admin:            opts.adminMerge,
 		})
 	})
 	if err != nil {
@@ -1435,6 +1436,7 @@ type ghOptions struct {
 	limit        int
 	deleteBranch bool
 	autoMerge    bool
+	adminMerge   bool
 	addLabels    []string
 	removeLabels []string
 }
@@ -1514,6 +1516,8 @@ func parseGHFlags(args []string) (ghOptions, error) {
 			opts.deleteBranch = true
 		case "--auto":
 			opts.autoMerge = true
+		case "--admin":
+			opts.adminMerge = true
 		case "--add-label":
 			value, next, err := requireValue(args, i, args[i])
 			if err != nil {
@@ -1599,6 +1603,10 @@ func encodePR(state *dtu.State, repo *dtu.Repository, pr dtu.PullRequest, fields
 			out[field] = pr.HeadSHA
 		case "mergeCommit":
 			out[field] = map[string]any{"oid": pr.HeadSHA}
+		case "commits":
+			out[field] = encodePRCommits(pr.Commits, pr.HeadSHA)
+		case "statusCheckRollup":
+			out[field] = encodeStatusCheckRollup(pr.Checks)
 		}
 	}
 	return out
@@ -1633,7 +1641,56 @@ func encodeLabels(labels []string) []map[string]string {
 	return out
 }
 
+func encodePRCommits(commits []dtu.PullRequestCommit, headSHA string) []map[string]any {
+	headSHA = strings.TrimSpace(headSHA)
+	if len(commits) == 0 {
+		if headSHA == "" {
+			return nil
+		}
+		return []map[string]any{{"oid": headSHA}}
+	}
+
+	out := make([]map[string]any, 0, len(commits))
+	for _, commit := range commits {
+		oid := strings.TrimSpace(commit.OID)
+		if oid == "" {
+			continue
+		}
+		out = append(out, map[string]any{"oid": oid})
+	}
+	if len(out) == 0 && headSHA != "" {
+		return []map[string]any{{"oid": headSHA}}
+	}
+	return out
+}
+
+func encodeStatusCheckRollup(checks []dtu.Check) []map[string]any {
+	out := make([]map[string]any, 0, len(checks))
+	for _, check := range checks {
+		out = append(out, map[string]any{
+			"name":       check.Name,
+			"conclusion": ghCheckConclusion(check.State),
+		})
+	}
+	return out
+}
+
 func ghCheckState(state dtu.CheckState) string {
+	switch state {
+	case dtu.CheckStateSuccess:
+		return "SUCCESS"
+	case dtu.CheckStateFailure:
+		return "FAILURE"
+	case dtu.CheckStateCancelled:
+		return "CANCELLED"
+	case dtu.CheckStateSkipped:
+		return "SKIPPED"
+	default:
+		return "PENDING"
+	}
+}
+
+func ghCheckConclusion(state dtu.CheckState) string {
 	switch state {
 	case dtu.CheckStateSuccess:
 		return "SUCCESS"

--- a/cli/internal/dtushim/shim_test.go
+++ b/cli/internal/dtushim/shim_test.go
@@ -68,8 +68,12 @@ func sampleState() *dtu.State {
 				HeadBranch: "fix/issue-1-bug-one",
 				HeadSHA:    "abc12345deadbeef",
 				Labels:     []string{"queued"},
-				Reviews:    []dtu.Review{{ID: 41, State: dtu.ReviewStateApproved}},
-				Checks:     []dtu.Check{{ID: 51, Name: "ci", State: dtu.CheckStateFailure}},
+				Commits: []dtu.PullRequestCommit{
+					{OID: "abc12345deadbeef"},
+					{OID: "feedfacecafebeef"},
+				},
+				Reviews: []dtu.Review{{ID: 41, State: dtu.ReviewStateApproved}},
+				Checks:  []dtu.Check{{ID: 51, Name: "ci", State: dtu.CheckStateFailure}},
 			}, {
 				Number:     11,
 				Title:      "Merged PR",
@@ -164,6 +168,30 @@ func TestExecuteGHPRSurfacesUsedByXylem(t *testing.T) {
 	}
 	if strings.TrimSpace(viewOut.String()) != "abc12345deadbeef" {
 		t.Fatalf("pr view output = %q", viewOut.String())
+	}
+
+	var releaseOut, releaseErr bytes.Buffer
+	code = Execute(
+		context.Background(),
+		"gh",
+		[]string{"pr", "view", "10", "--repo", "owner/repo", "--json", "commits,statusCheckRollup,labels"},
+		nil,
+		&releaseOut,
+		&releaseErr,
+		env,
+	)
+	if code != 0 {
+		t.Fatalf("pr release view code = %d, stderr = %q", code, releaseErr.String())
+	}
+	releaseJSON := releaseOut.String()
+	if !strings.Contains(releaseJSON, `"commits":[{"oid":"abc12345deadbeef"},{"oid":"feedfacecafebeef"}]`) {
+		t.Fatalf("pr release view output = %s", releaseJSON)
+	}
+	if !strings.Contains(releaseJSON, `"statusCheckRollup":[{"conclusion":"FAILURE","name":"ci"}]`) {
+		t.Fatalf("pr release view output = %s", releaseJSON)
+	}
+	if !strings.Contains(releaseJSON, `"labels":[{"name":"queued"}]`) {
+		t.Fatalf("pr release view output = %s", releaseJSON)
 	}
 
 	var checksOut, checksErr bytes.Buffer
@@ -300,10 +328,45 @@ func TestSmoke_S2_GHPRMergeWithAutoQueuesUntilChecksPass(t *testing.T) {
 	assert.False(t, pr.Merged)
 	assert.True(t, pr.AutoMergeEnabled)
 	assert.True(t, pr.AutoMergeDeleteBranch)
+	assert.False(t, pr.AutoMergeAdmin)
 	main := repo.BranchByName("main")
 	require.NotNil(t, main)
 	assert.Equal(t, "1111111111111111111111111111111111111111", main.SHA)
 	assert.NotNil(t, repo.BranchByName(pr.HeadBranch))
+}
+
+func TestExecuteGHPRMergeWithAdminMarksState(t *testing.T) {
+	t.Parallel()
+
+	state := sampleState()
+	state.Repositories[0].PullRequests[0].Checks[0].State = dtu.CheckStateSuccess
+	state.Repositories[0].Branches = []dtu.Branch{
+		{Name: "main", SHA: "1111111111111111111111111111111111111111"},
+		{Name: "fix/issue-1-bug-one", SHA: "abc12345deadbeef"},
+	}
+	store, stateDir := testStore(t, state)
+	env := envForStore(store, stateDir, state.UniverseID)
+
+	var mergeErr bytes.Buffer
+	code := Execute(
+		context.Background(),
+		"gh",
+		[]string{"pr", "merge", "10", "--repo", "owner/repo", "--delete-branch", "--squash", "--admin"},
+		nil,
+		ioDiscard{},
+		&mergeErr,
+		env,
+	)
+	require.Zero(t, code, "stderr = %q", mergeErr.String())
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	pr := loaded.RepositoryBySlug("owner/repo").PullRequestByNumber(10)
+	require.NotNil(t, pr)
+	assert.True(t, pr.Merged)
+	assert.True(t, pr.MergedByAdmin)
+	assert.False(t, pr.AutoMergeEnabled)
+	assert.False(t, pr.AutoMergeAdmin)
 }
 
 func TestExecuteGHAPIAndIssueCommentUseStateStore(t *testing.T) {
@@ -754,4 +817,17 @@ func TestMainPackagesCompile(t *testing.T) {
 			t.Fatalf("expected %s to exist: %v", path, err)
 		}
 	}
+}
+
+func TestEncodePRCommitsAllEmptyOIDsFallsBackToHeadSHA(t *testing.T) {
+	t.Parallel()
+
+	commits := []dtu.PullRequestCommit{
+		{OID: ""},
+		{OID: "   "},
+	}
+
+	got := encodePRCommits(commits, "abc123fallback")
+	want := []map[string]any{{"oid": "abc123fallback"}}
+	assert.Equal(t, want, got)
 }

--- a/cli/internal/source/scheduled.go
+++ b/cli/internal/source/scheduled.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/cadence"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
 
@@ -27,6 +28,7 @@ type Scheduled struct {
 	Schedule   string
 	Tasks      map[string]ScheduledTask
 	Queue      *queue.Queue
+	Now        func() time.Time
 }
 
 type scheduleState struct {
@@ -38,7 +40,7 @@ var safeScheduledPathComponent = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
 func (s *Scheduled) Name() string { return "scheduled" }
 
 func (s *Scheduled) Scan(_ context.Context) ([]queue.Vessel, error) {
-	interval, err := parseSchedule(s.Schedule)
+	spec, err := cadence.Parse(s.Schedule)
 	if err != nil {
 		if s.ConfigName != "" {
 			return nil, fmt.Errorf("scheduled source %q: parse schedule %q: %w", s.ConfigName, s.Schedule, err)
@@ -51,9 +53,14 @@ func (s *Scheduled) Scan(_ context.Context) ([]queue.Vessel, error) {
 		return nil, err
 	}
 
-	now := sourceNow()
-	bucket := now.UnixNano() / interval.Nanoseconds()
-	slotStart, slotEnd := scheduleWindow(now, interval)
+	now := s.now()
+	bucket, slotStart, slotEnd, err := spec.Bucket(now)
+	if err != nil {
+		if s.ConfigName != "" {
+			return nil, fmt.Errorf("scheduled source %q: compute schedule bucket %q: %w", s.ConfigName, s.Schedule, err)
+		}
+		return nil, fmt.Errorf("compute schedule bucket %q: %w", s.Schedule, err)
+	}
 	taskNames := make([]string, 0, len(s.Tasks))
 	for taskName := range s.Tasks {
 		taskNames = append(taskNames, taskName)
@@ -144,34 +151,6 @@ func (s *Scheduled) BranchName(vessel queue.Vessel) string {
 	return fmt.Sprintf("scheduled/%s-%s", taskName, sanitizeScheduledComponent(vessel.ID))
 }
 
-func parseSchedule(value string) (time.Duration, error) {
-	switch strings.TrimSpace(strings.ToLower(value)) {
-	case "@hourly":
-		return time.Hour, nil
-	case "@daily":
-		return 24 * time.Hour, nil
-	case "@weekly":
-		return 7 * 24 * time.Hour, nil
-	}
-
-	interval, err := time.ParseDuration(value)
-	if err != nil {
-		return 0, err
-	}
-	if interval <= 0 {
-		return 0, fmt.Errorf("must be greater than 0")
-	}
-	return interval, nil
-}
-
-func scheduleWindow(now time.Time, interval time.Duration) (time.Time, time.Time) {
-	now = now.UTC()
-	size := interval.Nanoseconds()
-	startUnix := now.UnixNano() / size * size
-	start := time.Unix(0, startUnix).UTC()
-	return start, start.Add(interval)
-}
-
 func (s *Scheduled) loadState() (*scheduleState, error) {
 	path := s.statePath()
 	data, err := os.ReadFile(path)
@@ -215,6 +194,13 @@ func (s *Scheduled) saveState(state *scheduleState) error {
 
 func (s *Scheduled) statePath() string {
 	return filepath.Join(s.StateDir, "schedules", sanitizeScheduledComponent(s.scope())+".json")
+}
+
+func (s *Scheduled) now() time.Time {
+	if s.Now != nil {
+		return s.Now().UTC()
+	}
+	return sourceNow()
 }
 
 func (s *Scheduled) scope() string {

--- a/cli/internal/source/scheduled_prop_test.go
+++ b/cli/internal/source/scheduled_prop_test.go
@@ -1,0 +1,66 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"pgregory.net/rapid"
+)
+
+func TestPropScheduledCronWindowContainsNow(t *testing.T) {
+	t.Parallel()
+
+	baseStateDir := t.TempDir()
+	baseQueueDir := t.TempDir()
+
+	rapid.Check(t, func(t *rapid.T) {
+		dayOffset := rapid.IntRange(0, 13).Draw(t, "day_offset")
+		hour := rapid.IntRange(0, 23).Draw(t, "hour")
+		minute := rapid.IntRange(0, 59).Draw(t, "minute")
+		now := time.Date(2026, time.April, 6+dayOffset, hour, minute, 0, 0, time.UTC)
+		caseID := fmt.Sprintf("%02d-%02d-%02d", dayOffset, hour, minute)
+
+		src := &Scheduled{
+			Repo:     "owner/repo",
+			StateDir: filepath.Join(baseStateDir, caseID),
+			Schedule: "0 10 * * 1,4",
+			Queue:    queue.New(filepath.Join(baseQueueDir, caseID+".jsonl")),
+			Now: func() time.Time {
+				return now
+			},
+			Tasks: map[string]ScheduledTask{
+				"cut-release": {Workflow: "cut-release"},
+			},
+		}
+
+		vessels, err := src.Scan(context.Background())
+		if err != nil {
+			t.Fatalf("Scan() error = %v", err)
+		}
+		if len(vessels) != 1 {
+			t.Fatalf("len(vessels) = %d, want 1", len(vessels))
+		}
+
+		slotStart, err := time.Parse(time.RFC3339, vessels[0].Meta["schedule_slot_start"])
+		if err != nil {
+			t.Fatalf("parse schedule_slot_start: %v", err)
+		}
+		slotEnd, err := time.Parse(time.RFC3339, vessels[0].Meta["schedule_slot_end"])
+		if err != nil {
+			t.Fatalf("parse schedule_slot_end: %v", err)
+		}
+		if slotStart.After(now) {
+			t.Fatalf("slotStart = %s, want <= now %s", slotStart, now)
+		}
+		if !slotEnd.After(now) {
+			t.Fatalf("slotEnd = %s, want > now %s", slotEnd, now)
+		}
+		if !slotEnd.After(slotStart) {
+			t.Fatalf("slotEnd = %s, want > slotStart %s", slotEnd, slotStart)
+		}
+	})
+}

--- a/cli/internal/source/scheduled_test.go
+++ b/cli/internal/source/scheduled_test.go
@@ -11,11 +11,15 @@ import (
 )
 
 func TestScheduledScanEnqueuesOnePerWindow(t *testing.T) {
+	now := time.Date(2026, time.April, 9, 10, 27, 0, 0, time.UTC)
 	q := queue.New(filepath.Join(t.TempDir(), "queue.jsonl"))
 	source := &Scheduled{
 		Repo:     "owner/repo",
 		Schedule: "@weekly",
 		Queue:    q,
+		Now: func() time.Time {
+			return now
+		},
 		Tasks: map[string]ScheduledTask{
 			"sota": {Workflow: "sota-gap-analysis", Ref: "sota-gap-analysis"},
 		},
@@ -47,22 +51,73 @@ func TestScheduledScanEnqueuesOnePerWindow(t *testing.T) {
 	}
 }
 
-func TestParseSchedule(t *testing.T) {
-	got, err := parseSchedule("@weekly")
-	if err != nil {
-		t.Fatalf("parseSchedule(@weekly) error = %v", err)
+func TestScheduledScanSupportsCronCadence(t *testing.T) {
+	stateDir := t.TempDir()
+	q := queue.New(filepath.Join(t.TempDir(), "queue.jsonl"))
+	now := time.Date(2026, time.April, 6, 10, 0, 0, 0, time.UTC) // Monday
+	source := &Scheduled{
+		Repo:     "owner/repo",
+		StateDir: stateDir,
+		Schedule: "0 10 * * 1,4",
+		Queue:    q,
+		Now: func() time.Time {
+			return now
+		},
+		Tasks: map[string]ScheduledTask{
+			"cut-release": {Workflow: "cut-release", Ref: "release-please-cut"},
+		},
 	}
-	if got != 7*24*time.Hour {
-		t.Fatalf("parseSchedule(@weekly) = %s, want 168h", got)
+
+	first, err := source.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("len(first) = %d, want 1", len(first))
+	}
+	if got, want := first[0].Meta["schedule_slot_start"], "2026-04-06T10:00:00Z"; got != want {
+		t.Fatalf("schedule_slot_start = %q, want %q", got, want)
+	}
+	if got, want := first[0].Meta["schedule_slot_end"], "2026-04-09T10:00:00Z"; got != want {
+		t.Fatalf("schedule_slot_end = %q, want %q", got, want)
+	}
+	if err := source.OnEnqueue(context.Background(), first[0]); err != nil {
+		t.Fatalf("OnEnqueue() error = %v", err)
+	}
+
+	now = time.Date(2026, time.April, 8, 12, 0, 0, 0, time.UTC) // Wednesday, same slot
+	suppressed, err := source.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("suppressed Scan() error = %v", err)
+	}
+	if len(suppressed) != 0 {
+		t.Fatalf("len(suppressed) = %d, want 0 within the same cron slot", len(suppressed))
+	}
+
+	now = time.Date(2026, time.April, 9, 10, 0, 0, 0, time.UTC) // Thursday
+	second, err := source.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("second Scan() error = %v", err)
+	}
+	if len(second) != 1 {
+		t.Fatalf("len(second) = %d, want 1 after the next cron slot begins", len(second))
+	}
+	if got, want := second[0].Meta["schedule_slot_start"], "2026-04-09T10:00:00Z"; got != want {
+		t.Fatalf("second schedule_slot_start = %q, want %q", got, want)
 	}
 }
 
-func TestScheduleWindow(t *testing.T) {
-	start, end := scheduleWindow(time.Date(2026, 4, 9, 10, 27, 0, 0, time.UTC), 24*time.Hour)
-	if end.Sub(start) != 24*time.Hour {
-		t.Fatalf("end-start = %s, want 24h", end.Sub(start))
+func TestScheduledScanRejectsMalformedSchedule(t *testing.T) {
+	source := &Scheduled{
+		Repo:     "owner/repo",
+		Schedule: "weeklyish",
+		Queue:    queue.New(filepath.Join(t.TempDir(), "queue.jsonl")),
+		Tasks: map[string]ScheduledTask{
+			"sota": {Workflow: "sota-gap-analysis"},
+		},
 	}
-	if start.After(time.Date(2026, 4, 9, 10, 27, 0, 0, time.UTC)) {
-		t.Fatalf("start = %s, want start at or before now", start)
+
+	if _, err := source.Scan(context.Background()); err == nil {
+		t.Fatal("Scan() error = nil, want malformed schedule error")
 	}
 }

--- a/cli/internal/workflow/cut_release_workflow_test.go
+++ b/cli/internal/workflow/cut_release_workflow_test.go
@@ -1,0 +1,44 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSmoke_S8_CutReleaseWorkflowUsesAdminMergeAndNoopGuards(t *testing.T) {
+	t.Parallel()
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller() failed")
+
+	workflowPath := filepath.Join(filepath.Dir(file), "..", "..", "..", ".xylem", "workflows", "cut-release.yaml")
+	data, err := os.ReadFile(workflowPath)
+	require.NoError(t, err, "ReadFile(%q)", workflowPath)
+
+	var wf Workflow
+	require.NoError(t, yaml.Unmarshal(data, &wf), "yaml.Unmarshal(%q)", workflowPath)
+	require.Len(t, wf.Phases, 3)
+
+	assert.Equal(t, "check", wf.Phases[0].Name)
+	require.NotNil(t, wf.Phases[0].NoOp)
+	assert.Equal(t, "XYLEM_NOOP", wf.Phases[0].NoOp.Match)
+	assert.Contains(t, wf.Phases[0].Run, `autorelease: pending`)
+
+	assert.Equal(t, "verify", wf.Phases[1].Name)
+	require.NotNil(t, wf.Phases[1].NoOp)
+	assert.Equal(t, "XYLEM_NOOP", wf.Phases[1].NoOp.Match)
+	assert.Contains(t, wf.Phases[1].Run, `block-release`)
+	assert.Contains(t, wf.Phases[1].Run, `statusCheckRollup`)
+	assert.Contains(t, wf.Phases[1].Run, `'"conclusion":"SUCCESS"'`)
+
+	assert.Equal(t, "merge", wf.Phases[2].Name)
+	assert.Equal(t, "command", wf.Phases[2].Type)
+	assert.Contains(t, wf.Phases[2].Run, "--admin")
+	assert.Contains(t, wf.Phases[2].Run, "{{.Repo.Slug}}")
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,7 +135,7 @@ Each key under `sources` is an arbitrary name (used in logs and vessel metadata)
 |-------|------|---------|----------|-------------|
 | `type` | string | -- | Yes | Source type. Supported values: `"github"`, `"github-pr"`, `"github-pr-events"`, `"github-merge"`, `"schedule"`, `"scheduled"`. |
 | `repo` | string | -- | Yes (GitHub sources and `scheduled`) | GitHub repository in `owner/name` format. Validated strictly -- both owner and name must be non-empty. |
-| `schedule` | string | -- | Required for `scheduled` | Recurring cadence for per-task scheduled sources. Supports `@hourly`, `@daily`, `@weekly`, or any positive Go duration like `168h`. |
+| `schedule` | string | -- | Required for `scheduled` | Recurring cadence for per-task scheduled sources. Supports `@hourly`, `@daily`, `@weekly`, standard 5-field cron expressions, or any positive Go duration like `168h`. |
 | `cadence` | string | -- | Yes (`schedule`) | Recurrence for scheduled sources. Accepts Go durations like `1h`, cron descriptors like `@daily`, and standard 5-field cron expressions. |
 | `workflow` | string | -- | Yes (`schedule`) | Workflow to enqueue each time a scheduled source fires. Scheduled sources define the workflow directly and do not use `tasks`. |
 | `exclude` | list of strings | `[]` | No | Labels that prevent an issue from being queued. If an issue has any of these labels, it is skipped. |
@@ -210,9 +210,21 @@ sources:
       weekly-self-gap-analysis:
         workflow: sota-gap-analysis
         ref: sota-gap-analysis
+
+  release-please-cut:
+    type: scheduled
+    repo: owner/repo
+    schedule: "0 10 * * 1,4" # Monday/Thursday at 10:00 UTC
+    timeout: "5m"
+    tasks:
+      cut-release:
+        workflow: cut-release
+        ref: release-please-cut
 ```
 
 The built-in `context-weight-audit` workflow is another `scheduled` use case: it reads persisted run summaries from `<state_dir>/phases/`, writes `context-weight-audit.{json,md}` under `<state_dir>/<harness.review.output_dir>/`, and opens de-duplicated GitHub hygiene issues for repeated high-footprint findings.
+
+For release cadence automation, a `scheduled` source can look for a release-please PR on a cron schedule, skip when the PR is still immature, and no-op when the PR carries a manual `block-release` label. That label is a simple human override: leave it on the release PR to suppress the next scheduled cut without disabling the source entirely.
 ### `status_labels`
 
 When `status_labels` is set, xylem records the configured labels in vessel metadata and applies them during source lifecycle hooks.


### PR DESCRIPTION
## Summary
Implements [issue #245](https://github.com/nicholls-inc/xylem/issues/245) by adding a daemon-driven `cut-release` workflow for mature release-please PRs, teaching `scheduled` sources to accept cron cadences, and extending DTU coverage for admin-merge release handling.

## Smoke scenarios covered
- `S1` Mature release PR gets admin merged
- `S2` Below commit threshold noops
- `S3` Block-release label noops
- `S8` Cut-release workflow uses admin merge and no-op guards

## Changes summary
### Files added
- `.xylem/workflows/cut-release.yaml`
- `cli/internal/dtu/testdata/release-please-cut-mature.yaml`
- `cli/internal/dtu/testdata/release-please-cut-below-threshold.yaml`
- `cli/internal/dtu/testdata/release-please-cut-blocked.yaml`
- `cli/internal/source/scheduled_prop_test.go`
- `cli/internal/workflow/cut_release_workflow_test.go`

### Files modified
- `.xylem.yml`
- `cli/internal/cadence/cadence.go`
- `cli/internal/config/config.go`
- `cli/internal/config/config_test.go`
- `cli/internal/source/scheduled.go`
- `cli/internal/source/scheduled_test.go`
- `cli/internal/dtu/manifest.go`
- `cli/internal/dtu/types.go`
- `cli/internal/dtu/dtu_test.go`
- `cli/internal/dtu/dtu_prop_test.go`
- `cli/internal/dtu/scenario_test.go`
- `cli/internal/dtushim/shim.go`
- `cli/internal/dtushim/shim_test.go`
- `docs/configuration.md`

### Key types and functions
- `cadence.Spec`, `Parse`, `FireTime`, `Bucket`, `currentCronWindow`, and `previousCronOccurrence`
- `source.Scheduled.Scan` and `source.Scheduled.OnEnqueue`
- `dtu.PullRequest` and `Repository.mergePullRequest`
- `dtushim.runGHPRMerge` and `parseGHFlags`

## Test plan
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #245