### PR TITLE
resolve-conflicts: enforce actual origin/main merge before conflict resolution

### DIFF
--- a/.xylem/prompts/resolve-conflicts/analyze.md
+++ b/.xylem/prompts/resolve-conflicts/analyze.md
@@ -5,14 +5,13 @@ URL: {{.Issue.URL}}
 
 {{.Issue.Body}}
 
-Check out the PR branch and attempt a merge from main:
+## Merge Attempt Output
+{{.PreviousOutputs.merge_main}}
 
-1. Run `gh pr checkout {{.Issue.Number}}`
-2. Run `git fetch origin main && git merge origin/main --no-commit`
+The workflow has already checked out the PR branch and attempted `git merge origin/{{ .Repo.DefaultBranch }} --no-commit --no-ff`.
+Do not rerun the merge. Inspect the current conflicted worktree state produced by that command.
 
 Do not modify, stage, or delete anything under `.xylem/`. The xylem control plane is out of scope for conflict resolution.
-
-If the merge completes with no conflicts, include the exact standalone line `XYLEM_NOOP` in your final output and explain that no conflict resolution is needed.
 
 If there are conflicts:
 

--- a/.xylem/prompts/resolve-conflicts/push.md
+++ b/.xylem/prompts/resolve-conflicts/push.md
@@ -6,10 +6,9 @@ URL: {{.Issue.URL}}
 ## Resolution
 {{.PreviousOutputs.resolve}}
 
-Commit and push the resolved conflicts:
+Push the already-completed merge resolution:
 
 ```
-git add -A && git commit -m "fix: resolve merge conflicts on #{{.Issue.Number}}"
 git push
 ```
 

--- a/.xylem/prompts/resolve-conflicts/resolve.md
+++ b/.xylem/prompts/resolve-conflicts/resolve.md
@@ -6,6 +6,9 @@ URL: {{.Issue.URL}}
 ## Analysis
 {{.PreviousOutputs.analyze}}
 
+## Merge Attempt Output
+{{.PreviousOutputs.merge_main}}
+
 {{if .GateResult}}
 ## Previous Gate Failure
 The following gate check failed after the previous attempt. Fix the issues and try again:
@@ -19,6 +22,8 @@ Resolve each conflict using these strategies:
 - **Overlapping**: both sides modified the same code. Combine the intent of both changes.
 - **Structural**: one side refactored while the other made localized edits. Apply the localized edits to the new structure.
 
+The workflow has already started a merge of `origin/{{ .Repo.DefaultBranch }}` into the PR branch. Resolve the current merge state in place; do not rely on self-reporting that a merge happened.
+
 Do not modify, stage, or delete anything under `.xylem/`. The xylem control plane is out of scope for conflict resolution.
 
 For every conflicting file:
@@ -27,4 +32,6 @@ For every conflicting file:
 2. Apply the appropriate resolution strategy
 3. Verify the file is syntactically valid
 
-After resolving all conflicts, run `cd cli && go vet ./... && go build ./cmd/xylem && go test ./...` to confirm the build and tests pass.
+After resolving all conflicts, stage the resolved files and complete the in-progress merge before validation. Because the workflow already ran `git merge ... --no-commit --no-ff`, finish that merge in place (for example, `git add <resolved-files> && git commit --no-edit` while `MERGE_HEAD` exists).
+
+Once the merge commit exists, run `cd cli && go vet ./... && go build ./cmd/xylem && go test ./...` to confirm the build and tests pass.

--- a/.xylem/workflows/resolve-conflicts.yaml
+++ b/.xylem/workflows/resolve-conflicts.yaml
@@ -1,13 +1,41 @@
 name: resolve-conflicts
 description: "Resolve merge conflicts on a PR branch"
 phases:
+  - name: merge_main
+    type: command
+    run: |
+      set -eu
+      gh pr checkout {{ .Issue.Number }} --repo {{ .Repo.Slug }}
+      test "$(git branch --show-current)" = "$(gh pr view {{ .Issue.Number }} --repo {{ .Repo.Slug }} --json headRefName --jq '.headRefName')"
+      git fetch origin {{ .Repo.DefaultBranch }}
+      merge_log=$(mktemp)
+      set +e
+      git merge origin/{{ .Repo.DefaultBranch }} --no-commit --no-ff >"$merge_log" 2>&1
+      merge_status=$?
+      set -e
+      cat "$merge_log"
+      rm -f "$merge_log"
+      if [ "$merge_status" -eq 0 ]; then
+        if git rev-parse -q --verify MERGE_HEAD >/dev/null 2>&1; then
+          git merge --abort
+        fi
+        printf '\nXYLEM_NOOP\n'
+        exit 0
+      fi
+      if git rev-parse -q --verify MERGE_HEAD >/dev/null 2>&1; then
+        if git diff --name-only --diff-filter=U | grep . >/dev/null 2>&1; then
+          exit 0
+        fi
+        git merge --abort
+      fi
+      exit "$merge_status"
+    noop:
+      match: XYLEM_NOOP
   - name: analyze
     prompt_file: .xylem/prompts/resolve-conflicts/analyze.md
     max_turns: 20
     llm: copilot
     model: gpt-5.4
-    noop:
-      match: XYLEM_NOOP
   - name: resolve
     prompt_file: .xylem/prompts/resolve-conflicts/resolve.md
     max_turns: 40

--- a/cli/internal/phase/phase_prop_test.go
+++ b/cli/internal/phase/phase_prop_test.go
@@ -1,0 +1,25 @@
+package phase
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropRenderPromptInterpolatesMergeMainPreviousOutput(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		mergeOutput := rapid.StringMatching(`[\t\n\r -~]{0,512}`).Draw(t, "mergeOutput")
+
+		got, err := RenderPrompt("{{.PreviousOutputs.merge_main}}", TemplateData{
+			PreviousOutputs: map[string]string{
+				"merge_main": mergeOutput,
+			},
+		})
+		if err != nil {
+			t.Fatalf("RenderPrompt() error = %v", err)
+		}
+		if got != mergeOutput {
+			t.Fatalf("RenderPrompt() = %q, want %q", got, mergeOutput)
+		}
+	})
+}

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -4657,6 +4657,54 @@ func TestDrainCommandPhaseWithGate(t *testing.T) {
 	}
 }
 
+func assertCommandPhaseOutputAvailableToNextPrompt(t *testing.T, workflowName string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, err := q.Enqueue(makeVessel(1, workflowName))
+	require.NoError(t, err)
+
+	writeWorkflowFile(t, dir, workflowName, []testPhase{
+		{name: "merge_main", phaseType: "command", run: "git merge origin/main --no-commit --no-ff"},
+		{name: "analyze", promptContent: "Merge output: {{.PreviousOutputs.merge_main}}", maxTurns: 10},
+	})
+
+	withTestWorkingDir(t, dir)
+
+	const mergeOutput = "Auto-merging cli/internal/runner/runner.go\nCONFLICT (content): Merge conflict in cli/internal/runner/runner.go\n"
+	var sawInterpolatedMergeOutput bool
+
+	cmdRunner := &mockCmdRunner{
+		gateOutput: []byte(mergeOutput),
+		runPhaseHook: func(_ string, prompt string, _ string, _ ...string) ([]byte, error, bool) {
+			sawInterpolatedMergeOutput = strings.Contains(prompt, "Merge output: "+mergeOutput)
+			return []byte("analyzed conflicts"), nil, true
+		},
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
+	require.Len(t, cmdRunner.phaseCalls, 1)
+	assert.True(t, sawInterpolatedMergeOutput, "prompt = %q, want command phase output", cmdRunner.phaseCalls[0].prompt)
+}
+
+func TestDrainCommandPhaseOutputAvailableToNextPrompt(t *testing.T) {
+	assertCommandPhaseOutputAvailableToNextPrompt(t, "fix-bug")
+}
+
+func TestSmoke_S8_ResolveConflictsDeterministicMergeOutputFeedsAnalysisPrompt(t *testing.T) {
+	assertCommandPhaseOutputAvailableToNextPrompt(t, "resolve-conflicts")
+}
+
 func TestDrainCommandPhaseWithNoOp(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 2)

--- a/cli/internal/workflow/pr_validation_workflow_test.go
+++ b/cli/internal/workflow/pr_validation_workflow_test.go
@@ -2,12 +2,23 @@ package workflow
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
+
+func checkedInWorkflowPromptPath(t *testing.T, workflowName, promptName string) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller() failed")
+
+	return filepath.Join(filepath.Dir(file), "..", "..", "..", ".xylem", "prompts", workflowName, promptName)
+}
 
 func TestSmoke_S5_FixPRChecksWorkflowUsesValidationTemplateCommands(t *testing.T) {
 	t.Parallel()
@@ -40,6 +51,20 @@ func TestSmoke_S6_ResolveConflictsWorkflowUsesRepoAndValidationTemplates(t *test
 	var wf Workflow
 	require.NoError(t, yaml.Unmarshal(data, &wf), "yaml.Unmarshal(%q)", workflowPath)
 
+	mergeMainPhase := findPhaseByName(t, wf.Phases, "merge_main")
+	assert.Equal(t, "command", mergeMainPhase.Type)
+	require.NotNil(t, mergeMainPhase.NoOp, "workflow %q missing merge_main noop", wf.Name)
+	assert.Equal(t, "XYLEM_NOOP", mergeMainPhase.NoOp.Match)
+	assert.Contains(t, mergeMainPhase.Run, "gh pr checkout {{ .Issue.Number }} --repo {{ .Repo.Slug }}")
+	assert.Contains(t, mergeMainPhase.Run, "git merge origin/{{ .Repo.DefaultBranch }} --no-commit --no-ff")
+	assert.Contains(t, mergeMainPhase.Run, "git diff --name-only --diff-filter=U")
+	assert.True(t, commandContainsInOrder(
+		mergeMainPhase.Run,
+		"gh pr checkout {{ .Issue.Number }} --repo {{ .Repo.Slug }}",
+		"git fetch origin {{ .Repo.DefaultBranch }}",
+		"git merge origin/{{ .Repo.DefaultBranch }} --no-commit --no-ff",
+	))
+
 	resolvePhase := findPhaseByName(t, wf.Phases, "resolve")
 	require.NotNil(t, resolvePhase.Gate, "workflow %q missing resolve gate", wf.Name)
 	assert.Equal(t, "command", resolvePhase.Gate.Type)
@@ -51,4 +76,30 @@ func TestSmoke_S6_ResolveConflictsWorkflowUsesRepoAndValidationTemplates(t *test
 	assert.Contains(t, resolvePhase.Gate.Run, "{{ .Validation.Test }}")
 	assert.NotContains(t, resolvePhase.Gate.Run, "go build ./cmd/xylem")
 	assert.NotContains(t, resolvePhase.Gate.Run, "--repo nicholls-inc/xylem")
+}
+
+func TestSmoke_S7_ResolveConflictsPromptsRelyOnDeterministicMergePhase(t *testing.T) {
+	t.Parallel()
+
+	analyzePromptPath := checkedInWorkflowPromptPath(t, "resolve-conflicts", "analyze.md")
+	analyzePrompt, err := os.ReadFile(analyzePromptPath)
+	require.NoError(t, err, "ReadFile(%q)", analyzePromptPath)
+	assert.Contains(t, string(analyzePrompt), "{{.PreviousOutputs.merge_main}}")
+	assert.Contains(t, string(analyzePrompt), "Do not rerun the merge.")
+	assert.NotContains(t, string(analyzePrompt), "Run `gh pr checkout")
+	assert.NotContains(t, string(analyzePrompt), "Run `git fetch origin main && git merge origin/main --no-commit`")
+
+	resolvePromptPath := checkedInWorkflowPromptPath(t, "resolve-conflicts", "resolve.md")
+	resolvePrompt, err := os.ReadFile(resolvePromptPath)
+	require.NoError(t, err, "ReadFile(%q)", resolvePromptPath)
+	assert.Contains(t, string(resolvePrompt), "{{.PreviousOutputs.merge_main}}")
+	assert.Contains(t, string(resolvePrompt), "do not rely on self-reporting that a merge happened")
+	assert.Contains(t, string(resolvePrompt), "complete the in-progress merge before validation")
+	assert.Contains(t, string(resolvePrompt), "git commit --no-edit")
+
+	pushPromptPath := checkedInWorkflowPromptPath(t, "resolve-conflicts", "push.md")
+	pushPrompt, err := os.ReadFile(pushPromptPath)
+	require.NoError(t, err, "ReadFile(%q)", pushPromptPath)
+	assert.Contains(t, string(pushPrompt), "Push the already-completed merge resolution")
+	assert.NotContains(t, string(pushPrompt), "git add -A && git commit")
 }


### PR DESCRIPTION
## Summary
- Implements https://github.com/nicholls-inc/xylem/issues/243
- Adds a deterministic `merge_main` command phase to the checked-in `resolve-conflicts` workflow so the workflow performs a real `git merge origin/{{ .Repo.DefaultBranch }} --no-commit --no-ff` before analysis and resolution.
- Updates the resolve-conflicts prompts and workflow assertions so later phases consume the actual merge output and finish the in-progress merge instead of relying on model self-reporting.

## Smoke scenarios covered
- S6 — Resolve conflicts workflow uses repo and validation templates
- S7 — Resolve conflicts prompts rely on deterministic merge phase
- S8 — Resolve conflicts deterministic merge output feeds analysis prompt

## Changes summary
- Modified `.xylem/workflows/resolve-conflicts.yaml` to add the `merge_main` command phase, move the no-op matcher onto that phase, and keep the resolve gate checking merge ancestry plus validation commands.
- Modified `.xylem/prompts/resolve-conflicts/analyze.md`, `.xylem/prompts/resolve-conflicts/resolve.md`, and `.xylem/prompts/resolve-conflicts/push.md` so analysis/resolve consume `{{.PreviousOutputs.merge_main}}`, do not rerun the merge, and only push after the in-progress merge is completed.
- Added `cli/internal/phase/phase_prop_test.go` with `TestPropRenderPromptInterpolatesMergeMainPreviousOutput` to cover previous-output interpolation for `merge_main`.
- Modified `cli/internal/runner/runner_test.go` to add `assertCommandPhaseOutputAvailableToNextPrompt`, `TestDrainCommandPhaseOutputAvailableToNextPrompt`, and `TestSmoke_S8_ResolveConflictsDeterministicMergeOutputFeedsAnalysisPrompt`.
- Modified `cli/internal/workflow/pr_validation_workflow_test.go` to assert the new `merge_main` command phase and prompt expectations for the checked-in resolve-conflicts workflow assets.

## Test plan
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #243