### PR TITLE
feat: add scheduled harness gap analysis for recurring autonomy gaps

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -133,6 +133,16 @@ sources:
         workflow: sota-gap-analysis
         ref: sota-gap-analysis
 
+  harness-gap-analysis:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "4h"
+    timeout: "30m"
+    tasks:
+      analyze-gaps:
+        workflow: harness-gap-analysis
+        ref: harness-gap-analysis
+
   # Post-merge wave dependency unblocking
   # NOTE: github-merge has no label filtering. The unblock-wave prompt
   # guards with XYLEM_NOOP for non-harness merges.

--- a/cli/cmd/xylem/builtin_audit.go
+++ b/cli/cmd/xylem/builtin_audit.go
@@ -25,7 +25,7 @@ func runBuiltInScheduledVessels(ctx context.Context, cfg *config.Config, q *queu
 
 	var result runner.DrainResult
 	for _, vessel := range pending {
-		if vessel.Source != "scheduled" || vessel.Workflow != reviewpkg.ContextWeightAuditWorkflow {
+		if vessel.Source != "scheduled" || !isBuiltInScheduledWorkflow(vessel.Workflow) {
 			continue
 		}
 		result.Launched++
@@ -44,13 +44,8 @@ func runBuiltInScheduledVessels(ctx context.Context, cfg *config.Config, q *queu
 		repo := resolveScheduledAuditRepo(cfg, *updated)
 		if strings.TrimSpace(repo) == "" {
 			state = queue.StateFailed
-			errMsg = "context-weight audit requires a source repo for GitHub issue publication"
-		} else if _, err := reviewpkg.RunContextWeightAudit(ctx, cfg.StateDir, repo, cmdRunner, reviewpkg.ContextWeightOptions{
-			LookbackRuns: cfg.HarnessReviewLookbackRuns(),
-			MinSamples:   cfg.HarnessReviewMinSamples(),
-			OutputDir:    cfg.HarnessReviewOutputDir(),
-			Now:          time.Now().UTC(),
-		}); err != nil {
+			errMsg = fmt.Sprintf("%s requires a source repo for GitHub issue publication", vessel.Workflow)
+		} else if err := runBuiltInScheduledWorkflow(ctx, cfg, vessel.Workflow, repo, cmdRunner); err != nil {
 			state = queue.StateFailed
 			errMsg = err.Error()
 		}
@@ -74,6 +69,37 @@ func runBuiltInScheduledVessels(ctx context.Context, cfg *config.Config, q *queu
 		}
 	}
 	return result, nil
+}
+
+func isBuiltInScheduledWorkflow(workflow string) bool {
+	switch workflow {
+	case reviewpkg.ContextWeightAuditWorkflow, reviewpkg.HarnessGapAnalysisWorkflow:
+		return true
+	default:
+		return false
+	}
+}
+
+func runBuiltInScheduledWorkflow(ctx context.Context, cfg *config.Config, workflowName, repo string, cmdRunner auditCommandRunner) error {
+	now := time.Now().UTC()
+	switch workflowName {
+	case reviewpkg.ContextWeightAuditWorkflow:
+		_, err := reviewpkg.RunContextWeightAudit(ctx, cfg.StateDir, repo, cmdRunner, reviewpkg.ContextWeightOptions{
+			LookbackRuns: cfg.HarnessReviewLookbackRuns(),
+			MinSamples:   cfg.HarnessReviewMinSamples(),
+			OutputDir:    cfg.HarnessReviewOutputDir(),
+			Now:          now,
+		})
+		return err
+	case reviewpkg.HarnessGapAnalysisWorkflow:
+		_, err := reviewpkg.RunHarnessGapAnalysis(ctx, cfg.StateDir, repo, cmdRunner, reviewpkg.HarnessGapOptions{
+			OutputDir: cfg.HarnessReviewOutputDir(),
+			Now:       now,
+		})
+		return err
+	default:
+		return fmt.Errorf("unsupported built-in scheduled workflow %q", workflowName)
+	}
 }
 
 func resolveScheduledAuditRepo(cfg *config.Config, vessel queue.Vessel) string {
@@ -114,7 +140,7 @@ func persistBuiltInAuditSummary(cfg *config.Config, vessel queue.Vessel) error {
 		StartedAt:  startedAt,
 		EndedAt:    endedAt,
 		DurationMS: endedAt.Sub(startedAt).Milliseconds(),
-		Note:       "Built-in context-weight audit uses persisted summary artifacts and may open de-duplicated GitHub issues.",
+		Note:       builtInScheduledWorkflowSummaryNote(vessel.Workflow),
 	}
 	if vessel.State == queue.StateFailed {
 		summary.Note = fmt.Sprintf("%s Failure: %s", summary.Note, vessel.Error)
@@ -123,6 +149,15 @@ func persistBuiltInAuditSummary(cfg *config.Config, vessel queue.Vessel) error {
 		return fmt.Errorf("save built-in audit summary for %s: %w", vessel.ID, err)
 	}
 	return nil
+}
+
+func builtInScheduledWorkflowSummaryNote(workflow string) string {
+	switch workflow {
+	case reviewpkg.HarnessGapAnalysisWorkflow:
+		return "Built-in harness-gap analysis uses persisted daemon/GitHub/git telemetry and may open de-duplicated GitHub issues."
+	default:
+		return "Built-in context-weight audit uses persisted summary artifacts and may open de-duplicated GitHub issues."
+	}
 }
 
 func addDrainResults(dst *runner.DrainResult, src runner.DrainResult) {

--- a/cli/cmd/xylem/builtin_audit_test.go
+++ b/cli/cmd/xylem/builtin_audit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,6 +20,26 @@ type auditTestRunner struct {
 func (r *auditTestRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
 	r.calls = append(r.calls, append([]string{name}, args...))
 	return []byte("[]"), nil
+}
+
+type harnessGapAuditTestRunner struct {
+	calls [][]string
+}
+
+func (r *harnessGapAuditTestRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	r.calls = append(r.calls, call)
+	switch strings.Join(call, "\x00") {
+	case strings.Join([]string{"gh", "--repo", "owner/repo", "pr", "list", "--state", "merged", "--limit", "100", "--json", "number,title,url,headRefName,mergedAt,mergedBy,labels"}, "\x00"),
+		strings.Join([]string{"gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--label", "needs-conflict-resolution", "--limit", "100", "--json", "number,title,url,mergeable,headRefName"}, "\x00"),
+		strings.Join([]string{"gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt"}, "\x00"),
+		strings.Join([]string{"gh", "--repo", "owner/repo", "issue", "list", "--state", "open", "--label", "xylem-failed", "--limit", "100", "--json", "number,title,url,labels"}, "\x00"):
+		return []byte("[]"), nil
+	case strings.Join([]string{"git", "rev-list", "--left-right", "--count", "origin/main...HEAD"}, "\x00"):
+		return []byte("0\t0\n"), nil
+	default:
+		return []byte("[]"), nil
+	}
 }
 
 func TestRunBuiltInScheduledVesselsCompletesContextWeightAudit(t *testing.T) {
@@ -83,6 +104,72 @@ func TestRunBuiltInScheduledVesselsCompletesContextWeightAudit(t *testing.T) {
 		t.Fatalf("context-weight-audit.json missing: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "phases", "scheduled-audit-1", "summary.json")); err != nil {
+		t.Fatalf("summary.json missing: %v", err)
+	}
+}
+
+func TestRunBuiltInScheduledVesselsCompletesHarnessGapAnalysis(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		StateDir: dir,
+		Claude: config.ClaudeConfig{
+			Command:      "claude",
+			DefaultModel: "claude-sonnet-4-6",
+		},
+		Sources: map[string]config.SourceConfig{
+			"harness-gap": {
+				Type:     "scheduled",
+				Repo:     "owner/repo",
+				Schedule: "4h",
+				Tasks: map[string]config.Task{
+					"analyze-gaps": {Workflow: reviewpkg.HarnessGapAnalysisWorkflow},
+				},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "scheduled-gap-1",
+		Source:    "scheduled",
+		Ref:       "scheduled://harness-gap/analyze-gaps@1",
+		Workflow:  reviewpkg.HarnessGapAnalysisWorkflow,
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+		Meta: map[string]string{
+			"config_source":         "harness-gap",
+			"scheduled_task_name":   "analyze-gaps",
+			"scheduled_bucket":      "1",
+			"scheduled_config_name": "harness-gap",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+
+	cmdRunner := &harnessGapAuditTestRunner{}
+	result, err := runBuiltInScheduledVessels(context.Background(), cfg, q, cmdRunner)
+	if err != nil {
+		t.Fatalf("runBuiltInScheduledVessels() error = %v", err)
+	}
+	if result.Completed != 1 {
+		t.Fatalf("Completed = %d, want 1", result.Completed)
+	}
+	if result.Failed != 0 {
+		t.Fatalf("Failed = %d, want 0", result.Failed)
+	}
+
+	vessel, err := q.FindByID("scheduled-gap-1")
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	if vessel.State != queue.StateCompleted {
+		t.Fatalf("vessel.State = %s, want %s", vessel.State, queue.StateCompleted)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "reviews", "harness-gap-analysis.json")); err != nil {
+		t.Fatalf("harness-gap-analysis.json missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "phases", "scheduled-gap-1", "summary.json")); err != nil {
 		t.Fatalf("summary.json missing: %v", err)
 	}
 }

--- a/cli/internal/review/harness_gap.go
+++ b/cli/internal/review/harness_gap.go
@@ -1,0 +1,887 @@
+package review
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	HarnessGapAnalysisWorkflow       = "harness-gap-analysis"
+	harnessGapReportJSONName         = "harness-gap-analysis.json"
+	harnessGapReportMarkdownName     = "harness-gap-analysis.md"
+	harnessGapIssueStateName         = "harness-gap-analysis-issues.json"
+	harnessGapFindingMarkerPrefix    = "<!-- xylem:harness-gap-fingerprint="
+	harnessGapMergedPRLookback       = 24 * time.Hour
+	harnessGapMergedPRThreshold      = 3
+	harnessGapStaleConflictThreshold = 1
+	harnessGapRestartThreshold       = 1
+	harnessGapIdleBacklogThreshold   = 15 * time.Minute
+	harnessGapReleasePRAgeThreshold  = 7 * 24 * time.Hour
+	harnessGapReleasePRCommitMinimum = 5
+	harnessGapFailedBacklogThreshold = 3
+	harnessGapLocalSignalsLookback   = 24 * time.Hour
+	harnessGapDaemonLogFileName      = "daemon.log"
+)
+
+var harnessGapIssueBranchPattern = regexp.MustCompile(`^(feat|fix|chore)/issue-\d+`)
+
+type HarnessGapOptions struct {
+	OutputDir string
+	Now       time.Time
+}
+
+type HarnessGapResult struct {
+	Report       *HarnessGapReport
+	JSONPath     string
+	MarkdownPath string
+	Markdown     string
+	Published    []PublishedIssue
+}
+
+type HarnessGapReport struct {
+	GeneratedAt time.Time           `json:"generated_at"`
+	Findings    []HarnessGapFinding `json:"findings,omitempty"`
+	Warnings    []string            `json:"warnings,omitempty"`
+}
+
+type HarnessGapFinding struct {
+	Fingerprint  string   `json:"fingerprint"`
+	Category     string   `json:"category"`
+	Title        string   `json:"title"`
+	Summary      string   `json:"summary"`
+	Observed     int      `json:"observed"`
+	Threshold    int      `json:"threshold"`
+	Evidence     []string `json:"evidence,omitempty"`
+	Remediations []string `json:"remediations,omitempty"`
+}
+
+type harnessGapIssueState struct {
+	Findings map[string]contextWeightIssueRecord `json:"findings,omitempty"`
+}
+
+type harnessGapDaemonEntry struct {
+	Time time.Time
+	Line string
+}
+
+type harnessGapIdleEpisode struct {
+	Start   time.Time
+	End     time.Time
+	Pending int
+}
+
+type harnessGapPullRequest struct {
+	Number      int               `json:"number"`
+	Title       string            `json:"title"`
+	URL         string            `json:"url"`
+	HeadRefName string            `json:"headRefName"`
+	Mergeable   string            `json:"mergeable"`
+	MergedAt    time.Time         `json:"mergedAt"`
+	CreatedAt   time.Time         `json:"createdAt"`
+	MergedBy    *harnessGapUser   `json:"mergedBy"`
+	Labels      []harnessGapLabel `json:"labels"`
+}
+
+type harnessGapCommit struct {
+	OID string `json:"oid"`
+}
+
+type harnessGapUser struct {
+	Login string `json:"login"`
+}
+
+type harnessGapLabel struct {
+	Name string `json:"name"`
+}
+
+type harnessGapIssue struct {
+	Number int               `json:"number"`
+	Title  string            `json:"title"`
+	URL    string            `json:"url"`
+	Body   string            `json:"body"`
+	Labels []harnessGapLabel `json:"labels"`
+}
+
+func GenerateHarnessGapAnalysis(ctx context.Context, stateDir, repo string, runner issueRunner, opts HarnessGapOptions) (*HarnessGapResult, error) {
+	if strings.TrimSpace(opts.OutputDir) == "" {
+		opts.OutputDir = defaultOutputDir
+	}
+	if opts.Now.IsZero() {
+		opts.Now = time.Now().UTC()
+	} else {
+		opts.Now = opts.Now.UTC()
+	}
+
+	findings, warnings, err := buildHarnessGapFindings(ctx, stateDir, repo, runner, opts.Now)
+	if err != nil {
+		return nil, fmt.Errorf("generate harness-gap analysis: %w", err)
+	}
+
+	report := &HarnessGapReport{
+		GeneratedAt: opts.Now,
+		Findings:    findings,
+		Warnings:    warnings,
+	}
+
+	outputDir := filepath.Join(stateDir, opts.OutputDir)
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return nil, fmt.Errorf("generate harness-gap analysis: create output dir: %w", err)
+	}
+
+	jsonPath := filepath.Join(outputDir, harnessGapReportJSONName)
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("generate harness-gap analysis: marshal report: %w", err)
+	}
+	if err := os.WriteFile(jsonPath, data, 0o644); err != nil {
+		return nil, fmt.Errorf("generate harness-gap analysis: write json report: %w", err)
+	}
+
+	markdown := renderHarnessGapMarkdown(report)
+	markdownPath := filepath.Join(outputDir, harnessGapReportMarkdownName)
+	if err := os.WriteFile(markdownPath, []byte(markdown), 0o644); err != nil {
+		return nil, fmt.Errorf("generate harness-gap analysis: write markdown report: %w", err)
+	}
+
+	return &HarnessGapResult{
+		Report:       report,
+		JSONPath:     jsonPath,
+		MarkdownPath: markdownPath,
+		Markdown:     markdown,
+	}, nil
+}
+
+func RunHarnessGapAnalysis(ctx context.Context, stateDir, repo string, runner issueRunner, opts HarnessGapOptions) (*HarnessGapResult, error) {
+	result, err := GenerateHarnessGapAnalysis(ctx, stateDir, repo, runner, opts)
+	if err != nil {
+		return nil, err
+	}
+	published, err := PublishHarnessGapIssues(ctx, stateDir, repo, runner, result.Report, opts.OutputDir, opts.Now)
+	if err != nil {
+		return nil, err
+	}
+	result.Published = published
+	return result, nil
+}
+
+func PublishHarnessGapIssues(ctx context.Context, stateDir, repo string, runner issueRunner, report *HarnessGapReport, outputDir string, now time.Time) ([]PublishedIssue, error) {
+	if report == nil {
+		return nil, nil
+	}
+	if strings.TrimSpace(outputDir) == "" {
+		outputDir = defaultOutputDir
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+
+	statePath := filepath.Join(stateDir, outputDir, harnessGapIssueStateName)
+	state, err := loadHarnessGapIssueState(statePath)
+	if err != nil {
+		return nil, err
+	}
+
+	openByFingerprint := map[string]contextWeightIssue{}
+	if runner != nil && strings.TrimSpace(repo) != "" && len(report.Findings) > 0 {
+		openByFingerprint, err = loadOpenHarnessGapIssues(ctx, runner, repo)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	published := make([]PublishedIssue, 0, len(report.Findings))
+	for _, finding := range report.Findings {
+		record, ok := state.Findings[finding.Fingerprint]
+		switch {
+		case ok:
+			record.Title = finding.Title
+			record.LastObservedAt = now
+			state.Findings[finding.Fingerprint] = record
+			published = append(published, PublishedIssue{
+				Fingerprint: finding.Fingerprint,
+				IssueNumber: record.IssueNumber,
+				Title:       record.Title,
+				Created:     false,
+			})
+			continue
+		case openByFingerprint[finding.Fingerprint].Number > 0:
+			issue := openByFingerprint[finding.Fingerprint]
+			state.Findings[finding.Fingerprint] = contextWeightIssueRecord{
+				IssueNumber:     issue.Number,
+				Title:           issue.Title,
+				FirstReportedAt: now,
+				LastObservedAt:  now,
+			}
+			published = append(published, PublishedIssue{
+				Fingerprint: finding.Fingerprint,
+				IssueNumber: issue.Number,
+				Title:       issue.Title,
+				Created:     false,
+			})
+			continue
+		}
+
+		if runner == nil || strings.TrimSpace(repo) == "" {
+			continue
+		}
+
+		body := renderHarnessGapIssueBody(finding)
+		out, err := runner.RunOutput(ctx, "gh", "issue", "create", "--repo", repo, "--title", finding.Title, "--body", body)
+		if err != nil {
+			return nil, fmt.Errorf("publish harness-gap issue for %s: %w", finding.Category, err)
+		}
+		issueNumber, err := parseIssueNumberFromCreateOutput(string(out))
+		if err != nil {
+			return nil, fmt.Errorf("publish harness-gap issue for %s: %w", finding.Category, err)
+		}
+		state.Findings[finding.Fingerprint] = contextWeightIssueRecord{
+			IssueNumber:     issueNumber,
+			Title:           finding.Title,
+			FirstReportedAt: now,
+			LastObservedAt:  now,
+		}
+		published = append(published, PublishedIssue{
+			Fingerprint: finding.Fingerprint,
+			IssueNumber: issueNumber,
+			Title:       finding.Title,
+			Created:     true,
+		})
+	}
+
+	if err := saveHarnessGapIssueState(statePath, state); err != nil {
+		return nil, err
+	}
+	return published, nil
+}
+
+func buildHarnessGapFindings(ctx context.Context, stateDir, repo string, runner issueRunner, now time.Time) ([]HarnessGapFinding, []string, error) {
+	findings := make([]HarnessGapFinding, 0, 7)
+	warnings := make([]string, 0, 1)
+
+	localFindings, localWarnings, err := buildHarnessGapLocalFindings(stateDir, now)
+	if err != nil {
+		return nil, nil, err
+	}
+	findings = append(findings, localFindings...)
+	warnings = append(warnings, localWarnings...)
+
+	if runner == nil || strings.TrimSpace(repo) == "" {
+		sortHarnessGapFindings(findings)
+		return findings, warnings, nil
+	}
+
+	if finding, err := detectAdminMergeGap(ctx, repo, runner, now); err != nil {
+		return nil, nil, err
+	} else if finding != nil {
+		findings = append(findings, *finding)
+	}
+	if finding, err := detectStaleConflictLabelGap(ctx, repo, runner); err != nil {
+		return nil, nil, err
+	} else if finding != nil {
+		findings = append(findings, *finding)
+	}
+	if finding, err := detectReleaseCadenceGap(ctx, repo, runner, now); err != nil {
+		return nil, nil, err
+	} else if finding != nil {
+		findings = append(findings, *finding)
+	}
+	if finding, err := detectConfigDriftGap(ctx, runner); err != nil {
+		return nil, nil, err
+	} else if finding != nil {
+		findings = append(findings, *finding)
+	}
+	if finding, err := detectFailedFingerprintBacklogGap(ctx, repo, runner); err != nil {
+		return nil, nil, err
+	} else if finding != nil {
+		findings = append(findings, *finding)
+	}
+
+	sortHarnessGapFindings(findings)
+	return findings, warnings, nil
+}
+
+func buildHarnessGapLocalFindings(stateDir string, now time.Time) ([]HarnessGapFinding, []string, error) {
+	path := filepath.Join(stateDir, harnessGapDaemonLogFileName)
+	entries, err := loadHarnessGapDaemonLog(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(entries) == 0 {
+		return nil, []string{"daemon log not available; skipped local restart/backlog signals"}, nil
+	}
+
+	findings := make([]HarnessGapFinding, 0, 2)
+	cutoff := now.Add(-harnessGapLocalSignalsLookback)
+	restarts := 0
+	restartEvidence := make([]string, 0, 3)
+	for _, entry := range entries {
+		if entry.Time.Before(cutoff) {
+			continue
+		}
+		if logFieldValue(entry.Line, "msg") != "daemon reconcile recovered orphaned vessels" {
+			continue
+		}
+		recovered, ok := logFieldInt(entry.Line, "recovered")
+		if !ok || recovered <= 0 {
+			continue
+		}
+		restarts += recovered
+		restartEvidence = append(restartEvidence, fmt.Sprintf("%s recovered %d orphaned vessel(s) after restart", entry.Time.Format(time.RFC3339), recovered))
+	}
+	if restarts >= harnessGapRestartThreshold {
+		finding := newHarnessGapFinding(
+			"daemon-restart-count",
+			"harness-gap-analysis: daemon restarts orphaned running vessels",
+			fmt.Sprintf("the daemon recovered %d orphaned vessel(s) in the last 24h, which means restart handling still depends on timeout recovery", restarts),
+			restarts,
+			harnessGapRestartThreshold,
+			restartEvidence,
+			[]string{
+				"Track and surface restart causes so the daemon can distinguish operator restarts from harness bugs.",
+				"Make restart recovery resumable or cancellable instead of relying on orphaned running vessels timing out later.",
+			},
+		)
+		findings = append(findings, finding)
+	}
+
+	episodes := detectIdleBacklogEpisodes(entries, cutoff)
+	if len(episodes) == 0 {
+		return findings, nil, nil
+	}
+
+	longest := idleBacklogLongest(episodes)
+	if longest.End.Sub(longest.Start) >= harnessGapIdleBacklogThreshold {
+		evidence := make([]string, 0, len(episodes))
+		for _, episode := range episodes {
+			evidence = append(evidence, fmt.Sprintf(
+				"%s to %s: pending=%d while running=0",
+				episode.Start.Format(time.RFC3339),
+				episode.End.Format(time.RFC3339),
+				episode.Pending,
+			))
+		}
+		finding := newHarnessGapFinding(
+			"idle-with-backlog",
+			"harness-gap-analysis: daemon stayed idle while backlog existed",
+			fmt.Sprintf("the daemon spent %s idle with queued backlog, which suggests missing wakeup or dequeue reliability", longest.End.Sub(longest.Start).Round(time.Minute)),
+			int(longest.End.Sub(longest.Start).Minutes()),
+			int(harnessGapIdleBacklogThreshold.Minutes()),
+			evidence,
+			[]string{
+				"Promote idle-with-backlog episodes to a first-class health signal instead of relying on log inspection.",
+				"Teach the daemon to self-heal when backlog remains pending across multiple drain intervals.",
+			},
+		)
+		findings = append(findings, finding)
+	}
+
+	return findings, nil, nil
+}
+
+func detectAdminMergeGap(ctx context.Context, repo string, runner issueRunner, now time.Time) (*HarnessGapFinding, error) {
+	args := append(harnessGapRepoArgs(repo), "pr", "list", "--state", "merged", "--limit", "100", "--json", "number,title,url,headRefName,mergedAt,mergedBy,labels")
+	out, err := runner.RunOutput(ctx, "gh", args...)
+	if err != nil {
+		return nil, fmt.Errorf("detect admin-merge gap: list merged pull requests: %w", err)
+	}
+	var prs []harnessGapPullRequest
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("detect admin-merge gap: parse gh pr list output: %w", err)
+	}
+
+	cutoff := now.Add(-harnessGapMergedPRLookback)
+	evidence := make([]string, 0, len(prs))
+	count := 0
+	for _, pr := range prs {
+		if pr.MergedAt.IsZero() || pr.MergedAt.Before(cutoff) {
+			continue
+		}
+		if !harnessGapIssueBranchPattern.MatchString(strings.TrimSpace(pr.HeadRefName)) {
+			continue
+		}
+		if !hasHarnessGapLabel(pr.Labels, "harness-impl") {
+			continue
+		}
+		if pr.MergedBy == nil || strings.TrimSpace(pr.MergedBy.Login) == "" || strings.Contains(pr.MergedBy.Login, "[bot]") {
+			continue
+		}
+		count++
+		evidence = append(evidence, fmt.Sprintf("#%d merged by @%s from `%s` at %s", pr.Number, pr.MergedBy.Login, pr.HeadRefName, pr.MergedAt.Format(time.RFC3339)))
+	}
+	if count < harnessGapMergedPRThreshold {
+		return nil, nil
+	}
+
+	finding := newHarnessGapFinding(
+		"merge-click-frequency",
+		"harness-gap-analysis: automate repeated human admin merges",
+		fmt.Sprintf("%d harness PRs were merged by humans in the last 24h, which is the manual merge work #244 was meant to remove", count),
+		count,
+		harnessGapMergedPRThreshold,
+		evidence,
+		[]string{
+			"Route merge-ready harness PRs through the daemon's auto-merge path instead of depending on a human admin merge click.",
+			"Emit a first-class merge automation signal when issue-branch PRs keep landing via human merges.",
+		},
+	)
+	return &finding, nil
+}
+
+func detectStaleConflictLabelGap(ctx context.Context, repo string, runner issueRunner) (*HarnessGapFinding, error) {
+	args := append(harnessGapRepoArgs(repo), "pr", "list", "--state", "open", "--label", "needs-conflict-resolution", "--limit", "100", "--json", "number,title,url,mergeable,headRefName")
+	out, err := runner.RunOutput(ctx, "gh", args...)
+	if err != nil {
+		return nil, fmt.Errorf("detect stale conflict-label gap: list open conflict PRs: %w", err)
+	}
+	var prs []harnessGapPullRequest
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("detect stale conflict-label gap: parse gh pr list output: %w", err)
+	}
+
+	evidence := make([]string, 0, len(prs))
+	count := 0
+	for _, pr := range prs {
+		if strings.EqualFold(strings.TrimSpace(pr.Mergeable), "CONFLICTING") {
+			continue
+		}
+		count++
+		evidence = append(evidence, fmt.Sprintf("#%d is `%s` but still labeled `needs-conflict-resolution`", pr.Number, strings.TrimSpace(pr.Mergeable)))
+	}
+	if count < harnessGapStaleConflictThreshold {
+		return nil, nil
+	}
+
+	finding := newHarnessGapFinding(
+		"stale-label-patterns",
+		"harness-gap-analysis: clean up stale conflict labels on mergeable PRs",
+		fmt.Sprintf("%d open PR(s) still carry `needs-conflict-resolution` even though GitHub no longer reports them as conflicting", count),
+		count,
+		harnessGapStaleConflictThreshold,
+		evidence,
+		[]string{
+			"Move stale conflict-label cleanup into a deterministic daemon path instead of waiting for a human to strip labels.",
+			"Escalate repeated stale conflict labels as resolve-conflicts reliability debt.",
+		},
+	)
+	return &finding, nil
+}
+
+func detectReleaseCadenceGap(ctx context.Context, repo string, runner issueRunner, now time.Time) (*HarnessGapFinding, error) {
+	args := append(harnessGapRepoArgs(repo), "pr", "list", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt")
+	out, err := runner.RunOutput(ctx, "gh", args...)
+	if err != nil {
+		return nil, fmt.Errorf("detect release cadence gap: list open pull requests: %w", err)
+	}
+	var prs []harnessGapPullRequest
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("detect release cadence gap: parse gh pr list output: %w", err)
+	}
+
+	var releasePR *harnessGapPullRequest
+	for i := range prs {
+		head := strings.ToLower(strings.TrimSpace(prs[i].HeadRefName))
+		title := strings.ToLower(strings.TrimSpace(prs[i].Title))
+		if strings.HasPrefix(head, "release-please") || strings.Contains(title, "release please") {
+			releasePR = &prs[i]
+			break
+		}
+	}
+	if releasePR == nil || releasePR.CreatedAt.IsZero() {
+		return nil, nil
+	}
+	age := now.Sub(releasePR.CreatedAt)
+	if age < harnessGapReleasePRAgeThreshold {
+		return nil, nil
+	}
+
+	viewArgs := append(harnessGapRepoArgs(repo), "pr", "view", strconv.Itoa(releasePR.Number), "--json", "commits")
+	commitOut, err := runner.RunOutput(ctx, "gh", viewArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("detect release cadence gap: view release pull request: %w", err)
+	}
+	var details struct {
+		Commits []harnessGapCommit `json:"commits"`
+	}
+	if err := json.Unmarshal(commitOut, &details); err != nil {
+		return nil, fmt.Errorf("detect release cadence gap: parse gh pr view output: %w", err)
+	}
+	if len(details.Commits) < harnessGapReleasePRCommitMinimum {
+		return nil, nil
+	}
+
+	finding := newHarnessGapFinding(
+		"release-cadence",
+		"harness-gap-analysis: release-please cadence is drifting",
+		fmt.Sprintf("release PR #%d has been open for %s with %d queued commit(s)", releasePR.Number, age.Round(24*time.Hour), len(details.Commits)),
+		len(details.Commits),
+		harnessGapReleasePRCommitMinimum,
+		[]string{
+			fmt.Sprintf("#%d opened at %s and still accumulating commits on `%s`", releasePR.Number, releasePR.CreatedAt.Format(time.RFC3339), releasePR.HeadRefName),
+		},
+		[]string{
+			"Teach the daemon to notice stale release PRs before they become week-long release debt.",
+			"Bound release PR age or commit count with an explicit cadence policy and issue escalation.",
+		},
+	)
+	return &finding, nil
+}
+
+func detectConfigDriftGap(ctx context.Context, runner issueRunner) (*HarnessGapFinding, error) {
+	out, err := runner.RunOutput(ctx, "git", "rev-list", "--left-right", "--count", "origin/main...HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("detect config drift gap: git rev-list: %w", err)
+	}
+	behind, ahead, err := parseGitRevListAheadBehind(string(out))
+	if err != nil {
+		return nil, fmt.Errorf("detect config drift gap: %w", err)
+	}
+	if behind == 0 && ahead == 0 {
+		return nil, nil
+	}
+
+	finding := newHarnessGapFinding(
+		"config-drift",
+		"harness-gap-analysis: daemon worktree drifted from origin/main",
+		fmt.Sprintf("the daemon worktree is behind by %d commit(s) and ahead by %d commit(s) versus origin/main", behind, ahead),
+		behind+ahead,
+		1,
+		[]string{fmt.Sprintf("git rev-list --left-right --count origin/main...HEAD => behind=%d ahead=%d", behind, ahead)},
+		[]string{
+			"Surface daemon worktree drift before scheduled scans keep running old control-plane code.",
+			"Turn drift detection into an explicit self-heal or issue-filing path instead of relying on operator discovery.",
+		},
+	)
+	return &finding, nil
+}
+
+func detectFailedFingerprintBacklogGap(ctx context.Context, repo string, runner issueRunner) (*HarnessGapFinding, error) {
+	args := append(harnessGapRepoArgs(repo), "issue", "list", "--state", "open", "--label", "xylem-failed", "--limit", "100", "--json", "number,title,url,labels")
+	out, err := runner.RunOutput(ctx, "gh", args...)
+	if err != nil {
+		return nil, fmt.Errorf("detect failed-fingerprint backlog gap: list failed issues: %w", err)
+	}
+	var issues []harnessGapIssue
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return nil, fmt.Errorf("detect failed-fingerprint backlog gap: parse gh issue list output: %w", err)
+	}
+
+	evidence := make([]string, 0, len(issues))
+	count := 0
+	for _, issue := range issues {
+		if hasHarnessGapLabel(issue.Labels, "ready-for-work") {
+			continue
+		}
+		count++
+		evidence = append(evidence, fmt.Sprintf("#%d `%s` is still labeled `xylem-failed` without `ready-for-work`", issue.Number, issue.Title))
+	}
+	if count < harnessGapFailedBacklogThreshold {
+		return nil, nil
+	}
+
+	finding := newHarnessGapFinding(
+		"failed-fingerprint-backlog",
+		"harness-gap-analysis: failed backlog is missing automatic retry routing",
+		fmt.Sprintf("%d failed issue(s) remain parked behind `xylem-failed` without a ready-for-work route", count),
+		count,
+		harnessGapFailedBacklogThreshold,
+		evidence,
+		[]string{
+			"Escalate parked failed issues when no retry cooldown or unlock path returns them to the backlog.",
+			"Pair failure fingerprints with deterministic requeue policies so failed work does not silently accumulate.",
+		},
+	)
+	return &finding, nil
+}
+
+func loadHarnessGapDaemonLog(path string) ([]harnessGapDaemonEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("load harness-gap daemon log: read %q: %w", path, err)
+	}
+	lines := strings.Split(string(data), "\n")
+	entries := make([]harnessGapDaemonEntry, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		rawTime := logFieldValue(line, "time")
+		if rawTime == "" {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339, rawTime)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, harnessGapDaemonEntry{Time: ts.UTC(), Line: line})
+	}
+	return entries, nil
+}
+
+func detectIdleBacklogEpisodes(entries []harnessGapDaemonEntry, cutoff time.Time) []harnessGapIdleEpisode {
+	episodes := make([]harnessGapIdleEpisode, 0)
+	var current *harnessGapIdleEpisode
+	for _, entry := range entries {
+		if entry.Time.Before(cutoff) {
+			continue
+		}
+		if logFieldValue(entry.Line, "msg") != "daemon tick summary" {
+			continue
+		}
+		pending, okPending := logFieldInt(entry.Line, "pending")
+		running, okRunning := logFieldInt(entry.Line, "running")
+		if !okPending || !okRunning {
+			continue
+		}
+		if pending > 0 && running == 0 {
+			if current == nil {
+				current = &harnessGapIdleEpisode{Start: entry.Time, End: entry.Time, Pending: pending}
+				continue
+			}
+			current.End = entry.Time
+			if pending > current.Pending {
+				current.Pending = pending
+			}
+			continue
+		}
+		if current != nil {
+			episodes = append(episodes, *current)
+			current = nil
+		}
+	}
+	if current != nil {
+		episodes = append(episodes, *current)
+	}
+	return episodes
+}
+
+func idleBacklogLongest(episodes []harnessGapIdleEpisode) harnessGapIdleEpisode {
+	longest := episodes[0]
+	for _, episode := range episodes[1:] {
+		if episode.End.Sub(episode.Start) > longest.End.Sub(longest.Start) {
+			longest = episode
+		}
+	}
+	return longest
+}
+
+func renderHarnessGapMarkdown(report *HarnessGapReport) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Harness gap analysis\n\n")
+	fmt.Fprintf(&b, "- Generated: %s\n", report.GeneratedAt.Format(time.RFC3339))
+	fmt.Fprintf(&b, "- Findings above threshold: %d\n\n", len(report.Findings))
+
+	if len(report.Warnings) > 0 {
+		fmt.Fprintf(&b, "## Warnings\n\n")
+		for _, warning := range report.Warnings {
+			fmt.Fprintf(&b, "- %s\n", warning)
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+
+	if len(report.Findings) == 0 {
+		fmt.Fprintf(&b, "No recurring autonomy gaps exceeded the built-in thresholds.\n")
+		return b.String()
+	}
+
+	fmt.Fprintf(&b, "## Findings\n\n")
+	for _, finding := range report.Findings {
+		fmt.Fprintf(&b, "### %s\n\n", finding.Title)
+		fmt.Fprintf(&b, "- Category: `%s`\n", finding.Category)
+		fmt.Fprintf(&b, "- Observed: %d (threshold %d)\n", finding.Observed, finding.Threshold)
+		fmt.Fprintf(&b, "- Summary: %s\n", finding.Summary)
+		if len(finding.Evidence) > 0 {
+			fmt.Fprintf(&b, "- Evidence:\n")
+			for _, evidence := range finding.Evidence {
+				fmt.Fprintf(&b, "  - %s\n", evidence)
+			}
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+	return b.String()
+}
+
+func renderHarnessGapIssueBody(finding HarnessGapFinding) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s%s -->\n", harnessGapFindingMarkerPrefix, finding.Fingerprint)
+	fmt.Fprintf(&b, "## Harness gap finding\n\n")
+	fmt.Fprintf(&b, "- Category: `%s`\n", finding.Category)
+	fmt.Fprintf(&b, "- Observed: %d (threshold %d)\n", finding.Observed, finding.Threshold)
+	fmt.Fprintf(&b, "- Summary: %s\n\n", finding.Summary)
+	fmt.Fprintf(&b, "This issue was generated from deterministic harness telemetry already persisted by xylem (daemon logs, GitHub state, git state, and phase summaries where available).\n\n")
+	if len(finding.Evidence) > 0 {
+		fmt.Fprintf(&b, "## Evidence\n\n")
+		for _, evidence := range finding.Evidence {
+			fmt.Fprintf(&b, "- %s\n", evidence)
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+	fmt.Fprintf(&b, "## Suggested follow-up\n\n")
+	for _, remediation := range finding.Remediations {
+		fmt.Fprintf(&b, "- %s\n", remediation)
+	}
+	return b.String()
+}
+
+func loadOpenHarnessGapIssues(ctx context.Context, runner issueRunner, repo string) (map[string]contextWeightIssue, error) {
+	out, err := runner.RunOutput(ctx, "gh", "issue", "list", "--repo", repo, "--state", "open", "--limit", "100", "--json", "number,title,body")
+	if err != nil {
+		return nil, fmt.Errorf("load open harness-gap issues: %w", err)
+	}
+	var issues []contextWeightIssue
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return nil, fmt.Errorf("load open harness-gap issues: parse gh issue list output: %w", err)
+	}
+	byFingerprint := make(map[string]contextWeightIssue, len(issues))
+	for _, issue := range issues {
+		fingerprint := parseHarnessGapMarker(issue.Body)
+		if fingerprint == "" {
+			continue
+		}
+		byFingerprint[fingerprint] = issue
+	}
+	return byFingerprint, nil
+}
+
+func parseHarnessGapMarker(body string) string {
+	start := strings.Index(body, harnessGapFindingMarkerPrefix)
+	if start == -1 {
+		return ""
+	}
+	start += len(harnessGapFindingMarkerPrefix)
+	end := strings.Index(body[start:], " -->")
+	if end == -1 {
+		return ""
+	}
+	return strings.TrimSpace(body[start : start+end])
+}
+
+func loadHarnessGapIssueState(path string) (*harnessGapIssueState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &harnessGapIssueState{Findings: make(map[string]contextWeightIssueRecord)}, nil
+		}
+		return nil, fmt.Errorf("load harness-gap issue state: %w", err)
+	}
+	var state harnessGapIssueState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("load harness-gap issue state: unmarshal: %w", err)
+	}
+	if state.Findings == nil {
+		state.Findings = make(map[string]contextWeightIssueRecord)
+	}
+	return &state, nil
+}
+
+func saveHarnessGapIssueState(path string, state *harnessGapIssueState) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("save harness-gap issue state: create dir: %w", err)
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("save harness-gap issue state: marshal: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("save harness-gap issue state: write: %w", err)
+	}
+	return nil
+}
+
+func newHarnessGapFinding(category, title, summary string, observed, threshold int, evidence, remediations []string) HarnessGapFinding {
+	finding := HarnessGapFinding{
+		Category:     category,
+		Title:        title,
+		Summary:      summary,
+		Observed:     observed,
+		Threshold:    threshold,
+		Evidence:     append([]string(nil), evidence...),
+		Remediations: append([]string(nil), remediations...),
+	}
+	finding.Fingerprint = harnessGapFindingFingerprint(finding)
+	return finding
+}
+
+func harnessGapFindingFingerprint(finding HarnessGapFinding) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		finding.Category,
+		finding.Title,
+	}, "\n")))
+	return fmt.Sprintf("%x", sum[:8])
+}
+
+func sortHarnessGapFindings(findings []HarnessGapFinding) {
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Category != findings[j].Category {
+			return findings[i].Category < findings[j].Category
+		}
+		return findings[i].Title < findings[j].Title
+	})
+}
+
+func logFieldValue(line, key string) string {
+	pattern := regexp.MustCompile(`(?:^| )` + regexp.QuoteMeta(key) + `=("[^"]*"|[^ ]+)`)
+	match := pattern.FindStringSubmatch(line)
+	if len(match) < 2 {
+		return ""
+	}
+	return strings.Trim(match[1], `"`)
+}
+
+func logFieldInt(line, key string) (int, bool) {
+	raw := strings.TrimSpace(logFieldValue(line, key))
+	if raw == "" {
+		return 0, false
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, false
+	}
+	return value, true
+}
+
+func parseGitRevListAheadBehind(raw string) (behind int, ahead int, err error) {
+	fields := strings.Fields(strings.TrimSpace(raw))
+	if len(fields) != 2 {
+		return 0, 0, fmt.Errorf("parse git rev-list counts %q: want two integers", strings.TrimSpace(raw))
+	}
+	behind, err = strconv.Atoi(fields[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse git rev-list behind count %q: %w", fields[0], err)
+	}
+	ahead, err = strconv.Atoi(fields[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse git rev-list ahead count %q: %w", fields[1], err)
+	}
+	return behind, ahead, nil
+}
+
+func hasHarnessGapLabel(labels []harnessGapLabel, want string) bool {
+	for _, label := range labels {
+		if label.Name == want {
+			return true
+		}
+	}
+	return false
+}
+
+func harnessGapRepoArgs(repo string) []string {
+	if strings.TrimSpace(repo) == "" {
+		return nil
+	}
+	return []string{"--repo", repo}
+}

--- a/cli/internal/review/harness_gap_prop_test.go
+++ b/cli/internal/review/harness_gap_prop_test.go
@@ -1,0 +1,25 @@
+package review
+
+import (
+	"fmt"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropParseGitRevListAheadBehindRoundTripsCounts(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		behind := rapid.IntRange(0, 500).Draw(t, "behind")
+		ahead := rapid.IntRange(0, 500).Draw(t, "ahead")
+		separator := rapid.SampledFrom([]string{" ", "\t", "  ", "\t\t"}).Draw(t, "separator")
+		raw := fmt.Sprintf("%d%s%d\n", behind, separator, ahead)
+
+		gotBehind, gotAhead, err := parseGitRevListAheadBehind(raw)
+		if err != nil {
+			t.Fatalf("parseGitRevListAheadBehind(%q) error = %v", raw, err)
+		}
+		if gotBehind != behind || gotAhead != ahead {
+			t.Fatalf("parseGitRevListAheadBehind(%q) = (%d,%d), want (%d,%d)", raw, gotBehind, gotAhead, behind, ahead)
+		}
+	})
+}

--- a/cli/internal/review/harness_gap_test.go
+++ b/cli/internal/review/harness_gap_test.go
@@ -1,0 +1,328 @@
+package review
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type harnessGapTestRunner struct {
+	calls       [][]string
+	responses   map[string][]byte
+	createCount int
+	createBody  string
+}
+
+func (r *harnessGapTestRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	r.calls = append(r.calls, call)
+	if name == "gh" && len(args) >= 2 && args[0] == "issue" && args[1] == "create" {
+		r.createCount++
+		r.createBody = valueAfterFlag(args, "--body")
+		return []byte("https://github.com/owner/repo/issues/91"), nil
+	}
+	if out, ok := r.responses[strings.Join(call, "\x00")]; ok {
+		return out, nil
+	}
+	return []byte("[]"), nil
+}
+
+func TestGenerateHarnessGapAnalysisDetectsObservedSignals(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 10, 1, 0, 0, 0, time.UTC)
+	writeDaemonLogFixture(t, stateDir, []string{
+		daemonLogLine(now.Add(-23*time.Hour), "daemon reconcile recovered orphaned vessels", "recovered=1"),
+		daemonLogLine(now.Add(-22*time.Hour), "daemon tick summary", "pending=3", "running=0", "completed=0", "failed=0"),
+		daemonLogLine(now.Add(-21*time.Hour-40*time.Minute), "daemon tick summary", "pending=4", "running=0", "completed=0", "failed=0"),
+		daemonLogLine(now.Add(-21*time.Hour-20*time.Minute), "daemon tick summary", "pending=0", "running=1", "completed=0", "failed=0"),
+	})
+
+	runner := &harnessGapTestRunner{
+		responses: map[string][]byte{
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "merged", "--limit", "100", "--json", "number,title,url,headRefName,mergedAt,mergedBy,labels"): mustJSON(t, []map[string]any{
+				{"number": 1, "title": "feat", "url": "https://example/pr/1", "headRefName": "feat/issue-201-201", "mergedAt": now.Add(-2 * time.Hour), "mergedBy": map[string]any{"login": "alice"}, "labels": []map[string]any{{"name": "harness-impl"}}},
+				{"number": 2, "title": "fix", "url": "https://example/pr/2", "headRefName": "fix/issue-202-202", "mergedAt": now.Add(-3 * time.Hour), "mergedBy": map[string]any{"login": "bob"}, "labels": []map[string]any{{"name": "harness-impl"}}},
+				{"number": 3, "title": "chore", "url": "https://example/pr/3", "headRefName": "chore/issue-203-203", "mergedAt": now.Add(-4 * time.Hour), "mergedBy": map[string]any{"login": "carol"}, "labels": []map[string]any{{"name": "harness-impl"}}},
+			}),
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--label", "needs-conflict-resolution", "--limit", "100", "--json", "number,title,url,mergeable,headRefName"): mustJSON(t, []map[string]any{
+				{"number": 11, "title": "conflict", "url": "https://example/pr/11", "mergeable": "MERGEABLE", "headRefName": "feat/issue-211-211"},
+			}),
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt"): mustJSON(t, []map[string]any{
+				{"number": 21, "title": "Release Please", "url": "https://example/pr/21", "headRefName": "release-please--branches--main", "createdAt": now.Add(-10 * 24 * time.Hour)},
+			}),
+			commandKey("gh", "--repo", "owner/repo", "pr", "view", "21", "--json", "commits"): mustJSON(t, map[string]any{
+				"commits": []map[string]any{{"oid": "a"}, {"oid": "b"}, {"oid": "c"}, {"oid": "d"}, {"oid": "e"}, {"oid": "f"}},
+			}),
+			commandKey("git", "rev-list", "--left-right", "--count", "origin/main...HEAD"): []byte("2\t1\n"),
+			commandKey("gh", "--repo", "owner/repo", "issue", "list", "--state", "open", "--label", "xylem-failed", "--limit", "100", "--json", "number,title,url,labels"): mustJSON(t, []map[string]any{
+				{"number": 31, "title": "failed one", "url": "https://example/issue/31", "labels": []map[string]any{{"name": "xylem-failed"}}},
+				{"number": 32, "title": "failed two", "url": "https://example/issue/32", "labels": []map[string]any{{"name": "xylem-failed"}}},
+				{"number": 33, "title": "failed three", "url": "https://example/issue/33", "labels": []map[string]any{{"name": "xylem-failed"}}},
+			}),
+		},
+	}
+
+	result, err := GenerateHarnessGapAnalysis(context.Background(), stateDir, "owner/repo", runner, HarnessGapOptions{
+		OutputDir: "reviews",
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("GenerateHarnessGapAnalysis() error = %v", err)
+	}
+
+	if len(result.Report.Findings) != 7 {
+		t.Fatalf("findings = %d, want 7", len(result.Report.Findings))
+	}
+	gotCategories := make(map[string]bool, len(result.Report.Findings))
+	for _, finding := range result.Report.Findings {
+		gotCategories[finding.Category] = true
+		if finding.Fingerprint == "" {
+			t.Fatalf("finding %#v has empty fingerprint", finding)
+		}
+	}
+	for _, category := range []string{
+		"config-drift",
+		"failed-fingerprint-backlog",
+		"idle-with-backlog",
+		"merge-click-frequency",
+		"release-cadence",
+		"stale-label-patterns",
+		"daemon-restart-count",
+	} {
+		if !gotCategories[category] {
+			t.Fatalf("missing category %q in %+v", category, result.Report.Findings)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(stateDir, "reviews", harnessGapReportJSONName)); err != nil {
+		t.Fatalf("report json missing: %v", err)
+	}
+	if !strings.Contains(result.Markdown, "Harness gap analysis") {
+		t.Fatalf("markdown = %q, want heading", result.Markdown)
+	}
+}
+
+func TestGenerateHarnessGapAnalysisNoSignalsWritesNoopReport(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 10, 1, 0, 0, 0, time.UTC)
+	runner := &harnessGapTestRunner{
+		responses: map[string][]byte{
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "merged", "--limit", "100", "--json", "number,title,url,headRefName,mergedAt,mergedBy,labels"):                        []byte("[]"),
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--label", "needs-conflict-resolution", "--limit", "100", "--json", "number,title,url,mergeable,headRefName"): []byte("[]"),
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt"):                                         []byte("[]"),
+			commandKey("git", "rev-list", "--left-right", "--count", "origin/main...HEAD"):                                                                                                          []byte("0 0\n"),
+			commandKey("gh", "--repo", "owner/repo", "issue", "list", "--state", "open", "--label", "xylem-failed", "--limit", "100", "--json", "number,title,url,labels"):                          []byte("[]"),
+		},
+	}
+
+	result, err := GenerateHarnessGapAnalysis(context.Background(), stateDir, "owner/repo", runner, HarnessGapOptions{
+		OutputDir: "reviews",
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("GenerateHarnessGapAnalysis() error = %v", err)
+	}
+	if len(result.Report.Findings) != 0 {
+		t.Fatalf("findings = %+v, want none", result.Report.Findings)
+	}
+	if !strings.Contains(result.Markdown, "No recurring autonomy gaps exceeded") {
+		t.Fatalf("markdown = %q, want no-op summary", result.Markdown)
+	}
+	if len(result.Report.Warnings) != 1 {
+		t.Fatalf("warnings = %+v, want daemon-log warning", result.Report.Warnings)
+	}
+}
+
+func TestSmoke_S1_HarnessGapAnalysisFilesAutoAdminMergeIssue(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 10, 1, 0, 0, 0, time.UTC)
+	runner := &harnessGapTestRunner{
+		responses: map[string][]byte{
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "merged", "--limit", "100", "--json", "number,title,url,headRefName,mergedAt,mergedBy,labels"): mustJSON(t, []map[string]any{
+				{"number": 1, "title": "feat", "url": "https://example/pr/1", "headRefName": "feat/issue-201-201", "mergedAt": now.Add(-2 * time.Hour), "mergedBy": map[string]any{"login": "alice"}, "labels": []map[string]any{{"name": "harness-impl"}}},
+				{"number": 2, "title": "fix", "url": "https://example/pr/2", "headRefName": "fix/issue-202-202", "mergedAt": now.Add(-3 * time.Hour), "mergedBy": map[string]any{"login": "bob"}, "labels": []map[string]any{{"name": "harness-impl"}}},
+				{"number": 3, "title": "chore", "url": "https://example/pr/3", "headRefName": "chore/issue-203-203", "mergedAt": now.Add(-4 * time.Hour), "mergedBy": map[string]any{"login": "carol"}, "labels": []map[string]any{{"name": "harness-impl"}}},
+			}),
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--label", "needs-conflict-resolution", "--limit", "100", "--json", "number,title,url,mergeable,headRefName"): []byte("[]"),
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt"):                                         []byte("[]"),
+			commandKey("git", "rev-list", "--left-right", "--count", "origin/main...HEAD"):                                                                                                          []byte("0\t0\n"),
+			commandKey("gh", "--repo", "owner/repo", "issue", "list", "--state", "open", "--label", "xylem-failed", "--limit", "100", "--json", "number,title,url,labels"):                          []byte("[]"),
+			commandKey("gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--limit", "100", "--json", "number,title,body"):                                                           []byte("[]"),
+		},
+	}
+
+	result, err := RunHarnessGapAnalysis(context.Background(), stateDir, "owner/repo", runner, HarnessGapOptions{
+		OutputDir: "reviews",
+		Now:       now,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, result.Report.Findings, 1)
+	finding := result.Report.Findings[0]
+	assert.Equal(t, "merge-click-frequency", finding.Category)
+	assert.Equal(t, "harness-gap-analysis: automate repeated human admin merges", finding.Title)
+	assert.Equal(t, harnessGapMergedPRThreshold, finding.Observed)
+	assert.Len(t, finding.Evidence, harnessGapMergedPRThreshold)
+
+	require.Len(t, result.Published, 1)
+	assert.True(t, result.Published[0].Created)
+	assert.Equal(t, 91, result.Published[0].IssueNumber)
+	assert.Equal(t, finding.Title, result.Published[0].Title)
+	assert.Equal(t, 1, runner.createCount)
+	assert.Contains(t, runner.createBody, "## Harness gap finding")
+	assert.Contains(t, runner.createBody, harnessGapFindingMarkerPrefix+finding.Fingerprint)
+	assert.Contains(t, runner.createBody, "#1 merged by @alice")
+
+	_, err = os.Stat(filepath.Join(stateDir, "reviews", harnessGapReportJSONName))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(stateDir, "reviews", harnessGapReportMarkdownName))
+	require.NoError(t, err)
+}
+
+func TestSmoke_S2_HarnessGapAnalysisNoopsWhenNoGapsDetected(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 10, 1, 0, 0, 0, time.UTC)
+	runner := &harnessGapTestRunner{
+		responses: map[string][]byte{
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "merged", "--limit", "100", "--json", "number,title,url,headRefName,mergedAt,mergedBy,labels"):                        []byte("[]"),
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--label", "needs-conflict-resolution", "--limit", "100", "--json", "number,title,url,mergeable,headRefName"): []byte("[]"),
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt"):                                         []byte("[]"),
+			commandKey("git", "rev-list", "--left-right", "--count", "origin/main...HEAD"):                                                                                                          []byte("0\t0\n"),
+			commandKey("gh", "--repo", "owner/repo", "issue", "list", "--state", "open", "--label", "xylem-failed", "--limit", "100", "--json", "number,title,url,labels"):                          []byte("[]"),
+		},
+	}
+
+	result, err := RunHarnessGapAnalysis(context.Background(), stateDir, "owner/repo", runner, HarnessGapOptions{
+		OutputDir: "reviews",
+		Now:       now,
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, result.Report.Findings)
+	assert.Empty(t, result.Published)
+	assert.Equal(t, 0, runner.createCount)
+	assert.Contains(t, result.Markdown, "No recurring autonomy gaps exceeded the built-in thresholds.")
+	assert.Equal(t, []string{"daemon log not available; skipped local restart/backlog signals"}, result.Report.Warnings)
+
+	reportJSON, err := os.ReadFile(filepath.Join(stateDir, "reviews", harnessGapReportJSONName))
+	require.NoError(t, err)
+	assert.Contains(t, string(reportJSON), "\"warnings\"")
+	assert.Contains(t, string(reportJSON), "daemon log not available")
+}
+
+func TestDetectAdminMergeGapIgnoresNonHarnessPullRequests(t *testing.T) {
+	now := time.Date(2026, time.April, 10, 1, 0, 0, 0, time.UTC)
+	runner := &harnessGapTestRunner{
+		responses: map[string][]byte{
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "merged", "--limit", "100", "--json", "number,title,url,headRefName,mergedAt,mergedBy,labels"): mustJSON(t, []map[string]any{
+				{"number": 1, "title": "bug fix", "url": "https://example/pr/1", "headRefName": "fix/issue-201-201", "mergedAt": now.Add(-2 * time.Hour), "mergedBy": map[string]any{"login": "alice"}, "labels": []map[string]any{{"name": "bug"}}},
+				{"number": 2, "title": "feature", "url": "https://example/pr/2", "headRefName": "feat/issue-202-202", "mergedAt": now.Add(-3 * time.Hour), "mergedBy": map[string]any{"login": "bob"}, "labels": []map[string]any{{"name": "enhancement"}}},
+				{"number": 3, "title": "docs", "url": "https://example/pr/3", "headRefName": "chore/issue-203-203", "mergedAt": now.Add(-4 * time.Hour), "mergedBy": map[string]any{"login": "carol"}, "labels": []map[string]any{{"name": "ready-to-merge"}}},
+			}),
+		},
+	}
+
+	finding, err := detectAdminMergeGap(context.Background(), "owner/repo", runner, now)
+	if err != nil {
+		t.Fatalf("detectAdminMergeGap() error = %v", err)
+	}
+	if finding != nil {
+		t.Fatalf("detectAdminMergeGap() = %+v, want nil", finding)
+	}
+}
+
+func TestPublishHarnessGapIssuesDedupsRepeatedFindings(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 10, 1, 0, 0, 0, time.UTC)
+	report := &HarnessGapReport{
+		GeneratedAt: now,
+		Findings: []HarnessGapFinding{
+			newHarnessGapFinding(
+				"config-drift",
+				"harness-gap-analysis: daemon worktree drifted from origin/main",
+				"drift detected",
+				2,
+				1,
+				[]string{"behind=1 ahead=1"},
+				[]string{"sync daemon worktree"},
+			),
+		},
+	}
+	runner := &harnessGapTestRunner{
+		responses: map[string][]byte{
+			commandKey("gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--limit", "100", "--json", "number,title,body"): []byte("[]"),
+		},
+	}
+
+	first, err := PublishHarnessGapIssues(context.Background(), stateDir, "owner/repo", runner, report, "reviews", now)
+	if err != nil {
+		t.Fatalf("first PublishHarnessGapIssues() error = %v", err)
+	}
+	if runner.createCount != 1 {
+		t.Fatalf("createCount after first publish = %d, want 1", runner.createCount)
+	}
+	if len(first) != 1 || !first[0].Created {
+		t.Fatalf("first publish = %+v, want created issue", first)
+	}
+
+	second, err := PublishHarnessGapIssues(context.Background(), stateDir, "owner/repo", runner, report, "reviews", now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("second PublishHarnessGapIssues() error = %v", err)
+	}
+	if runner.createCount != 1 {
+		t.Fatalf("createCount after second publish = %d, want 1", runner.createCount)
+	}
+	if len(second) != 1 || second[0].Created {
+		t.Fatalf("second publish = %+v, want deduped existing issue", second)
+	}
+	if !strings.Contains(runner.createBody, harnessGapFindingMarkerPrefix+report.Findings[0].Fingerprint) {
+		t.Fatalf("create body missing fingerprint marker: %q", runner.createBody)
+	}
+}
+
+func writeDaemonLogFixture(t *testing.T, stateDir string, lines []string) {
+	t.Helper()
+	path := filepath.Join(stateDir, harnessGapDaemonLogFileName)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}
+
+func daemonLogLine(ts time.Time, msg string, extra ...string) string {
+	fields := []string{
+		"time=" + ts.UTC().Format(time.RFC3339),
+		"level=INFO",
+		`msg="` + msg + `"`,
+	}
+	fields = append(fields, extra...)
+	return strings.Join(fields, " ")
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return data
+}
+
+func commandKey(name string, args ...string) string {
+	return strings.Join(append([]string{name}, args...), "\x00")
+}
+
+func valueAfterFlag(args []string, flag string) string {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag {
+			return args[i+1]
+		}
+	}
+	return ""
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -278,7 +278,7 @@ xylem drain [flags]
    - Executes workflow phases sequentially in the worktree. Prompt phases use the resolved provider (`claude` or `copilot`), and command phases run shell commands directly.
    - Runs quality gates between phases (command gates with retries, label gates with polling).
 4. Marks vessels as `completed`, `failed`, `waiting`, or `timed_out` based on outcome.
-5. Executes any built-in scheduled vessels already sitting in the queue (for example, `context-weight-audit`) without creating a worktree or launching an LLM session.
+5. Executes any built-in scheduled vessels already sitting in the queue (for example, `context-weight-audit` and `harness-gap-analysis`) without creating a worktree or launching an LLM session.
 6. If `harness.review` is configured for automatic cadence, regenerates the latest harness review as a best-effort post-drain step.
 7. Prints a summary line and exits.
 
@@ -460,7 +460,7 @@ Run the daemon from the **root of a dedicated git worktree on branch `main`**. A
 1. Parses scan and drain intervals from config (falling back to defaults).
 2. Enters a loop that alternates between scanning and draining based on elapsed time since each operation last ran.
 3. After each tick, logs a summary of the queue state (pending, running, completed, failed counts).
-4. Daemon drains also execute built-in scheduled vessels such as `context-weight-audit` before launching normal workflow runs.
+4. Daemon drains also execute built-in scheduled vessels such as `context-weight-audit` and `harness-gap-analysis` before launching normal workflow runs.
 5. Automatic harness review generation follows the same best-effort cadence as `xylem drain` because daemon draining uses the same post-drain hook.
 
 **Graceful shutdown**: Handles `SIGINT` and `SIGTERM`. On signal, the daemon logs a shutdown message and exits cleanly. Running sessions finish before the process terminates.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -237,6 +237,22 @@ sources:
 ```
 
 The built-in `context-weight-audit` workflow is another `scheduled` use case: it reads persisted run summaries from `<state_dir>/phases/`, writes `context-weight-audit.{json,md}` under `<state_dir>/<harness.review.output_dir>/`, and opens de-duplicated GitHub hygiene issues for repeated high-footprint findings.
+
+`harness-gap-analysis` is a sibling built-in scheduled workflow for xylem self-hosting. It reads existing daemon telemetry (for example `<state_dir>/daemon.log`), current GitHub state, and git drift, then writes `harness-gap-analysis.{json,md}` plus a durable issue-dedup state file under `<state_dir>/<harness.review.output_dir>/`.
+
+```yaml
+sources:
+  harness-gap-analysis:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "4h"
+    tasks:
+      analyze-gaps:
+        workflow: harness-gap-analysis
+        ref: harness-gap-analysis
+```
+
+To opt out, omit or delete the scheduled `harness-gap-analysis` source from your config; no separate feature flag is required.
 ### `status_labels`
 
 When `status_labels` is set, xylem records the configured labels in vessel metadata and applies them during source lifecycle hooks.
@@ -451,7 +467,7 @@ harness:
     output_dir: "reviews"
 ```
 
-`xylem review` writes `harness-review.json` and `harness-review.md` under `<state_dir>/<output_dir>/`. Automatic reviews are best-effort: failed review generation never fails `drain` or `daemon`. Built-in context-weight audits also write `context-weight-audit.json`, `context-weight-audit.md`, and a durable issue-dedup state file in the same directory when a scheduled `context-weight-audit` vessel runs. When failed or timed-out runs also have `<state_dir>/phases/<vessel-id>/failure-review.json`, the review loader reconstructs those recovery decisions alongside the existing evidence/cost/eval artifacts.
+`xylem review` writes `harness-review.json` and `harness-review.md` under `<state_dir>/<output_dir>/`. Automatic reviews are best-effort: failed review generation never fails `drain` or `daemon`. Built-in context-weight audits also write `context-weight-audit.json`, `context-weight-audit.md`, and a durable issue-dedup state file in the same directory when a scheduled `context-weight-audit` vessel runs. Built-in `harness-gap-analysis` runs do the same for `harness-gap-analysis.{json,md}` while surfacing recurring daemon-operation gaps such as drift, idle backlog episodes, stale conflict labels, and parked failed backlog. When failed or timed-out runs also have `<state_dir>/phases/<vessel-id>/failure-review.json`, the review loader reconstructs those recovery decisions alongside the existing evidence/cost/eval artifacts.
 
 ### Observability settings
 


### PR DESCRIPTION
## Summary
- Implements https://github.com/nicholls-inc/xylem/issues/246 by adding a built-in scheduled `harness-gap-analysis` vessel that inspects persisted daemon telemetry, GitHub state, and git drift to surface recurring autonomy gaps.
- Writes deterministic `harness-gap-analysis.{json,md}` review artifacts and publishes de-duplicated GitHub issues for findings that cross built-in thresholds.
- Wires the new built-in workflow into scheduled drain handling, the sample `.xylem.yml`, and the CLI/configuration docs.

## Smoke scenarios covered
- S1 - Harness gap analysis files auto admin merge issue (`TestSmoke_S1_HarnessGapAnalysisFilesAutoAdminMergeIssue`)
- S2 - Harness gap analysis noops when no gaps detected (`TestSmoke_S2_HarnessGapAnalysisNoopsWhenNoGapsDetected`)

## Changes summary
- Added `cli/internal/review/harness_gap.go` with `HarnessGapOptions`, `HarnessGapResult`, `HarnessGapReport`, `HarnessGapFinding`, `GenerateHarnessGapAnalysis`, `RunHarnessGapAnalysis`, and `PublishHarnessGapIssues`.
- Added `cli/internal/review/harness_gap_test.go` and `cli/internal/review/harness_gap_prop_test.go` covering deterministic finding generation, issue dedupe/publication, built-in smoke scenarios, and `git rev-list` parsing.
- Updated `cli/cmd/xylem/builtin_audit.go` and `cli/cmd/xylem/builtin_audit_test.go` so scheduled built-in drains recognize both `context-weight-audit` and `harness-gap-analysis`, dispatch through `runBuiltInScheduledWorkflow`, and persist workflow-specific summaries.
- Updated `.xylem.yml`, `docs/configuration.md`, and `docs/cli-reference.md` to document and schedule the new recurring built-in audit path.

## Test plan
- `cd cli && goimports -w .`
- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #246