### PR TITLE
feat: thread effort tier through workflows, phases, and vessels

### DIFF
--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -68,6 +68,7 @@ type Vessel struct {
 	Source    string            `json:"source"`
 	Ref       string            `json:"ref,omitempty"`
 	Workflow  string            `json:"workflow,omitempty"`
+	Tier      string            `json:"tier,omitempty"`
 	Prompt    string            `json:"prompt,omitempty"`
 	Meta      map[string]string `json:"meta,omitempty"`
 	State     VesselState       `json:"state"`

--- a/cli/internal/queue/queue_prop_test.go
+++ b/cli/internal/queue/queue_prop_test.go
@@ -1,0 +1,51 @@
+package queue
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropQueueRoundTripsTier(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		dir, err := os.MkdirTemp("", "queue-tier-prop-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(dir)
+
+		q := New(filepath.Join(dir, "queue.jsonl"))
+		tier := rapid.StringMatching(`[a-z][a-z0-9-]{0,7}`).Draw(t, "tier")
+		vessel := Vessel{
+			ID:        "issue-1",
+			Source:    "github-issue",
+			Ref:       "https://github.com/example/repo/issues/1",
+			Workflow:  "fix-bug",
+			Tier:      tier,
+			State:     StatePending,
+			CreatedAt: time.Now().UTC(),
+		}
+
+		enqueued, err := q.Enqueue(vessel)
+		if err != nil {
+			t.Fatalf("Enqueue() error = %v", err)
+		}
+		if !enqueued {
+			t.Fatal("expected vessel to be enqueued")
+		}
+
+		vessels, err := q.List()
+		if err != nil {
+			t.Fatalf("List() error = %v", err)
+		}
+		if len(vessels) != 1 {
+			t.Fatalf("len(vessels) = %d, want 1", len(vessels))
+		}
+		if vessels[0].Tier != tier {
+			t.Fatalf("Tier = %q, want %q", vessels[0].Tier, tier)
+		}
+	})
+}

--- a/cli/internal/queue/queue_test.go
+++ b/cli/internal/queue/queue_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/dtu"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // helperTransitionToWaiting transitions a vessel from pending -> running -> waiting via the queue.
@@ -97,6 +99,32 @@ func TestEnqueue(t *testing.T) {
 	if got.State != StatePending {
 		t.Fatalf("expected state pending, got %q", got.State)
 	}
+}
+
+func TestSmoke_S2_LegacyQueueJsonlWithoutTierLoadsEmptyTier(t *testing.T) {
+	q, path := newTestQueue(t)
+	legacy := `{"id":"issue-42","source":"github-issue","ref":"https://github.com/example/repo/issues/42","workflow":"fix-bug","state":"pending","created_at":"2026-04-10T00:00:00Z"}`
+	require.NoError(t, os.WriteFile(path, []byte(legacy+"\n"), 0o644))
+
+	vessels, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Empty(t, vessels[0].Tier)
+}
+
+func TestSmoke_S3_QueueJsonlRoundTripsTier(t *testing.T) {
+	q, _ := newTestQueue(t)
+	vessel := testVessel(77)
+	vessel.Tier = "high"
+
+	enqueued, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+	require.True(t, enqueued)
+
+	vessels, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "high", vessels[0].Tier)
 }
 
 // TestWS6S28VesselJSONLNoNewFields verifies that queue JSONL records remain

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -145,12 +145,13 @@ func (s *Scanner) buildSources() []sourceEntry {
 			tasks := convertTasks(srcCfg.Tasks)
 			entries = append(entries, sourceEntry{
 				src: &source.GitHub{
-					Repo:      srcCfg.Repo,
-					Tasks:     tasks,
-					Exclude:   srcCfg.Exclude,
-					StateDir:  s.Config.StateDir,
-					Queue:     s.Queue,
-					CmdRunner: s.CmdRunner,
+					Repo:        srcCfg.Repo,
+					Tasks:       tasks,
+					Exclude:     srcCfg.Exclude,
+					StateDir:    s.Config.StateDir,
+					DefaultTier: s.Config.LLMRouting.DefaultTier,
+					Queue:       s.Queue,
+					CmdRunner:   s.CmdRunner,
 				},
 				configName: name,
 			})
@@ -158,12 +159,13 @@ func (s *Scanner) buildSources() []sourceEntry {
 			tasks := convertTasks(srcCfg.Tasks)
 			entries = append(entries, sourceEntry{
 				src: &source.GitHubPR{
-					Repo:      srcCfg.Repo,
-					Tasks:     tasks,
-					Exclude:   srcCfg.Exclude,
-					StateDir:  s.Config.StateDir,
-					Queue:     s.Queue,
-					CmdRunner: s.CmdRunner,
+					Repo:        srcCfg.Repo,
+					Tasks:       tasks,
+					Exclude:     srcCfg.Exclude,
+					StateDir:    s.Config.StateDir,
+					DefaultTier: s.Config.LLMRouting.DefaultTier,
+					Queue:       s.Queue,
+					CmdRunner:   s.CmdRunner,
 				},
 				configName: name,
 			})
@@ -171,12 +173,13 @@ func (s *Scanner) buildSources() []sourceEntry {
 			prEventsTasks := convertPREventsTasks(srcCfg.Tasks)
 			entries = append(entries, sourceEntry{
 				src: &source.GitHubPREvents{
-					Repo:      srcCfg.Repo,
-					Tasks:     prEventsTasks,
-					Exclude:   srcCfg.Exclude,
-					StateDir:  s.Config.StateDir,
-					Queue:     s.Queue,
-					CmdRunner: s.CmdRunner,
+					Repo:        srcCfg.Repo,
+					Tasks:       prEventsTasks,
+					Exclude:     srcCfg.Exclude,
+					StateDir:    s.Config.StateDir,
+					DefaultTier: s.Config.LLMRouting.DefaultTier,
+					Queue:       s.Queue,
+					CmdRunner:   s.CmdRunner,
 				},
 				configName: name,
 			})
@@ -184,10 +187,11 @@ func (s *Scanner) buildSources() []sourceEntry {
 			mergeTasks := convertMergeTasks(srcCfg.Tasks)
 			entries = append(entries, sourceEntry{
 				src: &source.GitHubMerge{
-					Repo:      srcCfg.Repo,
-					Tasks:     mergeTasks,
-					Queue:     s.Queue,
-					CmdRunner: s.CmdRunner,
+					Repo:        srcCfg.Repo,
+					Tasks:       mergeTasks,
+					DefaultTier: s.Config.LLMRouting.DefaultTier,
+					Queue:       s.Queue,
+					CmdRunner:   s.CmdRunner,
 				},
 				configName: name,
 			})
@@ -195,12 +199,13 @@ func (s *Scanner) buildSources() []sourceEntry {
 			scheduledTasks := convertScheduledTasks(srcCfg.Tasks)
 			entries = append(entries, sourceEntry{
 				src: &source.Scheduled{
-					Repo:       srcCfg.Repo,
-					StateDir:   s.Config.StateDir,
-					ConfigName: name,
-					Schedule:   srcCfg.Schedule,
-					Tasks:      scheduledTasks,
-					Queue:      s.Queue,
+					Repo:        srcCfg.Repo,
+					StateDir:    s.Config.StateDir,
+					ConfigName:  name,
+					Schedule:    srcCfg.Schedule,
+					Tasks:       scheduledTasks,
+					DefaultTier: s.Config.LLMRouting.DefaultTier,
+					Queue:       s.Queue,
 				},
 				configName: name,
 			})
@@ -233,6 +238,7 @@ func convertPREventsTasks(cfgTasks map[string]config.Task) map[string]source.PRE
 	for name, t := range cfgTasks {
 		task := source.PREventsTask{
 			Workflow: t.Workflow,
+			Tier:     t.Tier,
 		}
 		if t.On != nil {
 			task.Labels = t.On.Labels
@@ -258,6 +264,7 @@ func convertMergeTasks(cfgTasks map[string]config.Task) map[string]source.MergeT
 	for name, t := range cfgTasks {
 		tasks[name] = source.MergeTask{
 			Workflow: t.Workflow,
+			Tier:     t.Tier,
 		}
 	}
 	return tasks
@@ -269,6 +276,7 @@ func convertScheduledTasks(cfgTasks map[string]config.Task) map[string]source.Sc
 		tasks[name] = source.ScheduledTask{
 			Workflow: t.Workflow,
 			Ref:      t.Ref,
+			Tier:     t.Tier,
 		}
 	}
 	return tasks

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -305,6 +305,52 @@ func TestScanBuildsScheduledSource(t *testing.T) {
 	}
 }
 
+func TestSmoke_S4_ScannerSetsVesselTierFromTaskOrDefault(t *testing.T) {
+	tests := []struct {
+		name        string
+		taskTier    string
+		defaultTier string
+		wantTier    string
+	}{
+		{name: "task tier wins", taskTier: "high", defaultTier: "low", wantTier: "high"},
+		{name: "falls back to routing default", taskTier: "", defaultTier: "low", wantTier: "low"},
+		{name: "falls back to med when default missing", taskTier: "", defaultTier: "", wantTier: config.DefaultLLMRoutingTier},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfg := makeConfig(dir)
+			cfg.LLMRouting.DefaultTier = tt.defaultTier
+			cfg.Sources["github"] = config.SourceConfig{
+				Type: "github",
+				Repo: "owner/repo",
+				Tasks: map[string]config.Task{
+					"fix-bugs": {Labels: []string{"bug"}, Workflow: "fix-bug", Tier: tt.taskTier},
+				},
+			}
+			q := queue.New(filepath.Join(dir, "queue.jsonl"))
+			r := newMock()
+			issues := []ghIssue{
+				{Number: 1, Title: "fix null response", URL: "https://github.com/owner/repo/issues/1", Labels: []struct {
+					Name string `json:"name"`
+				}{{Name: "bug"}}},
+			}
+			r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+
+			s := New(cfg, q, r)
+			result, err := s.Scan(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, 1, result.Added)
+
+			vessels, err := q.List()
+			require.NoError(t, err)
+			require.Len(t, vessels, 1)
+			assert.Equal(t, tt.wantTier, vessels[0].Tier)
+		})
+	}
+}
+
 func TestScanExistingPR(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeConfig(dir)

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -22,6 +22,7 @@ import (
 type GitHubTask struct {
 	Labels          []string
 	Workflow        string
+	Tier            string
 	StatusLabels    *StatusLabels
 	LabelGateLabels *LabelGateLabels
 }
@@ -32,6 +33,7 @@ type GitHub struct {
 	Tasks                  map[string]GitHubTask
 	Exclude                []string
 	StateDir               string
+	DefaultTier            string
 	Queue                  *queue.Queue
 	CmdRunner              CommandRunner
 	HarnessDigestResolver  func() string
@@ -119,6 +121,7 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					Source:    "github-issue",
 					Ref:       issue.URL,
 					Workflow:  task.Workflow,
+					Tier:      ResolveTaskTier(task.Tier, g.DefaultTier),
 					Meta:      baseMeta,
 					State:     queue.StatePending,
 					CreatedAt: sourceNow(),

--- a/cli/internal/source/github_merge.go
+++ b/cli/internal/source/github_merge.go
@@ -13,14 +13,16 @@ import (
 // MergeTask defines a task triggered by merged PRs.
 type MergeTask struct {
 	Workflow string
+	Tier     string
 }
 
 // GitHubMerge scans for merged PRs and produces vessels.
 type GitHubMerge struct {
-	Repo      string
-	Tasks     map[string]MergeTask
-	Queue     *queue.Queue
-	CmdRunner CommandRunner
+	Repo        string
+	Tasks       map[string]MergeTask
+	DefaultTier string
+	Queue       *queue.Queue
+	CmdRunner   CommandRunner
 }
 
 type ghMergeCommit struct {
@@ -73,6 +75,7 @@ func (g *GitHubMerge) Scan(ctx context.Context) ([]queue.Vessel, error) {
 				Source:   "github-merge",
 				Ref:      ref,
 				Workflow: task.Workflow,
+				Tier:     ResolveTaskTier(task.Tier, g.DefaultTier),
 				Meta: map[string]string{
 					"pr_num":         strconv.Itoa(pr.Number),
 					"event_type":     "merge",

--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -19,6 +19,7 @@ type GitHubPR struct {
 	Tasks                  map[string]GitHubTask
 	Exclude                []string
 	StateDir               string
+	DefaultTier            string
 	Queue                  *queue.Queue
 	CmdRunner              CommandRunner
 	HarnessDigestResolver  func() string
@@ -116,6 +117,7 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 					Source:   "github-pr",
 					Ref:      prWorkflowRef(pr.URL, task.Workflow),
 					Workflow: task.Workflow,
+					Tier:     ResolveTaskTier(task.Tier, g.DefaultTier),
 					Meta: map[string]string{
 						"pr_num":                   strconv.Itoa(pr.Number),
 						"pr_title":                 pr.Title,

--- a/cli/internal/source/github_pr_events.go
+++ b/cli/internal/source/github_pr_events.go
@@ -15,6 +15,7 @@ import (
 // PREventsTask defines a task triggered by PR events.
 type PREventsTask struct {
 	Workflow        string
+	Tier            string
 	Labels          []string
 	ReviewSubmitted bool
 	ChecksFailed    bool
@@ -32,13 +33,14 @@ type PREventsTask struct {
 
 // GitHubPREvents scans GitHub PRs for specific events and produces vessels.
 type GitHubPREvents struct {
-	Repo      string
-	Tasks     map[string]PREventsTask
-	Exclude   []string
-	StateDir  string
-	Queue     *queue.Queue
-	CmdRunner CommandRunner
-	Now       func() time.Time
+	Repo        string
+	Tasks       map[string]PREventsTask
+	Exclude     []string
+	StateDir    string
+	DefaultTier string
+	Queue       *queue.Queue
+	CmdRunner   CommandRunner
+	Now         func() time.Time
 
 	// selfLogin is the authenticated gh CLI user's login, looked up once
 	// per Scan. Used to unconditionally filter out events authored by
@@ -185,6 +187,7 @@ func (g *GitHubPREvents) Scan(ctx context.Context) ([]queue.Vessel, error) {
 								Source:   "github-pr-events",
 								Ref:      ref,
 								Workflow: task.Workflow,
+								Tier:     ResolveTaskTier(task.Tier, g.DefaultTier),
 								Meta: map[string]string{
 									"pr_num":         strconv.Itoa(pr.Number),
 									"event_type":     "label",
@@ -521,6 +524,7 @@ func (g *GitHubPREvents) newPREventVessel(pr ghPR, task PREventsTask, eventType,
 		Source:    g.Name(),
 		Ref:       ref,
 		Workflow:  task.Workflow,
+		Tier:      ResolveTaskTier(task.Tier, g.DefaultTier),
 		Meta:      meta,
 		State:     queue.StatePending,
 		CreatedAt: createdAt,

--- a/cli/internal/source/github_test.go
+++ b/cli/internal/source/github_test.go
@@ -917,6 +917,7 @@ func TestGitHubTaskFromConfigCopiesLabelGateLabels(t *testing.T) {
 	task := GitHubTaskFromConfig(config.Task{
 		Labels:   []string{"bug"},
 		Workflow: "fix-bug",
+		Tier:     "  high  ",
 		LabelGateLabels: &config.LabelGateLabels{
 			Waiting: "blocked",
 			Ready:   "ready-for-implementation",
@@ -931,6 +932,9 @@ func TestGitHubTaskFromConfigCopiesLabelGateLabels(t *testing.T) {
 	}
 	if task.LabelGateLabels.Ready != "ready-for-implementation" {
 		t.Errorf("LabelGateLabels.Ready = %q, want ready-for-implementation", task.LabelGateLabels.Ready)
+	}
+	if task.Tier != "high" {
+		t.Errorf("Tier = %q, want high", task.Tier)
 	}
 }
 

--- a/cli/internal/source/scheduled.go
+++ b/cli/internal/source/scheduled.go
@@ -18,15 +18,17 @@ import (
 type ScheduledTask struct {
 	Workflow string
 	Ref      string
+	Tier     string
 }
 
 type Scheduled struct {
-	Repo       string
-	StateDir   string
-	ConfigName string
-	Schedule   string
-	Tasks      map[string]ScheduledTask
-	Queue      *queue.Queue
+	Repo        string
+	StateDir    string
+	ConfigName  string
+	Schedule    string
+	Tasks       map[string]ScheduledTask
+	DefaultTier string
+	Queue       *queue.Queue
 }
 
 type scheduleState struct {
@@ -93,6 +95,7 @@ func (s *Scheduled) Scan(_ context.Context) ([]queue.Vessel, error) {
 			Source:    s.Name(),
 			Ref:       ref,
 			Workflow:  task.Workflow,
+			Tier:      ResolveTaskTier(task.Tier, s.DefaultTier),
 			Meta:      meta,
 			State:     queue.StatePending,
 			CreatedAt: now,

--- a/cli/internal/source/source.go
+++ b/cli/internal/source/source.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"context"
+	"strings"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
@@ -34,6 +35,7 @@ func GitHubTaskFromConfig(t config.Task) GitHubTask {
 	task := GitHubTask{
 		Labels:   t.Labels,
 		Workflow: t.Workflow,
+		Tier:     strings.TrimSpace(t.Tier),
 	}
 	if t.StatusLabels != nil {
 		task.StatusLabels = &StatusLabels{
@@ -51,6 +53,16 @@ func GitHubTaskFromConfig(t config.Task) GitHubTask {
 		}
 	}
 	return task
+}
+
+func ResolveTaskTier(taskTier, defaultTier string) string {
+	if tier := strings.TrimSpace(taskTier); tier != "" {
+		return tier
+	}
+	if tier := strings.TrimSpace(defaultTier); tier != "" {
+		return tier
+	}
+	return config.DefaultLLMRoutingTier
 }
 
 // ResolveRunningLabel returns the running status label for a vessel,

--- a/cli/internal/source/tier_prop_test.go
+++ b/cli/internal/source/tier_prop_test.go
@@ -1,0 +1,45 @@
+package source
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"pgregory.net/rapid"
+)
+
+func TestPropResolveTaskTierPrefersExplicitTaskTier(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		taskTier := rapid.StringMatching(`[a-z][a-z0-9-]{0,7}`).Draw(t, "task-tier")
+		defaultTier := rapid.StringMatching(`[a-z][a-z0-9-]{0,7}`).Draw(t, "default-tier")
+		paddedTaskTier := rapid.SampledFrom([]string{
+			taskTier,
+			" " + taskTier,
+			taskTier + " ",
+			"\t" + taskTier + "\n",
+		}).Draw(t, "padded-task-tier")
+
+		if got := ResolveTaskTier(paddedTaskTier, defaultTier); got != taskTier {
+			t.Fatalf("ResolveTaskTier(%q, %q) = %q, want %q", paddedTaskTier, defaultTier, got, taskTier)
+		}
+	})
+}
+
+func TestPropResolveTaskTierFallsBackToDefaultOrMed(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		defaultTier := rapid.SampledFrom([]string{
+			"",
+			"   ",
+			rapid.StringMatching(`[a-z][a-z0-9-]{0,7}`).Draw(t, "configured-default"),
+		}).Draw(t, "default-tier")
+
+		got := ResolveTaskTier("", defaultTier)
+		want := strings.TrimSpace(defaultTier)
+		if want == "" {
+			want = config.DefaultLLMRoutingTier
+		}
+		if got != want {
+			t.Fatalf("ResolveTaskTier(%q, %q) = %q, want %q", "", defaultTier, got, want)
+		}
+	})
+}

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -25,6 +25,7 @@ type Workflow struct {
 	Class                         policy.Class `yaml:"class,omitempty"`
 	LLM                           *string      `yaml:"llm,omitempty"`
 	Model                         *string      `yaml:"model,omitempty"`
+	Tier                          *string      `yaml:"tier,omitempty"`
 	AllowAdditiveProtectedWrites  bool         `yaml:"allow_additive_protected_writes,omitempty"`
 	AllowCanonicalProtectedWrites bool         `yaml:"allow_canonical_protected_writes,omitempty"`
 	Phases                        []Phase      `yaml:"phases"`
@@ -40,6 +41,7 @@ type workflowYAML struct {
 	Class                         *string `yaml:"class,omitempty"`
 	LLM                           *string `yaml:"llm,omitempty"`
 	Model                         *string `yaml:"model,omitempty"`
+	Tier                          *string `yaml:"tier,omitempty"`
 	AllowAdditiveProtectedWrites  *bool   `yaml:"allow_additive_protected_writes,omitempty"`
 	AllowCanonicalProtectedWrites *bool   `yaml:"allow_canonical_protected_writes,omitempty"`
 	Phases                        []Phase `yaml:"phases"`
@@ -63,6 +65,7 @@ type Phase struct {
 	MaxTurns     int      `yaml:"max_turns"`
 	LLM          *string  `yaml:"llm,omitempty"`
 	Model        *string  `yaml:"model,omitempty"`
+	Tier         *string  `yaml:"tier,omitempty"`
 	NoOp         *NoOp    `yaml:"noop,omitempty"`
 	Gate         *Gate    `yaml:"gate,omitempty"`
 	AllowedTools *string  `yaml:"allowed_tools,omitempty"`
@@ -314,6 +317,7 @@ func workflowFromYAML(raw workflowYAML) (*Workflow, error) {
 		Description: raw.Description,
 		LLM:         raw.LLM,
 		Model:       raw.Model,
+		Tier:        raw.Tier,
 		Phases:      raw.Phases,
 	}
 

--- a/cli/internal/workflow/workflow_prop_test.go
+++ b/cli/internal/workflow/workflow_prop_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
+	"gopkg.in/yaml.v3"
 	"pgregory.net/rapid"
 )
 
@@ -118,5 +119,53 @@ func TestPropValidateClassRejectsUnknownClasses(t *testing.T) {
 		if !strings.Contains(err.Error(), class) {
 			t.Fatalf("validateClass(%q) error = %q, want mention of class", class, err.Error())
 		}
+	})
+}
+
+func TestPropWorkflowTierYAMLRoundTripPreservesPointerSemantics(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		optionalTier := func(label string) *string {
+			kind := rapid.SampledFrom([]string{"nil", "empty", "value"}).Draw(t, label+"-kind")
+			switch kind {
+			case "nil":
+				return nil
+			case "empty":
+				value := ""
+				return &value
+			default:
+				value := rapid.StringMatching(`[a-z][a-z0-9-]{0,7}`).Draw(t, label+"-value")
+				return &value
+			}
+		}
+
+		wf := Workflow{
+			Name:   rapid.StringMatching(`[a-z][a-z0-9-]{0,7}`).Draw(t, "workflow-name"),
+			Tier:   optionalTier("workflow-tier"),
+			Phases: []Phase{{Name: "analyze", Tier: optionalTier("phase-tier")}},
+		}
+
+		data, err := yaml.Marshal(wf)
+		if err != nil {
+			t.Fatalf("yaml.Marshal() error = %v", err)
+		}
+
+		var roundTripped Workflow
+		if err := yaml.Unmarshal(data, &roundTripped); err != nil {
+			t.Fatalf("yaml.Unmarshal() error = %v", err)
+		}
+
+		assertOptional := func(name string, want, got *string) {
+			switch {
+			case want == nil && got != nil:
+				t.Fatalf("%s = %q, want nil", name, *got)
+			case want != nil && got == nil:
+				t.Fatalf("%s = nil, want %q", name, *want)
+			case want != nil && got != nil && *want != *got:
+				t.Fatalf("%s = %q, want %q", name, *got, *want)
+			}
+		}
+
+		assertOptional("workflow tier", wf.Tier, roundTripped.Tier)
+		assertOptional("phase tier", wf.Phases[0].Tier, roundTripped.Phases[0].Tier)
 	})
 }

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func writeWorkflowFile(t *testing.T, dir, name, content string) string {
@@ -58,6 +59,51 @@ func chdirTemp(t *testing.T, dir string) {
 		t.Fatalf("chdir %q: %v", dir, err)
 	}
 	t.Cleanup(func() { os.Chdir(orig) })
+}
+
+func tierPtr(s string) *string {
+	return &s
+}
+
+func TestSmoke_S1_WorkflowTierRoundTripPreservesNilAndEmptyStringDistinction(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+	createPromptFile(t, dir, "prompts/plan.md")
+	createPromptFile(t, dir, "prompts/apply.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+tier: high
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+  - name: plan
+    prompt_file: prompts/plan.md
+    max_turns: 10
+    tier: ""
+  - name: apply
+    prompt_file: prompts/apply.md
+    max_turns: 10
+    tier: low
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, tierPtr("high"), got.Tier)
+	require.Nil(t, got.Phases[0].Tier)
+	assert.Equal(t, tierPtr(""), got.Phases[1].Tier)
+	assert.Equal(t, tierPtr("low"), got.Phases[2].Tier)
+
+	data, err := yaml.Marshal(got)
+	require.NoError(t, err)
+
+	var roundTripped Workflow
+	require.NoError(t, yaml.Unmarshal(data, &roundTripped))
+	require.Equal(t, got.Tier, roundTripped.Tier)
+	require.Nil(t, roundTripped.Phases[0].Tier)
+	assert.Equal(t, got.Phases[1].Tier, roundTripped.Phases[1].Tier)
+	assert.Equal(t, got.Phases[2].Tier, roundTripped.Phases[2].Tier)
 }
 
 func TestSmoke_S11_GateWithoutEvidenceMetadataLoadsCleanlyWithNilEvidenceField(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements [#224](https://github.com/nicholls-inc/xylem/issues/224) by plumbing effort tier data through workflow parsing, vessel persistence, and source/scanner enqueue paths without changing runner execution behavior.

## Smoke scenarios covered

- `S1` — WorkflowTierRoundTripPreservesNilAndEmptyStringDistinction
- `S2` — LegacyQueueJsonlWithoutTierLoadsEmptyTier
- `S3` — QueueJsonlRoundTripsTier
- `S4` — ScannerSetsVesselTierFromTaskOrDefault

## Changes summary

### Files added

- `cli/internal/queue/queue_prop_test.go`
- `cli/internal/source/tier_prop_test.go`

### Files modified

- `cli/internal/workflow/workflow.go`
- `cli/internal/workflow/workflow_test.go`
- `cli/internal/workflow/workflow_prop_test.go`
- `cli/internal/queue/queue.go`
- `cli/internal/queue/queue_test.go`
- `cli/internal/scanner/scanner.go`
- `cli/internal/scanner/scanner_test.go`
- `cli/internal/source/source.go`
- `cli/internal/source/github.go`
- `cli/internal/source/github_pr.go`
- `cli/internal/source/github_pr_events.go`
- `cli/internal/source/github_merge.go`
- `cli/internal/source/scheduled.go`
- `cli/internal/source/github_test.go`

### Key types and functions

- Added `Tier *string` to `workflow.Workflow`, `workflow.workflowYAML`, and `workflow.Phase` so YAML tier values round-trip with nil-vs-empty preservation.
- Added `Tier string` to `queue.Vessel` so resolved enqueue-time tier data persists in JSONL.
- Added `source.ResolveTaskTier` and updated `source.GitHubTaskFromConfig` to trim task tier input and resolve task/default/med fallback consistently.
- Updated scanner source construction and task conversion so GitHub issue, PR, PR-event, merge, and scheduled sources all receive `DefaultTier` and carry tier data into enqueued vessels.
- Updated vessel construction in `github.go`, `github_pr.go`, `github_pr_events.go`, `github_merge.go`, and `scheduled.go` to stamp `Vessel.Tier` using resolved task/default tier.
- Added focused unit and property tests for workflow YAML round-trip, queue backward compatibility, queue tier persistence, scanner tier fallback behavior, and tier resolution helpers.

## Test plan

Run from `cli/`:

- `go vet ./...`
- `golangci-lint run`
- `go build ./cmd/xylem`
- `go test ./...`

Fixes #224