### PR TITLE
Add project-local Claude Code skills suite for xylem operators

### DIFF
--- a/.claude/skills/xylem-cancel/SKILL.md
+++ b/.claude/skills/xylem-cancel/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: xylem-cancel
+description: Cancel a pending or running vessel cleanly through the queue state machine. Use when the user asks to stop queued work, abort a run, clear a blocked vessel, or cancel an incorrect enqueue.
+argument-hint: "[vessel-id]"
+disable-model-invocation: true
+---
+
+This skill performs a queue mutation.
+
+1. Verify the target vessel with `cd cli && xylem status` or `cd cli && xylem status --json` before cancelling.
+2. Run `cd cli && xylem cancel <vessel-id>`.
+3. Confirm that the vessel is the intended pending or running vessel, then summarize the resulting state and any follow-up cleanup the operator may still need.
+4. If the vessel is already terminal, explain that clearly instead of pretending the cancel succeeded.

--- a/.claude/skills/xylem-config/SKILL.md
+++ b/.claude/skills/xylem-config/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: xylem-config
+description: Generate or revise `.xylem.yml` for this repository. Use when the user asks to set up xylem, change labels or sources, add workflows, tune daemon settings, or validate xylem configuration.
+argument-hint: "[goal-or-repo-slug]"
+disable-model-invocation: true
+---
+
+Treat `.xylem.yml` as the primary output surface.
+
+1. Read the current `.xylem.yml`, `.xylem/HARNESS.md`, and the available `.xylem/workflows/*.yaml` files before proposing changes.
+2. If the repo is not initialized yet, anchor the plan around `cd cli && xylem init` and then tailor `.xylem.yml` instead of inventing an unrelated layout.
+3. Prefer existing source and daemon patterns already used in this repo; only introduce new sections when the user asked for new behavior.
+4. After editing, validate the result with `cd cli && xylem scan --dry-run` when that is enough, or explain which follow-up command should be used if the change affects draining rather than scanning.
+5. Call out any required companion edits under `.xylem/workflows/`, `.xylem/prompts/`, or `.xylem/HARNESS.md`.

--- a/.claude/skills/xylem-dashboard/SKILL.md
+++ b/.claude/skills/xylem-dashboard/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: xylem-dashboard
+description: Build a rich operator snapshot of queue activity and recent xylem outcomes. Use when the user asks for a dashboard, control-room view, recent completions, failure trends, throughput, or an at-a-glance queue summary.
+argument-hint: "[state-or-time-window]"
+disable-model-invocation: true
+---
+
+This skill synthesizes existing xylem surfaces into a dashboard-style report.
+
+1. Start with `cd cli && xylem status --json` so you have structured queue data.
+2. Inspect recent `.xylem/phases/*/summary.json` files when you need recent completion, failure, duration, or cost trends.
+3. Present the result as a concise dashboard: state counts, running vessels, waiting gates, recent failures, recent completions, and any noteworthy throughput or anomaly patterns.
+4. If `$ARGUMENTS` narrows the request to a state or window, apply that filter explicitly in the narrative even when the raw data comes from `xylem status --json`.
+5. Close with the one or two operator actions that would most improve the dashboard state right now.

--- a/.claude/skills/xylem-debug/SKILL.md
+++ b/.claude/skills/xylem-debug/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: xylem-debug
+description: Investigate a stuck, failed, or confusing xylem run. Use when the user asks why a vessel failed, why work is waiting, why a drain skipped work, or to debug queue, workflow, or gate behavior.
+argument-hint: "[vessel-id-or-symptom]"
+disable-model-invocation: true
+---
+
+Run from the repository root.
+
+1. Begin with `cd cli && xylem status --json` to identify the target vessel, state, and any anomalies.
+2. If `$ARGUMENTS` names a vessel ID, focus on that vessel. Otherwise use the status output to find the most relevant failed, waiting, or timed-out vessel and explain why you chose it.
+3. Inspect `.xylem/phases/<vessel-id>` for phase outputs, especially `.xylem/phases/<vessel-id>/summary.json` and any prompt or gate artifacts referenced there.
+4. Cross-check the vessel's workflow under `.xylem/workflows/` and the matching prompt files under `.xylem/prompts/` so you can separate workflow-definition problems from runtime failures.
+5. Explain the failure mode concretely: state transition, gate wait, missing workflow asset, CLI error, or bad prompt/runtime output.
+6. End with the narrowest next action: rerun with `/xylem-retry`, inspect a specific file with `/xylem-logs`, cancel blocked work with `/xylem-cancel`, or fix the relevant workflow/config surface.

--- a/.claude/skills/xylem-doctor/SKILL.md
+++ b/.claude/skills/xylem-doctor/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: xylem-doctor
+description: Run a comprehensive xylem health check across config, queue, workflows, and runtime artifacts. Use when the user asks for a doctor command, health check, sanity audit, readiness review, or to diagnose why xylem is unhealthy.
+argument-hint: "[focus]"
+disable-model-invocation: true
+---
+
+Use this skill to produce a structured health report, not just one command output.
+
+1. Start with `cd cli && xylem status` to capture queue and daemon health.
+2. Validate core control surfaces: `.xylem.yml`, `.xylem/HARNESS.md`, `.xylem/workflows/`, and `.xylem/prompts/`.
+3. Run `cd cli && xylem visualize --format json` or another `xylem visualize` mode when you need to spot missing or orphaned workflows.
+4. Inspect recent `.xylem/phases/*/summary.json` files when runtime failures or degraded health need concrete evidence.
+5. Report findings in sections: configuration issues, queue/runtime issues, workflow graph issues, and recommended fixes.
+6. If the repo needs deeper repository-shape auditing, you may also use `cd cli && xylem bootstrap audit-legibility --root ..` as a secondary signal, but keep the main diagnosis grounded in xylem runtime surfaces.

--- a/.claude/skills/xylem-drain/SKILL.md
+++ b/.claude/skills/xylem-drain/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: xylem-drain
+description: Trigger a xylem drain cycle and report what moved through the queue. Use when the user asks to run pending work, kick the daemon manually, process queued vessels, or monitor a fresh drain.
+disable-model-invocation: true
+---
+
+Use this for an operator-driven drain.
+
+1. If the user wants a preview first, run `cd cli && xylem drain --dry-run`.
+2. Otherwise run `cd cli && xylem drain`.
+3. Follow the drain with `cd cli && xylem status` so you can report state transitions, remaining blockers, and whether failures or waiting gates need intervention.
+4. Highlight completed, failed, skipped, and waiting counts, not just the final exit code.
+5. If a specific vessel becomes the focus, hand off to `/xylem-debug`, `/xylem-logs`, `/xylem-retry`, or `/xylem-cancel`.

--- a/.claude/skills/xylem-enqueue/SKILL.md
+++ b/.claude/skills/xylem-enqueue/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: xylem-enqueue
+description: Manually enqueue ad-hoc xylem work without waiting for a GitHub issue scan. Use when the user asks to queue a one-off task, test a workflow, enqueue a prompt directly, or create a manual vessel.
+argument-hint: "[workflow-or-prompt]"
+disable-model-invocation: true
+---
+
+This skill performs a manual queue insertion.
+
+1. Prefer `cd cli && xylem enqueue --workflow <workflow> --ref "<reference>"` when the task maps to an existing workflow.
+2. Use `cd cli && xylem enqueue --prompt "<prompt>" --ref "<reference>"` only when the user explicitly wants a direct prompt or there is no matching workflow.
+3. Mention important flags when they help: `--source`, `--id`, and `--prompt-file`.
+4. After enqueueing, confirm the new vessel ID and recommend `cd cli && xylem status` or `/xylem-drain` so the user can watch it move.
+5. If the workflow name is uncertain, inspect `.xylem/workflows/` first instead of guessing.

--- a/.claude/skills/xylem-init/SKILL.md
+++ b/.claude/skills/xylem-init/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: xylem-init
+description: Scaffold xylem into a repository and populate the harness surfaces afterward. Use when the user asks to initialize xylem, bootstrap `.xylem/`, fill in `.xylem/HARNESS.md`, or adapt the harness after `xylem init`.
+disable-model-invocation: true
+---
+
+Use this when the repository needs its initial xylem scaffolding or a freshly generated harness needs real project details.
+
+1. If `.xylem.yml` and `.xylem/` are missing, run `cd cli && xylem init` first.
+2. Review the generated `.xylem/HARNESS.md`, `.xylem.yml`, `.xylem/workflows/`, and `.xylem/prompts/` so you can tell which surfaces still need project-specific edits.
+3. Populate `.xylem/HARNESS.md` with concrete architecture, build, test, and operational details drawn from the repo rather than generic advice.
+4. If initialization already happened, treat this as a harness-population pass instead of re-running `xylem init` unnecessarily.
+5. End with the next operational command the maintainer should run, usually `cd cli && xylem scan --dry-run` or `cd cli && xylem scan && xylem drain`.

--- a/.claude/skills/xylem-logs/SKILL.md
+++ b/.claude/skills/xylem-logs/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: xylem-logs
+description: Read xylem phase artifacts and summarize what happened in a specific vessel. Use when the user asks for logs, phase output, gate results, summaries, or the exact files under a vessel's phase directory.
+argument-hint: "[vessel-id] [phase]"
+disable-model-invocation: true
+---
+
+Treat the phase artifact directory as the source of truth.
+
+1. Inspect `.xylem/phases/<vessel-id>` first and orient yourself with `.xylem/phases/<vessel-id>/summary.json`.
+2. If the user also passed a phase name, narrow to the files associated with that phase before reading large outputs.
+3. Summarize the important evidence: prompt input, model output, gate outcomes, timing, and the exact error text when present.
+4. Never edit `.xylem/phases/<vessel-id>` artifacts; they are runtime outputs.
+5. If the logs indicate an actionable next step, point to `/xylem-debug`, `/xylem-retry`, `/xylem-cancel`, or the relevant workflow/prompt file.

--- a/.claude/skills/xylem-prompts/SKILL.md
+++ b/.claude/skills/xylem-prompts/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: xylem-prompts
+description: Improve existing xylem prompt templates for clarity, coverage, and better outcomes. Use when the user asks to refine prompt wording, reduce failures, tighten guardrails, or tune prompts for a workflow.
+argument-hint: "[workflow-or-prompt]"
+disable-model-invocation: true
+---
+
+Focus on prompt assets, not unrelated workflow plumbing.
+
+1. Read the target prompt files under `.xylem/prompts/` and the parent workflow YAML so the prompt edits stay consistent with the actual phase contract.
+2. If the user mentions failures or regressions, inspect `.xylem/phases/<vessel-id>/summary.json` or other `.xylem/phases/<vessel-id>` artifacts first so the edits address a real failure mode.
+3. Prefer tightening instructions, inputs, success criteria, and output contracts over adding generic verbosity.
+4. Keep naming and file layout aligned with the corresponding workflow YAML.
+5. In your summary, mention which prompt files changed and what execution behavior those edits are meant to improve.

--- a/.claude/skills/xylem-retry/SKILL.md
+++ b/.claude/skills/xylem-retry/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: xylem-retry
+description: Requeue a failed or timed-out vessel with the existing recovery context. Use when the user asks to retry a failed vessel, rerun timed-out work, resume a broken run, or start over from scratch.
+argument-hint: "[vessel-id] [--from-scratch]"
+disable-model-invocation: true
+---
+
+Only retry vessels that are actually retryable.
+
+1. Confirm the vessel is in `failed` or `timed_out` state with `cd cli && xylem status --json` before retrying.
+2. Use `cd cli && xylem retry <vessel-id>` for the normal recovery path.
+3. Use `cd cli && xylem retry <vessel-id> --from-scratch` only when the user explicitly wants to discard the resumed worktree path and restart all phases.
+4. Explain that xylem copies forward failure context and phase artifacts, including `.xylem/phases/<vessel-id>/summary.json`, unless the retry is forced from scratch.
+5. After the retry vessel is created, report the new vessel ID and suggest `/xylem-drain`, `/xylem-status`, or `/xylem-logs`.

--- a/.claude/skills/xylem-status/SKILL.md
+++ b/.claude/skills/xylem-status/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: xylem-status
+description: Inspect xylem queue state, daemon health, and vessel summaries. Use when the user asks for xylem status, running vessels, pending work, failed jobs, waiting gates, throughput, or overall health.
+argument-hint: "[state]"
+disable-model-invocation: true
+---
+
+Run from the repository root.
+
+1. Start with `cd cli && xylem status`.
+2. If `$ARGUMENTS` is a vessel state such as `pending`, `running`, `failed`, `waiting`, `completed`, `cancelled`, or `timed_out`, rerun as `cd cli && xylem status --state "$ARGUMENTS"`.
+3. Prefer `cd cli && xylem status --json` when you need to aggregate counts, sort vessels, or compare multiple states before answering.
+4. Summarize the queue counts, daemon health block, running or waiting bottlenecks, and any anomalous failed or timed-out vessels.
+5. If the output points to one problematic vessel, suggest following up with `/xylem-debug`, `/xylem-logs`, `/xylem-retry`, or `/xylem-cancel` as appropriate.

--- a/.claude/skills/xylem-workflow/SKILL.md
+++ b/.claude/skills/xylem-workflow/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: xylem-workflow
+description: Create or update xylem workflow YAML and prompt templates from a natural-language task description. Use when the user asks for a new workflow, phase plan, prompt set, gate sequence, or wants to adapt an existing workflow.
+argument-hint: "[workflow-goal]"
+disable-model-invocation: true
+---
+
+Work from the repository root and treat the workflow plus prompts as one unit.
+
+1. Read `.xylem/HARNESS.md`, the current `.xylem/workflows/` directory, and the corresponding `.xylem/prompts/` directories before changing anything.
+2. Reuse the nearest existing workflow shape instead of inventing a brand-new schema unless the task truly needs one.
+3. Keep workflow YAML in `.xylem/workflows/<name>.yaml` and prompt templates in `.xylem/prompts/<name>/`.
+4. Make sure every prompt or gate referenced by the workflow actually exists, and remove or rename stale prompt files when consolidating workflows.
+5. Summarize the operator-facing behavior: triggers, phases, gates, and the likely follow-up command (`xylem scan`, `xylem drain`, or manual enqueue).

--- a/cli/internal/skills/skills.go
+++ b/cli/internal/skills/skills.go
@@ -1,0 +1,215 @@
+package skills
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	DirName      = ".claude/skills"
+	EntryFile    = "SKILL.md"
+	maxNameChars = 64
+)
+
+var skillNamePattern = regexp.MustCompile(`^[a-z0-9-]{1,64}$`)
+
+// Definition is a project-local Claude Code skill definition.
+type Definition struct {
+	Directory              string
+	File                   string
+	Name                   string
+	Description            string
+	ArgumentHint           string
+	DisableModelInvocation bool
+	UserInvocable          *bool
+	AllowedTools           []string
+	Body                   string
+}
+
+type frontmatter struct {
+	Name                   string     `yaml:"name,omitempty"`
+	Description            string     `yaml:"description,omitempty"`
+	ArgumentHint           string     `yaml:"argument-hint,omitempty"`
+	DisableModelInvocation bool       `yaml:"disable-model-invocation,omitempty"`
+	UserInvocable          *bool      `yaml:"user-invocable,omitempty"`
+	AllowedTools           stringList `yaml:"allowed-tools,omitempty"`
+}
+
+type stringList []string
+
+func (l *stringList) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case 0:
+		return nil
+	case yaml.ScalarNode:
+		var raw string
+		if err := node.Decode(&raw); err != nil {
+			return err
+		}
+		*l = splitTools(raw)
+		return nil
+	case yaml.SequenceNode:
+		var values []string
+		if err := node.Decode(&values); err != nil {
+			return err
+		}
+		*l = normalizeTools(values)
+		return nil
+	default:
+		return fmt.Errorf("allowed-tools must be a string or list, got YAML kind %d", node.Kind)
+	}
+}
+
+// Discover loads and validates all project skills rooted at repoRoot.
+func Discover(repoRoot string) ([]Definition, error) {
+	skillsDir := filepath.Join(repoRoot, filepath.FromSlash(DirName))
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return nil, fmt.Errorf("discover skills: read %q: %w", skillsDir, err)
+	}
+
+	definitions := make([]Definition, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillPath := filepath.Join(skillsDir, entry.Name(), EntryFile)
+		data, err := os.ReadFile(skillPath)
+		if err != nil {
+			return nil, fmt.Errorf("discover skills: read %q: %w", skillPath, err)
+		}
+		def, err := Parse(skillPath, data)
+		if err != nil {
+			return nil, err
+		}
+		definitions = append(definitions, *def)
+	}
+
+	sort.Slice(definitions, func(i, j int) bool {
+		return definitions[i].Name < definitions[j].Name
+	})
+	return definitions, nil
+}
+
+// Parse decodes a SKILL.md file and validates the resulting definition.
+func Parse(path string, data []byte) (*Definition, error) {
+	content := strings.ReplaceAll(string(data), "\r\n", "\n")
+	fmText, body, hasFrontmatter, err := splitFrontmatter(content)
+	if err != nil {
+		return nil, fmt.Errorf("parse skill %q: %w", path, err)
+	}
+
+	var meta frontmatter
+	if hasFrontmatter {
+		if err := yaml.Unmarshal([]byte(fmText), &meta); err != nil {
+			return nil, fmt.Errorf("parse skill %q: decode frontmatter: %w", path, err)
+		}
+	}
+
+	dirName := filepath.Base(filepath.Dir(path))
+	name := strings.TrimSpace(meta.Name)
+	if name == "" {
+		name = dirName
+	}
+	def := &Definition{
+		Directory:              dirName,
+		File:                   path,
+		Name:                   name,
+		Description:            strings.TrimSpace(meta.Description),
+		ArgumentHint:           strings.TrimSpace(meta.ArgumentHint),
+		DisableModelInvocation: meta.DisableModelInvocation,
+		UserInvocable:          meta.UserInvocable,
+		AllowedTools:           normalizeTools(meta.AllowedTools),
+		Body:                   strings.TrimSpace(body),
+	}
+	if err := Validate(*def); err != nil {
+		return nil, fmt.Errorf("parse skill %q: %w", path, err)
+	}
+	return def, nil
+}
+
+// Render serializes a definition into a SKILL.md payload.
+func Render(def Definition) (string, error) {
+	if err := Validate(def); err != nil {
+		return "", err
+	}
+
+	meta := frontmatter{
+		Name:                   def.Name,
+		Description:            def.Description,
+		ArgumentHint:           def.ArgumentHint,
+		DisableModelInvocation: def.DisableModelInvocation,
+		UserInvocable:          def.UserInvocable,
+		AllowedTools:           normalizeTools(def.AllowedTools),
+	}
+	yamlBytes, err := yaml.Marshal(meta)
+	if err != nil {
+		return "", fmt.Errorf("render skill %q: marshal frontmatter: %w", def.Name, err)
+	}
+
+	return fmt.Sprintf("---\n%s---\n\n%s\n", string(yamlBytes), strings.TrimSpace(def.Body)), nil
+}
+
+// Validate enforces the project contract for checked-in skill definitions.
+func Validate(def Definition) error {
+	if !skillNamePattern.MatchString(def.Name) {
+		return fmt.Errorf("invalid skill name %q (expected lowercase letters, numbers, and hyphens; max %d chars)", def.Name, maxNameChars)
+	}
+	if def.Directory != "" && def.Directory != def.Name {
+		return fmt.Errorf("skill directory %q must match name %q", def.Directory, def.Name)
+	}
+	if strings.TrimSpace(def.Description) == "" {
+		return fmt.Errorf("missing description")
+	}
+	if !strings.Contains(def.Description, "Use when") {
+		return fmt.Errorf(`description must include "Use when"`)
+	}
+	if strings.TrimSpace(def.Body) == "" {
+		return fmt.Errorf("missing body")
+	}
+	return nil
+}
+
+func splitFrontmatter(content string) (frontmatterText, body string, hasFrontmatter bool, err error) {
+	if !strings.HasPrefix(content, "---\n") {
+		return "", content, false, nil
+	}
+
+	rest := content[len("---\n"):]
+	end := strings.Index(rest, "\n---\n")
+	if end >= 0 {
+		return rest[:end], rest[end+len("\n---\n"):], true, nil
+	}
+	if strings.HasSuffix(rest, "\n---") {
+		return strings.TrimSuffix(rest, "\n---"), "", true, nil
+	}
+	return "", "", false, fmt.Errorf("frontmatter opening delimiter without closing delimiter")
+}
+
+func splitTools(raw string) []string {
+	return normalizeTools(strings.Fields(raw))
+}
+
+func normalizeTools(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	tools := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		tools = append(tools, trimmed)
+	}
+	if len(tools) == 0 {
+		return nil
+	}
+	return tools
+}

--- a/cli/internal/skills/skills_prop_test.go
+++ b/cli/internal/skills/skills_prop_test.go
@@ -1,0 +1,91 @@
+package skills
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropRenderParseRoundTrip(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		def := Definition{
+			Directory:              rapid.StringMatching(`[a-z0-9-]{1,16}`).Draw(t, "directory"),
+			Description:            rapid.StringMatching(`Use when [a-z ]{5,40}\.`).Draw(t, "description"),
+			ArgumentHint:           rapid.SampledFrom([]string{"", "[vessel-id]", "[state]", "[workflow] [ref]"}).Draw(t, "argumentHint"),
+			DisableModelInvocation: rapid.Bool().Draw(t, "disableModelInvocation"),
+			AllowedTools: rapid.SampledFrom([][]string{
+				nil,
+				{"Read", "Grep"},
+				{"Bash", "Read"},
+			}).Draw(t, "allowedTools"),
+			Body: strings.TrimSpace(rapid.StringMatching(`[A-Za-z0-9 .,/<>:\-\n]{10,200}`).Draw(t, "body")),
+		}
+		def.Name = def.Directory
+		if def.Body == "" {
+			def.Body = "fallback body"
+		}
+		if rapid.Bool().Draw(t, "includeUserInvocable") {
+			value := rapid.Bool().Draw(t, "userInvocable")
+			def.UserInvocable = &value
+		}
+
+		rendered, err := Render(def)
+		if err != nil {
+			t.Fatalf("Render() error = %v", err)
+		}
+		parsed, err := Parse(filepath.Join("repo", filepath.FromSlash(DirName), def.Directory, EntryFile), []byte(rendered))
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+
+		if parsed.Directory != def.Directory {
+			t.Fatalf("Directory = %q, want %q", parsed.Directory, def.Directory)
+		}
+		if parsed.Name != def.Name {
+			t.Fatalf("Name = %q, want %q", parsed.Name, def.Name)
+		}
+		if parsed.Description != def.Description {
+			t.Fatalf("Description = %q, want %q", parsed.Description, def.Description)
+		}
+		if parsed.ArgumentHint != def.ArgumentHint {
+			t.Fatalf("ArgumentHint = %q, want %q", parsed.ArgumentHint, def.ArgumentHint)
+		}
+		if parsed.DisableModelInvocation != def.DisableModelInvocation {
+			t.Fatalf("DisableModelInvocation = %t, want %t", parsed.DisableModelInvocation, def.DisableModelInvocation)
+		}
+		if !equalBoolPtr(parsed.UserInvocable, def.UserInvocable) {
+			t.Fatalf("UserInvocable = %v, want %v", parsed.UserInvocable, def.UserInvocable)
+		}
+		if !equalStrings(parsed.AllowedTools, def.AllowedTools) {
+			t.Fatalf("AllowedTools = %v, want %v", parsed.AllowedTools, def.AllowedTools)
+		}
+		if parsed.Body != def.Body {
+			t.Fatalf("Body = %q, want %q", parsed.Body, def.Body)
+		}
+	})
+}
+
+func equalBoolPtr(left, right *bool) bool {
+	switch {
+	case left == nil && right == nil:
+		return true
+	case left == nil || right == nil:
+		return false
+	default:
+		return *left == *right
+	}
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cli/internal/skills/skills_test.go
+++ b/cli/internal/skills/skills_test.go
@@ -1,0 +1,169 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSmoke_S1_DiscoverProjectSkillsReturnsExpectedSuite(t *testing.T) {
+	t.Parallel()
+
+	definitions, err := Discover(projectRoot(t))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"xylem-cancel",
+		"xylem-config",
+		"xylem-dashboard",
+		"xylem-debug",
+		"xylem-doctor",
+		"xylem-drain",
+		"xylem-enqueue",
+		"xylem-init",
+		"xylem-logs",
+		"xylem-prompts",
+		"xylem-retry",
+		"xylem-status",
+		"xylem-workflow",
+	}, definitionNames(definitions))
+}
+
+func TestSmoke_S2_ProjectSkillsMapToRealXylemSurfaces(t *testing.T) {
+	t.Parallel()
+
+	definitions, err := Discover(projectRoot(t))
+	require.NoError(t, err)
+
+	byName := make(map[string]Definition, len(definitions))
+	for _, def := range definitions {
+		byName[def.Name] = def
+		assert.Contains(t, def.Description, "Use when")
+	}
+
+	expectedSnippets := map[string][]string{
+		"xylem-status":    {"xylem status", "--json"},
+		"xylem-debug":     {"xylem status --json", ".xylem/phases"},
+		"xylem-config":    {".xylem.yml", "xylem scan --dry-run"},
+		"xylem-workflow":  {".xylem/workflows", ".xylem/prompts"},
+		"xylem-prompts":   {".xylem/prompts", "workflow YAML"},
+		"xylem-init":      {"xylem init", ".xylem/HARNESS.md"},
+		"xylem-enqueue":   {"xylem enqueue", "--workflow"},
+		"xylem-drain":     {"xylem drain", "xylem status"},
+		"xylem-retry":     {"xylem retry", ".xylem/phases/<vessel-id>/summary.json"},
+		"xylem-cancel":    {"xylem cancel", "pending or running vessel"},
+		"xylem-logs":      {".xylem/phases/<vessel-id>", "summary.json"},
+		"xylem-dashboard": {"xylem status --json", "summary.json"},
+		"xylem-doctor":    {"xylem status", "xylem visualize"},
+	}
+
+	for name, snippets := range expectedSnippets {
+		def, ok := byName[name]
+		require.Truef(t, ok, "missing skill %q", name)
+		for _, snippet := range snippets {
+			assert.Containsf(t, def.Body, snippet, "skill %s should reference %q", name, snippet)
+		}
+	}
+}
+
+func TestSmoke_S3_ProjectSkillsStayManualAndArgumented(t *testing.T) {
+	t.Parallel()
+
+	definitions, err := Discover(projectRoot(t))
+	require.NoError(t, err)
+
+	withArguments := map[string]bool{
+		"xylem-cancel":    true,
+		"xylem-config":    true,
+		"xylem-dashboard": true,
+		"xylem-debug":     true,
+		"xylem-doctor":    true,
+		"xylem-enqueue":   true,
+		"xylem-logs":      true,
+		"xylem-prompts":   true,
+		"xylem-retry":     true,
+		"xylem-status":    true,
+		"xylem-workflow":  true,
+	}
+
+	for _, def := range definitions {
+		assert.Truef(t, def.DisableModelInvocation, "skill %s should remain slash-command driven", def.Name)
+		assert.Equalf(t, def.Directory, def.Name, "skill %s should keep its slash-command name aligned with its directory", def.Name)
+		if withArguments[def.Name] {
+			assert.NotEmptyf(t, def.ArgumentHint, "skill %s should advertise its arguments", def.Name)
+		}
+	}
+}
+
+func TestParseRejectsInvalidName(t *testing.T) {
+	t.Parallel()
+
+	_, err := Parse(filepath.Join("repo", filepath.FromSlash(DirName), "Bad_Name", EntryFile), []byte(`---
+name: Bad_Name
+description: bad
+---
+
+body
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid skill name")
+}
+
+func TestParseRejectsMismatchedDirectoryAndName(t *testing.T) {
+	t.Parallel()
+
+	_, err := Parse(filepath.Join("repo", filepath.FromSlash(DirName), "xylem-status", EntryFile), []byte(`---
+name: xylem-dashboard
+description: Use when checking status.
+---
+
+body
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must match name")
+}
+
+func TestParseRejectsDescriptionWithoutUseWhen(t *testing.T) {
+	t.Parallel()
+
+	_, err := Parse(filepath.Join("repo", filepath.FromSlash(DirName), "xylem-status", EntryFile), []byte(`---
+name: xylem-status
+description: Status skill.
+---
+
+body
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `description must include "Use when"`)
+}
+
+func TestDiscoverReturnsMissingSkillFileError(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, filepath.FromSlash(DirName), "xylem-status"), 0o755))
+
+	_, err := Discover(root)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), EntryFile)
+}
+
+func projectRoot(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+}
+
+func definitionNames(definitions []Definition) []string {
+	names := make([]string, 0, len(definitions))
+	for _, def := range definitions {
+		names = append(names, def.Name)
+	}
+	return names
+}


### PR DESCRIPTION
## Summary
+- Implements https://github.com/nicholls-inc/xylem/issues/277.
+- Adds a checked-in Claude Code skills suite for common xylem operator tasks across setup, queue management, workflow authoring, status/debugging, and artifact inspection.
+- Adds a Go parser/discovery package so the skill tree has a validated in-repo contract instead of an unstructured documentation drop.
+
+## Smoke scenarios covered
+- **S1 — Discover project skills returns expected suite**: verifies the repository exposes the full 13-skill xylem suite.
+- **S2 — Project skills map to real xylem surfaces**: verifies each skill body references the intended queue/config/workflow/artifact surface.
+- **S3 — Project skills stay manual and argumented**: verifies slash-command behavior stays manual, directory names stay aligned, and argument hints remain present where required.
+
+## Changes summary
+- **Added** `.claude/skills/xylem-{cancel,config,dashboard,debug,doctor,drain,enqueue,init,logs,prompts,retry,status,workflow}/SKILL.md` to cover the core operator flows for xylem management.
+- **Added** `cli/internal/skills/skills.go` with the `Definition` type and the `Discover`, `Parse`, `Render`, and `Validate` functions for loading and enforcing the project-local skill contract.
+- **Added** `cli/internal/skills/skills_test.go` with smoke-style coverage for suite discovery, surface mapping, and manual invocation constraints.
+- **Added** `cli/internal/skills/skills_prop_test.go` with round-trip property coverage for rendering and parsing skill definitions.
+
+## Test plan
+- `cd cli && goimports -l .`
+- `cd cli && go vet ./...`
+- `cd cli && golangci-lint run`
+- `cd cli && go build ./cmd/xylem`
+- `cd cli && go test ./...`
+

Fixes #277