### PR TITLE
feat: add scheduled vessel workflow health reporting

### DIFF
--- a/cli/cmd/xylem/builtin_audit.go
+++ b/cli/cmd/xylem/builtin_audit.go
@@ -73,7 +73,7 @@ func runBuiltInScheduledVessels(ctx context.Context, cfg *config.Config, q *queu
 
 func isBuiltInScheduledWorkflow(workflow string) bool {
 	switch workflow {
-	case reviewpkg.ContextWeightAuditWorkflow, reviewpkg.HarnessGapAnalysisWorkflow:
+	case reviewpkg.ContextWeightAuditWorkflow, reviewpkg.HarnessGapAnalysisWorkflow, reviewpkg.WorkflowHealthReportWorkflow:
 		return true
 	default:
 		return false
@@ -95,6 +95,14 @@ func runBuiltInScheduledWorkflow(ctx context.Context, cfg *config.Config, workfl
 		_, err := reviewpkg.RunHarnessGapAnalysis(ctx, cfg.StateDir, repo, cmdRunner, reviewpkg.HarnessGapOptions{
 			OutputDir: cfg.HarnessReviewOutputDir(),
 			Now:       now,
+		})
+		return err
+	case reviewpkg.WorkflowHealthReportWorkflow:
+		_, err := reviewpkg.RunWorkflowHealthReport(ctx, cfg.StateDir, repo, cmdRunner, reviewpkg.WorkflowHealthOptions{
+			LookbackRuns:        cfg.HarnessReviewLookbackRuns(),
+			OutputDir:           cfg.HarnessReviewOutputDir(),
+			Now:                 now,
+			EscalationThreshold: 2,
 		})
 		return err
 	default:
@@ -155,6 +163,8 @@ func builtInScheduledWorkflowSummaryNote(workflow string) string {
 	switch workflow {
 	case reviewpkg.HarnessGapAnalysisWorkflow:
 		return "Built-in harness-gap analysis uses persisted daemon/GitHub/git telemetry and may open de-duplicated GitHub issues."
+	case reviewpkg.WorkflowHealthReportWorkflow:
+		return "Built-in workflow-health reporting summarizes recent vessel health and may open weekly de-duplicated GitHub issues."
 	default:
 		return "Built-in context-weight audit uses persisted summary artifacts and may open de-duplicated GitHub issues."
 	}

--- a/cli/cmd/xylem/builtin_audit_test.go
+++ b/cli/cmd/xylem/builtin_audit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -11,38 +12,163 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	reviewpkg "github.com/nicholls-inc/xylem/cli/internal/review"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type auditTestRunner struct {
-	calls [][]string
+	calls       [][]string
+	createCount int
 }
 
 func (r *auditTestRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
-	r.calls = append(r.calls, append([]string{name}, args...))
+	call := append([]string{name}, args...)
+	r.calls = append(r.calls, call)
+	if name == "git" && len(args) == 4 && args[0] == "rev-list" && args[1] == "--left-right" && args[2] == "--count" {
+		return []byte("0\t0\n"), nil
+	}
+	if name == "gh" && len(args) >= 2 && args[0] == "issue" && args[1] == "create" {
+		r.createCount++
+		return []byte("https://github.com/owner/repo/issues/9" + strconv.Itoa(r.createCount)), nil
+	}
 	return []byte("[]"), nil
 }
 
-type harnessGapAuditTestRunner struct {
-	calls [][]string
+func (r *auditTestRunner) hasCallPrefix(want []string) bool {
+	for _, call := range r.calls {
+		if len(call) < len(want) {
+			continue
+		}
+		match := true
+		for i := range want {
+			if call[i] != want[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
 }
 
-func (r *harnessGapAuditTestRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
-	call := append([]string{name}, args...)
-	r.calls = append(r.calls, call)
-	switch strings.Join(call, "\x00") {
-	case strings.Join([]string{"gh", "--repo", "owner/repo", "pr", "list", "--state", "merged", "--limit", "100", "--json", "number,title,url,headRefName,mergedAt,mergedBy,labels"}, "\x00"),
-		strings.Join([]string{"gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--label", "needs-conflict-resolution", "--limit", "100", "--json", "number,title,url,mergeable,headRefName"}, "\x00"),
-		strings.Join([]string{"gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt"}, "\x00"),
-		strings.Join([]string{"gh", "--repo", "owner/repo", "issue", "list", "--state", "open", "--label", "xylem-failed", "--limit", "100", "--json", "number,title,url,labels"}, "\x00"):
-		return []byte("[]"), nil
-	case strings.Join([]string{"git", "rev-list", "--left-right", "--count", "origin/main...HEAD"}, "\x00"):
-		return []byte("0\t0\n"), nil
-	default:
-		return []byte("[]"), nil
+func TestRunBuiltInScheduledVesselsCompletesBuiltInAudits(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		sourceName       string
+		schedule         string
+		taskName         string
+		vesselID         string
+		workflow         string
+		reportFile       string
+		wantCreateCount  int
+		wantCreatePrefix []string
+	}{
+		{
+			name:            "context-weight-audit",
+			sourceName:      "scheduled-audit",
+			schedule:        "24h",
+			taskName:        "context",
+			vesselID:        "scheduled-audit-1",
+			workflow:        reviewpkg.ContextWeightAuditWorkflow,
+			reportFile:      "context-weight-audit.json",
+			wantCreateCount: 0,
+		},
+		{
+			name:            "harness-gap-analysis",
+			sourceName:      "harness-gap",
+			schedule:        "4h",
+			taskName:        "analyze-gaps",
+			vesselID:        "scheduled-gap-1",
+			workflow:        reviewpkg.HarnessGapAnalysisWorkflow,
+			reportFile:      "harness-gap-analysis.json",
+			wantCreateCount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			cfg := &config.Config{
+				StateDir: dir,
+				Claude: config.ClaudeConfig{
+					Command:      "claude",
+					DefaultModel: "claude-sonnet-4-6",
+				},
+				Sources: map[string]config.SourceConfig{
+					tc.sourceName: {
+						Type:     "scheduled",
+						Repo:     "owner/repo",
+						Schedule: tc.schedule,
+						Tasks: map[string]config.Task{
+							tc.taskName: {Workflow: tc.workflow},
+						},
+					},
+				},
+			}
+
+			q := queue.New(filepath.Join(dir, "queue.jsonl"))
+			_, err := q.Enqueue(queue.Vessel{
+				ID:        tc.vesselID,
+				Source:    "scheduled",
+				Ref:       "scheduled://" + tc.sourceName + "/" + tc.taskName + "@1",
+				Workflow:  tc.workflow,
+				State:     queue.StatePending,
+				CreatedAt: time.Now().UTC(),
+				Meta: map[string]string{
+					"config_source":         tc.sourceName,
+					"scheduled_task_name":   tc.taskName,
+					"scheduled_bucket":      "1",
+					"scheduled_config_name": tc.sourceName,
+				},
+			})
+			if err != nil {
+				t.Fatalf("Enqueue() error = %v", err)
+			}
+
+			cmdRunner := &auditTestRunner{}
+			result, err := runBuiltInScheduledVessels(context.Background(), cfg, q, cmdRunner)
+			if err != nil {
+				t.Fatalf("runBuiltInScheduledVessels() error = %v", err)
+			}
+			if result.Completed != 1 {
+				t.Fatalf("Completed = %d, want 1", result.Completed)
+			}
+			if result.Failed != 0 {
+				t.Fatalf("Failed = %d, want 0", result.Failed)
+			}
+			if cmdRunner.createCount != tc.wantCreateCount {
+				t.Fatalf("createCount = %d, want %d", cmdRunner.createCount, tc.wantCreateCount)
+			}
+			if len(tc.wantCreatePrefix) > 0 && !cmdRunner.hasCallPrefix(tc.wantCreatePrefix) {
+				t.Fatalf("missing issue creation call with prefix %q", strings.Join(tc.wantCreatePrefix, " "))
+			}
+
+			vessel, err := q.FindByID(tc.vesselID)
+			if err != nil {
+				t.Fatalf("FindByID() error = %v", err)
+			}
+			if vessel.State != queue.StateCompleted {
+				t.Fatalf("vessel.State = %s, want %s", vessel.State, queue.StateCompleted)
+			}
+
+			if _, err := os.Stat(filepath.Join(dir, "reviews", tc.reportFile)); err != nil {
+				t.Fatalf("%s missing: %v", tc.reportFile, err)
+			}
+			if _, err := os.Stat(filepath.Join(dir, "phases", tc.vesselID, "summary.json")); err != nil {
+				t.Fatalf("summary.json missing: %v", err)
+			}
+		})
 	}
 }
 
-func TestRunBuiltInScheduledVesselsCompletesContextWeightAudit(t *testing.T) {
+func TestSmoke_S4_ScheduledWorkflowHealthVesselPublishesWeeklyReport(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{
 		StateDir: dir,
@@ -51,125 +177,51 @@ func TestRunBuiltInScheduledVesselsCompletesContextWeightAudit(t *testing.T) {
 			DefaultModel: "claude-sonnet-4-6",
 		},
 		Sources: map[string]config.SourceConfig{
-			"scheduled-audit": {
+			"workflow-health": {
 				Type:     "scheduled",
 				Repo:     "owner/repo",
-				Schedule: "24h",
+				Schedule: "@weekly",
 				Tasks: map[string]config.Task{
-					"context": {Workflow: reviewpkg.ContextWeightAuditWorkflow},
+					"report": {Workflow: reviewpkg.WorkflowHealthReportWorkflow},
 				},
 			},
 		},
 	}
+
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
 	_, err := q.Enqueue(queue.Vessel{
-		ID:        "scheduled-audit-1",
+		ID:        "scheduled-health-1",
 		Source:    "scheduled",
-		Ref:       "scheduled://scheduled-audit/context@1",
-		Workflow:  reviewpkg.ContextWeightAuditWorkflow,
+		Ref:       "scheduled://workflow-health/report@1",
+		Workflow:  reviewpkg.WorkflowHealthReportWorkflow,
 		State:     queue.StatePending,
 		CreatedAt: time.Now().UTC(),
 		Meta: map[string]string{
-			"config_source":         "scheduled-audit",
-			"scheduled_task_name":   "context",
+			"config_source":         "workflow-health",
+			"scheduled_task_name":   "report",
 			"scheduled_bucket":      "1",
-			"scheduled_config_name": "scheduled-audit",
+			"scheduled_config_name": "workflow-health",
 		},
 	})
-	if err != nil {
-		t.Fatalf("Enqueue() error = %v", err)
-	}
+	require.NoError(t, err)
 
 	cmdRunner := &auditTestRunner{}
 	result, err := runBuiltInScheduledVessels(context.Background(), cfg, q, cmdRunner)
-	if err != nil {
-		t.Fatalf("runBuiltInScheduledVessels() error = %v", err)
-	}
-	if result.Completed != 1 {
-		t.Fatalf("Completed = %d, want 1", result.Completed)
-	}
-	if result.Failed != 0 {
-		t.Fatalf("Failed = %d, want 0", result.Failed)
-	}
+	require.NoError(t, err)
 
-	vessel, err := q.FindByID("scheduled-audit-1")
-	if err != nil {
-		t.Fatalf("FindByID() error = %v", err)
-	}
-	if vessel.State != queue.StateCompleted {
-		t.Fatalf("vessel.State = %s, want %s", vessel.State, queue.StateCompleted)
-	}
+	require.Equal(t, 1, result.Completed)
+	assert.Zero(t, result.Failed)
+	assert.Equal(t, 1, cmdRunner.createCount)
+	assert.True(t, cmdRunner.hasCallPrefix([]string{
+		"gh", "issue", "create", "--repo", "owner/repo", "--title", "[xylem] weekly workflow health",
+	}))
 
-	if _, err := os.Stat(filepath.Join(dir, "reviews", "context-weight-audit.json")); err != nil {
-		t.Fatalf("context-weight-audit.json missing: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(dir, "phases", "scheduled-audit-1", "summary.json")); err != nil {
-		t.Fatalf("summary.json missing: %v", err)
-	}
-}
+	vessel, err := q.FindByID("scheduled-health-1")
+	require.NoError(t, err)
+	require.Equal(t, queue.StateCompleted, vessel.State)
 
-func TestRunBuiltInScheduledVesselsCompletesHarnessGapAnalysis(t *testing.T) {
-	dir := t.TempDir()
-	cfg := &config.Config{
-		StateDir: dir,
-		Claude: config.ClaudeConfig{
-			Command:      "claude",
-			DefaultModel: "claude-sonnet-4-6",
-		},
-		Sources: map[string]config.SourceConfig{
-			"harness-gap": {
-				Type:     "scheduled",
-				Repo:     "owner/repo",
-				Schedule: "4h",
-				Tasks: map[string]config.Task{
-					"analyze-gaps": {Workflow: reviewpkg.HarnessGapAnalysisWorkflow},
-				},
-			},
-		},
-	}
-	q := queue.New(filepath.Join(dir, "queue.jsonl"))
-	_, err := q.Enqueue(queue.Vessel{
-		ID:        "scheduled-gap-1",
-		Source:    "scheduled",
-		Ref:       "scheduled://harness-gap/analyze-gaps@1",
-		Workflow:  reviewpkg.HarnessGapAnalysisWorkflow,
-		State:     queue.StatePending,
-		CreatedAt: time.Now().UTC(),
-		Meta: map[string]string{
-			"config_source":         "harness-gap",
-			"scheduled_task_name":   "analyze-gaps",
-			"scheduled_bucket":      "1",
-			"scheduled_config_name": "harness-gap",
-		},
-	})
-	if err != nil {
-		t.Fatalf("Enqueue() error = %v", err)
-	}
-
-	cmdRunner := &harnessGapAuditTestRunner{}
-	result, err := runBuiltInScheduledVessels(context.Background(), cfg, q, cmdRunner)
-	if err != nil {
-		t.Fatalf("runBuiltInScheduledVessels() error = %v", err)
-	}
-	if result.Completed != 1 {
-		t.Fatalf("Completed = %d, want 1", result.Completed)
-	}
-	if result.Failed != 0 {
-		t.Fatalf("Failed = %d, want 0", result.Failed)
-	}
-
-	vessel, err := q.FindByID("scheduled-gap-1")
-	if err != nil {
-		t.Fatalf("FindByID() error = %v", err)
-	}
-	if vessel.State != queue.StateCompleted {
-		t.Fatalf("vessel.State = %s, want %s", vessel.State, queue.StateCompleted)
-	}
-
-	if _, err := os.Stat(filepath.Join(dir, "reviews", "harness-gap-analysis.json")); err != nil {
-		t.Fatalf("harness-gap-analysis.json missing: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(dir, "phases", "scheduled-gap-1", "summary.json")); err != nil {
-		t.Fatalf("summary.json missing: %v", err)
-	}
+	_, err = os.Stat(filepath.Join(dir, "reviews", "workflow-health-report.json"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dir, "phases", "scheduled-health-1", "summary.json"))
+	require.NoError(t, err)
 }

--- a/cli/internal/review/workflow_health.go
+++ b/cli/internal/review/workflow_health.go
@@ -1,0 +1,1008 @@
+package review
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+)
+
+const (
+	WorkflowHealthReportWorkflow            = "workflow-health-report"
+	workflowHealthReportJSONName            = "workflow-health-report.json"
+	workflowHealthReportMarkdownName        = "workflow-health-report.md"
+	workflowHealthIssueStateName            = "workflow-health-report-issues.json"
+	workflowHealthReportTitle               = "[xylem] weekly workflow health"
+	workflowHealthEscalationTitle           = "[xylem] workflow health escalation"
+	workflowHealthReportMarkerPrefix        = "<!-- xylem:workflow-health-report-week="
+	workflowHealthEscalationMarkerPrefix    = "<!-- xylem:workflow-health-escalation-week="
+	defaultWorkflowHealthWindow             = 7 * 24 * time.Hour
+	defaultWorkflowHealthEscalationMinimum  = 2
+	maxWorkflowHealthEvidencePerFinding     = 5
+	maxWorkflowHealthRenderedCounts         = 5
+	maxWorkflowHealthRenderedWorkflowIssues = 5
+)
+
+type WorkflowHealthOptions struct {
+	LookbackRuns        int
+	Window              time.Duration
+	OutputDir           string
+	Now                 time.Time
+	EscalationThreshold int
+}
+
+type WorkflowHealthResult struct {
+	Report       *WorkflowHealthReport
+	JSONPath     string
+	MarkdownPath string
+	Markdown     string
+	Published    []WorkflowHealthPublication
+}
+
+type WorkflowHealthReport struct {
+	GeneratedAt         time.Time                `json:"generated_at"`
+	WindowStart         time.Time                `json:"window_start"`
+	WindowEnd           time.Time                `json:"window_end"`
+	LookbackRuns        int                      `json:"lookback_runs"`
+	EscalationThreshold int                      `json:"escalation_threshold"`
+	TotalRunsObserved   int                      `json:"total_runs_observed"`
+	ReviewedRuns        int                      `json:"reviewed_runs"`
+	CurrentVessels      int                      `json:"current_vessels"`
+	Fleet               runner.FleetStatusReport `json:"fleet"`
+	AnomalyCounts       []WorkflowHealthCount    `json:"anomaly_counts,omitempty"`
+	RetryOutcomes       []WorkflowHealthCount    `json:"retry_outcomes,omitempty"`
+	Workflows           []WorkflowHealthWorkflow `json:"workflows,omitempty"`
+	EscalationFindings  []WorkflowHealthFinding  `json:"escalation_findings,omitempty"`
+	Warnings            []string                 `json:"warnings,omitempty"`
+}
+
+type WorkflowHealthCount struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+type WorkflowHealthWorkflow struct {
+	Workflow                  string                `json:"workflow"`
+	Source                    string                `json:"source,omitempty"`
+	Runs                      int                   `json:"runs"`
+	Completed                 int                   `json:"completed"`
+	Failed                    int                   `json:"failed"`
+	TimedOut                  int                   `json:"timed_out"`
+	Cancelled                 int                   `json:"cancelled"`
+	HealthyRuns               int                   `json:"healthy_runs"`
+	DegradedRuns              int                   `json:"degraded_runs"`
+	UnhealthyRuns             int                   `json:"unhealthy_runs"`
+	AverageDurationMS         int64                 `json:"average_duration_ms"`
+	AveragePhaseCount         float64               `json:"average_phase_count"`
+	AverageCostUSDEst         float64               `json:"average_cost_usd_est"`
+	PreviousAverageCostUSDEst float64               `json:"previous_average_cost_usd_est,omitempty"`
+	CostDeltaUSDEst           float64               `json:"cost_delta_usd_est,omitempty"`
+	TopAnomalies              []WorkflowHealthCount `json:"top_anomalies,omitempty"`
+}
+
+type WorkflowHealthFinding struct {
+	Fingerprint     string   `json:"fingerprint"`
+	Workflow        string   `json:"workflow"`
+	Source          string   `json:"source,omitempty"`
+	Pattern         string   `json:"pattern"`
+	Count           int      `json:"count"`
+	VesselIDs       []string `json:"vessel_ids,omitempty"`
+	Evidence        []string `json:"evidence,omitempty"`
+	Recommendations []string `json:"recommendations,omitempty"`
+}
+
+type WorkflowHealthPublication struct {
+	Kind        string `json:"kind"`
+	Week        string `json:"week"`
+	IssueNumber int    `json:"issue_number"`
+	Title       string `json:"title"`
+	Created     bool   `json:"created"`
+}
+
+type workflowHealthIssueState struct {
+	Weeks map[string]workflowHealthWeekIssueState `json:"weeks,omitempty"`
+}
+
+type workflowHealthWeekIssueState struct {
+	ReportIssueNumber     int       `json:"report_issue_number,omitempty"`
+	ReportTitle           string    `json:"report_title,omitempty"`
+	EscalationIssueNumber int       `json:"escalation_issue_number,omitempty"`
+	EscalationTitle       string    `json:"escalation_title,omitempty"`
+	FirstReportedAt       time.Time `json:"first_reported_at,omitempty"`
+	LastObservedAt        time.Time `json:"last_observed_at,omitempty"`
+}
+
+type workflowHealthIssueSet struct {
+	Report     contextWeightIssue
+	Escalation contextWeightIssue
+}
+
+type workflowHealthWorkflowAccumulator struct {
+	source          string
+	workflow        string
+	runs            int
+	completed       int
+	failed          int
+	timedOut        int
+	cancelled       int
+	healthy         int
+	degraded        int
+	unhealthy       int
+	totalDurationMS int64
+	totalPhaseCount int
+	totalCostUSDEst float64
+	anomalyCounts   map[string]int
+}
+
+type workflowHealthTrendAccumulator struct {
+	runs            int
+	totalCostUSDEst float64
+}
+
+type workflowHealthFindingAccumulator struct {
+	source       string
+	workflow     string
+	pattern      string
+	vesselIDs    []string
+	evidence     []string
+	recommenders map[string]struct{}
+}
+
+func GenerateWorkflowHealthReport(stateDir string, opts WorkflowHealthOptions) (*WorkflowHealthResult, error) {
+	if opts.LookbackRuns <= 0 {
+		opts.LookbackRuns = defaultLookbackRuns
+	}
+	if opts.Window <= 0 {
+		opts.Window = defaultWorkflowHealthWindow
+	}
+	if strings.TrimSpace(opts.OutputDir) == "" {
+		opts.OutputDir = defaultOutputDir
+	}
+	if opts.Now.IsZero() {
+		opts.Now = time.Now().UTC()
+	} else {
+		opts.Now = opts.Now.UTC()
+	}
+	if opts.EscalationThreshold <= 0 {
+		opts.EscalationThreshold = defaultWorkflowHealthEscalationMinimum
+	}
+
+	windowStart := opts.Now.Add(-opts.Window)
+	allRuns, totalRuns, warnings, err := LoadRuns(stateDir, opts.LookbackRuns)
+	if err != nil {
+		return nil, fmt.Errorf("generate workflow-health report: %w", err)
+	}
+
+	currentVessels, fleet, err := loadWorkflowHealthFleet(stateDir)
+	if err != nil {
+		return nil, fmt.Errorf("generate workflow-health report: %w", err)
+	}
+
+	recentRuns, previousRuns := splitWorkflowHealthRuns(allRuns, windowStart, opts.Now, opts.Window)
+	anomalyCounts, workflows, escalationFindings := buildWorkflowHealthInsights(recentRuns, previousRuns, opts.EscalationThreshold)
+	retryOutcomes := workflowHealthRetryOutcomes(recentRuns)
+
+	report := &WorkflowHealthReport{
+		GeneratedAt:         opts.Now,
+		WindowStart:         windowStart,
+		WindowEnd:           opts.Now,
+		LookbackRuns:        opts.LookbackRuns,
+		EscalationThreshold: opts.EscalationThreshold,
+		TotalRunsObserved:   totalRuns,
+		ReviewedRuns:        len(recentRuns),
+		CurrentVessels:      currentVessels,
+		Fleet:               fleet,
+		AnomalyCounts:       anomalyCounts,
+		RetryOutcomes:       retryOutcomes,
+		Workflows:           workflows,
+		EscalationFindings:  escalationFindings,
+		Warnings:            append([]string(nil), warnings...),
+	}
+
+	outputDir := filepath.Join(stateDir, opts.OutputDir)
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return nil, fmt.Errorf("generate workflow-health report: create output dir: %w", err)
+	}
+
+	jsonPath := filepath.Join(outputDir, workflowHealthReportJSONName)
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("generate workflow-health report: marshal report: %w", err)
+	}
+	if err := os.WriteFile(jsonPath, data, 0o644); err != nil {
+		return nil, fmt.Errorf("generate workflow-health report: write json report: %w", err)
+	}
+
+	markdown := renderWorkflowHealthMarkdown(report)
+	markdownPath := filepath.Join(outputDir, workflowHealthReportMarkdownName)
+	if err := os.WriteFile(markdownPath, []byte(markdown), 0o644); err != nil {
+		return nil, fmt.Errorf("generate workflow-health report: write markdown report: %w", err)
+	}
+
+	return &WorkflowHealthResult{
+		Report:       report,
+		JSONPath:     jsonPath,
+		MarkdownPath: markdownPath,
+		Markdown:     markdown,
+	}, nil
+}
+
+func RunWorkflowHealthReport(ctx context.Context, stateDir, repo string, cmdRunner issueRunner, opts WorkflowHealthOptions) (*WorkflowHealthResult, error) {
+	result, err := GenerateWorkflowHealthReport(stateDir, opts)
+	if err != nil {
+		return nil, err
+	}
+	published, err := PublishWorkflowHealthIssues(ctx, stateDir, repo, cmdRunner, result.Report, opts.OutputDir, opts.Now)
+	if err != nil {
+		return nil, err
+	}
+	result.Published = published
+	return result, nil
+}
+
+func PublishWorkflowHealthIssues(ctx context.Context, stateDir, repo string, cmdRunner issueRunner, report *WorkflowHealthReport, outputDir string, now time.Time) ([]WorkflowHealthPublication, error) {
+	if report == nil {
+		return nil, nil
+	}
+	if strings.TrimSpace(outputDir) == "" {
+		outputDir = defaultOutputDir
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+
+	weekKey := workflowHealthWeekKey(report.WindowEnd)
+	statePath := filepath.Join(stateDir, outputDir, workflowHealthIssueStateName)
+	state, err := loadWorkflowHealthIssueState(statePath)
+	if err != nil {
+		return nil, err
+	}
+
+	openIssues := map[string]workflowHealthIssueSet{}
+	if cmdRunner != nil && strings.TrimSpace(repo) != "" {
+		openIssues, err = loadOpenWorkflowHealthIssues(ctx, cmdRunner, repo)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	weekState := state.Weeks[weekKey]
+	if weekState.FirstReportedAt.IsZero() {
+		weekState.FirstReportedAt = now
+	}
+	weekState.LastObservedAt = now
+
+	publications := make([]WorkflowHealthPublication, 0, 2)
+
+	reportIssue, ok := openIssues[weekKey]
+	switch {
+	case weekState.ReportIssueNumber > 0:
+		publications = append(publications, WorkflowHealthPublication{
+			Kind:        "report",
+			Week:        weekKey,
+			IssueNumber: weekState.ReportIssueNumber,
+			Title:       workflowHealthReportTitle,
+			Created:     false,
+		})
+	case ok && reportIssue.Report.Number > 0:
+		weekState.ReportIssueNumber = reportIssue.Report.Number
+		weekState.ReportTitle = reportIssue.Report.Title
+		publications = append(publications, WorkflowHealthPublication{
+			Kind:        "report",
+			Week:        weekKey,
+			IssueNumber: reportIssue.Report.Number,
+			Title:       reportIssue.Report.Title,
+			Created:     false,
+		})
+	case cmdRunner != nil && strings.TrimSpace(repo) != "":
+		body := renderWorkflowHealthIssueBody(report, weekKey)
+		out, err := cmdRunner.RunOutput(ctx, "gh", "issue", "create", "--repo", repo, "--title", workflowHealthReportTitle, "--body", body)
+		if err != nil {
+			return nil, fmt.Errorf("publish workflow-health report issue: %w", err)
+		}
+		issueNumber, err := parseIssueNumberFromCreateOutput(string(out))
+		if err != nil {
+			return nil, fmt.Errorf("publish workflow-health report issue: %w", err)
+		}
+		weekState.ReportIssueNumber = issueNumber
+		weekState.ReportTitle = workflowHealthReportTitle
+		publications = append(publications, WorkflowHealthPublication{
+			Kind:        "report",
+			Week:        weekKey,
+			IssueNumber: issueNumber,
+			Title:       workflowHealthReportTitle,
+			Created:     true,
+		})
+	}
+
+	if len(report.EscalationFindings) > 0 {
+		switch {
+		case weekState.EscalationIssueNumber > 0:
+			publications = append(publications, WorkflowHealthPublication{
+				Kind:        "escalation",
+				Week:        weekKey,
+				IssueNumber: weekState.EscalationIssueNumber,
+				Title:       workflowHealthEscalationTitle,
+				Created:     false,
+			})
+		case ok && reportIssue.Escalation.Number > 0:
+			weekState.EscalationIssueNumber = reportIssue.Escalation.Number
+			weekState.EscalationTitle = reportIssue.Escalation.Title
+			publications = append(publications, WorkflowHealthPublication{
+				Kind:        "escalation",
+				Week:        weekKey,
+				IssueNumber: reportIssue.Escalation.Number,
+				Title:       reportIssue.Escalation.Title,
+				Created:     false,
+			})
+		case cmdRunner != nil && strings.TrimSpace(repo) != "":
+			body := renderWorkflowHealthEscalationIssueBody(report, weekKey)
+			out, err := cmdRunner.RunOutput(ctx, "gh", "issue", "create", "--repo", repo, "--title", workflowHealthEscalationTitle, "--body", body)
+			if err != nil {
+				return nil, fmt.Errorf("publish workflow-health escalation issue: %w", err)
+			}
+			issueNumber, err := parseIssueNumberFromCreateOutput(string(out))
+			if err != nil {
+				return nil, fmt.Errorf("publish workflow-health escalation issue: %w", err)
+			}
+			weekState.EscalationIssueNumber = issueNumber
+			weekState.EscalationTitle = workflowHealthEscalationTitle
+			publications = append(publications, WorkflowHealthPublication{
+				Kind:        "escalation",
+				Week:        weekKey,
+				IssueNumber: issueNumber,
+				Title:       workflowHealthEscalationTitle,
+				Created:     true,
+			})
+		}
+	}
+
+	state.Weeks[weekKey] = weekState
+	if err := saveWorkflowHealthIssueState(statePath, state); err != nil {
+		return nil, err
+	}
+
+	return publications, nil
+}
+
+func loadWorkflowHealthFleet(stateDir string) (int, runner.FleetStatusReport, error) {
+	q := queue.New(filepath.Join(stateDir, "queue.jsonl"))
+	vessels, err := q.List()
+	if err != nil {
+		return 0, runner.FleetStatusReport{}, fmt.Errorf("load queue: %w", err)
+	}
+	ids := make([]string, 0, len(vessels))
+	for _, vessel := range vessels {
+		ids = append(ids, vessel.ID)
+	}
+	summaries, err := runner.LoadVesselSummaries(stateDir, ids)
+	if err != nil {
+		return 0, runner.FleetStatusReport{}, fmt.Errorf("load queue summaries: %w", err)
+	}
+	return len(vessels), runner.AnalyzeFleetStatus(vessels, summaries), nil
+}
+
+func splitWorkflowHealthRuns(runs []LoadedRun, windowStart, now time.Time, window time.Duration) ([]LoadedRun, []LoadedRun) {
+	recent := make([]LoadedRun, 0, len(runs))
+	previous := make([]LoadedRun, 0, len(runs))
+	previousStart := windowStart.Add(-window)
+	for _, run := range runs {
+		endedAt := run.Summary.EndedAt.UTC()
+		switch {
+		case !endedAt.Before(windowStart) && !endedAt.After(now):
+			recent = append(recent, run)
+		case !endedAt.Before(previousStart) && endedAt.Before(windowStart):
+			previous = append(previous, run)
+		}
+	}
+	return recent, previous
+}
+
+func buildWorkflowHealthInsights(recentRuns, previousRuns []LoadedRun, escalationThreshold int) ([]WorkflowHealthCount, []WorkflowHealthWorkflow, []WorkflowHealthFinding) {
+	anomalyCounts := map[string]int{}
+	workflowStats := map[string]*workflowHealthWorkflowAccumulator{}
+	previousCost := map[string]*workflowHealthTrendAccumulator{}
+	findingStats := map[string]*workflowHealthFindingAccumulator{}
+
+	for _, run := range previousRuns {
+		key := workflowHealthWorkflowKey(run.Summary.Source, run.Summary.Workflow)
+		if previousCost[key] == nil {
+			previousCost[key] = &workflowHealthTrendAccumulator{}
+		}
+		previousCost[key].runs++
+		previousCost[key].totalCostUSDEst += run.Summary.TotalCostUSDEst
+	}
+
+	for _, run := range recentRuns {
+		status := workflowHealthRunStatus(run)
+		key := workflowHealthWorkflowKey(run.Summary.Source, run.Summary.Workflow)
+		group := workflowStats[key]
+		if group == nil {
+			group = &workflowHealthWorkflowAccumulator{
+				source:        run.Summary.Source,
+				workflow:      run.Summary.Workflow,
+				anomalyCounts: make(map[string]int),
+			}
+			workflowStats[key] = group
+		}
+		group.runs++
+		group.totalDurationMS += run.Summary.DurationMS
+		group.totalPhaseCount += len(run.Summary.Phases)
+		group.totalCostUSDEst += run.Summary.TotalCostUSDEst
+		switch run.Summary.State {
+		case string(queue.StateCompleted):
+			group.completed++
+		case string(queue.StateFailed):
+			group.failed++
+		case string(queue.StateTimedOut):
+			group.timedOut++
+		case string(queue.StateCancelled):
+			group.cancelled++
+		}
+		switch status.Health {
+		case runner.VesselHealthHealthy:
+			group.healthy++
+		case runner.VesselHealthDegraded:
+			group.degraded++
+		case runner.VesselHealthUnhealthy:
+			group.unhealthy++
+		}
+
+		codes := runner.AnomalyCodes(status.Anomalies)
+		for _, code := range codes {
+			anomalyCounts[code]++
+			group.anomalyCounts[code]++
+		}
+
+		finding := workflowHealthFindingForRun(run, status, escalationThreshold)
+		if finding == nil {
+			continue
+		}
+		cluster := findingStats[finding.Fingerprint]
+		if cluster == nil {
+			cluster = &workflowHealthFindingAccumulator{
+				source:       finding.Source,
+				workflow:     finding.Workflow,
+				pattern:      finding.Pattern,
+				recommenders: make(map[string]struct{}),
+			}
+			findingStats[finding.Fingerprint] = cluster
+		}
+		cluster.vesselIDs = append(cluster.vesselIDs, finding.VesselIDs...)
+		cluster.evidence = append(cluster.evidence, finding.Evidence...)
+		for _, recommendation := range finding.Recommendations {
+			cluster.recommenders[recommendation] = struct{}{}
+		}
+	}
+
+	workflows := make([]WorkflowHealthWorkflow, 0, len(workflowStats))
+	for key, group := range workflowStats {
+		prevAvg := 0.0
+		if prev := previousCost[key]; prev != nil && prev.runs > 0 {
+			prevAvg = prev.totalCostUSDEst / float64(prev.runs)
+		}
+		entry := WorkflowHealthWorkflow{
+			Workflow:                  group.workflow,
+			Source:                    group.source,
+			Runs:                      group.runs,
+			Completed:                 group.completed,
+			Failed:                    group.failed,
+			TimedOut:                  group.timedOut,
+			Cancelled:                 group.cancelled,
+			HealthyRuns:               group.healthy,
+			DegradedRuns:              group.degraded,
+			UnhealthyRuns:             group.unhealthy,
+			AverageDurationMS:         avgInt64(group.totalDurationMS, group.runs),
+			AveragePhaseCount:         avgFloat64(float64(group.totalPhaseCount), group.runs),
+			AverageCostUSDEst:         avgFloat64(group.totalCostUSDEst, group.runs),
+			PreviousAverageCostUSDEst: prevAvg,
+			CostDeltaUSDEst:           avgFloat64(group.totalCostUSDEst, group.runs) - prevAvg,
+			TopAnomalies:              topWorkflowHealthCounts(group.anomalyCounts, maxWorkflowHealthRenderedCounts),
+		}
+		workflows = append(workflows, entry)
+	}
+	sort.Slice(workflows, func(i, j int) bool {
+		if workflows[i].UnhealthyRuns != workflows[j].UnhealthyRuns {
+			return workflows[i].UnhealthyRuns > workflows[j].UnhealthyRuns
+		}
+		if workflows[i].Failed != workflows[j].Failed {
+			return workflows[i].Failed > workflows[j].Failed
+		}
+		if workflows[i].CostDeltaUSDEst != workflows[j].CostDeltaUSDEst {
+			return workflows[i].CostDeltaUSDEst > workflows[j].CostDeltaUSDEst
+		}
+		return workflows[i].Workflow < workflows[j].Workflow
+	})
+
+	findings := make([]WorkflowHealthFinding, 0, len(findingStats))
+	for fingerprint, cluster := range findingStats {
+		if len(cluster.vesselIDs) < escalationThreshold {
+			continue
+		}
+		findings = append(findings, WorkflowHealthFinding{
+			Fingerprint:     fingerprint,
+			Workflow:        cluster.workflow,
+			Source:          cluster.source,
+			Pattern:         cluster.pattern,
+			Count:           len(cluster.vesselIDs),
+			VesselIDs:       append([]string(nil), cluster.vesselIDs...),
+			Evidence:        limitStrings(cluster.evidence, maxWorkflowHealthEvidencePerFinding),
+			Recommendations: sortedKeys(cluster.recommenders),
+		})
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Count != findings[j].Count {
+			return findings[i].Count > findings[j].Count
+		}
+		if findings[i].Workflow != findings[j].Workflow {
+			return findings[i].Workflow < findings[j].Workflow
+		}
+		return findings[i].Pattern < findings[j].Pattern
+	})
+
+	return topWorkflowHealthCounts(anomalyCounts, 0), workflows, findings
+}
+
+func workflowHealthRunStatus(run LoadedRun) runner.VesselStatusReport {
+	vesselState := queue.VesselState(run.Summary.State)
+	vessel := queue.Vessel{
+		ID:          run.Summary.VesselID,
+		Source:      run.Summary.Source,
+		Workflow:    run.Summary.Workflow,
+		Ref:         run.Summary.Ref,
+		State:       vesselState,
+		CreatedAt:   run.Summary.StartedAt,
+		StartedAt:   &run.Summary.StartedAt,
+		EndedAt:     &run.Summary.EndedAt,
+		FailedPhase: "",
+	}
+	return runner.AnalyzeVesselStatus(vessel, &run.Summary)
+}
+
+func workflowHealthRetryOutcomes(runs []LoadedRun) []WorkflowHealthCount {
+	counts := make(map[string]int)
+	for _, run := range runs {
+		outcome := strings.TrimSpace(summaryRetryOutcome(run.Summary))
+		if outcome == "" && run.Recovery != nil {
+			outcome = strings.TrimSpace(run.Recovery.RetryOutcome)
+		}
+		if outcome == "" && run.Summary.Recovery != nil && run.Summary.Recovery.RetrySuppressed {
+			outcome = "suppressed"
+		}
+		if outcome == "" {
+			continue
+		}
+		counts[outcome]++
+	}
+	return topWorkflowHealthCounts(counts, 0)
+}
+
+func workflowHealthFindingForRun(run LoadedRun, status runner.VesselStatusReport, escalationThreshold int) *WorkflowHealthFinding {
+	if escalationThreshold <= 1 {
+		escalationThreshold = defaultWorkflowHealthEscalationMinimum
+	}
+	if status.Health == runner.VesselHealthHealthy {
+		return nil
+	}
+	codes := runner.AnomalyCodes(status.Anomalies)
+	if len(codes) == 0 {
+		return nil
+	}
+	sort.Strings(codes)
+	failedPhase := failedPhaseForSummary(run.Summary)
+	pattern := strings.Join(codes, ", ")
+	if failedPhase != "" {
+		pattern = fmt.Sprintf("%s (failed phase: %s)", pattern, failedPhase)
+	}
+	fingerprint := workflowHealthPatternFingerprint(run.Summary.Workflow, codes, failedPhase, retryOutcomeForRun(run))
+	recommendations := workflowHealthRecommendations(codes)
+	evidence := fmt.Sprintf("%s ended %s with anomalies: %s", run.Summary.VesselID, run.Summary.State, pattern)
+	return &WorkflowHealthFinding{
+		Fingerprint:     fingerprint,
+		Workflow:        run.Summary.Workflow,
+		Source:          run.Summary.Source,
+		Pattern:         pattern,
+		Count:           1,
+		VesselIDs:       []string{run.Summary.VesselID},
+		Evidence:        []string{evidence},
+		Recommendations: recommendations,
+	}
+}
+
+func workflowHealthPatternFingerprint(workflow string, anomalyCodes []string, failedPhase, retryOutcome string) string {
+	sortedCodes := append([]string(nil), anomalyCodes...)
+	sort.Strings(sortedCodes)
+	h := sha256.Sum256([]byte(strings.Join([]string{
+		workflow,
+		strings.Join(sortedCodes, ","),
+		strings.TrimSpace(failedPhase),
+		strings.TrimSpace(retryOutcome),
+	}, "\x00")))
+	return fmt.Sprintf("%x", h[:8])
+}
+
+func workflowHealthRecommendations(anomalyCodes []string) []string {
+	recs := make(map[string]struct{})
+	for _, code := range anomalyCodes {
+		switch code {
+		case "run_failed", "phase_failed":
+			recs["Inspect the repeated failing workflow and compare the affected phase outputs side by side."] = struct{}{}
+		case "gate_failed":
+			recs["Review the validation gate for flaky or overly strict checks before rerunning the workflow."] = struct{}{}
+		case "timed_out":
+			recs["Profile the slow phase and tighten prompt/tool scope before increasing timeouts."] = struct{}{}
+		case "budget_exceeded", "budget_warning":
+			recs["Audit token footprint and model tier selection for the affected workflow."] = struct{}{}
+		case "waiting_on_gate":
+			recs["Clear or automate the blocking gate condition so waiting vessels do not accumulate."] = struct{}{}
+		case "cancelled":
+			recs["Check for operator or daemon interruptions that are cancelling runs mid-flight."] = struct{}{}
+		default:
+			recs["Review the recent vessel summaries for the repeated anomaly pattern and file a targeted fix."] = struct{}{}
+		}
+	}
+	return sortedKeys(recs)
+}
+
+func renderWorkflowHealthMarkdown(report *WorkflowHealthReport) string {
+	if report == nil {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Weekly workflow health\n\n")
+	if report.ReviewedRuns == 0 {
+		fmt.Fprintf(&b, "No completed or failed vessel runs landed in the reporting window (%s to %s).\n\n",
+			report.WindowStart.Format(time.RFC3339), report.WindowEnd.Format(time.RFC3339))
+	} else {
+		fmt.Fprintf(&b, "Reviewed **%d** recent runs across **%d** currently tracked vessels. Fleet health is **%d healthy / %d degraded / %d unhealthy**.\n\n",
+			report.ReviewedRuns, report.CurrentVessels, report.Fleet.Healthy, report.Fleet.Degraded, report.Fleet.Unhealthy)
+	}
+
+	fmt.Fprintf(&b, "## Key metrics\n\n")
+	fmt.Fprintf(&b, "| Metric | Value |\n")
+	fmt.Fprintf(&b, "|--------|-------|\n")
+	fmt.Fprintf(&b, "| Window | %s to %s |\n", report.WindowStart.Format("2006-01-02"), report.WindowEnd.Format("2006-01-02"))
+	fmt.Fprintf(&b, "| Runs reviewed | %d |\n", report.ReviewedRuns)
+	fmt.Fprintf(&b, "| Current vessels | %d |\n", report.CurrentVessels)
+	fmt.Fprintf(&b, "| Fleet health | %d healthy / %d degraded / %d unhealthy |\n\n",
+		report.Fleet.Healthy, report.Fleet.Degraded, report.Fleet.Unhealthy)
+
+	fmt.Fprintf(&b, "## Anomaly counts\n\n")
+	if len(report.AnomalyCounts) == 0 {
+		fmt.Fprintf(&b, "No recurring anomaly codes were detected in the reporting window.\n\n")
+	} else {
+		for _, count := range limitWorkflowHealthCounts(report.AnomalyCounts, maxWorkflowHealthRenderedCounts) {
+			fmt.Fprintf(&b, "- `%s`: %d runs\n", count.Name, count.Count)
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+
+	fmt.Fprintf(&b, "## Highest-risk workflows\n\n")
+	if len(report.Workflows) == 0 {
+		fmt.Fprintf(&b, "No workflow history was available in the reporting window.\n\n")
+	} else {
+		fmt.Fprintf(&b, "| Workflow | Runs | Failed | Timed out | Unhealthy | Avg cost | Cost delta |\n")
+		fmt.Fprintf(&b, "|----------|------|--------|-----------|-----------|----------|------------|\n")
+		for _, workflow := range limitWorkflowHealthWorkflows(report.Workflows, maxWorkflowHealthRenderedWorkflowIssues) {
+			fmt.Fprintf(&b, "| %s | %d | %d | %d | %d | $%.2f | $%.2f |\n",
+				workflow.Workflow, workflow.Runs, workflow.Failed, workflow.TimedOut, workflow.UnhealthyRuns, workflow.AverageCostUSDEst, workflow.CostDeltaUSDEst)
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+
+	fmt.Fprintf(&b, "## Retry outcomes\n\n")
+	if len(report.RetryOutcomes) == 0 {
+		fmt.Fprintf(&b, "No retry review outcomes were captured in the reporting window.\n\n")
+	} else {
+		for _, outcome := range report.RetryOutcomes {
+			fmt.Fprintf(&b, "- `%s`: %d\n", outcome.Name, outcome.Count)
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+
+	fmt.Fprintf(&b, "## Escalation candidates\n\n")
+	if len(report.EscalationFindings) == 0 {
+		fmt.Fprintf(&b, "No repeated workflow failure pattern crossed the escalation threshold.\n\n")
+	} else {
+		for _, finding := range report.EscalationFindings {
+			fmt.Fprintf(&b, "- **%s** — %d runs matched `%s`\n", finding.Workflow, finding.Count, finding.Pattern)
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+
+	if len(report.Warnings) > 0 {
+		fmt.Fprintf(&b, "## Incomplete local state\n\n")
+		for _, warning := range report.Warnings {
+			fmt.Fprintf(&b, "- %s\n", warning)
+		}
+	}
+
+	return b.String()
+}
+
+func renderWorkflowHealthIssueBody(report *WorkflowHealthReport, weekKey string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s%s -->\n\n", workflowHealthReportMarkerPrefix, weekKey)
+	fmt.Fprintf(&b, "## Executive summary\n\n")
+	if report.ReviewedRuns == 0 {
+		fmt.Fprintf(&b, "No recent completed or failed vessel runs were recorded for this weekly reporting window.\n\n")
+	} else {
+		fmt.Fprintf(&b, "Reviewed %d runs from %s through %s. Current fleet health is %d healthy, %d degraded, and %d unhealthy vessels.\n\n",
+			report.ReviewedRuns,
+			report.WindowStart.Format("2006-01-02"),
+			report.WindowEnd.Format("2006-01-02"),
+			report.Fleet.Healthy,
+			report.Fleet.Degraded,
+			report.Fleet.Unhealthy,
+		)
+	}
+
+	fmt.Fprintf(&b, "## Key metrics\n\n")
+	fmt.Fprintf(&b, "| Metric | Value |\n")
+	fmt.Fprintf(&b, "|--------|-------|\n")
+	fmt.Fprintf(&b, "| Runs reviewed | %d |\n", report.ReviewedRuns)
+	fmt.Fprintf(&b, "| Current vessels | %d |\n", report.CurrentVessels)
+	fmt.Fprintf(&b, "| Escalation threshold | %d matching runs |\n\n", report.EscalationThreshold)
+
+	fmt.Fprintf(&b, "## Anomaly counts\n\n")
+	if len(report.AnomalyCounts) == 0 {
+		fmt.Fprintf(&b, "- None in this reporting window.\n\n")
+	} else {
+		for _, count := range limitWorkflowHealthCounts(report.AnomalyCounts, maxWorkflowHealthRenderedCounts) {
+			fmt.Fprintf(&b, "- `%s`: %d runs\n", count.Name, count.Count)
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+
+	fmt.Fprintf(&b, "## Highest-risk workflows\n\n")
+	if len(report.Workflows) == 0 {
+		fmt.Fprintf(&b, "No workflow history was available.\n\n")
+	} else {
+		fmt.Fprintf(&b, "| Workflow | Failed | Timed out | Unhealthy | Avg cost |\n")
+		fmt.Fprintf(&b, "|----------|--------|-----------|-----------|----------|\n")
+		for _, workflow := range limitWorkflowHealthWorkflows(report.Workflows, maxWorkflowHealthRenderedWorkflowIssues) {
+			fmt.Fprintf(&b, "| %s | %d | %d | %d | $%.2f |\n",
+				workflow.Workflow, workflow.Failed, workflow.TimedOut, workflow.UnhealthyRuns, workflow.AverageCostUSDEst)
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+
+	fmt.Fprintf(&b, "## Retry outcomes\n\n")
+	if len(report.RetryOutcomes) == 0 {
+		fmt.Fprintf(&b, "- None recorded.\n\n")
+	} else {
+		for _, outcome := range report.RetryOutcomes {
+			fmt.Fprintf(&b, "- `%s`: %d\n", outcome.Name, outcome.Count)
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+
+	fmt.Fprintf(&b, "## Recommended follow-ups\n\n")
+	if len(report.EscalationFindings) == 0 {
+		fmt.Fprintf(&b, "- No escalation issue was required this week.\n")
+	} else {
+		fmt.Fprintf(&b, "- Review the grouped escalation findings below and route the follow-up issue if it has not already been created.\n")
+		for _, finding := range report.EscalationFindings {
+			fmt.Fprintf(&b, "- %s: %d runs repeated `%s`\n", finding.Workflow, finding.Count, finding.Pattern)
+		}
+	}
+	fmt.Fprintf(&b, "\n")
+
+	if len(report.Warnings) > 0 {
+		fmt.Fprintf(&b, "## Incomplete local state\n\n")
+		for _, warning := range report.Warnings {
+			fmt.Fprintf(&b, "- %s\n", warning)
+		}
+	}
+
+	return b.String()
+}
+
+func renderWorkflowHealthEscalationIssueBody(report *WorkflowHealthReport, weekKey string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s%s -->\n\n", workflowHealthEscalationMarkerPrefix, weekKey)
+	fmt.Fprintf(&b, "## Escalation summary\n\n")
+	fmt.Fprintf(&b, "%d repeated workflow failure patterns crossed the weekly escalation threshold of %d matching runs.\n\n",
+		len(report.EscalationFindings), report.EscalationThreshold)
+	fmt.Fprintf(&b, "## Findings\n\n")
+	for _, finding := range report.EscalationFindings {
+		fmt.Fprintf(&b, "### %s\n\n", finding.Workflow)
+		fmt.Fprintf(&b, "- Pattern: `%s`\n", finding.Pattern)
+		fmt.Fprintf(&b, "- Matching runs: %d\n", finding.Count)
+		if len(finding.Evidence) > 0 {
+			fmt.Fprintf(&b, "- Evidence:\n")
+			for _, evidence := range finding.Evidence {
+				fmt.Fprintf(&b, "  - %s\n", evidence)
+			}
+		}
+		if len(finding.Recommendations) > 0 {
+			fmt.Fprintf(&b, "- Recommended actions:\n")
+			for _, recommendation := range finding.Recommendations {
+				fmt.Fprintf(&b, "  - %s\n", recommendation)
+			}
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+	return b.String()
+}
+
+func loadOpenWorkflowHealthIssues(ctx context.Context, cmdRunner issueRunner, repo string) (map[string]workflowHealthIssueSet, error) {
+	out, err := cmdRunner.RunOutput(ctx, "gh", "issue", "list", "--repo", repo, "--state", "open", "--limit", "100", "--json", "number,title,body")
+	if err != nil {
+		return nil, fmt.Errorf("load open workflow-health issues: %w", err)
+	}
+	var issues []contextWeightIssue
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return nil, fmt.Errorf("load open workflow-health issues: parse gh issue list output: %w", err)
+	}
+	byWeek := make(map[string]workflowHealthIssueSet)
+	for _, issue := range issues {
+		if week := parseMarkedValue(issue.Body, workflowHealthReportMarkerPrefix); week != "" {
+			set := byWeek[week]
+			set.Report = issue
+			byWeek[week] = set
+			continue
+		}
+		if week := parseMarkedValue(issue.Body, workflowHealthEscalationMarkerPrefix); week != "" {
+			set := byWeek[week]
+			set.Escalation = issue
+			byWeek[week] = set
+		}
+	}
+	return byWeek, nil
+}
+
+func loadWorkflowHealthIssueState(path string) (*workflowHealthIssueState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &workflowHealthIssueState{Weeks: make(map[string]workflowHealthWeekIssueState)}, nil
+		}
+		return nil, fmt.Errorf("load workflow-health issue state: %w", err)
+	}
+	var state workflowHealthIssueState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("load workflow-health issue state: unmarshal: %w", err)
+	}
+	if state.Weeks == nil {
+		state.Weeks = make(map[string]workflowHealthWeekIssueState)
+	}
+	return &state, nil
+}
+
+func saveWorkflowHealthIssueState(path string, state *workflowHealthIssueState) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("save workflow-health issue state: create dir: %w", err)
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("save workflow-health issue state: marshal: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("save workflow-health issue state: write: %w", err)
+	}
+	return nil
+}
+
+func workflowHealthWeekKey(t time.Time) string {
+	year, week := t.UTC().ISOWeek()
+	return fmt.Sprintf("%04d-W%02d", year, week)
+}
+
+func workflowHealthWorkflowKey(source, workflow string) string {
+	return source + "\x00" + workflow
+}
+
+func failedPhaseForSummary(summary runner.VesselSummary) string {
+	for _, phase := range summary.Phases {
+		if phase.Status == "failed" {
+			return phase.Name
+		}
+	}
+	return ""
+}
+
+func retryOutcomeForRun(run LoadedRun) string {
+	outcome := strings.TrimSpace(summaryRetryOutcome(run.Summary))
+	if outcome == "" && run.Recovery != nil {
+		outcome = strings.TrimSpace(run.Recovery.RetryOutcome)
+	}
+	if outcome == "" && run.Summary.Recovery != nil && run.Summary.Recovery.RetrySuppressed {
+		outcome = "suppressed"
+	}
+	return outcome
+}
+
+func topWorkflowHealthCounts(counts map[string]int, limit int) []WorkflowHealthCount {
+	items := make([]WorkflowHealthCount, 0, len(counts))
+	for name, count := range counts {
+		if count <= 0 {
+			continue
+		}
+		items = append(items, WorkflowHealthCount{Name: name, Count: count})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Count != items[j].Count {
+			return items[i].Count > items[j].Count
+		}
+		return items[i].Name < items[j].Name
+	})
+	if limit > 0 && len(items) > limit {
+		items = items[:limit]
+	}
+	return items
+}
+
+func limitWorkflowHealthCounts(counts []WorkflowHealthCount, limit int) []WorkflowHealthCount {
+	if limit <= 0 || len(counts) <= limit {
+		return counts
+	}
+	return counts[:limit]
+}
+
+func limitWorkflowHealthWorkflows(workflows []WorkflowHealthWorkflow, limit int) []WorkflowHealthWorkflow {
+	if limit <= 0 || len(workflows) <= limit {
+		return workflows
+	}
+	return workflows[:limit]
+}
+
+func avgInt64(total int64, count int) int64 {
+	if count == 0 {
+		return 0
+	}
+	return total / int64(count)
+}
+
+func avgFloat64(total float64, count int) float64 {
+	if count == 0 {
+		return 0
+	}
+	return total / float64(count)
+}
+
+func limitStrings(values []string, limit int) []string {
+	if limit <= 0 || len(values) <= limit {
+		return append([]string(nil), values...)
+	}
+	return append([]string(nil), values[:limit]...)
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func parseMarkedValue(body, prefix string) string {
+	start := strings.Index(body, prefix)
+	if start == -1 {
+		return ""
+	}
+	start += len(prefix)
+	end := strings.Index(body[start:], " -->")
+	if end == -1 {
+		return ""
+	}
+	return strings.TrimSpace(body[start : start+end])
+}
+
+func summaryRetryOutcome(summary runner.VesselSummary) string {
+	if summary.Recovery == nil {
+		return ""
+	}
+	return summary.Recovery.RetryOutcome
+}

--- a/cli/internal/review/workflow_health_prop_test.go
+++ b/cli/internal/review/workflow_health_prop_test.go
@@ -1,0 +1,45 @@
+package review
+
+import (
+	"math/rand"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropWorkflowHealthPatternFingerprintIgnoresAnomalyOrder(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		unique := rapid.SampledFrom([]string{
+			"budget_exceeded",
+			"budget_warning",
+			"gate_failed",
+			"phase_failed",
+			"run_failed",
+			"timed_out",
+			"waiting_on_gate",
+		})
+		count := rapid.IntRange(1, 5).Draw(t, "count")
+		seen := make(map[string]struct{}, count)
+		codes := make([]string, 0, count)
+		for len(codes) < count {
+			code := unique.Draw(t, "code")
+			if _, ok := seen[code]; ok {
+				continue
+			}
+			seen[code] = struct{}{}
+			codes = append(codes, code)
+		}
+
+		permuted := append([]string(nil), codes...)
+		rng := rand.New(rand.NewSource(int64(rapid.Int().Draw(t, "seed")))) //nolint:gosec
+		rng.Shuffle(len(permuted), func(i, j int) {
+			permuted[i], permuted[j] = permuted[j], permuted[i]
+		})
+
+		got := workflowHealthPatternFingerprint("build", codes, "implement", "suppressed")
+		permutedGot := workflowHealthPatternFingerprint("build", permuted, "implement", "suppressed")
+		if got != permutedGot {
+			t.Fatalf("fingerprint changed across permutations: %q != %q", got, permutedGot)
+		}
+	})
+}

--- a/cli/internal/review/workflow_health_test.go
+++ b/cli/internal/review/workflow_health_test.go
@@ -1,0 +1,249 @@
+package review
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type workflowHealthTestRunner struct {
+	calls        [][]string
+	issueList    []contextWeightIssue
+	createCount  int
+	createTitles []string
+	createBodies []string
+}
+
+func (r *workflowHealthTestRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	r.calls = append(r.calls, call)
+	if name != "gh" || len(args) < 2 {
+		return []byte{}, nil
+	}
+	switch {
+	case args[0] == "issue" && args[1] == "list":
+		return json.Marshal(r.issueList)
+	case args[0] == "issue" && args[1] == "create":
+		r.createCount++
+		r.createTitles = append(r.createTitles, valueAfterFlag(args, "--title"))
+		r.createBodies = append(r.createBodies, valueAfterFlag(args, "--body"))
+		return []byte("https://github.com/owner/repo/issues/" + strconv.Itoa(90+r.createCount)), nil
+	default:
+		return []byte{}, nil
+	}
+}
+
+func TestSmoke_S1_CollectAnalyzeReportAndEscalateRepeatedFailures(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 10, 12, 0, 0, 0, time.UTC)
+	failedGate := false
+
+	for i := range 3 {
+		writeRunArtifacts(t, stateDir, runFixture{
+			vesselID:  "build-failed-" + string(rune('a'+i)),
+			source:    "github-issue",
+			workflow:  "build",
+			state:     "failed",
+			startedAt: now.Add(-time.Duration(24-i) * time.Hour),
+			endedAt:   now.Add(-time.Duration(24-i)*time.Hour + 5*time.Minute),
+			phases: []runner.PhaseSummary{{
+				Name:       "implement",
+				Type:       "prompt",
+				Status:     "failed",
+				GateType:   "command",
+				GatePassed: &failedGate,
+				CostUSDEst: 0.40,
+			}},
+			totalCost: 0.40,
+			recoveryArtifact: recovery.Build(recovery.Input{
+				VesselID:    "build-failed-" + string(rune('a'+i)),
+				Source:      "github-issue",
+				Workflow:    "build",
+				State:       queue.StateFailed,
+				FailedPhase: "implement",
+				Error:       "tests failed",
+				Meta: map[string]string{
+					recovery.MetaRetryOutcome: "suppressed",
+				},
+				CreatedAt: now,
+			}),
+		})
+	}
+
+	writeRunArtifacts(t, stateDir, runFixture{
+		vesselID:  "build-previous",
+		source:    "github-issue",
+		workflow:  "build",
+		state:     "completed",
+		startedAt: now.Add(-10 * 24 * time.Hour),
+		endedAt:   now.Add(-10*24*time.Hour + 4*time.Minute),
+		phases: []runner.PhaseSummary{{
+			Name:       "implement",
+			Type:       "prompt",
+			Status:     "completed",
+			CostUSDEst: 0.10,
+		}},
+		totalCost: 0.10,
+	})
+	writeRunArtifacts(t, stateDir, runFixture{
+		vesselID:  "stable-run",
+		source:    "github-issue",
+		workflow:  "stable",
+		state:     "completed",
+		startedAt: now.Add(-2 * time.Hour),
+		endedAt:   now.Add(-90 * time.Minute),
+		phases: []runner.PhaseSummary{{
+			Name:       "implement",
+			Type:       "prompt",
+			Status:     "completed",
+			CostUSDEst: 0.05,
+		}},
+		totalCost: 0.05,
+	})
+
+	q := queue.New(filepath.Join(stateDir, "queue.jsonl"))
+	for _, vessel := range []queue.Vessel{
+		{ID: "build-failed-a", Source: "github-issue", Workflow: "build", State: queue.StateFailed, CreatedAt: now.Add(-24 * time.Hour)},
+		{ID: "stable-run", Source: "github-issue", Workflow: "stable", State: queue.StateCompleted, CreatedAt: now.Add(-2 * time.Hour)},
+	} {
+		_, err := q.Enqueue(vessel)
+		require.NoError(t, err)
+	}
+
+	result, err := GenerateWorkflowHealthReport(stateDir, WorkflowHealthOptions{
+		LookbackRuns:        20,
+		Window:              7 * 24 * time.Hour,
+		OutputDir:           "reviews",
+		Now:                 now,
+		EscalationThreshold: 2,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 4, result.Report.ReviewedRuns)
+	assert.Equal(t, 2, result.Report.CurrentVessels)
+	assert.Equal(t, 1, result.Report.Fleet.Healthy)
+	assert.Equal(t, 1, result.Report.Fleet.Unhealthy)
+
+	require.NotEmpty(t, result.Report.AnomalyCounts)
+	assert.Equal(t, "gate_failed", result.Report.AnomalyCounts[0].Name)
+	assert.Equal(t, 3, result.Report.AnomalyCounts[0].Count)
+
+	require.NotEmpty(t, result.Report.RetryOutcomes)
+	assert.Equal(t, "suppressed", result.Report.RetryOutcomes[0].Name)
+	assert.Equal(t, 3, result.Report.RetryOutcomes[0].Count)
+
+	require.NotEmpty(t, result.Report.Workflows)
+	assert.Equal(t, "build", result.Report.Workflows[0].Workflow)
+	assert.Equal(t, 3, result.Report.Workflows[0].Failed)
+	assert.Greater(t, result.Report.Workflows[0].CostDeltaUSDEst, 0.0)
+
+	require.Len(t, result.Report.EscalationFindings, 1)
+	finding := result.Report.EscalationFindings[0]
+	assert.Equal(t, "build", finding.Workflow)
+	assert.Equal(t, 3, finding.Count)
+	assert.Contains(t, finding.Pattern, "gate_failed")
+	assert.Contains(t, finding.Pattern, "implement")
+	assert.NotEmpty(t, finding.Recommendations)
+
+	assert.Contains(t, result.Markdown, "## Escalation candidates")
+	assert.Contains(t, result.Markdown, "build")
+	_, err = os.Stat(filepath.Join(stateDir, "reviews", workflowHealthReportJSONName))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(stateDir, "reviews", workflowHealthReportMarkdownName))
+	require.NoError(t, err)
+}
+
+func TestSmoke_S2_PublishWeeklyIssuesOnlyOncePerWeek(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 10, 12, 0, 0, 0, time.UTC)
+	failedGate := false
+
+	for i := range 2 {
+		writeRunArtifacts(t, stateDir, runFixture{
+			vesselID:  "build-repeat-" + string(rune('a'+i)),
+			source:    "github-issue",
+			workflow:  "build",
+			state:     "failed",
+			startedAt: now.Add(-time.Duration(i+1) * time.Hour),
+			endedAt:   now.Add(-time.Duration(i+1)*time.Hour + 2*time.Minute),
+			phases: []runner.PhaseSummary{{
+				Name:       "implement",
+				Type:       "prompt",
+				Status:     "failed",
+				GateType:   "command",
+				GatePassed: &failedGate,
+			}},
+		})
+	}
+
+	runner := &workflowHealthTestRunner{}
+	first, err := RunWorkflowHealthReport(context.Background(), stateDir, "owner/repo", runner, WorkflowHealthOptions{
+		LookbackRuns:        10,
+		OutputDir:           "reviews",
+		Now:                 now,
+		EscalationThreshold: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, first.Published, 2)
+	assert.True(t, first.Published[0].Created)
+	assert.True(t, first.Published[1].Created)
+	assert.Equal(t, 2, runner.createCount)
+	assert.Equal(t, workflowHealthReportTitle, runner.createTitles[0])
+	assert.Equal(t, workflowHealthEscalationTitle, runner.createTitles[1])
+	assert.Contains(t, runner.createBodies[0], workflowHealthReportMarkerPrefix+workflowHealthWeekKey(now))
+	assert.Contains(t, runner.createBodies[1], workflowHealthEscalationMarkerPrefix+workflowHealthWeekKey(now))
+
+	second, err := RunWorkflowHealthReport(context.Background(), stateDir, "owner/repo", runner, WorkflowHealthOptions{
+		LookbackRuns:        10,
+		OutputDir:           "reviews",
+		Now:                 now.Add(2 * time.Hour),
+		EscalationThreshold: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, second.Published, 2)
+	assert.False(t, second.Published[0].Created)
+	assert.False(t, second.Published[1].Created)
+	assert.Equal(t, 2, runner.createCount)
+
+	stateJSON, err := os.ReadFile(filepath.Join(stateDir, "reviews", workflowHealthIssueStateName))
+	require.NoError(t, err)
+	assert.Contains(t, string(stateJSON), workflowHealthWeekKey(now))
+}
+
+func TestSmoke_S3_WriteReportWhenWindowHasNoRecentRuns(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 10, 12, 0, 0, 0, time.UTC)
+
+	writeRunArtifacts(t, stateDir, runFixture{
+		vesselID:  "old-run",
+		source:    "github-issue",
+		workflow:  "build",
+		state:     "completed",
+		startedAt: now.Add(-20 * 24 * time.Hour),
+		endedAt:   now.Add(-20*24*time.Hour + time.Minute),
+	})
+
+	result, err := GenerateWorkflowHealthReport(stateDir, WorkflowHealthOptions{
+		LookbackRuns: 10,
+		Window:       7 * 24 * time.Hour,
+		OutputDir:    "reviews",
+		Now:          now,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, result.Report.ReviewedRuns)
+	assert.Empty(t, result.Report.EscalationFindings)
+	assert.Contains(t, result.Markdown, "No completed or failed vessel runs landed in the reporting window")
+	assert.NotContains(t, strings.Join(result.Report.Warnings, "\n"), "error")
+}


### PR DESCRIPTION
## Summary
- Implements https://github.com/nicholls-inc/xylem/issues/276
- Adds a built-in `workflow-health-report` review flow that summarizes recent vessel health, detects recurring failure patterns, and publishes weekly de-duplicated GitHub report/escalation issues for scheduled self-hosted review vessels.
- Wires the scheduled built-in audit runner to execute the new workflow and persist vessel summaries for the reporting run.

## Smoke scenarios covered
- S1 — Collect, analyze, report, and escalate repeated failures
- S2 — Publish weekly issues only once per week
- S3 — Write a report when the window has no recent runs
- S4 — Scheduled workflow-health vessel publishes the weekly report

## Changes summary
- **Added** `cli/internal/review/workflow_health.go`
  - Introduces `WorkflowHealthOptions`, `WorkflowHealthResult`, `WorkflowHealthReport`, `WorkflowHealthWorkflow`, `WorkflowHealthFinding`, and `WorkflowHealthPublication`
  - Adds `GenerateWorkflowHealthReport`, `RunWorkflowHealthReport`, and `PublishWorkflowHealthIssues`
  - Adds workflow health aggregation, markdown/json rendering, escalation fingerprinting, weekly issue de-duplication, and issue-state persistence
- **Added** `cli/internal/review/workflow_health_test.go`
  - Covers S1-S3 report generation/publication behavior and weekly de-duplication semantics
- **Added** `cli/internal/review/workflow_health_prop_test.go`
  - Adds a property test for anomaly-order-independent escalation fingerprinting
- **Modified** `cli/cmd/xylem/builtin_audit.go`
  - Registers `workflow-health-report` as a built-in scheduled workflow
  - Routes scheduled vessels through `RunWorkflowHealthReport`
  - Persists scheduled workflow-health summary notes alongside the existing built-in audit summaries
- **Modified** `cli/cmd/xylem/builtin_audit_test.go`
  - Extends built-in scheduled vessel coverage with S4 for the new weekly workflow-health reporting path

## Test plan
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #276