### PR TITLE
fix: auto-merge broken by unsupported gh v2.9.0 fields

### DIFF
--- a/cli/cmd/xylem/automerge.go
+++ b/cli/cmd/xylem/automerge.go
@@ -79,12 +79,11 @@ func isReviewerNotCollaborator(err error) bool {
 
 // prSummary is a minimal projection of `gh pr list` / `gh pr view` output.
 type prSummary struct {
-	Number            int       `json:"number"`
-	HeadRefName       string    `json:"headRefName"`
-	Mergeable         string    `json:"mergeable"`
-	State             string    `json:"state"`
-	ReviewDecision    string    `json:"reviewDecision"`
-	AutoMergeRequest  *struct{} `json:"autoMergeRequest"`
+	Number            int    `json:"number"`
+	HeadRefName       string `json:"headRefName"`
+	Mergeable         string `json:"mergeable"`
+	State             string `json:"state"`
+	ReviewDecision    string `json:"reviewDecision"`
 	StatusCheckRollup []struct {
 		Conclusion string `json:"conclusion"`
 		Status     string `json:"status"`
@@ -98,9 +97,6 @@ type prSummary struct {
 		} `json:"author"`
 		State string `json:"state"`
 	} `json:"latestReviews"`
-	ReviewThreads []struct {
-		IsResolved bool `json:"isResolved"`
-	} `json:"reviewThreads"`
 	Labels []struct {
 		Name string `json:"name"`
 	} `json:"labels"`
@@ -129,15 +125,14 @@ func (p prSummary) hasLabels(names ...string) bool {
 type autoMergeAction int
 
 const (
-	actionSkip                 autoMergeAction = iota // not a merge-ready xylem PR, or skip for other reasons
-	actionRequestReview                               // request copilot review, then continue with admin merge
-	actionWaitForChecks                               // CI still running
-	actionWaitForMergeable                            // unknown mergeable state (github computing)
-	actionRouteConflict                               // conflicts — add labels so resolve-conflicts workflow picks it up
-	actionAddressReview                               // changes requested; another workflow handles
-	actionWaitForReviewThreads                        // unresolved review threads remain
-	actionBlockedOptOut                               // explicit no-auto-admin-merge label
-	actionAdminMerge                                  // merge immediately with admin bypass
+	actionSkip             autoMergeAction = iota // not a merge-ready xylem PR, or skip for other reasons
+	actionRequestReview                           // request copilot review, then continue with admin merge
+	actionWaitForChecks                           // CI still running
+	actionWaitForMergeable                        // unknown mergeable state (github computing)
+	actionRouteConflict                           // conflicts — add labels so resolve-conflicts workflow picks it up
+	actionAddressReview                           // changes requested; another workflow handles
+	actionBlockedOptOut                           // explicit no-auto-admin-merge label
+	actionAdminMerge                              // merge immediately with admin bypass
 )
 
 // decideAutoMergeAction returns the action to take for a given PR. It does
@@ -147,15 +142,14 @@ const (
 // Decision order:
 // 1. Non-xylem branch or not merge-ready → skip
 // 2. Closed/merged → skip
-// 3. Conflicts + missing resolve-conflicts labels → add labels (routeConflict)
-// 4. Conflicts + labels already present → wait (workflow handles)
-// 5. Unknown mergeable state → wait (github computing)
-// 6. CI failing/running → wait (fix-pr-checks handles failures)
-// 7. Changes requested → wait (respond-to-pr-review handles)
-// 8. Explicit no-auto-admin-merge label → stay blocked
-// 9. Unresolved review threads → wait
-// 10. No copilot review requested or submitted → request review, then admin-merge
-// 11. Otherwise admin-merge immediately
+// 3. Explicit no-auto-admin-merge label → stay blocked
+// 4. Conflicts + missing resolve-conflicts labels → add labels (routeConflict)
+// 5. Conflicts + labels already present → wait (workflow handles)
+// 6. Unknown mergeable state → wait (github computing)
+// 7. CI failing/running → wait (fix-pr-checks handles failures)
+// 8. Changes requested → wait (respond-to-pr-review handles)
+// 9. No copilot review requested or submitted → request review, then admin-merge
+// 10. Otherwise admin-merge immediately
 func decideAutoMergeAction(pr prSummary, settings autoMergeSettings) autoMergeAction {
 	if !isMergeReadyPR(pr, settings) {
 		return actionSkip
@@ -186,9 +180,6 @@ func decideAutoMergeAction(pr prSummary, settings autoMergeSettings) autoMergeAc
 	if pr.ReviewDecision == "CHANGES_REQUESTED" {
 		return actionAddressReview
 	}
-	if hasUnresolvedReviewThreads(pr) {
-		return actionWaitForReviewThreads
-	}
 	if settings.reviewer != "" && !reviewRequestedOrSubmitted(pr, settings.reviewer) {
 		return actionRequestReview
 	}
@@ -198,15 +189,6 @@ func decideAutoMergeAction(pr prSummary, settings autoMergeSettings) autoMergeAc
 func isMergeReadyPR(pr prSummary, settings autoMergeSettings) bool {
 	return settings.branchPattern.MatchString(pr.HeadRefName) &&
 		pr.hasLabels(settings.labels...)
-}
-
-func hasUnresolvedReviewThreads(pr prSummary) bool {
-	for _, thread := range pr.ReviewThreads {
-		if !thread.IsResolved {
-			return true
-		}
-	}
-	return false
 }
 
 // reviewRequestedOrSubmitted returns true if the configured reviewer has either
@@ -348,10 +330,6 @@ func autoMergeXylemPRs(ctx context.Context, dc config.DaemonConfig) {
 			slog.Info("daemon auto-merge waiting for review follow-up",
 				"repo", repo,
 				"pr", pr.Number)
-		case actionWaitForReviewThreads:
-			slog.Info("daemon auto-merge waiting for unresolved review threads",
-				"repo", repo,
-				"pr", pr.Number)
 		case actionBlockedOptOut:
 			slog.Info("daemon auto-merge blocked by opt-out label",
 				"repo", repo,
@@ -401,7 +379,7 @@ func listOpenPRs(ctx context.Context, repo string) ([]prSummary, error) {
 func getPRSummary(ctx context.Context, repo string, number int) (prSummary, error) {
 	args := []string{
 		"pr", "view", strconv.Itoa(number),
-		"--json", "number,headRefName,mergeable,state,reviewDecision,autoMergeRequest,statusCheckRollup,reviewRequests,latestReviews,reviewThreads,labels",
+		"--json", "number,headRefName,mergeable,state,reviewDecision,statusCheckRollup,reviewRequests,latestReviews,labels",
 	}
 	if repo != "" {
 		args = append(args, "--repo", repo)

--- a/cli/cmd/xylem/automerge_prop_test.go
+++ b/cli/cmd/xylem/automerge_prop_test.go
@@ -73,9 +73,6 @@ func TestPropDecideAutoMergeActionAdminMergesWithReviewerEvidence(t *testing.T) 
 				Conclusion string `json:"conclusion"`
 				Status     string `json:"status"`
 			}{{Conclusion: "SUCCESS", Status: "COMPLETED"}},
-			ReviewThreads: []struct {
-				IsResolved bool `json:"isResolved"`
-			}{{IsResolved: true}},
 		}
 		switch reviewEvidence {
 		case "request":
@@ -107,7 +104,6 @@ func TestPropDecideAutoMergeActionAdminMergesWithReviewerEvidence(t *testing.T) 
 func TestPropDecideAutoMergeActionOptOutLabelAlwaysBlocks(t *testing.T) {
 	settings := xylemAutoMergeSettings(t)
 	rapid.Check(t, func(t *rapid.T) {
-		resolved := rapid.Bool().Draw(t, "resolved")
 		pr := prSummary{
 			HeadRefName:    "feat/issue-42-42",
 			State:          "OPEN",
@@ -120,9 +116,6 @@ func TestPropDecideAutoMergeActionOptOutLabelAlwaysBlocks(t *testing.T) {
 				Conclusion string `json:"conclusion"`
 				Status     string `json:"status"`
 			}{{Conclusion: "SUCCESS", Status: "COMPLETED"}},
-			ReviewThreads: []struct {
-				IsResolved bool `json:"isResolved"`
-			}{{IsResolved: resolved}},
 		}
 
 		if got := decideAutoMergeAction(pr, settings); got != actionBlockedOptOut {

--- a/cli/cmd/xylem/automerge_test.go
+++ b/cli/cmd/xylem/automerge_test.go
@@ -165,31 +165,6 @@ func TestNewAutoMergeSettingsCustomizesLabelsPatternAndReviewer(t *testing.T) {
 	assert.False(t, settings.branchPattern.MatchString("feat/issue-1-1"))
 }
 
-func TestHasUnresolvedReviewThreads(t *testing.T) {
-	tests := []struct {
-		name    string
-		threads []struct {
-			IsResolved bool `json:"isResolved"`
-		}
-		want bool
-	}{
-		{name: "no threads", want: false},
-		{name: "all resolved", threads: []struct {
-			IsResolved bool `json:"isResolved"`
-		}{{IsResolved: true}, {IsResolved: true}}, want: false},
-		{name: "unresolved present", threads: []struct {
-			IsResolved bool `json:"isResolved"`
-		}{{IsResolved: true}, {IsResolved: false}}, want: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pr := prSummary{ReviewThreads: tt.threads}
-			assert.Equal(t, tt.want, hasUnresolvedReviewThreads(pr))
-		})
-	}
-}
-
 func TestAllChecksGreen(t *testing.T) {
 	mkcheck := func(conclusion, status string) struct {
 		Conclusion string `json:"conclusion"`
@@ -323,17 +298,6 @@ func TestDecideAutoMergeAction(t *testing.T) {
 				Labels: mergeReadyLabels, StatusCheckRollup: greenChecks, ReviewDecision: "CHANGES_REQUESTED",
 			},
 			want: actionAddressReview,
-		},
-		{
-			name: "xylem PR with unresolved review threads waits",
-			pr: prSummary{
-				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "MERGEABLE",
-				Labels: mergeReadyLabels, StatusCheckRollup: greenChecks, ReviewDecision: "REVIEW_REQUIRED",
-				ReviewThreads: []struct {
-					IsResolved bool `json:"isResolved"`
-				}{{IsResolved: false}},
-			},
-			want: actionWaitForReviewThreads,
 		},
 		{
 			name: "xylem PR without review requests asks for copilot review first",
@@ -499,9 +463,6 @@ func TestSmoke_S9_AutoAdminMergeWithinOneDaemonTick(t *testing.T) {
 			Conclusion string `json:"conclusion"`
 			Status     string `json:"status"`
 		}{{Conclusion: "SUCCESS", Status: "COMPLETED"}},
-		ReviewThreads: []struct {
-			IsResolved bool `json:"isResolved"`
-		}{{IsResolved: true}},
 	}
 
 	listOpenPRsFn = func(context.Context, string) ([]prSummary, error) {


### PR DESCRIPTION
## Summary

- Auto-admin-merge (PR #260) was **completely non-functional** because `getPRSummary` requested `reviewThreads` and `autoMergeRequest` JSON fields from `gh pr view`, which are not supported in gh CLI v2.9.0
- Every call to `getPRSummary` failed with `Unknown JSON field: "reviewThreads"` (exit code 1), causing the daemon to silently skip every PR
- 6 green, mergeable PRs (#281, #282, #284, #285, #286, #287) have been sitting unmerged despite having correct labels and passing CI

## Changes

- Remove `reviewThreads` and `autoMergeRequest` from `gh pr view --json` field list
- Remove `hasUnresolvedReviewThreads` check (data unavailable on gh v2.9.0)
- Remove `AutoMergeRequest` and `ReviewThreads` fields from `prSummary` struct
- Clean up associated tests and property tests

## Test plan

- [x] All `cmd/xylem` unit tests pass
- [x] All property-based tests pass
- [x] Full `go test ./...` suite passes
- [x] `go vet` clean
- [x] `goimports` clean
- [ ] After merge + daemon auto-upgrade: verify PRs #281/#282 are auto-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)