### PR TITLE
feat(workflow): add self-hosting auto-triage-issues scheduled workflow

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -43,6 +43,16 @@ sources:
           failed: xylem-failed
           timed_out: xylem-failed
 
+  auto-triage:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "6h"
+    timeout: "45m"
+    tasks:
+      triage-unlabeled-issues:
+        workflow: auto-triage-issues
+        ref: auto-triage-issues
+
   refinement:
     type: github
     repo: nicholls-inc/xylem

--- a/.xylem/prompts/auto-triage-issues/apply.md
+++ b/.xylem/prompts/auto-triage-issues/apply.md
@@ -1,0 +1,38 @@
+Apply the approved classification plan to the repository's currently unlabeled issues.
+
+Repository: {{.Repo.Slug}}
+
+## Classification plan
+{{.PreviousOutputs.classify}}
+
+For each planned issue:
+
+1. Re-fetch the live issue before editing:
+
+   `gh issue view <number> --repo {{.Repo.Slug}} --json number,title,url,labels`
+
+2. If the issue already has one or more labels, skip it and record that it was already triaged elsewhere.
+3. If the issue is still unlabeled, apply the planned labels with:
+
+   `gh issue edit <number> --repo {{.Repo.Slug}} --add-label "label-a,label-b"`
+
+4. Re-fetch the issue labels after editing and verify the requested labels are present.
+5. If any `gh issue edit` or verification command fails, stop immediately and surface the failing command/output instead of pretending the run succeeded.
+
+Write the final output as a markdown audit report with these sections:
+
+## Auto-triage summary
+- Processed: <n>
+- Labeled: <n>
+- Skipped: <n>
+
+## Applied
+- #<number> — `<comma-separated labels>` — <short rationale>
+
+## Skipped
+- #<number> — <reason>
+
+## Follow-up recommendations
+- Call out any issues that were labeled only with `needs-triage` and why they need human review.
+
+The final markdown report is the persistent audit trail for this scheduled run, so keep it concrete and repo-specific.

--- a/.xylem/prompts/auto-triage-issues/classify.md
+++ b/.xylem/prompts/auto-triage-issues/classify.md
@@ -1,0 +1,52 @@
+Classify the unlabeled issues discovered in the previous phase and produce a deterministic labeling plan.
+
+## Discover manifest
+{{.PreviousOutputs.discover}}
+
+Output JSON only. Do not wrap it in code fences and do not add commentary before or after the JSON.
+
+Use the repository's existing label set from the discover manifest. Never invent labels that are not present there.
+
+Default xylem heuristics if those labels exist in the repo:
+
+- Type labels: `bug`, `enhancement`, `documentation`, `question`, `testing`
+- Component labels: `cli`, `workflows`, `compiler`, `mcp`, `security`, `performance`
+- Priority/community labels: `priority-high`, `good first issue`, `community`
+- Fallback label: `needs-triage`
+
+Conservative rules:
+
+1. Prefer missing a component label over guessing one.
+2. If confidence is below `0.80`, or the issue could reasonably fit multiple conflicting labels, include `needs-triage` and set `fallback` to `true`.
+3. Only apply `community` when the author is not a bot and `author_association` is not `OWNER`, `MEMBER`, or `COLLABORATOR`.
+4. Only apply `good first issue` when the change is narrow, low-risk, and suitable for a newcomer.
+5. Only apply `priority-high` for issues that appear release-blocking, security-sensitive, data-loss related, or severe user-facing breakage.
+6. If a label category is unavailable in the repo label set, skip it rather than substituting a different label.
+7. Every issue must receive at least one label. If nothing else is safe, use only `needs-triage`.
+
+Return this schema:
+
+```json
+{
+  "issues": [
+    {
+      "number": 123,
+      "title": "Example",
+      "url": "https://github.com/owner/repo/issues/123",
+      "labels": ["bug", "cli"],
+      "confidence": 0.93,
+      "fallback": false,
+      "rationale": "Clear bug report against CLI behavior with concrete reproduction steps.",
+      "signals": ["mentions panic", "touches command output", "member-authored"]
+    }
+  ],
+  "summary": {
+    "processed": 1,
+    "auto_labeled": 1,
+    "needs_triage": 0,
+    "community": 0
+  }
+}
+```
+
+Deduplicate labels per issue and keep them in a stable order: type/community first, then component labels, then priority/fallback labels.

--- a/.xylem/prompts/auto-triage-issues/discover.md
+++ b/.xylem/prompts/auto-triage-issues/discover.md
@@ -1,0 +1,55 @@
+Prepare the next batch of unlabeled GitHub issues for automated triage.
+
+Repository: {{.Repo.Slug}}
+
+Your job in this phase is discovery only. Do not edit issues or labels yet.
+
+1. List the repository labels so later phases can validate against the real taxonomy:
+
+   `gh label list --repo {{.Repo.Slug}} --limit 200 --json name,description,color`
+
+2. List open issues and keep only issues that currently have zero labels:
+
+   `gh issue list --repo {{.Repo.Slug}} --state open --limit 100 --json number,title,body,url,author,labels,createdAt,updatedAt`
+
+3. Sort the unlabeled issues by `updatedAt` ascending so older untouched issues are handled first.
+4. Keep at most 10 issues for this run.
+5. For each selected issue, fetch `authorAssociation` separately with GraphQL. `gh issue list --json` does not expose author association, so do not guess it. Use a query in this shape, substituting the owner/name from `{{.Repo.Slug}}` and the issue number:
+
+   `gh api graphql -f query='query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { issue(number:$number) { authorAssociation } } }' -F owner=<owner> -F repo=<repo> -F number=<number>`
+
+6. For each selected issue, capture:
+   - `number`
+   - `title`
+   - `url`
+   - `author_login`
+   - `author_association`
+   - `created_at`
+   - `updated_at`
+   - `body_excerpt` — concise excerpt or summary of the problem statement, reproduction steps, and requested change. Keep it short enough for later phases.
+
+If there are no open unlabeled issues, output a standalone line containing `XYLEM_NOOP`, then a one-sentence explanation.
+
+Otherwise output JSON only, with no code fences or prose before/after it, using this shape:
+
+```json
+{
+  "repo": "{{.Repo.Slug}}",
+  "batch_limit": 10,
+  "repo_labels": [
+    {"name": "bug", "description": "", "color": "d73a4a"}
+  ],
+  "issues": [
+    {
+      "number": 123,
+      "title": "Example",
+      "url": "https://github.com/owner/repo/issues/123",
+      "author_login": "octocat",
+      "author_association": "NONE",
+      "created_at": "2026-04-10T00:00:00Z",
+      "updated_at": "2026-04-10T01:00:00Z",
+      "body_excerpt": "Short summary of the issue body."
+    }
+  ]
+}
+```

--- a/.xylem/workflows/auto-triage-issues.yaml
+++ b/.xylem/workflows/auto-triage-issues.yaml
@@ -1,0 +1,57 @@
+name: auto-triage-issues
+description: "Recurring batch labeling for open unlabeled issues"
+phases:
+  - name: discover
+    prompt_file: .xylem/prompts/auto-triage-issues/discover.md
+    max_turns: 20
+    llm: copilot
+    model: gpt-5.4
+    noop:
+      match: XYLEM_NOOP
+  - name: classify
+    prompt_file: .xylem/prompts/auto-triage-issues/classify.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4
+    gate:
+      type: command
+      run: |
+        set -euo pipefail
+
+        plan=".xylem/phases/{{.Vessel.ID}}/classify.output"
+        test -s "$plan"
+
+        jq -e '.issues | type == "array"' "$plan" >/dev/null
+        jq -e '
+          all(.issues[]?;
+            (.number | type == "number") and
+            (.title | type == "string") and
+            (.url | type == "string") and
+            (.labels | type == "array" and length > 0) and
+            (all(.labels[]; type == "string" and length > 0)) and
+            (.confidence | type == "number") and
+            (.fallback | type == "boolean") and
+            (.rationale | type == "string")
+          )
+        ' "$plan" >/dev/null
+
+        repo_labels=$(mktemp)
+        proposed_labels=$(mktemp)
+        missing_labels=$(mktemp)
+        trap 'rm -f "$repo_labels" "$proposed_labels" "$missing_labels"' EXIT
+
+        gh label list --repo {{.Repo.Slug}} --limit 200 --json name --jq '.[].name' | sort -u > "$repo_labels"
+        jq -r '.issues[].labels[]' "$plan" | sort -u > "$proposed_labels"
+
+        comm -23 "$proposed_labels" "$repo_labels" > "$missing_labels"
+        if [ -s "$missing_labels" ]; then
+          echo "ERROR: classify plan proposed labels that do not exist in {{.Repo.Slug}}:"
+          cat "$missing_labels"
+          exit 1
+        fi
+      retries: 1
+  - name: apply
+    prompt_file: .xylem/prompts/auto-triage-issues/apply.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -36,6 +36,7 @@ var expectedCoreWorkflows = []string{
 }
 
 var expectedSelfHostingWorkflows = []string{
+	"auto-triage-issues",
 	"diagnose-failures",
 	"implement-harness",
 	"sota-gap-analysis",
@@ -481,6 +482,9 @@ func TestInitProfileCoreAndSelfHostingXylem(t *testing.T) {
 	cfg, err := config.Load(configPath)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"core", "self-hosting-xylem"}, cfg.Profiles)
+	if _, ok := cfg.Sources["auto-triage"]; !ok {
+		t.Fatal("expected auto-triage source from self-hosting overlay")
+	}
 	if _, ok := cfg.Sources["harness-impl"]; !ok {
 		t.Fatal("expected harness-impl source from self-hosting overlay")
 	}
@@ -558,17 +562,45 @@ func TestSmoke_S5_CorePlusSelfHostingOverlayScaffoldsOverlayWorkflows(t *testing
 	expectedWorkflows := append(append([]string{}, expectedCoreWorkflows...), expectedSelfHostingWorkflows...)
 	sort.Strings(expectedWorkflows)
 	assert.Equal(t, expectedWorkflows, scaffoldedWorkflowNames(t, dir))
+	assert.Contains(t, output, "Created .xylem/workflows/auto-triage-issues.yaml")
 	assert.Contains(t, output, "Created .xylem/workflows/implement-harness.yaml")
 	assert.Contains(t, output, "Created .xylem/workflows/unblock-wave.yaml")
+
+	autoTriageWorkflow, err := os.ReadFile(filepath.Join(dir, ".xylem", "workflows", "auto-triage-issues.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(autoTriageWorkflow), "name: auto-triage-issues")
+	assert.Contains(t, string(autoTriageWorkflow), "prompt_file: .xylem/prompts/auto-triage-issues/discover.md")
+	assert.Contains(t, string(autoTriageWorkflow), "gh label list --repo {{.Repo.Slug}}")
+
+	discoverPrompt, err := os.ReadFile(filepath.Join(dir, ".xylem", "prompts", "auto-triage-issues", "discover.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(discoverPrompt), "gh api graphql")
+	assert.Contains(t, string(discoverPrompt), "authorAssociation")
+
+	classifyPrompt, err := os.ReadFile(filepath.Join(dir, ".xylem", "prompts", "auto-triage-issues", "classify.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(classifyPrompt), "Output JSON only.")
+	assert.Contains(t, string(classifyPrompt), "needs-triage")
+
+	applyPrompt, err := os.ReadFile(filepath.Join(dir, ".xylem", "prompts", "auto-triage-issues", "apply.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(applyPrompt), "gh issue edit")
+	assert.Contains(t, string(applyPrompt), "summary")
 
 	lockData, err := os.ReadFile(filepath.Join(dir, ".xylem", "profile.lock"))
 	require.NoError(t, err)
 	assert.Contains(t, string(lockData), "name: core")
 	assert.Contains(t, string(lockData), "name: self-hosting-xylem")
 
+	configData, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(configData), "auto-triage:")
+	assert.Contains(t, string(configData), "workflow: auto-triage-issues")
+
 	cfg, err := config.Load(configPath)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"core", "self-hosting-xylem"}, cfg.Profiles)
+	assert.Contains(t, cfg.Sources, "auto-triage")
 	assert.Contains(t, cfg.Sources, "harness-impl")
 	assert.Contains(t, cfg.Sources, "harness-pr-lifecycle")
 	require.NoError(t, cfg.Validate())

--- a/cli/internal/profiles/profiles_prop_test.go
+++ b/cli/internal/profiles/profiles_prop_test.go
@@ -1,6 +1,7 @@
 package profiles
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"testing"
@@ -76,6 +77,62 @@ func TestPropComposeCoreKeepsSecurityComplianceBundlePresent(t *testing.T) {
 	})
 }
 
+func TestPropComposeCoreAndSelfHostingRetainsAutoTriageAssets(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		composed, err := Compose("core", "self-hosting-xylem")
+		if err != nil {
+			t.Fatalf("Compose(core, self-hosting-xylem) error = %v", err)
+		}
+
+		stable, err := Compose("core", "self-hosting-xylem")
+		if err != nil {
+			t.Fatalf("Compose(core, self-hosting-xylem) stable call error = %v", err)
+		}
+
+		expected, err := autoTriageAssetSnapshot(stable)
+		if err != nil {
+			t.Fatalf("snapshot stable auto-triage assets: %v", err)
+		}
+
+		candidates := make([]assetRef, 0, len(expected))
+		for _, asset := range composedAssets(composed) {
+			if _, ok := expected[asset.name]; ok {
+				candidates = append(candidates, asset)
+			}
+		}
+		if len(candidates) == 0 {
+			t.Fatal("no auto-triage assets available for mutation")
+		}
+
+		asset := candidates[rapid.IntRange(0, len(candidates)-1).Draw(t, "assetIndex")]
+		byteIndex := rapid.IntRange(0, len(asset.data)-1).Draw(t, "byteIndex")
+		asset.data[byteIndex] ^= 0xff
+		if bytes.Equal(asset.data, expected[asset.name]) {
+			t.Fatalf("mutating %s did not change its bytes", asset.name)
+		}
+
+		fresh, err := Compose("core", "self-hosting-xylem")
+		if err != nil {
+			t.Fatalf("Compose(core, self-hosting-xylem) fresh call error = %v", err)
+		}
+
+		got, err := autoTriageAssetSnapshot(fresh)
+		if err != nil {
+			t.Fatalf("snapshot fresh auto-triage assets: %v", err)
+		}
+		if len(got) != len(expected) {
+			t.Fatalf("fresh snapshot count mismatch: got %d, want %d", len(got), len(expected))
+		}
+		for name, want := range expected {
+			if !bytes.Equal(got[name], want) {
+				t.Fatalf("fresh asset %s mismatch after mutating %s", name, asset.name)
+			}
+		}
+	})
+}
+
 type assetRef struct {
 	name string
 	data []byte
@@ -120,4 +177,51 @@ func composedAssets(composed *ComposedProfile) []assetRef {
 		assets = append(assets, assetRef{name: fmt.Sprintf("overlay:%d", i), data: overlay})
 	}
 	return assets
+}
+
+func autoTriageAssetSnapshot(composed *ComposedProfile) (map[string][]byte, error) {
+	if composed == nil {
+		return nil, fmt.Errorf("composed profile is nil")
+	}
+
+	snapshot := make(map[string][]byte, 5)
+	requiredAssets := []struct {
+		name string
+		data []byte
+		ok   bool
+	}{
+		{name: "workflow:auto-triage-issues", data: composed.Workflows["auto-triage-issues"], ok: composed.Workflows["auto-triage-issues"] != nil},
+		{name: "prompt:auto-triage-issues/discover", data: composed.Prompts["auto-triage-issues/discover"], ok: composed.Prompts["auto-triage-issues/discover"] != nil},
+		{name: "prompt:auto-triage-issues/classify", data: composed.Prompts["auto-triage-issues/classify"], ok: composed.Prompts["auto-triage-issues/classify"] != nil},
+		{name: "prompt:auto-triage-issues/apply", data: composed.Prompts["auto-triage-issues/apply"], ok: composed.Prompts["auto-triage-issues/apply"] != nil},
+		{name: "source:auto-triage", data: composed.Sources["auto-triage"], ok: composed.Sources["auto-triage"] != nil},
+	}
+	for _, asset := range requiredAssets {
+		if !asset.ok {
+			return nil, fmt.Errorf("missing %s", asset.name)
+		}
+		if len(asset.data) == 0 {
+			return nil, fmt.Errorf("%s is empty", asset.name)
+		}
+		snapshot[asset.name] = append([]byte(nil), asset.data...)
+	}
+
+	overlayMatches := 0
+	for i, overlay := range composed.ConfigOverlays {
+		if !bytes.Contains(overlay, []byte("auto-triage:")) {
+			continue
+		}
+
+		name := fmt.Sprintf("overlay:%d", i)
+		if len(overlay) == 0 {
+			return nil, fmt.Errorf("%s is empty", name)
+		}
+		snapshot[name] = append([]byte(nil), overlay...)
+		overlayMatches++
+	}
+	if overlayMatches != 1 {
+		return nil, fmt.Errorf("expected 1 auto-triage overlay, got %d", overlayMatches)
+	}
+
+	return snapshot, nil
 }

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -112,21 +112,46 @@ func TestComposeRejectsConflictingSourceKeys(t *testing.T) {
 	assert.True(t, strings.Count(err.Error(), `"core"`) >= 2, "expected both conflicting profiles in error: %q", err.Error())
 }
 
-func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
+func TestSmoke_S4_ComposeCoreAndSelfHostingXylemIncludesAutoTriageOverlayAssets(t *testing.T) {
 	t.Parallel()
 
 	composed, err := Compose("core", "self-hosting-xylem")
 	require.NoError(t, err)
 
+	assert.Contains(t, sortedKeys(composed.Workflows), "auto-triage-issues")
 	assert.Contains(t, sortedKeys(composed.Workflows), "implement-harness")
 	assert.Contains(t, sortedKeys(composed.Workflows), "sota-gap-analysis")
 	assert.Contains(t, sortedKeys(composed.Workflows), "unblock-wave")
 	assert.Contains(t, sortedKeys(composed.Workflows), "diagnose-failures")
+	assert.Contains(t, sortedKeys(composed.Prompts), "auto-triage-issues/discover")
+	assert.Contains(t, sortedKeys(composed.Prompts), "auto-triage-issues/classify")
+	assert.Contains(t, sortedKeys(composed.Prompts), "auto-triage-issues/apply")
 	assert.Contains(t, sortedKeys(composed.Prompts), "implement-harness/pr_draft")
+	assert.Contains(t, sortedKeys(composed.Sources), "auto-triage")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-impl")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-pr-lifecycle")
 	assert.Contains(t, sortedKeys(composed.Sources), "sota-gap")
 	require.Len(t, composed.ConfigOverlays, 2)
+
+	assert.Contains(t, string(composed.Workflows["auto-triage-issues"]), "name: auto-triage-issues")
+	assert.Contains(t, string(composed.Prompts["auto-triage-issues/discover"]), "gh api graphql")
+	assert.Contains(t, string(composed.Prompts["auto-triage-issues/discover"]), "authorAssociation")
+	assert.Contains(t, string(composed.Prompts["auto-triage-issues/classify"]), "Output JSON only.")
+	assert.Contains(t, string(composed.Prompts["auto-triage-issues/apply"]), "gh issue edit")
+
+	foundAutoTriageOverlay := false
+	for _, overlay := range composed.ConfigOverlays {
+		overlayText := string(overlay)
+		if !strings.Contains(overlayText, "auto-triage:") {
+			continue
+		}
+
+		foundAutoTriageOverlay = true
+		assert.Contains(t, overlayText, `schedule: "6h"`)
+		assert.Contains(t, overlayText, "workflow: auto-triage-issues")
+		assert.Contains(t, overlayText, "ref: auto-triage-issues")
+	}
+	assert.True(t, foundAutoTriageOverlay, "expected self-hosting overlay to define auto-triage source")
 }
 
 func TestAdaptRepoWorkflowAssetParsesCleanly(t *testing.T) {

--- a/cli/internal/profiles/self-hosting-xylem/prompts/auto-triage-issues/apply.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/auto-triage-issues/apply.md
@@ -1,0 +1,38 @@
+Apply the approved classification plan to the repository's currently unlabeled issues.
+
+Repository: {{.Repo.Slug}}
+
+## Classification plan
+{{.PreviousOutputs.classify}}
+
+For each planned issue:
+
+1. Re-fetch the live issue before editing:
+
+   `gh issue view <number> --repo {{.Repo.Slug}} --json number,title,url,labels`
+
+2. If the issue already has one or more labels, skip it and record that it was already triaged elsewhere.
+3. If the issue is still unlabeled, apply the planned labels with:
+
+   `gh issue edit <number> --repo {{.Repo.Slug}} --add-label "label-a,label-b"`
+
+4. Re-fetch the issue labels after editing and verify the requested labels are present.
+5. If any `gh issue edit` or verification command fails, stop immediately and surface the failing command/output instead of pretending the run succeeded.
+
+Write the final output as a markdown audit report with these sections:
+
+## Auto-triage summary
+- Processed: <n>
+- Labeled: <n>
+- Skipped: <n>
+
+## Applied
+- #<number> — `<comma-separated labels>` — <short rationale>
+
+## Skipped
+- #<number> — <reason>
+
+## Follow-up recommendations
+- Call out any issues that were labeled only with `needs-triage` and why they need human review.
+
+The final markdown report is the persistent audit trail for this scheduled run, so keep it concrete and repo-specific.

--- a/cli/internal/profiles/self-hosting-xylem/prompts/auto-triage-issues/classify.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/auto-triage-issues/classify.md
@@ -1,0 +1,52 @@
+Classify the unlabeled issues discovered in the previous phase and produce a deterministic labeling plan.
+
+## Discover manifest
+{{.PreviousOutputs.discover}}
+
+Output JSON only. Do not wrap it in code fences and do not add commentary before or after the JSON.
+
+Use the repository's existing label set from the discover manifest. Never invent labels that are not present there.
+
+Default xylem heuristics if those labels exist in the repo:
+
+- Type labels: `bug`, `enhancement`, `documentation`, `question`, `testing`
+- Component labels: `cli`, `workflows`, `compiler`, `mcp`, `security`, `performance`
+- Priority/community labels: `priority-high`, `good first issue`, `community`
+- Fallback label: `needs-triage`
+
+Conservative rules:
+
+1. Prefer missing a component label over guessing one.
+2. If confidence is below `0.80`, or the issue could reasonably fit multiple conflicting labels, include `needs-triage` and set `fallback` to `true`.
+3. Only apply `community` when the author is not a bot and `author_association` is not `OWNER`, `MEMBER`, or `COLLABORATOR`.
+4. Only apply `good first issue` when the change is narrow, low-risk, and suitable for a newcomer.
+5. Only apply `priority-high` for issues that appear release-blocking, security-sensitive, data-loss related, or severe user-facing breakage.
+6. If a label category is unavailable in the repo label set, skip it rather than substituting a different label.
+7. Every issue must receive at least one label. If nothing else is safe, use only `needs-triage`.
+
+Return this schema:
+
+```json
+{
+  "issues": [
+    {
+      "number": 123,
+      "title": "Example",
+      "url": "https://github.com/owner/repo/issues/123",
+      "labels": ["bug", "cli"],
+      "confidence": 0.93,
+      "fallback": false,
+      "rationale": "Clear bug report against CLI behavior with concrete reproduction steps.",
+      "signals": ["mentions panic", "touches command output", "member-authored"]
+    }
+  ],
+  "summary": {
+    "processed": 1,
+    "auto_labeled": 1,
+    "needs_triage": 0,
+    "community": 0
+  }
+}
+```
+
+Deduplicate labels per issue and keep them in a stable order: type/community first, then component labels, then priority/fallback labels.

--- a/cli/internal/profiles/self-hosting-xylem/prompts/auto-triage-issues/discover.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/auto-triage-issues/discover.md
@@ -1,0 +1,55 @@
+Prepare the next batch of unlabeled GitHub issues for automated triage.
+
+Repository: {{.Repo.Slug}}
+
+Your job in this phase is discovery only. Do not edit issues or labels yet.
+
+1. List the repository labels so later phases can validate against the real taxonomy:
+
+   `gh label list --repo {{.Repo.Slug}} --limit 200 --json name,description,color`
+
+2. List open issues and keep only issues that currently have zero labels:
+
+   `gh issue list --repo {{.Repo.Slug}} --state open --limit 100 --json number,title,body,url,author,labels,createdAt,updatedAt`
+
+3. Sort the unlabeled issues by `updatedAt` ascending so older untouched issues are handled first.
+4. Keep at most 10 issues for this run.
+5. For each selected issue, fetch `authorAssociation` separately with GraphQL. `gh issue list --json` does not expose author association, so do not guess it. Use a query in this shape, substituting the owner/name from `{{.Repo.Slug}}` and the issue number:
+
+   `gh api graphql -f query='query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { issue(number:$number) { authorAssociation } } }' -F owner=<owner> -F repo=<repo> -F number=<number>`
+
+6. For each selected issue, capture:
+   - `number`
+   - `title`
+   - `url`
+   - `author_login`
+   - `author_association`
+   - `created_at`
+   - `updated_at`
+   - `body_excerpt` — concise excerpt or summary of the problem statement, reproduction steps, and requested change. Keep it short enough for later phases.
+
+If there are no open unlabeled issues, output a standalone line containing `XYLEM_NOOP`, then a one-sentence explanation.
+
+Otherwise output JSON only, with no code fences or prose before/after it, using this shape:
+
+```json
+{
+  "repo": "{{.Repo.Slug}}",
+  "batch_limit": 10,
+  "repo_labels": [
+    {"name": "bug", "description": "", "color": "d73a4a"}
+  ],
+  "issues": [
+    {
+      "number": 123,
+      "title": "Example",
+      "url": "https://github.com/owner/repo/issues/123",
+      "author_login": "octocat",
+      "author_association": "NONE",
+      "created_at": "2026-04-10T00:00:00Z",
+      "updated_at": "2026-04-10T01:00:00Z",
+      "body_excerpt": "Short summary of the issue body."
+    }
+  ]
+}
+```

--- a/cli/internal/profiles/self-hosting-xylem/workflows/auto-triage-issues.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/auto-triage-issues.yaml
@@ -1,0 +1,57 @@
+name: auto-triage-issues
+description: "Recurring batch labeling for open unlabeled issues"
+phases:
+  - name: discover
+    prompt_file: .xylem/prompts/auto-triage-issues/discover.md
+    max_turns: 20
+    llm: copilot
+    model: gpt-5.4
+    noop:
+      match: XYLEM_NOOP
+  - name: classify
+    prompt_file: .xylem/prompts/auto-triage-issues/classify.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4
+    gate:
+      type: command
+      run: |
+        set -euo pipefail
+
+        plan=".xylem/phases/{{.Vessel.ID}}/classify.output"
+        test -s "$plan"
+
+        jq -e '.issues | type == "array"' "$plan" >/dev/null
+        jq -e '
+          all(.issues[]?;
+            (.number | type == "number") and
+            (.title | type == "string") and
+            (.url | type == "string") and
+            (.labels | type == "array" and length > 0) and
+            (all(.labels[]; type == "string" and length > 0)) and
+            (.confidence | type == "number") and
+            (.fallback | type == "boolean") and
+            (.rationale | type == "string")
+          )
+        ' "$plan" >/dev/null
+
+        repo_labels=$(mktemp)
+        proposed_labels=$(mktemp)
+        missing_labels=$(mktemp)
+        trap 'rm -f "$repo_labels" "$proposed_labels" "$missing_labels"' EXIT
+
+        gh label list --repo {{.Repo.Slug}} --limit 200 --json name --jq '.[].name' | sort -u > "$repo_labels"
+        jq -r '.issues[].labels[]' "$plan" | sort -u > "$proposed_labels"
+
+        comm -23 "$proposed_labels" "$repo_labels" > "$missing_labels"
+        if [ -s "$missing_labels" ]; then
+          echo "ERROR: classify plan proposed labels that do not exist in {{.Repo.Slug}}:"
+          cat "$missing_labels"
+          exit 1
+        fi
+      retries: 1
+  - name: apply
+    prompt_file: .xylem/prompts/auto-triage-issues/apply.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -59,6 +59,15 @@ sources:
       weekly-self-gap-analysis:
         workflow: sota-gap-analysis
         ref: sota-gap-analysis
+  auto-triage:
+    type: scheduled
+    repo: "{{ .Repo }}"
+    schedule: "6h"
+    timeout: "45m"
+    tasks:
+      triage-unlabeled-issues:
+        workflow: auto-triage-issues
+        ref: auto-triage-issues
   harness-post-merge:
     type: github-merge
     repo: "{{ .Repo }}"


### PR DESCRIPTION
## Summary
Adds the self-hosting `auto-triage-issues` workflow and profile scaffolding for automated labeling of open unlabeled issues in xylem.

Issue: https://github.com/nicholls-inc/xylem/issues/272

## Smoke scenarios covered
- S4 — Compose core + self-hosting profile includes auto-triage overlay assets
- S5 — Init scaffolds core + self-hosting auto-triage workflow and prompts

## Changes summary
- Added checked-in workflow assets: `.xylem/workflows/auto-triage-issues.yaml` plus `.xylem/prompts/auto-triage-issues/{discover,classify,apply}.md`
- Added matching self-hosting profile assets under `cli/internal/profiles/self-hosting-xylem/workflows/auto-triage-issues.yaml` and `cli/internal/profiles/self-hosting-xylem/prompts/auto-triage-issues/{discover,classify,apply}.md`
- Updated `.xylem.yml` and `cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml` to register the scheduled `auto-triage` source and `triage-unlabeled-issues` task
- Updated `cli/cmd/xylem/init_test.go`, `cli/internal/profiles/profiles_test.go`, and `cli/internal/profiles/profiles_prop_test.go`
- Key types/functions touched or exercised: `profiles.Compose`, `config.Load`, `scaffoldedWorkflowNames`, `autoTriageAssetSnapshot`

## Test plan
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #272