### PR TITLE
feat(workflow): add continuous-refactoring workflow for semantic refactor and file-diet issue generation

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -143,6 +143,41 @@ sources:
         workflow: harness-gap-analysis
         ref: harness-gap-analysis
 
+  continuous-refactor-semantic:
+    type: schedule
+    repo: nicholls-inc/xylem
+    cadence: "@weekly"
+    workflow: continuous-refactoring
+    params:
+      mode: semantic_refactor
+      source_dirs:
+        - cli
+      file_extensions:
+        - .go
+      exclude_patterns:
+        - "**/*_test.go"
+        - "cli/internal/dtu/testdata/**"
+        - "cli/internal/worktree/.claude/**"
+      max_issues_per_run: 3
+
+  continuous-refactor-file-diet:
+    type: schedule
+    repo: nicholls-inc/xylem
+    cadence: "0 7 * * 1-5"
+    workflow: continuous-refactoring
+    params:
+      mode: file_diet
+      source_dirs:
+        - cli
+      file_extensions:
+        - .go
+      exclude_patterns:
+        - "**/*_test.go"
+        - "cli/internal/dtu/testdata/**"
+        - "cli/internal/worktree/.claude/**"
+      loc_threshold: 500
+      max_issues_per_run: 1
+
   # Post-merge wave dependency unblocking
   # NOTE: github-merge has no label filtering. The unblock-wave prompt
   # guards with XYLEM_NOOP for non-harness merges.

--- a/.xylem/prompts/continuous-refactoring/analyze.md
+++ b/.xylem/prompts/continuous-refactoring/analyze.md
@@ -1,0 +1,38 @@
+Prepare the semantic-refactor path for the recurring continuous-refactoring workflow.
+
+Mode: `{{index .Source.Params "mode"}}`
+Source dirs: `{{index .Source.Params "source_dirs"}}`
+File extensions: `{{index .Source.Params "file_extensions"}}`
+Exclude patterns: `{{index .Source.Params "exclude_patterns"}}`
+Max issues per run: `{{index .Source.Params "max_issues_per_run"}}`
+
+If the mode is not `semantic_refactor`, do not inspect the repo. Output exactly:
+
+```
+Semantic refactor path skipped for mode {{index .Source.Params "mode"}}.
+```
+
+If the mode is `semantic_refactor`:
+
+1. Inspect the configured directories and non-test source files.
+2. Group files by their apparent responsibility.
+3. Identify up to `{{index .Source.Params "max_issues_per_run"}}` high-signal candidates where:
+   - a function or tightly related function cluster appears misplaced,
+   - duplicate or near-duplicate logic is likely present, or
+   - a file's semantic theme is diluted by unrelated helpers.
+4. Do not create issues in this phase.
+
+Output a concise structured report with one section per candidate using this exact heading format:
+
+```
+Candidate N: <short title>
+Current file: <path>
+Functions:
+- <name>
+Why misplaced:
+- <reason>
+Suggested destination:
+- <path or package>
+Potential duplicates:
+- <path or "none">
+```

--- a/.xylem/prompts/continuous-refactoring/create_refactor_issue.md
+++ b/.xylem/prompts/continuous-refactoring/create_refactor_issue.md
@@ -1,0 +1,28 @@
+Create semantic-refactor GitHub issues from the prepared drafts.
+
+Mode: `{{index .Source.Params "mode"}}`
+Drafts:
+
+{{index .PreviousOutputs "propose"}}
+
+If the mode is not `semantic_refactor`, output exactly:
+
+```
+Semantic refactor issue creation skipped for mode {{index .Source.Params "mode"}}.
+```
+
+If there are no drafts, output exactly:
+
+```
+No semantic refactor issues created.
+```
+
+Otherwise:
+
+1. Re-read the drafts from the previous phase.
+2. Use `gh issue create --repo {{.Repo.Slug}}` to file each draft.
+3. Apply labels `refactor`, `enhancement`, and `ready-for-work`.
+4. Create at most `{{index .Source.Params "max_issues_per_run"}}` issues.
+5. Do not create duplicates; if the command phase already reported an open issue, stop without filing anything.
+
+Report the created issue URLs, one per line, prefixed with `Created:`. If nothing is created, say so plainly.

--- a/.xylem/prompts/continuous-refactoring/file_issue.md
+++ b/.xylem/prompts/continuous-refactoring/file_issue.md
@@ -1,0 +1,27 @@
+Create the file-diet GitHub issue from the prepared split plan.
+
+Mode: `{{index .Source.Params "mode"}}`
+Split plan:
+
+{{index .PreviousOutputs "split_plan"}}
+
+If the mode is not `file_diet`, output exactly:
+
+```
+File-diet issue creation skipped for mode {{index .Source.Params "mode"}}.
+```
+
+If there is no split plan, output exactly:
+
+```
+No file-diet issue created.
+```
+
+Otherwise:
+
+1. Use `gh issue create --repo {{.Repo.Slug}}`.
+2. Create exactly one issue from the split-plan draft.
+3. Apply labels `file-diet`, `enhancement`, and `ready-for-work`.
+4. Respect the dedupe command-phase result; do not create a duplicate issue for the same target file.
+
+Report the created issue URL prefixed with `Created:`. If nothing is created, say so plainly.

--- a/.xylem/prompts/continuous-refactoring/measure.md
+++ b/.xylem/prompts/continuous-refactoring/measure.md
@@ -1,0 +1,38 @@
+Prepare the file-diet path for the recurring continuous-refactoring workflow.
+
+Mode: `{{index .Source.Params "mode"}}`
+Source dirs: `{{index .Source.Params "source_dirs"}}`
+File extensions: `{{index .Source.Params "file_extensions"}}`
+Exclude patterns: `{{index .Source.Params "exclude_patterns"}}`
+LOC threshold: `{{index .Source.Params "loc_threshold"}}`
+
+If the mode is not `file_diet`, output exactly:
+
+```
+File-diet measurement skipped for mode {{index .Source.Params "mode"}}.
+```
+
+If the mode is `file_diet`:
+
+1. Measure candidate source files in the configured directories.
+2. Ignore generated/test fixtures and excluded patterns.
+3. Find the single largest file over the configured LOC threshold.
+4. If no file exceeds the threshold, say so clearly.
+
+If a target exists, start your output with:
+
+```
+Target file: <path>
+Target LOC: <count>
+```
+
+Then add:
+
+```
+Top offenders:
+- <path> (<loc>)
+- ...
+
+Why this file is a good file-diet candidate:
+- ...
+```

--- a/.xylem/prompts/continuous-refactoring/propose.md
+++ b/.xylem/prompts/continuous-refactoring/propose.md
@@ -1,0 +1,42 @@
+Turn the semantic-refactor analysis into issue drafts.
+
+Mode: `{{index .Source.Params "mode"}}`
+Previous analysis:
+
+{{index .PreviousOutputs "analyze"}}
+
+If the mode is not `semantic_refactor`, output exactly:
+
+```
+Semantic refactor issue drafting skipped for mode {{index .Source.Params "mode"}}.
+```
+
+If the analysis found no strong candidate, output exactly:
+
+```
+No semantic refactor issue drafts proposed.
+```
+
+Otherwise, produce up to `{{index .Source.Params "max_issues_per_run"}}` issue drafts. Do not call `gh` in this phase.
+
+For each draft, use this exact format:
+
+```
+Title: [refactor] <succinct refactor title>
+Labels: refactor, enhancement, ready-for-work
+Body:
+## Summary
+...
+
+## Why now
+...
+
+## Proposed change
+...
+
+## Files
+- ...
+
+## Acceptance criteria
+- ...
+```

--- a/.xylem/prompts/continuous-refactoring/split_plan.md
+++ b/.xylem/prompts/continuous-refactoring/split_plan.md
@@ -1,0 +1,44 @@
+Turn the file-diet measurement into a semantically meaningful split plan.
+
+Mode: `{{index .Source.Params "mode"}}`
+Measurement:
+
+{{index .PreviousOutputs "measure"}}
+
+If the mode is not `file_diet`, output exactly:
+
+```
+File-diet split planning skipped for mode {{index .Source.Params "mode"}}.
+```
+
+If there is no target file in the measurement output, output exactly:
+
+```
+No file-diet split plan proposed.
+```
+
+Otherwise, produce one issue draft for the largest offending file using this exact format:
+
+```
+Title: [file-diet] <target file>
+Target file: <path>
+Labels: file-diet, enhancement, ready-for-work
+Body:
+## Summary
+...
+
+## Why this file is oversized
+...
+
+## Proposed split
+1. ...
+2. ...
+3. ...
+
+## Suggested new files
+- <path>: <responsibility>
+- ...
+
+## Acceptance criteria
+- ...
+```

--- a/.xylem/workflows/continuous-refactoring.yaml
+++ b/.xylem/workflows/continuous-refactoring.yaml
@@ -1,0 +1,100 @@
+name: continuous-refactoring
+description: "Recurring semantic refactor and file-diet issue generation"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/continuous-refactoring/analyze.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4
+  - name: propose
+    prompt_file: .xylem/prompts/continuous-refactoring/propose.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4
+  - name: dedupe_refactor
+    type: command
+    noop:
+      match: XYLEM_NOOP
+    run: |
+      set -euo pipefail
+
+      mode='{{index .Source.Params "mode"}}'
+      if [ "$mode" != "semantic_refactor" ]; then
+        echo "Skipping semantic refactor dedupe for mode $mode."
+        exit 0
+      fi
+
+      existing_count=$(gh issue list \
+        --repo {{.Repo.Slug}} \
+        --state open \
+        --label refactor \
+        --search '"[refactor]" in:title' \
+        --json number \
+        --limit 1 \
+        --jq 'length')
+      if [ "$existing_count" != "0" ]; then
+        echo "Open [refactor] issue already exists; skipping this run."
+        echo "XYLEM_NOOP"
+        exit 0
+      fi
+
+      echo "No open [refactor] issue found."
+  - name: create_refactor_issue
+    prompt_file: .xylem/prompts/continuous-refactoring/create_refactor_issue.md
+    max_turns: 30
+    llm: copilot
+    model: gpt-5.4
+  - name: measure
+    prompt_file: .xylem/prompts/continuous-refactoring/measure.md
+    max_turns: 30
+    llm: copilot
+    model: gpt-5.4
+  - name: split_plan
+    prompt_file: .xylem/prompts/continuous-refactoring/split_plan.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4
+  - name: dedupe_file_diet
+    type: command
+    noop:
+      match: XYLEM_NOOP
+    run: |
+      set -euo pipefail
+
+      mode='{{index .Source.Params "mode"}}'
+      if [ "$mode" != "file_diet" ]; then
+        echo "Skipping file-diet dedupe for mode $mode."
+        exit 0
+      fi
+
+      split_plan=$(cat <<'XYLEM_SPLIT_PLAN'
+      {{index .PreviousOutputs "split_plan"}}
+      XYLEM_SPLIT_PLAN
+      )
+      target_file=$(printf '%s\n' "$split_plan" | sed -n 's/^Target file: //p' | head -n1)
+      if [ -z "$target_file" ]; then
+        echo "No file-diet target declared by split_plan; nothing to file."
+        echo "XYLEM_NOOP"
+        exit 0
+      fi
+
+      existing_count=$(gh issue list \
+        --repo {{.Repo.Slug}} \
+        --state open \
+        --label file-diet \
+        --search "\"[file-diet] $target_file\" in:title" \
+        --json number \
+        --limit 1 \
+        --jq 'length')
+      if [ "$existing_count" != "0" ]; then
+        echo "Open [file-diet] issue already exists for $target_file; skipping this run."
+        echo "XYLEM_NOOP"
+        exit 0
+      fi
+
+      echo "No open [file-diet] issue found for $target_file."
+  - name: file_issue
+    prompt_file: .xylem/prompts/continuous-refactoring/file_issue.md
+    max_turns: 30
+    llm: copilot
+    model: gpt-5.4

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -36,6 +36,7 @@ var expectedCoreWorkflows = []string{
 }
 
 var expectedSelfHostingWorkflows = []string{
+	"continuous-refactoring",
 	"diagnose-failures",
 	"implement-harness",
 	"sota-gap-analysis",
@@ -571,6 +572,8 @@ func TestSmoke_S5_CorePlusSelfHostingOverlayScaffoldsOverlayWorkflows(t *testing
 	assert.Equal(t, []string{"core", "self-hosting-xylem"}, cfg.Profiles)
 	assert.Contains(t, cfg.Sources, "harness-impl")
 	assert.Contains(t, cfg.Sources, "harness-pr-lifecycle")
+	assert.Contains(t, cfg.Sources, "continuous-refactor-semantic")
+	assert.Contains(t, cfg.Sources, "continuous-refactor-file-diet")
 	require.NoError(t, cfg.Validate())
 }
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -107,6 +107,7 @@ type SourceConfig struct {
 	Schedule string          `yaml:"schedule,omitempty"`
 	Cadence  string          `yaml:"cadence,omitempty"`
 	Workflow string          `yaml:"workflow,omitempty"`
+	Params   map[string]any  `yaml:"params,omitempty"`
 	LLM      string          `yaml:"llm,omitempty"`
 	Model    string          `yaml:"model,omitempty"`
 	Timeout  string          `yaml:"timeout,omitempty"`
@@ -155,6 +156,7 @@ type Task struct {
 	Workflow        string           `yaml:"workflow"`
 	Tier            string           `yaml:"tier,omitempty"`
 	Ref             string           `yaml:"ref,omitempty"`
+	Params          map[string]any   `yaml:"params,omitempty"`
 	StatusLabels    *StatusLabels    `yaml:"status_labels,omitempty"`
 	LabelGateLabels *LabelGateLabels `yaml:"label_gate_labels,omitempty"`
 	On              *PREventsConfig  `yaml:"on,omitempty"`

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -195,6 +195,31 @@ claude:
 	}
 }
 
+func TestLoadScheduleSourceParams(t *testing.T) {
+	path := writeConfigFile(t, `sources:
+  continuous-refactor-file-diet:
+    type: schedule
+    repo: owner/name
+    cadence: "0 7 * * 1-5"
+    workflow: continuous-refactoring
+    params:
+      mode: file_diet
+      source_dirs: [cli]
+      loc_threshold: 500
+claude:
+  default_model: "claude-sonnet-4-6"
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+
+	src, ok := cfg.Sources["continuous-refactor-file-diet"]
+	require.True(t, ok)
+	assert.Equal(t, "file_diet", src.Params["mode"])
+	assert.Equal(t, []any{"cli"}, src.Params["source_dirs"])
+	assert.Equal(t, 500, src.Params["loc_threshold"])
+}
+
 func validConfig() *Config {
 	cfg := &Config{
 		Repo: "owner/name",

--- a/cli/internal/phase/phase.go
+++ b/cli/internal/phase/phase.go
@@ -58,8 +58,9 @@ type RepoData struct {
 
 // SourceData describes the configured source that produced the vessel.
 type SourceData struct {
-	Name string
-	Repo string
+	Name   string
+	Repo   string
+	Params map[string]any
 }
 
 // ValidationData describes optional repo-specific validation commands.

--- a/cli/internal/phase/phase_test.go
+++ b/cli/internal/phase/phase_test.go
@@ -124,6 +124,19 @@ func TestRenderPrompt(t *testing.T) {
 			want: "Gate: all checks passed",
 		},
 		{
+			name:     "renders source params",
+			template: "Mode: {{index .Source.Params \"mode\"}} Threshold: {{index .Source.Params \"loc_threshold\"}}",
+			data: TemplateData{
+				Source: SourceData{
+					Params: map[string]any{
+						"mode":          "file_diet",
+						"loc_threshold": 500,
+					},
+				},
+			},
+			want: "Mode: file_diet Threshold: 500",
+		},
+		{
 			name:     "renders vessel ID and source",
 			template: "Vessel: {{.Vessel.ID}} from {{.Vessel.Source}}",
 			data: TemplateData{

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -122,10 +122,14 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	assert.Contains(t, sortedKeys(composed.Workflows), "sota-gap-analysis")
 	assert.Contains(t, sortedKeys(composed.Workflows), "unblock-wave")
 	assert.Contains(t, sortedKeys(composed.Workflows), "diagnose-failures")
+	assert.Contains(t, sortedKeys(composed.Workflows), "continuous-refactoring")
 	assert.Contains(t, sortedKeys(composed.Prompts), "implement-harness/pr_draft")
+	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-refactoring/analyze")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-impl")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-pr-lifecycle")
 	assert.Contains(t, sortedKeys(composed.Sources), "sota-gap")
+	assert.Contains(t, sortedKeys(composed.Sources), "continuous-refactor-semantic")
+	assert.Contains(t, sortedKeys(composed.Sources), "continuous-refactor-file-diet")
 	require.Len(t, composed.ConfigOverlays, 2)
 }
 

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-refactoring/analyze.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-refactoring/analyze.md
@@ -1,0 +1,38 @@
+Prepare the semantic-refactor path for the recurring continuous-refactoring workflow.
+
+Mode: `{{index .Source.Params "mode"}}`
+Source dirs: `{{index .Source.Params "source_dirs"}}`
+File extensions: `{{index .Source.Params "file_extensions"}}`
+Exclude patterns: `{{index .Source.Params "exclude_patterns"}}`
+Max issues per run: `{{index .Source.Params "max_issues_per_run"}}`
+
+If the mode is not `semantic_refactor`, do not inspect the repo. Output exactly:
+
+```
+Semantic refactor path skipped for mode {{index .Source.Params "mode"}}.
+```
+
+If the mode is `semantic_refactor`:
+
+1. Inspect the configured directories and non-test source files.
+2. Group files by their apparent responsibility.
+3. Identify up to `{{index .Source.Params "max_issues_per_run"}}` high-signal candidates where:
+   - a function or tightly related function cluster appears misplaced,
+   - duplicate or near-duplicate logic is likely present, or
+   - a file's semantic theme is diluted by unrelated helpers.
+4. Do not create issues in this phase.
+
+Output a concise structured report with one section per candidate using this exact heading format:
+
+```
+Candidate N: <short title>
+Current file: <path>
+Functions:
+- <name>
+Why misplaced:
+- <reason>
+Suggested destination:
+- <path or package>
+Potential duplicates:
+- <path or "none">
+```

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-refactoring/create_refactor_issue.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-refactoring/create_refactor_issue.md
@@ -1,0 +1,28 @@
+Create semantic-refactor GitHub issues from the prepared drafts.
+
+Mode: `{{index .Source.Params "mode"}}`
+Drafts:
+
+{{index .PreviousOutputs "propose"}}
+
+If the mode is not `semantic_refactor`, output exactly:
+
+```
+Semantic refactor issue creation skipped for mode {{index .Source.Params "mode"}}.
+```
+
+If there are no drafts, output exactly:
+
+```
+No semantic refactor issues created.
+```
+
+Otherwise:
+
+1. Re-read the drafts from the previous phase.
+2. Use `gh issue create --repo {{.Repo.Slug}}` to file each draft.
+3. Apply labels `refactor`, `enhancement`, and `ready-for-work`.
+4. Create at most `{{index .Source.Params "max_issues_per_run"}}` issues.
+5. Do not create duplicates; if the command phase already reported an open issue, stop without filing anything.
+
+Report the created issue URLs, one per line, prefixed with `Created:`. If nothing is created, say so plainly.

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-refactoring/file_issue.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-refactoring/file_issue.md
@@ -1,0 +1,27 @@
+Create the file-diet GitHub issue from the prepared split plan.
+
+Mode: `{{index .Source.Params "mode"}}`
+Split plan:
+
+{{index .PreviousOutputs "split_plan"}}
+
+If the mode is not `file_diet`, output exactly:
+
+```
+File-diet issue creation skipped for mode {{index .Source.Params "mode"}}.
+```
+
+If there is no split plan, output exactly:
+
+```
+No file-diet issue created.
+```
+
+Otherwise:
+
+1. Use `gh issue create --repo {{.Repo.Slug}}`.
+2. Create exactly one issue from the split-plan draft.
+3. Apply labels `file-diet`, `enhancement`, and `ready-for-work`.
+4. Respect the dedupe command-phase result; do not create a duplicate issue for the same target file.
+
+Report the created issue URL prefixed with `Created:`. If nothing is created, say so plainly.

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-refactoring/measure.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-refactoring/measure.md
@@ -1,0 +1,38 @@
+Prepare the file-diet path for the recurring continuous-refactoring workflow.
+
+Mode: `{{index .Source.Params "mode"}}`
+Source dirs: `{{index .Source.Params "source_dirs"}}`
+File extensions: `{{index .Source.Params "file_extensions"}}`
+Exclude patterns: `{{index .Source.Params "exclude_patterns"}}`
+LOC threshold: `{{index .Source.Params "loc_threshold"}}`
+
+If the mode is not `file_diet`, output exactly:
+
+```
+File-diet measurement skipped for mode {{index .Source.Params "mode"}}.
+```
+
+If the mode is `file_diet`:
+
+1. Measure candidate source files in the configured directories.
+2. Ignore generated/test fixtures and excluded patterns.
+3. Find the single largest file over the configured LOC threshold.
+4. If no file exceeds the threshold, say so clearly.
+
+If a target exists, start your output with:
+
+```
+Target file: <path>
+Target LOC: <count>
+```
+
+Then add:
+
+```
+Top offenders:
+- <path> (<loc>)
+- ...
+
+Why this file is a good file-diet candidate:
+- ...
+```

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-refactoring/propose.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-refactoring/propose.md
@@ -1,0 +1,42 @@
+Turn the semantic-refactor analysis into issue drafts.
+
+Mode: `{{index .Source.Params "mode"}}`
+Previous analysis:
+
+{{index .PreviousOutputs "analyze"}}
+
+If the mode is not `semantic_refactor`, output exactly:
+
+```
+Semantic refactor issue drafting skipped for mode {{index .Source.Params "mode"}}.
+```
+
+If the analysis found no strong candidate, output exactly:
+
+```
+No semantic refactor issue drafts proposed.
+```
+
+Otherwise, produce up to `{{index .Source.Params "max_issues_per_run"}}` issue drafts. Do not call `gh` in this phase.
+
+For each draft, use this exact format:
+
+```
+Title: [refactor] <succinct refactor title>
+Labels: refactor, enhancement, ready-for-work
+Body:
+## Summary
+...
+
+## Why now
+...
+
+## Proposed change
+...
+
+## Files
+- ...
+
+## Acceptance criteria
+- ...
+```

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-refactoring/split_plan.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-refactoring/split_plan.md
@@ -1,0 +1,44 @@
+Turn the file-diet measurement into a semantically meaningful split plan.
+
+Mode: `{{index .Source.Params "mode"}}`
+Measurement:
+
+{{index .PreviousOutputs "measure"}}
+
+If the mode is not `file_diet`, output exactly:
+
+```
+File-diet split planning skipped for mode {{index .Source.Params "mode"}}.
+```
+
+If there is no target file in the measurement output, output exactly:
+
+```
+No file-diet split plan proposed.
+```
+
+Otherwise, produce one issue draft for the largest offending file using this exact format:
+
+```
+Title: [file-diet] <target file>
+Target file: <path>
+Labels: file-diet, enhancement, ready-for-work
+Body:
+## Summary
+...
+
+## Why this file is oversized
+...
+
+## Proposed split
+1. ...
+2. ...
+3. ...
+
+## Suggested new files
+- <path>: <responsibility>
+- ...
+
+## Acceptance criteria
+- ...
+```

--- a/cli/internal/profiles/self-hosting-xylem/workflows/continuous-refactoring.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/continuous-refactoring.yaml
@@ -1,0 +1,100 @@
+name: continuous-refactoring
+description: "Recurring semantic refactor and file-diet issue generation"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/continuous-refactoring/analyze.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4
+  - name: propose
+    prompt_file: .xylem/prompts/continuous-refactoring/propose.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4
+  - name: dedupe_refactor
+    type: command
+    noop:
+      match: XYLEM_NOOP
+    run: |
+      set -euo pipefail
+
+      mode='{{index .Source.Params "mode"}}'
+      if [ "$mode" != "semantic_refactor" ]; then
+        echo "Skipping semantic refactor dedupe for mode $mode."
+        exit 0
+      fi
+
+      existing_count=$(gh issue list \
+        --repo {{.Repo.Slug}} \
+        --state open \
+        --label refactor \
+        --search '"[refactor]" in:title' \
+        --json number \
+        --limit 1 \
+        --jq 'length')
+      if [ "$existing_count" != "0" ]; then
+        echo "Open [refactor] issue already exists; skipping this run."
+        echo "XYLEM_NOOP"
+        exit 0
+      fi
+
+      echo "No open [refactor] issue found."
+  - name: create_refactor_issue
+    prompt_file: .xylem/prompts/continuous-refactoring/create_refactor_issue.md
+    max_turns: 30
+    llm: copilot
+    model: gpt-5.4
+  - name: measure
+    prompt_file: .xylem/prompts/continuous-refactoring/measure.md
+    max_turns: 30
+    llm: copilot
+    model: gpt-5.4
+  - name: split_plan
+    prompt_file: .xylem/prompts/continuous-refactoring/split_plan.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4
+  - name: dedupe_file_diet
+    type: command
+    noop:
+      match: XYLEM_NOOP
+    run: |
+      set -euo pipefail
+
+      mode='{{index .Source.Params "mode"}}'
+      if [ "$mode" != "file_diet" ]; then
+        echo "Skipping file-diet dedupe for mode $mode."
+        exit 0
+      fi
+
+      split_plan=$(cat <<'XYLEM_SPLIT_PLAN'
+      {{index .PreviousOutputs "split_plan"}}
+      XYLEM_SPLIT_PLAN
+      )
+      target_file=$(printf '%s\n' "$split_plan" | sed -n 's/^Target file: //p' | head -n1)
+      if [ -z "$target_file" ]; then
+        echo "No file-diet target declared by split_plan; nothing to file."
+        echo "XYLEM_NOOP"
+        exit 0
+      fi
+
+      existing_count=$(gh issue list \
+        --repo {{.Repo.Slug}} \
+        --state open \
+        --label file-diet \
+        --search "\"[file-diet] $target_file\" in:title" \
+        --json number \
+        --limit 1 \
+        --jq 'length')
+      if [ "$existing_count" != "0" ]; then
+        echo "Open [file-diet] issue already exists for $target_file; skipping this run."
+        echo "XYLEM_NOOP"
+        exit 0
+      fi
+
+      echo "No open [file-diet] issue found for $target_file."
+  - name: file_issue
+    prompt_file: .xylem/prompts/continuous-refactoring/file_issue.md
+    max_turns: 30
+    llm: copilot
+    model: gpt-5.4

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -59,6 +59,39 @@ sources:
       weekly-self-gap-analysis:
         workflow: sota-gap-analysis
         ref: sota-gap-analysis
+  continuous-refactor-semantic:
+    type: schedule
+    repo: "{{ .Repo }}"
+    cadence: "@weekly"
+    workflow: continuous-refactoring
+    params:
+      mode: semantic_refactor
+      source_dirs:
+        - cli
+      file_extensions:
+        - .go
+      exclude_patterns:
+        - "**/*_test.go"
+        - "cli/internal/dtu/testdata/**"
+        - "cli/internal/worktree/.claude/**"
+      max_issues_per_run: 3
+  continuous-refactor-file-diet:
+    type: schedule
+    repo: "{{ .Repo }}"
+    cadence: "0 7 * * 1-5"
+    workflow: continuous-refactoring
+    params:
+      mode: file_diet
+      source_dirs:
+        - cli
+      file_extensions:
+        - .go
+      exclude_patterns:
+        - "**/*_test.go"
+        - "cli/internal/dtu/testdata/**"
+        - "cli/internal/worktree/.claude/**"
+      loc_threshold: 500
+      max_issues_per_run: 1
   harness-post-merge:
     type: github-merge
     repo: "{{ .Repo }}"

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -621,7 +621,14 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			phaseStart := r.runtimeNow()
 
 			// Build template data
-			td := r.buildTemplateData(vessel, issueData, p.Name, i, previousOutputs, gateResult)
+			td, err := r.buildTemplateData(vessel, issueData, p.Name, i, previousOutputs, gateResult)
+			if err != nil {
+				r.failVessel(vessel.ID, fmt.Sprintf("build template data for phase %s: %v", p.Name, err))
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
+				return "failed"
+			}
 
 			var output []byte
 			var runErr error
@@ -1382,9 +1389,11 @@ func waitedDuration(since *time.Time, now time.Time) time.Duration {
 	return now.Sub(*since)
 }
 
-func (r *Runner) watchVesselCancellation(parent context.Context, vesselID string) (context.Context, context.CancelCauseFunc) {
+func (r *Runner) watchVesselCancellation(parent context.Context, vesselID string) (context.Context, func(error)) {
 	ctx, cancel := context.WithCancelCause(parent)
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		ticker := time.NewTicker(vesselCancelPollInterval)
 		defer ticker.Stop()
 		for {
@@ -1403,7 +1412,10 @@ func (r *Runner) watchVesselCancellation(parent context.Context, vesselID string
 			}
 		}
 	}()
-	return ctx, cancel
+	return ctx, func(cause error) {
+		cancel(cause)
+		<-done
+	}
 }
 
 func (r *Runner) isVesselCancelled(vesselID string) (bool, error) {
@@ -1914,7 +1926,14 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		log.Printf("%sphase %q starting (orchestrated)", vesselLabel(vessel), p.Name)
 		phaseStart := r.runtimeNow()
 
-		td := r.buildTemplateData(vessel, issueData, p.Name, phaseIdx, previousOutputs, gateResult)
+		td, err := r.buildTemplateData(vessel, issueData, p.Name, phaseIdx, previousOutputs, gateResult)
+		if err != nil {
+			r.failVessel(vessel.ID, fmt.Sprintf("build template data for phase %s: %v", p.Name, err))
+			if err := src.OnFail(ctx, vessel); err != nil {
+				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+			}
+			return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
+		}
 
 		var output []byte
 		var runErr error
@@ -3679,6 +3698,8 @@ func (r *Runner) resolveRepo(vessel queue.Vessel) string {
 		return s.Repo
 	case *source.GitHubMerge:
 		return s.Repo
+	case *source.Schedule:
+		return s.Repo
 	case *source.Scheduled:
 		return s.Repo
 	default:
@@ -3693,7 +3714,7 @@ func (r *Runner) resolveDefaultBranch() string {
 	return "main"
 }
 
-func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueData, phaseName string, phaseIndex int, previousOutputs map[string]string, gateResult string) phase.TemplateData {
+func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueData, phaseName string, phaseIndex int, previousOutputs map[string]string, gateResult string) (phase.TemplateData, error) {
 	sourceName := vessel.Source
 	if configSource := r.sourceConfigNameFromMeta(vessel); configSource != "" {
 		sourceName = configSource
@@ -3707,6 +3728,10 @@ func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueDat
 			Build:  strings.TrimSpace(r.Config.Validation.Build),
 			Test:   strings.TrimSpace(r.Config.Validation.Test),
 		}
+	}
+	sourceParams, err := source.DecodeTaskParams(vessel.Meta[source.TaskParamsMetaKey])
+	if err != nil {
+		return phase.TemplateData{}, fmt.Errorf("decode task params for vessel %s: %w", vessel.ID, err)
 	}
 	return phase.TemplateData{
 		Issue: issueData,
@@ -3727,11 +3752,12 @@ func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueDat
 			DefaultBranch: r.resolveDefaultBranch(),
 		},
 		Source: phase.SourceData{
-			Name: sourceName,
-			Repo: repoSlug,
+			Name:   sourceName,
+			Repo:   repoSlug,
+			Params: sourceParams,
 		},
 		Validation: validation,
-	}
+	}, nil
 }
 
 func vesselLabel(v queue.Vessel) string {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -4933,12 +4933,68 @@ func TestSmoke_S4_BuildTemplateDataExposesRepoAndValidation(t *testing.T) {
 			"schedule.source_name": "security-compliance",
 		},
 	}
-	td := r.buildTemplateData(vessel, phase.IssueData{Number: 42}, "merge", 0, nil, "")
+	td, err := r.buildTemplateData(vessel, phase.IssueData{Number: 42}, "merge", 0, nil, "")
+	require.NoError(t, err)
 
 	rendered, err := renderCommandTemplate("merge", "command", "gh pr merge {{.Issue.Number}} --repo {{.Repo.Slug}} && echo {{.Source.Name}} {{.Source.Repo}} {{.Repo.DefaultBranch}} {{.Validation.Format}} {{.Validation.Lint}} {{.Validation.Build}} {{.Validation.Test}} {{.Vessel.Ref}} {{index .Vessel.Meta \"schedule.source_name\"}}", td)
 	require.NoError(t, err)
 	assert.Contains(t, rendered, "gh pr merge 42 --repo owner/config-repo")
 	assert.Contains(t, rendered, "echo harness-merge owner/config-repo trunk fmt ./... lint ./... build ./... test ./... https://github.com/owner/config-repo/pull/42 security-compliance")
+}
+
+func TestSmoke_S5_BuildTemplateDataExposesScheduledTaskParams(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.Sources["continuous-refactor-file-diet"] = config.SourceConfig{
+		Type:     "schedule",
+		Repo:     "owner/config-repo",
+		Cadence:  "@weekly",
+		Workflow: "continuous-refactoring",
+	}
+	r := &Runner{
+		Config: cfg,
+		Sources: map[string]source.Source{
+			"continuous-refactor-file-diet": &source.Schedule{Repo: "owner/config-repo"},
+		},
+	}
+
+	encoded, err := source.EncodeTaskParams(map[string]any{
+		"mode":          "file_diet",
+		"loc_threshold": 500,
+	})
+	require.NoError(t, err)
+
+	td, err := r.buildTemplateData(queue.Vessel{
+		ID:     "schedule-1",
+		Source: "schedule",
+		Meta: map[string]string{
+			"config_source":          "continuous-refactor-file-diet",
+			source.TaskParamsMetaKey: encoded,
+		},
+	}, phase.IssueData{}, "measure", 0, nil, "")
+	require.NoError(t, err)
+	assert.Equal(t, "continuous-refactor-file-diet", td.Source.Name)
+	assert.Equal(t, "owner/config-repo", td.Source.Repo)
+	assert.Equal(t, "owner/config-repo", td.Repo.Slug)
+	assert.Equal(t, "file_diet", td.Source.Params["mode"])
+	assert.Equal(t, float64(500), td.Source.Params["loc_threshold"])
+}
+
+func TestBuildTemplateDataRejectsMalformedTaskParams(t *testing.T) {
+	t.Parallel()
+
+	r := &Runner{}
+	_, err := r.buildTemplateData(queue.Vessel{
+		ID:     "schedule-1",
+		Source: "schedule",
+		Meta: map[string]string{
+			source.TaskParamsMetaKey: "{not-json",
+		},
+	}, phase.IssueData{}, "measure", 0, nil, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode task params")
 }
 
 func TestResolveSourcePrefersConfigSource(t *testing.T) {

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"context"
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
 	"time"
@@ -213,8 +214,10 @@ func (s *Scanner) buildSources() []sourceEntry {
 			entries = append(entries, sourceEntry{
 				src: &source.Schedule{
 					ConfigName: name,
+					Repo:       srcCfg.Repo,
 					Cadence:    srcCfg.Cadence,
 					Workflow:   srcCfg.Workflow,
+					Params:     maps.Clone(srcCfg.Params),
 					StateDir:   s.Config.StateDir,
 					Queue:      s.Queue,
 				},
@@ -277,6 +280,7 @@ func convertScheduledTasks(cfgTasks map[string]config.Task) map[string]source.Sc
 			Workflow: t.Workflow,
 			Ref:      t.Ref,
 			Tier:     t.Tier,
+			Params:   maps.Clone(t.Params),
 		}
 	}
 	return tasks

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -424,6 +424,39 @@ func TestScanScheduleSource(t *testing.T) {
 	}
 }
 
+func TestBuildSourcesScheduleCarriesRepoAndParams(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 2,
+		MaxTurns:    50,
+		Timeout:     "30m",
+		StateDir:    dir,
+		Claude:      config.ClaudeConfig{Command: "claude", DefaultModel: "claude-sonnet-4-6"},
+		Sources: map[string]config.SourceConfig{
+			"continuous-refactor-file-diet": {
+				Type:     "schedule",
+				Repo:     "owner/repo",
+				Cadence:  "@weekly",
+				Workflow: "continuous-refactoring",
+				Params: map[string]any{
+					"mode":               "file_diet",
+					"max_issues_per_run": 1,
+				},
+			},
+		},
+	}
+	s := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), newMock())
+
+	entries := s.buildSources()
+	require.Len(t, entries, 1)
+
+	scheduleSource, ok := entries[0].src.(*source.Schedule)
+	require.True(t, ok)
+	assert.Equal(t, "owner/repo", scheduleSource.Repo)
+	assert.Equal(t, "file_diet", scheduleSource.Params["mode"])
+	assert.Equal(t, 1, scheduleSource.Params["max_issues_per_run"])
+}
+
 func TestScanMultipleScheduleSourcesKeepConfigNamesDistinct(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{

--- a/cli/internal/source/params.go
+++ b/cli/internal/source/params.go
@@ -1,0 +1,37 @@
+package source
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const TaskParamsMetaKey = "task_params_json"
+
+func EncodeTaskParams(params map[string]any) (string, error) {
+	if len(params) == 0 {
+		return "", nil
+	}
+
+	data, err := json.Marshal(params)
+	if err != nil {
+		return "", fmt.Errorf("marshal task params: %w", err)
+	}
+	return string(data), nil
+}
+
+func DecodeTaskParams(raw string) (map[string]any, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	var params map[string]any
+	if err := json.Unmarshal([]byte(raw), &params); err != nil {
+		return nil, fmt.Errorf("unmarshal task params: %w", err)
+	}
+	if len(params) == 0 {
+		return nil, nil
+	}
+	return params, nil
+}

--- a/cli/internal/source/params_prop_test.go
+++ b/cli/internal/source/params_prop_test.go
@@ -1,0 +1,66 @@
+package source
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func taskParamsGen() *rapid.Generator[map[string]any] {
+	return rapid.Custom(func(t *rapid.T) map[string]any {
+		count := rapid.IntRange(1, 5).Draw(t, "count")
+		params := make(map[string]any, count)
+		for i := 0; i < count; i++ {
+			key := fmt.Sprintf("key_%d", i)
+			switch rapid.IntRange(0, 2).Draw(t, fmt.Sprintf("kind_%d", i)) {
+			case 0:
+				params[key] = rapid.StringMatching(`[a-z_]{1,12}`).Draw(t, fmt.Sprintf("string_%d", i))
+			case 1:
+				params[key] = rapid.IntRange(0, 2000).Draw(t, fmt.Sprintf("int_%d", i))
+			default:
+				size := rapid.IntRange(0, 4).Draw(t, fmt.Sprintf("slice_size_%d", i))
+				values := make([]any, 0, size)
+				for j := 0; j < size; j++ {
+					values = append(values, rapid.StringMatching(`[a-z_]{1,12}`).Draw(t, fmt.Sprintf("slice_%d_%d", i, j)))
+				}
+				params[key] = values
+			}
+		}
+		return params
+	})
+}
+
+func TestPropTaskParamsEncodeProducesJSONShape(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		params := taskParamsGen().Draw(t, "params")
+		encoded, err := EncodeTaskParams(params)
+		if err != nil {
+			t.Fatalf("EncodeTaskParams() error = %v", err)
+		}
+
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(encoded), &decoded); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v", err)
+		}
+
+		for key, want := range params {
+			got, ok := decoded[key]
+			if !ok {
+				t.Fatalf("decoded params missing key %q in %#v", key, decoded)
+			}
+			switch typed := want.(type) {
+			case int:
+				if got != float64(typed) {
+					t.Fatalf("decoded[%q] = %#v, want %v", key, got, float64(typed))
+				}
+			default:
+				if !reflect.DeepEqual(got, typed) {
+					t.Fatalf("decoded[%q] = %#v, want %#v", key, got, typed)
+				}
+			}
+		}
+	})
+}

--- a/cli/internal/source/params_test.go
+++ b/cli/internal/source/params_test.go
@@ -1,0 +1,57 @@
+package source
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeTaskParamsProducesJSONObject(t *testing.T) {
+	t.Parallel()
+
+	params := map[string]any{
+		"mode":               "file_diet",
+		"loc_threshold":      500,
+		"source_dirs":        []any{"cli", "internal"},
+		"max_issues_per_run": 1,
+	}
+
+	encoded, err := EncodeTaskParams(params)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(encoded), &decoded))
+	assert.Equal(t, "file_diet", decoded["mode"])
+	assert.Equal(t, float64(500), decoded["loc_threshold"])
+	assert.Equal(t, float64(1), decoded["max_issues_per_run"])
+	assert.Equal(t, []any{"cli", "internal"}, decoded["source_dirs"])
+}
+
+func TestDecodeTaskParamsParsesJSONObject(t *testing.T) {
+	t.Parallel()
+
+	decoded, err := DecodeTaskParams(`{"mode":"semantic_refactor","max_issues_per_run":3,"source_dirs":["cli"]}`)
+	require.NoError(t, err)
+	assert.Equal(t, "semantic_refactor", decoded["mode"])
+	assert.Equal(t, float64(3), decoded["max_issues_per_run"])
+	assert.Equal(t, []any{"cli"}, decoded["source_dirs"])
+}
+
+func TestDecodeTaskParamsBlankReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	decoded, err := DecodeTaskParams("   ")
+	require.NoError(t, err)
+	assert.Nil(t, decoded)
+}
+
+func TestDecodeTaskParamsRejectsMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	decoded, err := DecodeTaskParams("{not-json")
+	require.Error(t, err)
+	assert.Nil(t, decoded)
+	assert.Contains(t, err.Error(), "unmarshal task params")
+}

--- a/cli/internal/source/schedule.go
+++ b/cli/internal/source/schedule.go
@@ -19,8 +19,10 @@ const legacyScheduleStateFileName = "schedule-state.json"
 
 type Schedule struct {
 	ConfigName string
+	Repo       string
 	Cadence    string
 	Workflow   string
+	Params     map[string]any
 	StateDir   string
 	Queue      *queue.Queue
 	Now        func() time.Time
@@ -67,7 +69,10 @@ func (s *Schedule) Scan(_ context.Context) ([]queue.Vessel, error) {
 		return nil, nil
 	}
 
-	vessel := s.buildVessel(firedAt, spec.Raw())
+	vessel, err := s.buildVessel(firedAt, spec.Raw())
+	if err != nil {
+		return nil, fmt.Errorf("schedule source %q: build vessel: %w", s.ConfigName, err)
+	}
 	if s.Queue != nil && s.Queue.HasRefAny(vessel.Ref) {
 		return nil, nil
 	}
@@ -116,7 +121,7 @@ func ValidateCadence(expr string) error {
 	return err
 }
 
-func (s *Schedule) buildVessel(firedAt time.Time, rawCadence string) queue.Vessel {
+func (s *Schedule) buildVessel(firedAt time.Time, rawCadence string) (queue.Vessel, error) {
 	firedAt = firedAt.UTC().Truncate(time.Second)
 	idTime := firedAt.Format("20060102t150405z")
 	refTime := firedAt.Format(time.RFC3339)
@@ -124,22 +129,28 @@ func (s *Schedule) buildVessel(firedAt time.Time, rawCadence string) queue.Vesse
 	if configName == "" {
 		configName = "schedule"
 	}
+	meta := map[string]string{
+		"schedule.cadence":     rawCadence,
+		"schedule.fired_at":    refTime,
+		"schedule.source_name": configName,
+		"schedule_cadence":     rawCadence,
+		"schedule_fired_at":    refTime,
+		"schedule_name":        configName,
+	}
+	if encodedParams, err := EncodeTaskParams(s.Params); err != nil {
+		return queue.Vessel{}, fmt.Errorf("encode params: %w", err)
+	} else if encodedParams != "" {
+		meta[TaskParamsMetaKey] = encodedParams
+	}
 	return queue.Vessel{
-		ID:       fmt.Sprintf("schedule-%s-%s", scheduleSlug(configName), idTime),
-		Source:   s.Name(),
-		Ref:      fmt.Sprintf("schedule://%s/%s", configName, refTime),
-		Workflow: s.Workflow,
-		Meta: map[string]string{
-			"schedule.cadence":     rawCadence,
-			"schedule.fired_at":    refTime,
-			"schedule.source_name": configName,
-			"schedule_cadence":     rawCadence,
-			"schedule_fired_at":    refTime,
-			"schedule_name":        configName,
-		},
+		ID:        fmt.Sprintf("schedule-%s-%s", scheduleSlug(configName), idTime),
+		Source:    s.Name(),
+		Ref:       fmt.Sprintf("schedule://%s/%s", configName, refTime),
+		Workflow:  s.Workflow,
+		Meta:      meta,
 		State:     queue.StatePending,
 		CreatedAt: firedAt,
-	}
+	}, nil
 }
 
 func (s *Schedule) loadLastFiredAt() (*time.Time, error) {

--- a/cli/internal/source/schedule_test.go
+++ b/cli/internal/source/schedule_test.go
@@ -418,3 +418,34 @@ func TestScheduleScanReadsLegacyStateFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, vessels)
 }
+
+func TestSmoke_S3_ScheduleSourceCarriesConfiguredParamsIntoVesselMeta(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 9, 6, 45, 12, 0, time.UTC)
+	s := &Schedule{
+		ConfigName: "continuous-refactor",
+		Cadence:    "@weekly",
+		Workflow:   "continuous-refactoring",
+		Params: map[string]any{
+			"mode":          "file_diet",
+			"loc_threshold": 500,
+		},
+		StateDir: t.TempDir(),
+		Queue:    queue.New(filepath.Join(t.TempDir(), "queue.jsonl")),
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	vessels, err := s.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+
+	decoded, err := DecodeTaskParams(vessels[0].Meta[TaskParamsMetaKey])
+	require.NoError(t, err)
+	assert.Equal(t, "continuous-refactor", vessels[0].Meta["schedule.source_name"])
+	assert.Equal(t, "@weekly", vessels[0].Meta["schedule.cadence"])
+	assert.Equal(t, "file_diet", decoded["mode"])
+	assert.Equal(t, float64(500), decoded["loc_threshold"])
+}

--- a/cli/internal/source/scheduled.go
+++ b/cli/internal/source/scheduled.go
@@ -19,6 +19,7 @@ type ScheduledTask struct {
 	Workflow string
 	Ref      string
 	Tier     string
+	Params   map[string]any
 }
 
 type Scheduled struct {
@@ -88,6 +89,14 @@ func (s *Scheduled) Scan(_ context.Context) ([]queue.Vessel, error) {
 		}
 		if refName := strings.TrimSpace(task.Ref); refName != "" {
 			meta["schedule_ref"] = refName
+		}
+		if encodedParams, err := EncodeTaskParams(task.Params); err != nil {
+			if s.ConfigName != "" {
+				return nil, fmt.Errorf("scheduled source %q: encode params for task %q: %w", s.ConfigName, taskName, err)
+			}
+			return nil, fmt.Errorf("encode scheduled params for task %q: %w", taskName, err)
+		} else if encodedParams != "" {
+			meta[TaskParamsMetaKey] = encodedParams
 		}
 
 		vessels = append(vessels, queue.Vessel{

--- a/cli/internal/source/scheduled_test.go
+++ b/cli/internal/source/scheduled_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScheduledScanEnqueuesOnePerWindow(t *testing.T) {
@@ -65,4 +67,32 @@ func TestScheduleWindow(t *testing.T) {
 	if start.After(time.Date(2026, 4, 9, 10, 27, 0, 0, time.UTC)) {
 		t.Fatalf("start = %s, want start at or before now", start)
 	}
+}
+
+func TestScheduledScanEncodesTaskParamsIntoVesselMeta(t *testing.T) {
+	t.Parallel()
+
+	src := &Scheduled{
+		Repo:     "owner/repo",
+		Schedule: "@weekly",
+		Queue:    queue.New(filepath.Join(t.TempDir(), "queue.jsonl")),
+		Tasks: map[string]ScheduledTask{
+			"semantic": {
+				Workflow: "continuous-refactoring",
+				Params: map[string]any{
+					"mode":               "semantic_refactor",
+					"max_issues_per_run": 3,
+				},
+			},
+		},
+	}
+
+	vessels, err := src.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+
+	decoded, err := DecodeTaskParams(vessels[0].Meta[TaskParamsMetaKey])
+	require.NoError(t, err)
+	assert.Equal(t, "semantic_refactor", decoded["mode"])
+	assert.Equal(t, float64(3), decoded["max_issues_per_run"])
 }

--- a/cli/internal/workflow/continuous_refactoring_workflow_test.go
+++ b/cli/internal/workflow/continuous_refactoring_workflow_test.go
@@ -1,0 +1,89 @@
+package workflow
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSmoke_S8_ContinuousRefactoringWorkflowUsesTemplateParamsAndDedupeCommandPhases(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := checkedInWorkflowPath(t, "continuous-refactoring.yaml")
+	data, err := os.ReadFile(workflowPath)
+	require.NoError(t, err, "ReadFile(%q)", workflowPath)
+
+	var wf Workflow
+	require.NoError(t, yaml.Unmarshal(data, &wf), "yaml.Unmarshal(%q)", workflowPath)
+
+	assert.Equal(t, "continuous-refactoring", wf.Name)
+
+	refactorDedupe := findPhaseByName(t, wf.Phases, "dedupe_refactor")
+	assert.Equal(t, "command", refactorDedupe.Type)
+	require.NotNil(t, refactorDedupe.NoOp)
+	assert.Equal(t, "XYLEM_NOOP", refactorDedupe.NoOp.Match)
+	assert.Contains(t, refactorDedupe.Run, `{{index .Source.Params "mode"}}`)
+	assert.Contains(t, refactorDedupe.Run, `--label refactor`)
+	assert.Contains(t, refactorDedupe.Run, `"[refactor]" in:title`)
+
+	fileDietDedupe := findPhaseByName(t, wf.Phases, "dedupe_file_diet")
+	assert.Equal(t, "command", fileDietDedupe.Type)
+	require.NotNil(t, fileDietDedupe.NoOp)
+	assert.Equal(t, "XYLEM_NOOP", fileDietDedupe.NoOp.Match)
+	assert.Contains(t, fileDietDedupe.Run, `{{index .Source.Params "mode"}}`)
+	assert.Contains(t, fileDietDedupe.Run, `{{index .PreviousOutputs "split_plan"}}`)
+	assert.Contains(t, fileDietDedupe.Run, `--label file-diet`)
+	assert.Contains(t, fileDietDedupe.Run, `[file-diet] $target_file`)
+	assert.Contains(t, fileDietDedupe.Run, `in:title`)
+}
+
+func TestSmoke_S9_ContinuousRefactoringPromptsReferenceConfiguredParamsLabelsAndIssueCreationRules(t *testing.T) {
+	t.Parallel()
+
+	analyzePromptPath := checkedInWorkflowPromptPath(t, "continuous-refactoring", "analyze.md")
+	analyzePrompt, err := os.ReadFile(analyzePromptPath)
+	require.NoError(t, err, "ReadFile(%q)", analyzePromptPath)
+	assert.Contains(t, string(analyzePrompt), `{{index .Source.Params "source_dirs"}}`)
+	assert.Contains(t, string(analyzePrompt), `{{index .Source.Params "file_extensions"}}`)
+	assert.Contains(t, string(analyzePrompt), `{{index .Source.Params "exclude_patterns"}}`)
+	assert.Contains(t, string(analyzePrompt), `{{index .Source.Params "max_issues_per_run"}}`)
+
+	proposePromptPath := checkedInWorkflowPromptPath(t, "continuous-refactoring", "propose.md")
+	proposePrompt, err := os.ReadFile(proposePromptPath)
+	require.NoError(t, err, "ReadFile(%q)", proposePromptPath)
+	assert.Contains(t, string(proposePrompt), "Title: [refactor]")
+	assert.Contains(t, string(proposePrompt), "Labels: refactor, enhancement, ready-for-work")
+	assert.Contains(t, string(proposePrompt), `{{index .Source.Params "max_issues_per_run"}}`)
+
+	createRefactorIssuePromptPath := checkedInWorkflowPromptPath(t, "continuous-refactoring", "create_refactor_issue.md")
+	createRefactorIssuePrompt, err := os.ReadFile(createRefactorIssuePromptPath)
+	require.NoError(t, err, "ReadFile(%q)", createRefactorIssuePromptPath)
+	assert.Contains(t, string(createRefactorIssuePrompt), "gh issue create --repo {{.Repo.Slug}}")
+	assert.Contains(t, string(createRefactorIssuePrompt), "Apply labels `refactor`, `enhancement`, and `ready-for-work`.")
+	assert.Contains(t, string(createRefactorIssuePrompt), `{{index .Source.Params "max_issues_per_run"}}`)
+
+	measurePromptPath := checkedInWorkflowPromptPath(t, "continuous-refactoring", "measure.md")
+	measurePrompt, err := os.ReadFile(measurePromptPath)
+	require.NoError(t, err, "ReadFile(%q)", measurePromptPath)
+	assert.Contains(t, string(measurePrompt), `{{index .Source.Params "source_dirs"}}`)
+	assert.Contains(t, string(measurePrompt), `{{index .Source.Params "file_extensions"}}`)
+	assert.Contains(t, string(measurePrompt), `{{index .Source.Params "exclude_patterns"}}`)
+	assert.Contains(t, string(measurePrompt), `{{index .Source.Params "loc_threshold"}}`)
+
+	splitPlanPromptPath := checkedInWorkflowPromptPath(t, "continuous-refactoring", "split_plan.md")
+	splitPlanPrompt, err := os.ReadFile(splitPlanPromptPath)
+	require.NoError(t, err, "ReadFile(%q)", splitPlanPromptPath)
+	assert.Contains(t, string(splitPlanPrompt), "Title: [file-diet]")
+	assert.Contains(t, string(splitPlanPrompt), "Target file:")
+	assert.Contains(t, string(splitPlanPrompt), "Labels: file-diet, enhancement, ready-for-work")
+
+	fileIssuePromptPath := checkedInWorkflowPromptPath(t, "continuous-refactoring", "file_issue.md")
+	fileIssuePrompt, err := os.ReadFile(fileIssuePromptPath)
+	require.NoError(t, err, "ReadFile(%q)", fileIssuePromptPath)
+	assert.Contains(t, string(fileIssuePrompt), "gh issue create --repo {{.Repo.Slug}}")
+	assert.Contains(t, string(fileIssuePrompt), "Create exactly one issue from the split-plan draft.")
+	assert.Contains(t, string(fileIssuePrompt), "Apply labels `file-diet`, `enhancement`, and `ready-for-work`.")
+}


### PR DESCRIPTION
## Summary
- Implements [issue #271](https://github.com/nicholls-inc/xylem/issues/271).
- Adds a new checked-in `continuous-refactoring` workflow that supports two scheduled modes: semantic function refactor candidate generation and large-file simplification (`file_diet`) issue generation.
- Threads schedule task params from config/source scanning into phase template data so the workflow prompts and dedupe command phases can branch on mode-specific settings.

## Smoke scenarios covered
- `S3` — `ScheduleSourceCarriesConfiguredParamsIntoVesselMeta`
- `S5` — `BuildTemplateDataExposesScheduledTaskParams`
- `S8` — `ContinuousRefactoringWorkflowUsesTemplateParamsAndDedupeCommandPhases`
- `S9` — `ContinuousRefactoringPromptsReferenceConfiguredParamsLabelsAndIssueCreationRules`

## Changes summary
### Files added
- `.xylem/workflows/continuous-refactoring.yaml`
- `.xylem/prompts/continuous-refactoring/analyze.md`
- `.xylem/prompts/continuous-refactoring/propose.md`
- `.xylem/prompts/continuous-refactoring/create_refactor_issue.md`
- `.xylem/prompts/continuous-refactoring/measure.md`
- `.xylem/prompts/continuous-refactoring/split_plan.md`
- `.xylem/prompts/continuous-refactoring/file_issue.md`
- `cli/internal/profiles/self-hosting-xylem/workflows/continuous-refactoring.yaml`
- `cli/internal/profiles/self-hosting-xylem/prompts/continuous-refactoring/*`
- `cli/internal/source/params.go`
- `cli/internal/source/params_test.go`
- `cli/internal/source/params_prop_test.go`
- `cli/internal/workflow/continuous_refactoring_workflow_test.go`

### Files modified
- `.xylem.yml`
- `cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml`
- `cli/cmd/xylem/init_test.go`
- `cli/internal/config/config.go`
- `cli/internal/config/config_test.go`
- `cli/internal/phase/phase.go`
- `cli/internal/phase/phase_test.go`
- `cli/internal/profiles/profiles_test.go`
- `cli/internal/runner/runner.go`
- `cli/internal/runner/runner_test.go`
- `cli/internal/scanner/scanner.go`
- `cli/internal/scanner/scanner_test.go`
- `cli/internal/source/schedule.go`
- `cli/internal/source/schedule_test.go`
- `cli/internal/source/scheduled.go`
- `cli/internal/source/scheduled_test.go`

### Key types and functions
- `config.SourceConfig.Params` now carries schedule-level workflow params from `.xylem.yml`.
- `source.EncodeTaskParams` / `source.DecodeTaskParams` serialize schedule params into vessel metadata.
- `source.Schedule.buildVessel` and `source.Scheduled.Scan` attach encoded params to emitted vessels.
- `scanner.buildSources` / `convertScheduledTasks` clone configured params into runtime source structs.
- `runner.buildTemplateData` now decodes task params and exposes them via `phase.SourceData.Params`.
- `continuous-refactoring.yaml` adds `dedupe_refactor` and `dedupe_file_diet` command phases plus prompt-driven issue generation phases for both paths.

## Test plan
- `cd cli && export PATH="$HOME/bin:$(go env GOPATH)/bin:$PATH" && goimports -w . && goimports -l . && golangci-lint run && go vet ./... && go build ./cmd/xylem && go test ./...`
- `cd cli && go vet ./... && go build ./cmd/xylem && go test ./...`

Fixes #271