### PR TITLE
feat: add continuous-simplicity scheduled workflow and PR planning helpers

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -133,6 +133,16 @@ sources:
         workflow: sota-gap-analysis
         ref: sota-gap-analysis
 
+  continuous-simplicity:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "@weekly"
+    timeout: "90m"
+    tasks:
+      weekly-continuous-simplicity:
+        workflow: continuous-simplicity
+        ref: continuous-simplicity
+
   harness-gap-analysis:
     type: scheduled
     repo: nicholls-inc/xylem

--- a/.xylem/prompts/continuous-simplicity/apply.md
+++ b/.xylem/prompts/continuous-simplicity/apply.md
@@ -1,0 +1,26 @@
+Implement the selected continuous-simplicity changes.
+
+Read:
+
+1. `.xylem/state/continuous-simplicity/pr-plan.json`
+2. `.xylem/state/continuous-simplicity/simplifications.json`
+3. `.xylem/state/continuous-simplicity/duplications.json`
+
+The planner has already filtered and capped the work. Only implement the entries in `selected`.
+
+For each selected entry:
+
+1. create or reset the branch named in `selected[].branch` from `main`
+2. apply the change described by `selected[].implementation`
+3. keep the change behavior-preserving
+4. commit the result with the PR title as the commit subject
+5. push the branch to `origin`
+
+Constraints:
+
+1. do not touch entries that were skipped
+2. do not combine multiple selected entries onto one branch
+3. do not edit tests unless needed to preserve existing behavior
+4. do not modify `.xylem/workflows/` or `.xylem/prompts/`
+
+After pushing every selected branch, return the worktree to its original branch and print a short summary listing each pushed branch and the files changed on it.

--- a/.xylem/prompts/continuous-simplicity/dedup.md
+++ b/.xylem/prompts/continuous-simplicity/dedup.md
@@ -1,0 +1,48 @@
+Prepare duplicate-code candidates for the continuous-simplicity run.
+
+Read:
+
+1. `.xylem/state/continuous-simplicity/changed-files.json`
+2. `cli/` production code relevant to the areas touched recently
+3. `.xylem/state/continuous-simplicity/simplifications.json`
+
+Goal:
+
+Find **semantic duplication** that is worth extracting now. Focus on production Go code. Exclude:
+
+1. `*_test.go`
+2. `.xylem/workflows/**`
+3. `.xylem/prompts/**`
+4. tiny or cosmetic duplication
+
+Only keep findings that plausibly exceed the planner thresholds:
+
+1. at least ~10 duplicated lines
+2. at least 3 locations
+
+Write `.xylem/state/continuous-simplicity/duplications.json` with this shape:
+
+```json
+{
+  "version": 1,
+  "generated_at": "RFC3339",
+  "findings": [
+    {
+      "id": "stable-kebab-id",
+      "kind": "duplication",
+      "title": "refactor: short PR title",
+      "summary": "Why this duplication is worth removing now",
+      "paths": ["path/one.go", "path/two.go", "path/three.go"],
+      "confidence": 0.91,
+      "duplicate_lines": 18,
+      "location_count": 3,
+      "implementation": "Concrete implementation instructions for the apply phase",
+      "pull_request_body": "Markdown body for the eventual PR"
+    }
+  ]
+}
+```
+
+Use a stable kebab-case `id` for each finding, and ensure it does not reuse any `id` already present in `.xylem/state/continuous-simplicity/simplifications.json`.
+
+If no worthwhile duplication exists, write a valid empty file and print `No duplication candidates selected`.

--- a/.xylem/prompts/continuous-simplicity/simplify.md
+++ b/.xylem/prompts/continuous-simplicity/simplify.md
@@ -1,0 +1,48 @@
+Prepare the simplification candidates for the continuous-simplicity run.
+
+Read:
+
+1. `.xylem/state/continuous-simplicity/changed-files.json`
+2. The recently changed source files listed there
+
+Goal:
+
+Identify only **behavior-preserving** simplifications in recently changed production code. Prefer:
+
+1. extracting small helpers
+2. early returns that remove nesting
+3. simplifying boolean branches
+4. replacing hand-rolled code with stdlib or already-present helpers
+5. consolidating repetitive error wrapping / validation
+
+Do **not** propose:
+
+1. feature changes
+2. speculative cleanups without clear payoff
+3. test-only changes
+4. edits under `.xylem/workflows/` or `.xylem/prompts/`
+
+Write `.xylem/state/continuous-simplicity/simplifications.json` with this shape:
+
+```json
+{
+  "version": 1,
+  "generated_at": "RFC3339",
+  "findings": [
+    {
+      "id": "stable-kebab-id",
+      "kind": "simplification",
+      "title": "refactor: short PR title",
+      "summary": "One-paragraph explanation of the simplification",
+      "paths": ["path/to/file.go"],
+      "confidence": 0.93,
+      "implementation": "Concrete implementation instructions for the apply phase",
+      "pull_request_body": "Markdown body for the eventual PR"
+    }
+  ]
+}
+```
+
+Use a stable kebab-case `id` for each finding, and keep every `id` unique across the entire continuous-simplicity run.
+
+Keep the list tight. If nothing clearly worthwhile exists, still write a valid file with an empty `findings` array and print `No simplifications selected`.

--- a/.xylem/workflows/continuous-simplicity.yaml
+++ b/.xylem/workflows/continuous-simplicity.yaml
@@ -1,0 +1,50 @@
+name: continuous-simplicity
+description: "Recurring code simplification and duplicate-detection sweep for xylem"
+phases:
+  - name: scan_changes
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem continuous-simplicity scan-changes \
+        --repo-root .. \
+        --days 7 \
+        --output ../.xylem/state/continuous-simplicity/changed-files.json
+  - name: simplify
+    prompt_file: .xylem/prompts/continuous-simplicity/simplify.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4
+  - name: dedup
+    prompt_file: .xylem/prompts/continuous-simplicity/dedup.md
+    max_turns: 50
+    llm: copilot
+    model: gpt-5.4
+  - name: plan_prs
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem continuous-simplicity plan-prs \
+        --simplifications ../.xylem/state/continuous-simplicity/simplifications.json \
+        --duplications ../.xylem/state/continuous-simplicity/duplications.json \
+        --output ../.xylem/state/continuous-simplicity/pr-plan.json
+  - name: apply
+    prompt_file: .xylem/prompts/continuous-simplicity/apply.md
+    max_turns: 80
+    llm: copilot
+    model: gpt-5.4
+    gate:
+      type: command
+      run: |
+        set -euo pipefail
+        cd cli
+        go build ./... && go test ./...
+  - name: pr
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem continuous-simplicity open-prs \
+        --plan ../.xylem/state/continuous-simplicity/pr-plan.json \
+        --output ../.xylem/state/continuous-simplicity/opened-prs.json

--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -37,7 +37,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "bootstrap", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "enqueue", "daemon", "retry", "visualize", "version"}
+	expected := []string{"init", "bootstrap", "continuous-simplicity", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "enqueue", "daemon", "retry", "visualize", "version"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/continuous_simplicity.go
+++ b/cli/cmd/xylem/continuous_simplicity.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholls-inc/xylem/cli/internal/simplicity"
+)
+
+var simplicityNow = func() time.Time {
+	return time.Now().UTC()
+}
+
+var newSimplicityRunner = func() simplicity.CommandRunner {
+	return &realCmdRunner{}
+}
+
+func newContinuousSimplicityCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "continuous-simplicity",
+		Short: "Deterministic helpers for the continuous-simplicity workflow",
+	}
+	cmd.AddCommand(
+		newContinuousSimplicityScanChangesCmd(),
+		newContinuousSimplicityPlanPRsCmd(),
+		newContinuousSimplicityOpenPRsCmd(),
+	)
+	return cmd
+}
+
+func newContinuousSimplicityScanChangesCmd() *cobra.Command {
+	var repoRoot, outputPath string
+	var windowDays int
+	cmd := &cobra.Command{
+		Use:   "scan-changes",
+		Short: "Write a durable manifest of recently changed files",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			manifest, err := simplicity.ScanRecentChanges(context.Background(), newSimplicityRunner(), repoRoot, simplicityNow(), windowDays)
+			if err != nil {
+				return err
+			}
+			if err := simplicity.WriteJSON(outputPath, manifest); err != nil {
+				return err
+			}
+			fmt.Printf("Wrote %s\n", outputPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repoRoot, "repo-root", ".", "Repository root to inspect")
+	cmd.Flags().IntVar(&windowDays, "days", simplicity.DefaultWindowDays, "Number of days of git history to inspect")
+	cmd.Flags().StringVar(&outputPath, "output", "", "Path to write the changed-file manifest JSON")
+	cmd.MarkFlagRequired("output") //nolint:errcheck
+	return cmd
+}
+
+func newContinuousSimplicityPlanPRsCmd() *cobra.Command {
+	var simplificationsPath, duplicationsPath, outputPath string
+	var repo, baseBranch string
+	var maxPRs, minDuplicateLines, minDuplicateLocations int
+	var minConfidence float64
+	var excludeGlobs []string
+	cmd := &cobra.Command{
+		Use:   "plan-prs",
+		Short: "Filter and cap simplification candidates into a PR plan",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			simplifications, err := simplicity.LoadFindings(simplificationsPath)
+			if err != nil {
+				return err
+			}
+			duplications, err := simplicity.LoadFindings(duplicationsPath)
+			if err != nil {
+				return err
+			}
+			plan, err := simplicity.BuildPlan(effectiveRepo(repo), effectiveBaseBranch(baseBranch), simplicity.PlanOptions{
+				MaxPRs:                maxPRs,
+				MinConfidence:         minConfidence,
+				MinDuplicateLines:     minDuplicateLines,
+				MinDuplicateLocations: minDuplicateLocations,
+				ExcludeGlobs:          append([]string(nil), excludeGlobs...),
+			}, simplifications, duplications, simplicityNow())
+			if err != nil {
+				return err
+			}
+			if err := simplicity.WriteJSON(outputPath, plan); err != nil {
+				return err
+			}
+			fmt.Printf("Wrote %s\n", outputPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&simplificationsPath, "simplifications", "", "Path to simplification findings JSON")
+	cmd.Flags().StringVar(&duplicationsPath, "duplications", "", "Path to duplication findings JSON")
+	cmd.Flags().StringVar(&outputPath, "output", "", "Path to write the PR plan JSON")
+	cmd.Flags().StringVar(&repo, "repo", "", "GitHub repository slug (defaults to config repo)")
+	cmd.Flags().StringVar(&baseBranch, "base-branch", "", "Base branch for generated PRs (defaults to config/default main)")
+	cmd.Flags().IntVar(&maxPRs, "max-prs", simplicity.DefaultMaxPRs, "Maximum PRs to select for this run")
+	cmd.Flags().Float64Var(&minConfidence, "min-confidence", simplicity.DefaultMinConfidence, "Minimum confidence required to keep a finding")
+	cmd.Flags().IntVar(&minDuplicateLines, "min-duplicate-lines", simplicity.DefaultMinDuplicateLines, "Minimum duplicated lines for duplication findings")
+	cmd.Flags().IntVar(&minDuplicateLocations, "min-duplicate-locations", simplicity.DefaultMinDuplicateTargets, "Minimum duplicated locations for duplication findings")
+	cmd.Flags().StringSliceVar(&excludeGlobs, "exclude-glob", append([]string(nil), simplicity.DefaultExcludeGlobs...), "Low-value path globs to exclude from duplication planning")
+	cmd.MarkFlagRequired("simplifications") //nolint:errcheck
+	cmd.MarkFlagRequired("duplications")    //nolint:errcheck
+	cmd.MarkFlagRequired("output")          //nolint:errcheck
+	return cmd
+}
+
+func newContinuousSimplicityOpenPRsCmd() *cobra.Command {
+	var planPath, outputPath string
+	cmd := &cobra.Command{
+		Use:   "open-prs",
+		Short: "Create PRs for branches listed in a continuous-simplicity plan",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plan, err := simplicity.LoadPlan(planPath)
+			if err != nil {
+				return err
+			}
+			result, err := simplicity.OpenPRs(context.Background(), newSimplicityRunner(), plan, simplicityNow())
+			if err != nil {
+				return err
+			}
+			if err := simplicity.WriteJSON(outputPath, result); err != nil {
+				return err
+			}
+			fmt.Printf("Wrote %s\n", outputPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&planPath, "plan", "", "Path to the PR plan JSON")
+	cmd.Flags().StringVar(&outputPath, "output", "", "Path to write the PR creation result JSON")
+	cmd.MarkFlagRequired("plan")   //nolint:errcheck
+	cmd.MarkFlagRequired("output") //nolint:errcheck
+	return cmd
+}
+
+func effectiveRepo(flagValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if deps != nil && deps.cfg != nil {
+		return deps.cfg.Repo
+	}
+	return ""
+}
+
+func effectiveBaseBranch(flagValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if deps != nil && deps.cfg != nil && deps.cfg.DefaultBranch != "" {
+		return deps.cfg.DefaultBranch
+	}
+	return "main"
+}

--- a/cli/cmd/xylem/continuous_simplicity_test.go
+++ b/cli/cmd/xylem/continuous_simplicity_test.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/simplicity"
+)
+
+type simplicityRunnerStub struct {
+	outputs map[string][]byte
+	calls   [][]string
+}
+
+func (r *simplicityRunnerStub) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	r.calls = append(r.calls, call)
+	key := strings.Join(call, "\x00")
+	out, ok := r.outputs[key]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return out, nil
+}
+
+func TestContinuousSimplicityScanChangesCommandWritesManifest(t *testing.T) {
+	setupTestDeps(t)
+
+	repoRoot := t.TempDir()
+	writeCommandTestFile(t, repoRoot, "README.md")
+	writeCommandTestFile(t, repoRoot, "cli/cmd/xylem/root.go")
+	now := time.Date(2026, 4, 10, 5, 24, 49, 0, time.UTC)
+	runner := &simplicityRunnerStub{
+		outputs: map[string][]byte{
+			strings.Join([]string{
+				"git", "-C", repoRoot, "log", "--name-only", "--pretty=format:", "--diff-filter=ACMRTUXB", "--since",
+				now.Add(-7 * 24 * time.Hour).Format(time.RFC3339), "HEAD",
+			}, "\x00"): []byte("README.md\ncli/cmd/xylem/root.go\n"),
+		},
+	}
+
+	oldNow := simplicityNow
+	oldRunner := newSimplicityRunner
+	simplicityNow = func() time.Time { return now }
+	newSimplicityRunner = func() simplicity.CommandRunner { return runner }
+	t.Cleanup(func() {
+		simplicityNow = oldNow
+		newSimplicityRunner = oldRunner
+	})
+
+	outputPath := filepath.Join(t.TempDir(), "manifest.json")
+	cmd := newContinuousSimplicityCmd()
+	cmd.SetArgs([]string{"scan-changes", "--repo-root", repoRoot, "--output", outputPath})
+
+	output := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+	if strings.TrimSpace(output) != "Wrote "+outputPath {
+		t.Fatalf("stdout = %q, want %q", output, "Wrote "+outputPath)
+	}
+
+	manifestData, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", outputPath, err)
+	}
+	var manifest simplicity.ChangeManifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	wantManifest := simplicity.ChangeManifest{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		RepoRoot:    filepath.Clean(repoRoot),
+		WindowDays:  simplicity.DefaultWindowDays,
+		Since:       now.Add(-7 * 24 * time.Hour).Format(time.RFC3339),
+		Files: []simplicity.ChangedFile{
+			{Path: "README.md"},
+			{Path: "cli/cmd/xylem/root.go"},
+		},
+	}
+	if !reflect.DeepEqual(manifest, wantManifest) {
+		t.Fatalf("manifest = %#v, want %#v", manifest, wantManifest)
+	}
+	wantCalls := [][]string{{
+		"git", "-C", repoRoot, "log", "--name-only", "--pretty=format:", "--diff-filter=ACMRTUXB", "--since",
+		now.Add(-7 * 24 * time.Hour).Format(time.RFC3339), "HEAD",
+	}}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("runner calls = %#v, want %#v", runner.calls, wantCalls)
+	}
+}
+
+func TestContinuousSimplicityPlanPRsCommandUsesConfigRepoDefaults(t *testing.T) {
+	setupTestDeps(t)
+
+	dir := t.TempDir()
+	now := time.Date(2026, 4, 10, 5, 24, 49, 0, time.UTC)
+	simplificationsPath := filepath.Join(dir, "simplifications.json")
+	duplicationsPath := filepath.Join(dir, "duplications.json")
+	outputPath := filepath.Join(dir, "plan.json")
+
+	writeJSONFixture(t, simplificationsPath, simplicity.FindingsFile{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		Findings: []simplicity.Finding{{
+			ID:         "extract-helper",
+			Kind:       "simplification",
+			Title:      "refactor: extract helper",
+			Summary:    "summary",
+			Paths:      []string{"cli/internal/example.go"},
+			Confidence: 0.9,
+		}},
+	})
+	writeJSONFixture(t, duplicationsPath, simplicity.FindingsFile{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		Findings:    []simplicity.Finding{},
+	})
+
+	oldNow := simplicityNow
+	simplicityNow = func() time.Time { return now }
+	t.Cleanup(func() {
+		simplicityNow = oldNow
+	})
+
+	cmd := newContinuousSimplicityCmd()
+	cmd.SetArgs([]string{
+		"plan-prs",
+		"--simplifications", simplificationsPath,
+		"--duplications", duplicationsPath,
+		"--output", outputPath,
+	})
+
+	output := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+	if strings.TrimSpace(output) != "Wrote "+outputPath {
+		t.Fatalf("stdout = %q, want %q", output, "Wrote "+outputPath)
+	}
+
+	planData, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", outputPath, err)
+	}
+	var plan simplicity.PRPlan
+	if err := json.Unmarshal(planData, &plan); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if plan.Repo != "owner/repo" {
+		t.Fatalf("Repo = %q, want owner/repo", plan.Repo)
+	}
+	if plan.BaseBranch != "main" {
+		t.Fatalf("BaseBranch = %q, want main", plan.BaseBranch)
+	}
+	if !reflect.DeepEqual(plan.Options.ExcludeGlobs, simplicity.DefaultExcludeGlobs) {
+		t.Fatalf("ExcludeGlobs = %#v, want %#v", plan.Options.ExcludeGlobs, simplicity.DefaultExcludeGlobs)
+	}
+	if len(plan.Selected) != 1 {
+		t.Fatalf("len(Selected) = %d, want 1", len(plan.Selected))
+	}
+	wantSelected := simplicity.PlannedPR{
+		ID:         "extract-helper",
+		Kind:       "simplification",
+		Branch:     "continuous-simplicity/01-extract-helper",
+		Title:      "refactor: extract helper",
+		Body:       "## Summary\n- summary\n\n## Paths\n- `cli/internal/example.go`",
+		Summary:    "summary",
+		Paths:      []string{"cli/internal/example.go"},
+		Confidence: 0.9,
+	}
+	if !reflect.DeepEqual(plan.Selected[0], wantSelected) {
+		t.Fatalf("Selected[0] = %#v, want %#v", plan.Selected[0], wantSelected)
+	}
+	if len(plan.Skipped) != 0 {
+		t.Fatalf("Skipped = %#v, want none", plan.Skipped)
+	}
+}
+
+func TestContinuousSimplicityOpenPRsCommandWritesResult(t *testing.T) {
+	setupTestDeps(t)
+
+	dir := t.TempDir()
+	now := time.Date(2026, 4, 10, 5, 24, 49, 0, time.UTC)
+	planPath := filepath.Join(dir, "plan.json")
+	outputPath := filepath.Join(dir, "result.json")
+	writeJSONFixture(t, planPath, simplicity.PRPlan{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		Repo:        "owner/repo",
+		BaseBranch:  "main",
+		Options: simplicity.PlanOptions{
+			MaxPRs:                1,
+			MinConfidence:         0.8,
+			MinDuplicateLines:     10,
+			MinDuplicateLocations: 3,
+		},
+		Selected: []simplicity.PlannedPR{{
+			ID:         "extract-helper",
+			Kind:       "simplification",
+			Branch:     "continuous-simplicity/01-extract-helper",
+			Title:      "refactor: extract helper",
+			Body:       "body",
+			Summary:    "summary",
+			Paths:      []string{"cli/internal/example.go"},
+			Confidence: 0.9,
+		}},
+	})
+	runner := &simplicityRunnerStub{
+		outputs: map[string][]byte{
+			strings.Join([]string{"gh", "pr", "list", "--repo", "owner/repo", "--head", "continuous-simplicity/01-extract-helper", "--state", "open", "--json", "url", "--limit", "1"}, "\x00"):                          []byte(`[]`),
+			strings.Join([]string{"gh", "pr", "create", "--repo", "owner/repo", "--head", "continuous-simplicity/01-extract-helper", "--base", "main", "--title", "refactor: extract helper", "--body", "body"}, "\x00"): []byte("https://github.com/owner/repo/pull/5\n"),
+		},
+	}
+
+	oldNow := simplicityNow
+	oldRunner := newSimplicityRunner
+	simplicityNow = func() time.Time { return now }
+	newSimplicityRunner = func() simplicity.CommandRunner { return runner }
+	t.Cleanup(func() {
+		simplicityNow = oldNow
+		newSimplicityRunner = oldRunner
+	})
+
+	cmd := newContinuousSimplicityCmd()
+	cmd.SetArgs([]string{"open-prs", "--plan", planPath, "--output", outputPath})
+	output := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+	if strings.TrimSpace(output) != "Wrote "+outputPath {
+		t.Fatalf("stdout = %q, want %q", output, "Wrote "+outputPath)
+	}
+
+	resultData, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", outputPath, err)
+	}
+	var result simplicity.OpenResult
+	if err := json.Unmarshal(resultData, &result); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	wantResult := simplicity.OpenResult{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		Repo:        "owner/repo",
+		Created: []simplicity.OpenedPRResult{{
+			ID:     "extract-helper",
+			Branch: "continuous-simplicity/01-extract-helper",
+			URL:    "https://github.com/owner/repo/pull/5",
+		}},
+	}
+	if !reflect.DeepEqual(result, wantResult) {
+		t.Fatalf("result = %#v, want %#v", result, wantResult)
+	}
+	wantCalls := [][]string{
+		{"gh", "pr", "list", "--repo", "owner/repo", "--head", "continuous-simplicity/01-extract-helper", "--state", "open", "--json", "url", "--limit", "1"},
+		{"gh", "pr", "create", "--repo", "owner/repo", "--head", "continuous-simplicity/01-extract-helper", "--base", "main", "--title", "refactor: extract helper", "--body", "body"},
+	}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("runner calls = %#v, want %#v", runner.calls, wantCalls)
+	}
+}
+
+func writeCommandTestFile(t *testing.T, root, rel string) {
+	t.Helper()
+	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}
+
+func writeJSONFixture(t *testing.T, path string, value any) {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -36,6 +36,7 @@ var expectedCoreWorkflows = []string{
 }
 
 var expectedSelfHostingWorkflows = []string{
+	"continuous-simplicity",
 	"diagnose-failures",
 	"implement-harness",
 	"sota-gap-analysis",
@@ -558,6 +559,7 @@ func TestSmoke_S5_CorePlusSelfHostingOverlayScaffoldsOverlayWorkflows(t *testing
 	expectedWorkflows := append(append([]string{}, expectedCoreWorkflows...), expectedSelfHostingWorkflows...)
 	sort.Strings(expectedWorkflows)
 	assert.Equal(t, expectedWorkflows, scaffoldedWorkflowNames(t, dir))
+	assert.Contains(t, output, "Created .xylem/workflows/continuous-simplicity.yaml")
 	assert.Contains(t, output, "Created .xylem/workflows/implement-harness.yaml")
 	assert.Contains(t, output, "Created .xylem/workflows/unblock-wave.yaml")
 

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -82,6 +82,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		newInitCmd(),
 		newBootstrapCmd(),
+		newContinuousSimplicityCmd(),
 		newDtuCmd(),
 		newShimDispatchCmd(),
 		newScanCmd(),

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -119,12 +119,14 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, sortedKeys(composed.Workflows), "implement-harness")
+	assert.Contains(t, sortedKeys(composed.Workflows), "continuous-simplicity")
 	assert.Contains(t, sortedKeys(composed.Workflows), "sota-gap-analysis")
 	assert.Contains(t, sortedKeys(composed.Workflows), "unblock-wave")
 	assert.Contains(t, sortedKeys(composed.Workflows), "diagnose-failures")
 	assert.Contains(t, sortedKeys(composed.Prompts), "implement-harness/pr_draft")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-impl")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-pr-lifecycle")
+	assert.Contains(t, sortedKeys(composed.Sources), "continuous-simplicity")
 	assert.Contains(t, sortedKeys(composed.Sources), "sota-gap")
 	require.Len(t, composed.ConfigOverlays, 2)
 }

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-simplicity/apply.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-simplicity/apply.md
@@ -1,0 +1,26 @@
+Implement the selected continuous-simplicity changes.
+
+Read:
+
+1. `.xylem/state/continuous-simplicity/pr-plan.json`
+2. `.xylem/state/continuous-simplicity/simplifications.json`
+3. `.xylem/state/continuous-simplicity/duplications.json`
+
+The planner has already filtered and capped the work. Only implement the entries in `selected`.
+
+For each selected entry:
+
+1. create or reset the branch named in `selected[].branch` from `main`
+2. apply the change described by `selected[].implementation`
+3. keep the change behavior-preserving
+4. commit the result with the PR title as the commit subject
+5. push the branch to `origin`
+
+Constraints:
+
+1. do not touch entries that were skipped
+2. do not combine multiple selected entries onto one branch
+3. do not edit tests unless needed to preserve existing behavior
+4. do not modify `.xylem/workflows/` or `.xylem/prompts/`
+
+After pushing every selected branch, return the worktree to its original branch and print a short summary listing each pushed branch and the files changed on it.

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-simplicity/dedup.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-simplicity/dedup.md
@@ -1,0 +1,48 @@
+Prepare duplicate-code candidates for the continuous-simplicity run.
+
+Read:
+
+1. `.xylem/state/continuous-simplicity/changed-files.json`
+2. `cli/` production code relevant to the areas touched recently
+3. `.xylem/state/continuous-simplicity/simplifications.json`
+
+Goal:
+
+Find **semantic duplication** that is worth extracting now. Focus on production Go code. Exclude:
+
+1. `*_test.go`
+2. `.xylem/workflows/**`
+3. `.xylem/prompts/**`
+4. tiny or cosmetic duplication
+
+Only keep findings that plausibly exceed the planner thresholds:
+
+1. at least ~10 duplicated lines
+2. at least 3 locations
+
+Write `.xylem/state/continuous-simplicity/duplications.json` with this shape:
+
+```json
+{
+  "version": 1,
+  "generated_at": "RFC3339",
+  "findings": [
+    {
+      "id": "stable-kebab-id",
+      "kind": "duplication",
+      "title": "refactor: short PR title",
+      "summary": "Why this duplication is worth removing now",
+      "paths": ["path/one.go", "path/two.go", "path/three.go"],
+      "confidence": 0.91,
+      "duplicate_lines": 18,
+      "location_count": 3,
+      "implementation": "Concrete implementation instructions for the apply phase",
+      "pull_request_body": "Markdown body for the eventual PR"
+    }
+  ]
+}
+```
+
+Use a stable kebab-case `id` for each finding, and ensure it does not reuse any `id` already present in `.xylem/state/continuous-simplicity/simplifications.json`.
+
+If no worthwhile duplication exists, write a valid empty file and print `No duplication candidates selected`.

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-simplicity/simplify.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-simplicity/simplify.md
@@ -1,0 +1,48 @@
+Prepare the simplification candidates for the continuous-simplicity run.
+
+Read:
+
+1. `.xylem/state/continuous-simplicity/changed-files.json`
+2. The recently changed source files listed there
+
+Goal:
+
+Identify only **behavior-preserving** simplifications in recently changed production code. Prefer:
+
+1. extracting small helpers
+2. early returns that remove nesting
+3. simplifying boolean branches
+4. replacing hand-rolled code with stdlib or already-present helpers
+5. consolidating repetitive error wrapping / validation
+
+Do **not** propose:
+
+1. feature changes
+2. speculative cleanups without clear payoff
+3. test-only changes
+4. edits under `.xylem/workflows/` or `.xylem/prompts/`
+
+Write `.xylem/state/continuous-simplicity/simplifications.json` with this shape:
+
+```json
+{
+  "version": 1,
+  "generated_at": "RFC3339",
+  "findings": [
+    {
+      "id": "stable-kebab-id",
+      "kind": "simplification",
+      "title": "refactor: short PR title",
+      "summary": "One-paragraph explanation of the simplification",
+      "paths": ["path/to/file.go"],
+      "confidence": 0.93,
+      "implementation": "Concrete implementation instructions for the apply phase",
+      "pull_request_body": "Markdown body for the eventual PR"
+    }
+  ]
+}
+```
+
+Use a stable kebab-case `id` for each finding, and keep every `id` unique across the entire continuous-simplicity run.
+
+Keep the list tight. If nothing clearly worthwhile exists, still write a valid file with an empty `findings` array and print `No simplifications selected`.

--- a/cli/internal/profiles/self-hosting-xylem/workflows/continuous-simplicity.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/continuous-simplicity.yaml
@@ -1,0 +1,50 @@
+name: continuous-simplicity
+description: "Recurring code simplification and duplicate-detection sweep for xylem"
+phases:
+  - name: scan_changes
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem continuous-simplicity scan-changes \
+        --repo-root .. \
+        --days 7 \
+        --output ../.xylem/state/continuous-simplicity/changed-files.json
+  - name: simplify
+    prompt_file: .xylem/prompts/continuous-simplicity/simplify.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4
+  - name: dedup
+    prompt_file: .xylem/prompts/continuous-simplicity/dedup.md
+    max_turns: 50
+    llm: copilot
+    model: gpt-5.4
+  - name: plan_prs
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem continuous-simplicity plan-prs \
+        --simplifications ../.xylem/state/continuous-simplicity/simplifications.json \
+        --duplications ../.xylem/state/continuous-simplicity/duplications.json \
+        --output ../.xylem/state/continuous-simplicity/pr-plan.json
+  - name: apply
+    prompt_file: .xylem/prompts/continuous-simplicity/apply.md
+    max_turns: 80
+    llm: copilot
+    model: gpt-5.4
+    gate:
+      type: command
+      run: |
+        set -euo pipefail
+        cd cli
+        go build ./... && go test ./...
+  - name: pr
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem continuous-simplicity open-prs \
+        --plan ../.xylem/state/continuous-simplicity/pr-plan.json \
+        --output ../.xylem/state/continuous-simplicity/opened-prs.json

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -59,6 +59,15 @@ sources:
       weekly-self-gap-analysis:
         workflow: sota-gap-analysis
         ref: sota-gap-analysis
+  continuous-simplicity:
+    type: scheduled
+    repo: "{{ .Repo }}"
+    schedule: "@weekly"
+    timeout: "90m"
+    tasks:
+      weekly-continuous-simplicity:
+        workflow: continuous-simplicity
+        ref: continuous-simplicity
   harness-post-merge:
     type: github-merge
     repo: "{{ .Repo }}"

--- a/cli/internal/simplicity/simplicity.go
+++ b/cli/internal/simplicity/simplicity.go
@@ -1,0 +1,683 @@
+package simplicity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultWindowDays          = 7
+	DefaultMaxPRs              = 3
+	DefaultMinConfidence       = 0.8
+	DefaultMinDuplicateLines   = 10
+	DefaultMinDuplicateTargets = 3
+)
+
+var DefaultExcludeGlobs = []string{
+	"**/*_test.go",
+	".xylem/workflows/**",
+	".xylem/prompts/**",
+}
+
+type CommandRunner interface {
+	RunOutput(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type ChangeManifest struct {
+	Version     int           `json:"version"`
+	GeneratedAt string        `json:"generated_at"`
+	RepoRoot    string        `json:"repo_root"`
+	WindowDays  int           `json:"window_days"`
+	Since       string        `json:"since"`
+	Files       []ChangedFile `json:"files"`
+}
+
+type ChangedFile struct {
+	Path string `json:"path"`
+}
+
+type Finding struct {
+	ID              string   `json:"id"`
+	Kind            string   `json:"kind"`
+	Title           string   `json:"title"`
+	Summary         string   `json:"summary"`
+	Paths           []string `json:"paths"`
+	Confidence      float64  `json:"confidence"`
+	DuplicateLines  int      `json:"duplicate_lines,omitempty"`
+	LocationCount   int      `json:"location_count,omitempty"`
+	Implementation  string   `json:"implementation,omitempty"`
+	PullRequestBody string   `json:"pull_request_body,omitempty"`
+}
+
+type FindingsFile struct {
+	Version     int       `json:"version"`
+	GeneratedAt string    `json:"generated_at"`
+	Findings    []Finding `json:"findings"`
+}
+
+type PlanOptions struct {
+	MaxPRs                int      `json:"max_prs"`
+	MinConfidence         float64  `json:"min_confidence"`
+	MinDuplicateLines     int      `json:"min_duplicate_lines"`
+	MinDuplicateLocations int      `json:"min_duplicate_locations"`
+	ExcludeGlobs          []string `json:"exclude_globs,omitempty"`
+}
+
+type PRPlan struct {
+	Version     int         `json:"version"`
+	GeneratedAt string      `json:"generated_at"`
+	Repo        string      `json:"repo"`
+	BaseBranch  string      `json:"base_branch"`
+	Options     PlanOptions `json:"options"`
+	Selected    []PlannedPR `json:"selected"`
+	Skipped     []SkippedPR `json:"skipped"`
+}
+
+type PlannedPR struct {
+	ID             string   `json:"id"`
+	Kind           string   `json:"kind"`
+	Branch         string   `json:"branch"`
+	Title          string   `json:"title"`
+	Body           string   `json:"body"`
+	Summary        string   `json:"summary"`
+	Paths          []string `json:"paths"`
+	Confidence     float64  `json:"confidence"`
+	DuplicateLines int      `json:"duplicate_lines,omitempty"`
+	LocationCount  int      `json:"location_count,omitempty"`
+	Implementation string   `json:"implementation,omitempty"`
+}
+
+type SkippedPR struct {
+	ID     string `json:"id"`
+	Reason string `json:"reason"`
+}
+
+type OpenResult struct {
+	Version     int              `json:"version"`
+	GeneratedAt string           `json:"generated_at"`
+	Repo        string           `json:"repo"`
+	Created     []OpenedPRResult `json:"created"`
+	Skipped     []OpenedPRResult `json:"skipped"`
+}
+
+type OpenedPRResult struct {
+	ID     string `json:"id"`
+	Branch string `json:"branch"`
+	URL    string `json:"url,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+func ScanRecentChanges(ctx context.Context, runner CommandRunner, repoRoot string, now time.Time, windowDays int) (*ChangeManifest, error) {
+	if runner == nil {
+		return nil, fmt.Errorf("runner is required")
+	}
+	repoRoot = strings.TrimSpace(repoRoot)
+	if repoRoot == "" {
+		return nil, fmt.Errorf("repo_root is required")
+	}
+	if windowDays <= 0 {
+		return nil, fmt.Errorf("window_days must be greater than 0")
+	}
+
+	since := now.UTC().Add(-time.Duration(windowDays) * 24 * time.Hour)
+	out, err := runner.RunOutput(
+		ctx,
+		"git",
+		"-C", repoRoot,
+		"log",
+		"--name-only",
+		"--pretty=format:",
+		"--diff-filter=ACMRTUXB",
+		"--since", since.Format(time.RFC3339),
+		"HEAD",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("git log changed files: %w", err)
+	}
+
+	files, err := parseChangedFiles(string(out), repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	return &ChangeManifest{
+		Version:     1,
+		GeneratedAt: now.UTC().Format(time.RFC3339),
+		RepoRoot:    filepath.Clean(repoRoot),
+		WindowDays:  windowDays,
+		Since:       since.Format(time.RFC3339),
+		Files:       files,
+	}, nil
+}
+
+func parseChangedFiles(raw, repoRoot string) ([]ChangedFile, error) {
+	seen := make(map[string]struct{})
+	files := make([]ChangedFile, 0)
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := filepath.ToSlash(strings.TrimSpace(line))
+		if trimmed == "" {
+			continue
+		}
+		clean := strings.TrimPrefix(filepath.Clean(trimmed), "./")
+		if clean == "." {
+			continue
+		}
+		info, err := os.Stat(filepath.Join(repoRoot, filepath.FromSlash(clean)))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("stat changed file %q: %w", clean, err)
+		}
+		if info.IsDir() {
+			continue
+		}
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		files = append(files, ChangedFile{Path: clean})
+	}
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files, nil
+}
+
+func LoadFindings(path string) (*FindingsFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read findings %q: %w", path, err)
+	}
+	var findings FindingsFile
+	if err := json.Unmarshal(data, &findings); err != nil {
+		return nil, fmt.Errorf("parse findings %q: %w", path, err)
+	}
+	if err := findings.Validate(); err != nil {
+		return nil, fmt.Errorf("validate findings %q: %w", path, err)
+	}
+	return &findings, nil
+}
+
+func (f *FindingsFile) Validate() error {
+	if f == nil {
+		return fmt.Errorf("findings file must not be nil")
+	}
+	if f.Version <= 0 {
+		return fmt.Errorf("version must be greater than 0")
+	}
+	if strings.TrimSpace(f.GeneratedAt) == "" {
+		return fmt.Errorf("generated_at is required")
+	}
+	if _, err := time.Parse(time.RFC3339, f.GeneratedAt); err != nil {
+		return fmt.Errorf("generated_at must be RFC3339: %w", err)
+	}
+	seen := make(map[string]struct{}, len(f.Findings))
+	for i := range f.Findings {
+		if err := f.Findings[i].Validate(); err != nil {
+			return fmt.Errorf("findings[%d]: %w", i, err)
+		}
+		if _, ok := seen[f.Findings[i].ID]; ok {
+			return fmt.Errorf("duplicate finding id %q", f.Findings[i].ID)
+		}
+		seen[f.Findings[i].ID] = struct{}{}
+	}
+	return nil
+}
+
+func (f *Finding) Validate() error {
+	if strings.TrimSpace(f.ID) == "" {
+		return fmt.Errorf("id is required")
+	}
+	switch f.Kind {
+	case "simplification", "duplication":
+	default:
+		return fmt.Errorf("kind %q is invalid", f.Kind)
+	}
+	if strings.TrimSpace(f.Title) == "" {
+		return fmt.Errorf("title is required")
+	}
+	if strings.TrimSpace(f.Summary) == "" {
+		return fmt.Errorf("summary is required")
+	}
+	if f.Confidence < 0 || f.Confidence > 1 {
+		return fmt.Errorf("confidence must be between 0 and 1")
+	}
+	if len(f.Paths) == 0 {
+		return fmt.Errorf("paths must not be empty")
+	}
+	seen := make(map[string]struct{}, len(f.Paths))
+	for _, path := range f.Paths {
+		path = normalizePath(path)
+		if path == "" {
+			return fmt.Errorf("paths must not contain empty entries")
+		}
+		if _, ok := seen[path]; ok {
+			return fmt.Errorf("paths must not contain duplicates")
+		}
+		seen[path] = struct{}{}
+	}
+	if f.Kind == "duplication" {
+		if f.DuplicateLines < 0 {
+			return fmt.Errorf("duplicate_lines must be non-negative")
+		}
+		if f.LocationCount < 0 {
+			return fmt.Errorf("location_count must be non-negative")
+		}
+	}
+	return nil
+}
+
+func BuildPlan(repo, baseBranch string, options PlanOptions, simplifications, duplicates *FindingsFile, now time.Time) (*PRPlan, error) {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return nil, fmt.Errorf("repo is required")
+	}
+	baseBranch = strings.TrimSpace(baseBranch)
+	if baseBranch == "" {
+		return nil, fmt.Errorf("base_branch is required")
+	}
+	if err := validatePlanOptions(options); err != nil {
+		return nil, err
+	}
+	if simplifications == nil || duplicates == nil {
+		return nil, fmt.Errorf("simplification and duplication findings are required")
+	}
+	if err := simplifications.Validate(); err != nil {
+		return nil, fmt.Errorf("simplifications: %w", err)
+	}
+	if err := duplicates.Validate(); err != nil {
+		return nil, fmt.Errorf("duplications: %w", err)
+	}
+
+	candidates := make([]scoredFinding, 0, len(simplifications.Findings)+len(duplicates.Findings))
+	skipped := make([]SkippedPR, 0)
+	for _, finding := range append(append([]Finding(nil), simplifications.Findings...), duplicates.Findings...) {
+		reason := skipReason(finding, options)
+		if reason != "" {
+			skipped = append(skipped, SkippedPR{ID: finding.ID, Reason: reason})
+			continue
+		}
+		candidates = append(candidates, scoredFinding{
+			Finding: finding,
+			Score:   scoreFinding(finding),
+		})
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].Score != candidates[j].Score {
+			return candidates[i].Score > candidates[j].Score
+		}
+		return candidates[i].ID < candidates[j].ID
+	})
+
+	selected := make([]PlannedPR, 0, min(options.MaxPRs, len(candidates)))
+	seenSelectedIDs := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if _, ok := seenSelectedIDs[candidate.ID]; ok {
+			skipped = append(skipped, SkippedPR{ID: candidate.ID, Reason: "duplicate finding id"})
+			continue
+		}
+		if len(selected) >= options.MaxPRs {
+			skipped = append(skipped, SkippedPR{ID: candidate.ID, Reason: "exceeds max_prs"})
+			continue
+		}
+		selected = append(selected, planEntry(candidate.Finding, len(selected)+1))
+		seenSelectedIDs[candidate.ID] = struct{}{}
+	}
+	sort.Slice(skipped, func(i, j int) bool {
+		if skipped[i].Reason != skipped[j].Reason {
+			return skipped[i].Reason < skipped[j].Reason
+		}
+		return skipped[i].ID < skipped[j].ID
+	})
+
+	return &PRPlan{
+		Version:     1,
+		GeneratedAt: now.UTC().Format(time.RFC3339),
+		Repo:        repo,
+		BaseBranch:  baseBranch,
+		Options:     options,
+		Selected:    selected,
+		Skipped:     skipped,
+	}, nil
+}
+
+func (p *PRPlan) Validate() error {
+	if p == nil {
+		return fmt.Errorf("plan must not be nil")
+	}
+	if p.Version <= 0 {
+		return fmt.Errorf("version must be greater than 0")
+	}
+	if strings.TrimSpace(p.GeneratedAt) == "" {
+		return fmt.Errorf("generated_at is required")
+	}
+	if _, err := time.Parse(time.RFC3339, p.GeneratedAt); err != nil {
+		return fmt.Errorf("generated_at must be RFC3339: %w", err)
+	}
+	if strings.TrimSpace(p.Repo) == "" {
+		return fmt.Errorf("repo is required")
+	}
+	if strings.TrimSpace(p.BaseBranch) == "" {
+		return fmt.Errorf("base_branch is required")
+	}
+	if err := validatePlanOptions(p.Options); err != nil {
+		return err
+	}
+	if len(p.Selected) > p.Options.MaxPRs {
+		return fmt.Errorf("selected entries exceed max_prs")
+	}
+	seenIDs := make(map[string]struct{}, len(p.Selected))
+	seenBranches := make(map[string]struct{}, len(p.Selected))
+	for i := range p.Selected {
+		if err := p.Selected[i].Validate(); err != nil {
+			return fmt.Errorf("selected[%d]: %w", i, err)
+		}
+		if _, ok := seenIDs[p.Selected[i].ID]; ok {
+			return fmt.Errorf("duplicate selected id %q", p.Selected[i].ID)
+		}
+		if _, ok := seenBranches[p.Selected[i].Branch]; ok {
+			return fmt.Errorf("duplicate selected branch %q", p.Selected[i].Branch)
+		}
+		seenIDs[p.Selected[i].ID] = struct{}{}
+		seenBranches[p.Selected[i].Branch] = struct{}{}
+	}
+	return nil
+}
+
+func (p *PlannedPR) Validate() error {
+	if strings.TrimSpace(p.ID) == "" {
+		return fmt.Errorf("id is required")
+	}
+	switch p.Kind {
+	case "simplification", "duplication":
+	default:
+		return fmt.Errorf("kind %q is invalid", p.Kind)
+	}
+	if strings.TrimSpace(p.Branch) == "" {
+		return fmt.Errorf("branch is required")
+	}
+	if strings.TrimSpace(p.Title) == "" {
+		return fmt.Errorf("title is required")
+	}
+	if strings.TrimSpace(p.Body) == "" {
+		return fmt.Errorf("body is required")
+	}
+	if strings.TrimSpace(p.Summary) == "" {
+		return fmt.Errorf("summary is required")
+	}
+	if p.Confidence < 0 || p.Confidence > 1 {
+		return fmt.Errorf("confidence must be between 0 and 1")
+	}
+	if len(p.Paths) == 0 {
+		return fmt.Errorf("paths must not be empty")
+	}
+	return nil
+}
+
+func OpenPRs(ctx context.Context, runner CommandRunner, plan *PRPlan, now time.Time) (*OpenResult, error) {
+	if runner == nil {
+		return nil, fmt.Errorf("runner is required")
+	}
+	if err := plan.Validate(); err != nil {
+		return nil, fmt.Errorf("plan: %w", err)
+	}
+
+	result := &OpenResult{
+		Version:     1,
+		GeneratedAt: now.UTC().Format(time.RFC3339),
+		Repo:        plan.Repo,
+	}
+	for _, entry := range plan.Selected {
+		existingURL, err := lookupOpenPR(ctx, runner, plan.Repo, entry.Branch)
+		if err != nil {
+			return nil, fmt.Errorf("lookup open PR for %s: %w", entry.Branch, err)
+		}
+		if existingURL != "" {
+			result.Skipped = append(result.Skipped, OpenedPRResult{
+				ID:     entry.ID,
+				Branch: entry.Branch,
+				URL:    existingURL,
+				Reason: "already open",
+			})
+			continue
+		}
+		out, err := runner.RunOutput(
+			ctx,
+			"gh", "pr", "create",
+			"--repo", plan.Repo,
+			"--head", entry.Branch,
+			"--base", plan.BaseBranch,
+			"--title", entry.Title,
+			"--body", entry.Body,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create PR for %s: %w", entry.Branch, err)
+		}
+		result.Created = append(result.Created, OpenedPRResult{
+			ID:     entry.ID,
+			Branch: entry.Branch,
+			URL:    strings.TrimSpace(string(out)),
+		})
+	}
+	return result, nil
+}
+
+func LoadPlan(path string) (*PRPlan, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read plan %q: %w", path, err)
+	}
+	var plan PRPlan
+	if err := json.Unmarshal(data, &plan); err != nil {
+		return nil, fmt.Errorf("parse plan %q: %w", path, err)
+	}
+	if err := plan.Validate(); err != nil {
+		return nil, fmt.Errorf("validate plan %q: %w", path, err)
+	}
+	return &plan, nil
+}
+
+func WriteJSON(path string, value any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create parent dir for %q: %w", path, err)
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal json for %q: %w", path, err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write json %q: %w", path, err)
+	}
+	return nil
+}
+
+type scoredFinding struct {
+	Finding
+	Score float64
+}
+
+func validatePlanOptions(options PlanOptions) error {
+	if options.MaxPRs <= 0 {
+		return fmt.Errorf("max_prs must be greater than 0")
+	}
+	if options.MinConfidence < 0 || options.MinConfidence > 1 {
+		return fmt.Errorf("min_confidence must be between 0 and 1")
+	}
+	if options.MinDuplicateLines < 0 {
+		return fmt.Errorf("min_duplicate_lines must be non-negative")
+	}
+	if options.MinDuplicateLocations < 0 {
+		return fmt.Errorf("min_duplicate_locations must be non-negative")
+	}
+	return nil
+}
+
+func skipReason(f Finding, options PlanOptions) string {
+	if f.Confidence < options.MinConfidence {
+		return "below min_confidence"
+	}
+	if matchesAnyPath(f.Paths, options.ExcludeGlobs) {
+		return "matches excluded path"
+	}
+	if f.Kind == "duplication" {
+		if f.DuplicateLines < options.MinDuplicateLines {
+			return "below min_duplicate_lines"
+		}
+		if f.LocationCount < options.MinDuplicateLocations {
+			return "below min_duplicate_locations"
+		}
+	}
+	return ""
+}
+
+func matchesAnyPath(paths, globs []string) bool {
+	for _, path := range paths {
+		normalized := normalizePath(path)
+		for _, glob := range globs {
+			matched, err := doublestarMatch(glob, normalized)
+			if err == nil && matched {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func doublestarMatch(pattern, target string) (bool, error) {
+	pattern = normalizePath(pattern)
+	target = normalizePath(target)
+	if !strings.Contains(pattern, "**") {
+		return path.Match(pattern, target)
+	}
+	if strings.HasPrefix(pattern, "**/") {
+		suffix := strings.TrimPrefix(pattern, "**/")
+		for candidate := target; ; {
+			matched, err := path.Match(suffix, candidate)
+			if matched || err != nil {
+				return matched, err
+			}
+			slash := strings.IndexByte(candidate, '/')
+			if slash < 0 {
+				return false, nil
+			}
+			candidate = candidate[slash+1:]
+		}
+	}
+	if strings.HasSuffix(pattern, "/**") {
+		prefix := strings.TrimSuffix(pattern, "/**")
+		return target == prefix || strings.HasPrefix(target, prefix+"/"), nil
+	}
+	return path.Match(strings.ReplaceAll(pattern, "**", "*"), target)
+}
+
+func scoreFinding(f Finding) float64 {
+	score := f.Confidence * 100
+	if f.Kind == "duplication" {
+		score += float64(f.DuplicateLines) + float64(f.LocationCount*10)
+		return score
+	}
+	score += float64(len(f.Paths) * 5)
+	return score
+}
+
+func planEntry(f Finding, ordinal int) PlannedPR {
+	paths := make([]string, 0, len(f.Paths))
+	for _, path := range f.Paths {
+		paths = append(paths, normalizePath(path))
+	}
+	sort.Strings(paths)
+
+	body := strings.TrimSpace(f.PullRequestBody)
+	if body == "" {
+		body = fmt.Sprintf("## Summary\n- %s\n\n## Paths\n%s", f.Summary, bulletList(paths))
+	}
+	return PlannedPR{
+		ID:             f.ID,
+		Kind:           f.Kind,
+		Branch:         fmt.Sprintf("continuous-simplicity/%02d-%s", ordinal, sanitizeBranchComponent(f.ID)),
+		Title:          f.Title,
+		Body:           body,
+		Summary:        f.Summary,
+		Paths:          paths,
+		Confidence:     f.Confidence,
+		DuplicateLines: f.DuplicateLines,
+		LocationCount:  f.LocationCount,
+		Implementation: strings.TrimSpace(f.Implementation),
+	}
+}
+
+func lookupOpenPR(ctx context.Context, runner CommandRunner, repo, branch string) (string, error) {
+	out, err := runner.RunOutput(
+		ctx,
+		"gh", "pr", "list",
+		"--repo", repo,
+		"--head", branch,
+		"--state", "open",
+		"--json", "url",
+		"--limit", "1",
+	)
+	if err != nil {
+		return "", err
+	}
+	var prs []struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return "", fmt.Errorf("parse gh pr list output: %w", err)
+	}
+	if len(prs) == 0 {
+		return "", nil
+	}
+	return strings.TrimSpace(prs[0].URL), nil
+}
+
+func normalizePath(path string) string {
+	return strings.TrimPrefix(filepath.ToSlash(filepath.Clean(strings.TrimSpace(path))), "./")
+}
+
+func sanitizeBranchComponent(raw string) string {
+	replacer := strings.NewReplacer("/", "-", "_", "-", " ", "-", ".", "-")
+	value := strings.ToLower(strings.TrimSpace(replacer.Replace(raw)))
+	var out strings.Builder
+	lastDash := false
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			out.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			out.WriteByte('-')
+			lastDash = true
+		}
+	}
+	result := strings.Trim(out.String(), "-")
+	if result == "" {
+		return "candidate"
+	}
+	return result
+}
+
+func bulletList(paths []string) string {
+	lines := make([]string, 0, len(paths))
+	for _, path := range paths {
+		lines = append(lines, "- `"+path+"`")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cli/internal/simplicity/simplicity_prop_test.go
+++ b/cli/internal/simplicity/simplicity_prop_test.go
@@ -1,0 +1,68 @@
+package simplicity
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropBuildPlanNeverExceedsConfiguredCap(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		maxPRs := rapid.IntRange(1, 5).Draw(t, "max_prs")
+		count := rapid.IntRange(1, 12).Draw(t, "count")
+		findings := make([]Finding, 0, count)
+		for i := 0; i < count; i++ {
+			findings = append(findings, Finding{
+				ID:         fmt.Sprintf("candidate-%d-%s", i, strings.ToLower(rapid.StringMatching(`[a-z]{4,8}`).Draw(t, "id"))),
+				Kind:       "simplification",
+				Title:      "refactor: " + rapid.StringMatching(`[a-z]{4,10}`).Draw(t, "title"),
+				Summary:    "summary",
+				Paths:      []string{"cli/internal/" + rapid.StringMatching(`[a-z]{4,10}`).Draw(t, "path") + ".go"},
+				Confidence: rapid.Float64Range(0.8, 1.0).Draw(t, "confidence"),
+			})
+		}
+		file := &FindingsFile{
+			Version:     1,
+			GeneratedAt: time.Date(2026, 4, 10, 5, 24, 49, 0, time.UTC).Format(time.RFC3339),
+			Findings:    findings,
+		}
+		plan, err := BuildPlan("owner/repo", "main", PlanOptions{
+			MaxPRs:                maxPRs,
+			MinConfidence:         0.8,
+			MinDuplicateLines:     10,
+			MinDuplicateLocations: 3,
+		}, file, &FindingsFile{
+			Version:     1,
+			GeneratedAt: file.GeneratedAt,
+			Findings:    nil,
+		}, time.Date(2026, 4, 10, 5, 24, 49, 0, time.UTC))
+		if err != nil {
+			t.Fatalf("BuildPlan() error = %v", err)
+		}
+		if len(plan.Selected) > maxPRs {
+			t.Fatalf("len(Selected) = %d, want <= %d", len(plan.Selected), maxPRs)
+		}
+	})
+}
+
+func TestPropSanitizeBranchComponentReturnsSafeSlug(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		raw := rapid.String().Draw(t, "raw")
+		got := sanitizeBranchComponent(raw)
+		if got == "" {
+			t.Fatal("sanitizeBranchComponent() returned empty string")
+		}
+		for _, r := range got {
+			if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' {
+				t.Fatalf("sanitizeBranchComponent(%q) produced unsafe rune %q in %q", raw, r, got)
+			}
+		}
+	})
+}

--- a/cli/internal/simplicity/simplicity_test.go
+++ b/cli/internal/simplicity/simplicity_test.go
@@ -1,0 +1,491 @@
+package simplicity
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubRunner struct {
+	outputs map[string][]byte
+	errs    map[string]error
+	calls   [][]string
+}
+
+func (r *stubRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	r.calls = append(r.calls, call)
+	key := strings.Join(call, "\x00")
+	if err, ok := r.errs[key]; ok {
+		return nil, err
+	}
+	if out, ok := r.outputs[key]; ok {
+		return out, nil
+	}
+	return nil, fmt.Errorf("unexpected call %q", key)
+}
+
+func TestScanRecentChangesDeduplicatesAndSorts(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot, "cli/cmd/xylem/root.go")
+	writeTestFile(t, repoRoot, "README.md")
+	now := time.Date(2026, 4, 10, 5, 24, 49, 0, time.UTC)
+
+	runner := &stubRunner{
+		outputs: map[string][]byte{
+			strings.Join([]string{
+				"git", "-C", repoRoot, "log", "--name-only", "--pretty=format:", "--diff-filter=ACMRTUXB", "--since",
+				now.Add(-7 * 24 * time.Hour).Format(time.RFC3339), "HEAD",
+			}, "\x00"): []byte("\nREADME.md\ncli/cmd/xylem/root.go\nREADME.md\nmissing.txt\n"),
+		},
+	}
+
+	manifest, err := ScanRecentChanges(context.Background(), runner, repoRoot, now, 7)
+	if err != nil {
+		t.Fatalf("ScanRecentChanges() error = %v", err)
+	}
+	wantManifest := &ChangeManifest{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		RepoRoot:    filepath.Clean(repoRoot),
+		WindowDays:  7,
+		Since:       now.Add(-7 * 24 * time.Hour).Format(time.RFC3339),
+		Files: []ChangedFile{
+			{Path: "README.md"},
+			{Path: "cli/cmd/xylem/root.go"},
+		},
+	}
+	if !reflect.DeepEqual(manifest, wantManifest) {
+		t.Fatalf("manifest = %#v, want %#v", manifest, wantManifest)
+	}
+	wantCalls := [][]string{{
+		"git", "-C", repoRoot, "log", "--name-only", "--pretty=format:", "--diff-filter=ACMRTUXB", "--since",
+		now.Add(-7 * 24 * time.Hour).Format(time.RFC3339), "HEAD",
+	}}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("runner calls = %#v, want %#v", runner.calls, wantCalls)
+	}
+}
+
+func TestBuildPlanFiltersAndCapsEntries(t *testing.T) {
+	now := time.Date(2026, 4, 10, 5, 24, 49, 0, time.UTC)
+	simplifications := &FindingsFile{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		Findings: []Finding{
+			{
+				ID:         "extract-helper",
+				Kind:       "simplification",
+				Title:      "refactor: extract shared helper for queue summaries",
+				Summary:    "Extract a small helper used by the queue summary paths.",
+				Paths:      []string{"cli/internal/queue/summary.go"},
+				Confidence: 0.92,
+			},
+			{
+				ID:         "low-confidence",
+				Kind:       "simplification",
+				Title:      "refactor: risky simplification",
+				Summary:    "This should be filtered out.",
+				Paths:      []string{"cli/internal/runner/runner.go"},
+				Confidence: 0.4,
+			},
+		},
+	}
+	duplicates := &FindingsFile{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		Findings: []Finding{
+			{
+				ID:             "duplicate-git-json",
+				Kind:           "duplication",
+				Title:          "refactor: consolidate duplicated GitHub JSON decoding",
+				Summary:        "The same gh JSON decoding logic appears in multiple command helpers.",
+				Paths:          []string{"cli/cmd/xylem/gap_report.go", "cli/cmd/xylem/lessons.go", "cli/cmd/xylem/continuous_simplicity.go"},
+				Confidence:     0.95,
+				DuplicateLines: 18,
+				LocationCount:  3,
+			},
+			{
+				ID:             "duplicate-tests",
+				Kind:           "duplication",
+				Title:          "refactor: deduplicate test-only helper",
+				Summary:        "Should be dropped because it only hits test paths.",
+				Paths:          []string{"cli/internal/queue/queue_test.go", "cli/internal/runner/runner_test.go", "cli/internal/source/scheduled_test.go"},
+				Confidence:     0.99,
+				DuplicateLines: 40,
+				LocationCount:  3,
+			},
+			{
+				ID:             "small-duplication",
+				Kind:           "duplication",
+				Title:          "refactor: small duplication",
+				Summary:        "Too small to include.",
+				Paths:          []string{"cli/internal/a.go", "cli/internal/b.go", "cli/internal/c.go"},
+				Confidence:     0.9,
+				DuplicateLines: 6,
+				LocationCount:  3,
+			},
+		},
+	}
+
+	plan, err := BuildPlan("owner/repo", "main", PlanOptions{
+		MaxPRs:                2,
+		MinConfidence:         0.8,
+		MinDuplicateLines:     10,
+		MinDuplicateLocations: 3,
+		ExcludeGlobs:          DefaultExcludeGlobs,
+	}, simplifications, duplicates, now)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	if len(plan.Selected) != 2 {
+		t.Fatalf("len(Selected) = %d, want 2", len(plan.Selected))
+	}
+	if plan.Selected[0].ID != "duplicate-git-json" {
+		t.Fatalf("Selected[0].ID = %q, want duplicate-git-json", plan.Selected[0].ID)
+	}
+	if plan.Selected[1].ID != "extract-helper" {
+		t.Fatalf("Selected[1].ID = %q, want extract-helper", plan.Selected[1].ID)
+	}
+	if plan.Selected[0].Branch != "continuous-simplicity/01-duplicate-git-json" {
+		t.Fatalf("Selected[0].Branch = %q", plan.Selected[0].Branch)
+	}
+
+	gotReasons := make(map[string]string, len(plan.Skipped))
+	for _, skipped := range plan.Skipped {
+		gotReasons[skipped.ID] = skipped.Reason
+	}
+	if gotReasons["low-confidence"] != "below min_confidence" {
+		t.Fatalf("skip reason for low-confidence = %q", gotReasons["low-confidence"])
+	}
+	if gotReasons["duplicate-tests"] != "matches excluded path" {
+		t.Fatalf("skip reason for duplicate-tests = %q", gotReasons["duplicate-tests"])
+	}
+	if gotReasons["small-duplication"] != "below min_duplicate_lines" {
+		t.Fatalf("skip reason for small-duplication = %q", gotReasons["small-duplication"])
+	}
+}
+
+func TestBuildPlanDeduplicatesIDsAcrossFindingFiles(t *testing.T) {
+	now := time.Date(2026, 4, 10, 5, 24, 49, 0, time.UTC)
+	simplifications := &FindingsFile{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		Findings: []Finding{{
+			ID:         "shared-id",
+			Kind:       "simplification",
+			Title:      "refactor: lower-value simplification",
+			Summary:    "This should lose to the stronger duplicate candidate.",
+			Paths:      []string{"cli/internal/queue/summary.go"},
+			Confidence: 0.85,
+		}},
+	}
+	duplicates := &FindingsFile{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		Findings: []Finding{{
+			ID:             "shared-id",
+			Kind:           "duplication",
+			Title:          "refactor: consolidate shared helper",
+			Summary:        "This should be retained because it scores higher.",
+			Paths:          []string{"cli/cmd/xylem/gap_report.go", "cli/cmd/xylem/lessons.go", "cli/cmd/xylem/continuous_simplicity.go"},
+			Confidence:     0.95,
+			DuplicateLines: 18,
+			LocationCount:  3,
+		}},
+	}
+
+	plan, err := BuildPlan("owner/repo", "main", PlanOptions{
+		MaxPRs:                3,
+		MinConfidence:         0.8,
+		MinDuplicateLines:     10,
+		MinDuplicateLocations: 3,
+		ExcludeGlobs:          DefaultExcludeGlobs,
+	}, simplifications, duplicates, now)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	if len(plan.Selected) != 1 {
+		t.Fatalf("len(Selected) = %d, want 1", len(plan.Selected))
+	}
+	if plan.Selected[0].Kind != "duplication" {
+		t.Fatalf("Selected[0].Kind = %q, want duplication", plan.Selected[0].Kind)
+	}
+	foundDuplicateSkip := false
+	for _, skipped := range plan.Skipped {
+		if skipped.ID == "shared-id" && skipped.Reason == "duplicate finding id" {
+			foundDuplicateSkip = true
+			break
+		}
+	}
+	if !foundDuplicateSkip {
+		t.Fatalf("Skipped = %#v, want duplicate finding id entry", plan.Skipped)
+	}
+}
+
+func TestOpenPRsCreatesMissingAndSkipsExisting(t *testing.T) {
+	now := time.Date(2026, 4, 10, 5, 24, 49, 0, time.UTC)
+	plan := &PRPlan{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		Repo:        "owner/repo",
+		BaseBranch:  "main",
+		Options: PlanOptions{
+			MaxPRs:                3,
+			MinConfidence:         0.8,
+			MinDuplicateLines:     10,
+			MinDuplicateLocations: 3,
+		},
+		Selected: []PlannedPR{
+			{
+				ID:         "existing",
+				Kind:       "simplification",
+				Branch:     "continuous-simplicity/01-existing",
+				Title:      "refactor: existing",
+				Body:       "body",
+				Summary:    "summary",
+				Paths:      []string{"cli/internal/a.go"},
+				Confidence: 0.9,
+			},
+			{
+				ID:         "new",
+				Kind:       "duplication",
+				Branch:     "continuous-simplicity/02-new",
+				Title:      "refactor: new",
+				Body:       "body",
+				Summary:    "summary",
+				Paths:      []string{"cli/internal/b.go"},
+				Confidence: 0.95,
+			},
+		},
+	}
+	runner := &stubRunner{
+		outputs: map[string][]byte{
+			strings.Join([]string{"gh", "pr", "list", "--repo", "owner/repo", "--head", "continuous-simplicity/01-existing", "--state", "open", "--json", "url", "--limit", "1"}, "\x00"):          []byte(`[{"url":"https://github.com/owner/repo/pull/1"}]`),
+			strings.Join([]string{"gh", "pr", "list", "--repo", "owner/repo", "--head", "continuous-simplicity/02-new", "--state", "open", "--json", "url", "--limit", "1"}, "\x00"):               []byte(`[]`),
+			strings.Join([]string{"gh", "pr", "create", "--repo", "owner/repo", "--head", "continuous-simplicity/02-new", "--base", "main", "--title", "refactor: new", "--body", "body"}, "\x00"): []byte("https://github.com/owner/repo/pull/2\n"),
+		},
+	}
+
+	result, err := OpenPRs(context.Background(), runner, plan, now)
+	if err != nil {
+		t.Fatalf("OpenPRs() error = %v", err)
+	}
+	if len(result.Created) != 1 || result.Created[0].URL != "https://github.com/owner/repo/pull/2" {
+		t.Fatalf("Created = %#v, want created PR #2", result.Created)
+	}
+	if len(result.Skipped) != 1 || result.Skipped[0].Reason != "already open" {
+		t.Fatalf("Skipped = %#v, want already-open skip", result.Skipped)
+	}
+}
+
+func TestLoadersRoundTripJSON(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 4, 10, 5, 24, 49, 0, time.UTC)
+	findings := &FindingsFile{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		Findings: []Finding{{
+			ID:         "extract-helper",
+			Kind:       "simplification",
+			Title:      "refactor: extract helper",
+			Summary:    "summary",
+			Paths:      []string{"cli/internal/example.go"},
+			Confidence: 0.9,
+		}},
+	}
+	findingsPath := filepath.Join(dir, "findings.json")
+	if err := WriteJSON(findingsPath, findings); err != nil {
+		t.Fatalf("WriteJSON(findings) error = %v", err)
+	}
+	rawFindings, err := os.ReadFile(findingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", findingsPath, err)
+	}
+	if !strings.HasSuffix(string(rawFindings), "\n") {
+		t.Fatalf("findings json should end with newline: %q", string(rawFindings))
+	}
+	loadedFindings, err := LoadFindings(findingsPath)
+	if err != nil {
+		t.Fatalf("LoadFindings() error = %v", err)
+	}
+	if !reflect.DeepEqual(loadedFindings, findings) {
+		t.Fatalf("loaded findings = %#v, want %#v", loadedFindings, findings)
+	}
+
+	plan := &PRPlan{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		Repo:        "owner/repo",
+		BaseBranch:  "main",
+		Options: PlanOptions{
+			MaxPRs:                1,
+			MinConfidence:         0.8,
+			MinDuplicateLines:     10,
+			MinDuplicateLocations: 3,
+		},
+		Selected: []PlannedPR{{
+			ID:         "extract-helper",
+			Kind:       "simplification",
+			Branch:     "continuous-simplicity/01-extract-helper",
+			Title:      "refactor: extract helper",
+			Body:       "body",
+			Summary:    "summary",
+			Paths:      []string{"cli/internal/example.go"},
+			Confidence: 0.9,
+		}},
+	}
+	planPath := filepath.Join(dir, "plan.json")
+	if err := WriteJSON(planPath, plan); err != nil {
+		t.Fatalf("WriteJSON(plan) error = %v", err)
+	}
+	rawPlan, err := os.ReadFile(planPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", planPath, err)
+	}
+	if !strings.HasSuffix(string(rawPlan), "\n") {
+		t.Fatalf("plan json should end with newline: %q", string(rawPlan))
+	}
+	loadedPlan, err := LoadPlan(planPath)
+	if err != nil {
+		t.Fatalf("LoadPlan() error = %v", err)
+	}
+	if !reflect.DeepEqual(loadedPlan, plan) {
+		t.Fatalf("loaded plan = %#v, want %#v", loadedPlan, plan)
+	}
+}
+
+func TestSmoke_S2_ContinuousSimplicityPlanCapsReviewLoadAndFiltersLowValueDuplication(t *testing.T) {
+	now := time.Date(2026, 4, 10, 5, 24, 49, 0, time.UTC)
+	simplifications := &FindingsFile{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		Findings: []Finding{
+			{
+				ID:         "extract-helper",
+				Kind:       "simplification",
+				Title:      "refactor: extract helper for queue summaries",
+				Summary:    "Extract a shared helper for queue summary rendering.",
+				Paths:      []string{"cli/internal/queue/summary.go", "cli/internal/queue/report.go"},
+				Confidence: 0.91,
+			},
+			{
+				ID:         "early-return",
+				Kind:       "simplification",
+				Title:      "refactor: simplify nested conditional in runner",
+				Summary:    "Replace nested conditionals with an early return in the runner.",
+				Paths:      []string{"cli/internal/runner/runner.go"},
+				Confidence: 0.82,
+			},
+		},
+	}
+	duplicates := &FindingsFile{
+		Version:     1,
+		GeneratedAt: now.Format(time.RFC3339),
+		Findings: []Finding{
+			{
+				ID:             "duplicate-gh-json",
+				Kind:           "duplication",
+				Title:          "refactor: consolidate duplicated gh JSON parsing",
+				Summary:        "The same gh JSON parsing flow appears across multiple commands.",
+				Paths:          []string{"cli/cmd/xylem/gap_report.go", "cli/cmd/xylem/lessons.go", "cli/cmd/xylem/continuous_simplicity.go"},
+				Confidence:     0.95,
+				DuplicateLines: 22,
+				LocationCount:  3,
+			},
+			{
+				ID:             "duplicate-queue-formatting",
+				Kind:           "duplication",
+				Title:          "refactor: extract repeated queue formatting helper",
+				Summary:        "Several queue paths repeat the same formatting logic.",
+				Paths:          []string{"cli/internal/queue/summary.go", "cli/internal/queue/queue.go", "cli/internal/queue/report.go"},
+				Confidence:     0.9,
+				DuplicateLines: 18,
+				LocationCount:  3,
+			},
+			{
+				ID:             "duplicate-test-only-helper",
+				Kind:           "duplication",
+				Title:          "refactor: deduplicate test helper",
+				Summary:        "This should be skipped because it only touches test files.",
+				Paths:          []string{"cli/internal/source/scheduled_test.go", "cli/internal/runner/runner_test.go", "cli/internal/queue/queue_test.go"},
+				Confidence:     0.99,
+				DuplicateLines: 40,
+				LocationCount:  3,
+			},
+			{
+				ID:             "duplicate-workflow-template",
+				Kind:           "duplication",
+				Title:          "refactor: deduplicate workflow prompt template",
+				Summary:        "This should be skipped because prompt templates are excluded.",
+				Paths:          []string{".xylem/prompts/continuous-simplicity/simplify.md", ".xylem/prompts/continuous-simplicity/dedup.md", ".xylem/prompts/implement-harness/smoke.md"},
+				Confidence:     0.93,
+				DuplicateLines: 14,
+				LocationCount:  3,
+			},
+			{
+				ID:             "small-duplication",
+				Kind:           "duplication",
+				Title:          "refactor: tiny duplicated guard",
+				Summary:        "This should be skipped because it is below the configured size threshold.",
+				Paths:          []string{"cli/internal/a.go", "cli/internal/b.go", "cli/internal/c.go"},
+				Confidence:     0.88,
+				DuplicateLines: 8,
+				LocationCount:  3,
+			},
+		},
+	}
+
+	plan, err := BuildPlan("nicholls-inc/xylem", "main", PlanOptions{
+		MaxPRs:                DefaultMaxPRs,
+		MinConfidence:         DefaultMinConfidence,
+		MinDuplicateLines:     DefaultMinDuplicateLines,
+		MinDuplicateLocations: DefaultMinDuplicateTargets,
+		ExcludeGlobs:          DefaultExcludeGlobs,
+	}, simplifications, duplicates, now)
+	require.NoError(t, err)
+	require.Len(t, plan.Selected, 3)
+
+	assert.Equal(t, []string{
+		"duplicate-gh-json",
+		"duplicate-queue-formatting",
+		"extract-helper",
+	}, []string{plan.Selected[0].ID, plan.Selected[1].ID, plan.Selected[2].ID})
+	assert.Equal(t, []string{
+		"continuous-simplicity/01-duplicate-gh-json",
+		"continuous-simplicity/02-duplicate-queue-formatting",
+		"continuous-simplicity/03-extract-helper",
+	}, []string{plan.Selected[0].Branch, plan.Selected[1].Branch, plan.Selected[2].Branch})
+	assert.Equal(t, "nicholls-inc/xylem", plan.Repo)
+	assert.Equal(t, "main", plan.BaseBranch)
+	assert.Equal(t, DefaultMaxPRs, plan.Options.MaxPRs)
+	assert.Equal(t, "## Summary\n- Extract a shared helper for queue summary rendering.\n\n## Paths\n- `cli/internal/queue/report.go`\n- `cli/internal/queue/summary.go`", plan.Selected[2].Body)
+
+	gotReasons := make(map[string]string, len(plan.Skipped))
+	for _, skipped := range plan.Skipped {
+		gotReasons[skipped.ID] = skipped.Reason
+	}
+	assert.Equal(t, "exceeds max_prs", gotReasons["early-return"])
+	assert.Equal(t, "matches excluded path", gotReasons["duplicate-test-only-helper"])
+	assert.Equal(t, "matches excluded path", gotReasons["duplicate-workflow-template"])
+	assert.Equal(t, "below min_duplicate_lines", gotReasons["small-duplication"])
+}
+
+func writeTestFile(t *testing.T, root, rel string) {
+	t.Helper()
+	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte("package test\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}

--- a/cli/internal/source/scheduled_test.go
+++ b/cli/internal/source/scheduled_test.go
@@ -2,12 +2,17 @@ package source
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScheduledScanEnqueuesOnePerWindow(t *testing.T) {
@@ -65,4 +70,92 @@ func TestScheduleWindow(t *testing.T) {
 	if start.After(time.Date(2026, 4, 9, 10, 27, 0, 0, time.UTC)) {
 		t.Fatalf("start = %s, want start at or before now", start)
 	}
+}
+
+func TestSmoke_S1_ContinuousSimplicityScheduledVesselEnqueuesOncePerWindow(t *testing.T) {
+	ctx := context.Background()
+	stateDir := t.TempDir()
+	queuePath := filepath.Join(t.TempDir(), "queue.jsonl")
+	q := queue.New(queuePath)
+	interval, err := parseSchedule("@weekly")
+	require.NoError(t, err)
+
+	src := &Scheduled{
+		Repo:       "nicholls-inc/xylem",
+		StateDir:   stateDir,
+		ConfigName: "continuous-simplicity",
+		Schedule:   "@weekly",
+		Queue:      q,
+		Tasks: map[string]ScheduledTask{
+			"weekly-continuous-simplicity": {
+				Workflow: "continuous-simplicity",
+				Ref:      "continuous-simplicity",
+			},
+		},
+	}
+
+	before := sourceNow()
+	first, err := src.Scan(ctx)
+	after := sourceNow()
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+
+	vessel := first[0]
+	slotStart, slotEnd := scheduleWindow(vessel.CreatedAt, interval)
+	bucket := slotStart.UnixNano() / interval.Nanoseconds()
+
+	assert.Equal(t, "scheduled", vessel.Source)
+	assert.Equal(t, queue.StatePending, vessel.State)
+	assert.Equal(t, "continuous-simplicity", vessel.Workflow)
+	assert.Equal(t, "continuous-simplicity", vessel.Meta["schedule_ref"])
+	assert.Equal(t, "weekly-continuous-simplicity", vessel.Meta["schedule_task"])
+	assert.Equal(t, "@weekly", vessel.Meta["schedule_spec"])
+	assert.Equal(t, "continuous-simplicity", vessel.Meta["scheduled_config_name"])
+	assert.Equal(t, "nicholls-inc/xylem", vessel.Meta["scheduled_repo"])
+	assert.Equal(t, fmt.Sprintf("%d", bucket), vessel.Meta["scheduled_bucket"])
+	assert.Equal(t, slotStart.Format(time.RFC3339), vessel.Meta["schedule_slot_start"])
+	assert.Equal(t, slotEnd.Format(time.RFC3339), vessel.Meta["schedule_slot_end"])
+	assert.Equal(t, vessel.CreatedAt.UTC().Format(time.RFC3339), vessel.CreatedAt.Format(time.RFC3339))
+	assert.True(t, !vessel.CreatedAt.Before(before) && !vessel.CreatedAt.After(after))
+	assert.Equal(t,
+		"scheduled://continuous-simplicity/weekly-continuous-simplicity@"+vessel.Meta["scheduled_bucket"],
+		vessel.Ref,
+	)
+	assert.Equal(t, "scheduled-continuous-simplicity-weekly-continuous-simplicity-"+vessel.Meta["scheduled_bucket"], vessel.ID)
+	assert.Equal(t,
+		scheduledFingerprint("continuous-simplicity", "weekly-continuous-simplicity", "continuous-simplicity", "continuous-simplicity"),
+		vessel.Meta["scheduled_fingerprint"],
+	)
+
+	_, err = q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	duplicate, err := src.Scan(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, duplicate)
+
+	require.NoError(t, src.OnEnqueue(ctx, vessel))
+
+	stateBytes, err := os.ReadFile(filepath.Join(stateDir, "schedules", "continuous-simplicity.json"))
+	require.NoError(t, err)
+	var persisted scheduleState
+	require.NoError(t, json.Unmarshal(stateBytes, &persisted))
+	assert.Equal(t, map[string]int64{"weekly-continuous-simplicity": bucket}, persisted.LastEnqueuedBuckets)
+
+	restarted := &Scheduled{
+		Repo:       "nicholls-inc/xylem",
+		StateDir:   stateDir,
+		ConfigName: "continuous-simplicity",
+		Schedule:   "@weekly",
+		Queue:      queue.New(filepath.Join(t.TempDir(), "queue-restart.jsonl")),
+		Tasks: map[string]ScheduledTask{
+			"weekly-continuous-simplicity": {
+				Workflow: "continuous-simplicity",
+				Ref:      "continuous-simplicity",
+			},
+		},
+	}
+	suppressed, err := restarted.Scan(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, suppressed)
 }


### PR DESCRIPTION
## Summary
Implements https://github.com/nicholls-inc/xylem/issues/270 by adding a weekly `continuous-simplicity` scheduled vessel, seeding its workflow/prompt assets into self-hosting scaffolds, and wiring deterministic helper commands that scan recent changes, filter simplification and duplication findings, cap PR fan-out, and open PRs from the generated plan.

## Smoke scenarios covered
- S1 — Continuous simplicity scheduled vessel enqueues once per window
- S2 — Continuous simplicity plan caps review load and filters low-value duplication

## Changes summary
- Added workflow and prompt assets for `continuous-simplicity` in `.xylem/workflows/continuous-simplicity.yaml`, `.xylem/prompts/continuous-simplicity/*`, and the mirrored self-hosting profile assets under `cli/internal/profiles/self-hosting-xylem/`.
- Added the `xylem continuous-simplicity` command surface in `cli/cmd/xylem/continuous_simplicity.go` and registered it from `cli/cmd/xylem/root.go`.
- Added `cli/internal/simplicity/simplicity.go` with the core types `ChangeManifest`, `Finding`, `FindingsFile`, `PlanOptions`, `PRPlan`, `PlannedPR`, and `OpenResult`, plus the helpers `ScanRecentChanges`, `BuildPlan`, `OpenPRs`, `LoadFindings`, `LoadPlan`, and `WriteJSON`.
- Updated scheduled/self-hosting configuration and coverage in `.xylem.yml`, `cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml`, `cli/internal/source/scheduled_test.go`, `cli/cmd/xylem/continuous_simplicity_test.go`, `cli/internal/simplicity/simplicity_test.go`, `cli/internal/simplicity/simplicity_prop_test.go`, `cli/cmd/xylem/cobra_test.go`, `cli/cmd/xylem/init_test.go`, and `cli/internal/profiles/profiles_test.go`.

## Test plan
- `cd cli && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`
- `cd cli && go vet ./... && go build ./cmd/xylem && go test ./...`

Fixes #270