### PR TITLE
feat: add ready-to-merge label when implement-harness creates PRs

### DIFF
--- a/.xylem/workflows/implement-harness.yaml
+++ b/.xylem/workflows/implement-harness.yaml
@@ -113,4 +113,5 @@ phases:
         --repo nicholls-inc/xylem \
         --title "$TITLE" \
         --body "$BODY" \
-        --label "harness-impl"
+        --label "harness-impl" \
+        --label "ready-to-merge"

--- a/cli/internal/profiles/profiles_prop_test.go
+++ b/cli/internal/profiles/profiles_prop_test.go
@@ -53,32 +53,92 @@ func TestPropComposeCoreKeepsSecurityComplianceBundlePresent(t *testing.T) {
 			t.Fatalf("Compose(core) error = %v", err)
 		}
 
-		checks := []assetRef{
-			{name: "workflow:security-compliance", data: composed.Workflows["security-compliance"]},
-			{name: "prompt:security-compliance/scan_secrets", data: composed.Prompts["security-compliance/scan_secrets"]},
-			{name: "prompt:security-compliance/synthesize", data: composed.Prompts["security-compliance/synthesize"]},
-			{name: "source:security-compliance", data: composed.Sources["security-compliance"]},
-		}
+		checks := securityComplianceBundle(composed)
 		check := checks[rapid.IntRange(0, len(checks)-1).Draw(t, "checkIndex")]
 		if len(check.data) == 0 {
 			t.Fatalf("%s missing or empty", check.name)
 		}
+		byteIndex := rapid.IntRange(0, len(check.data)-1).Draw(t, "byteIndex")
+		check.data[byteIndex] ^= 0xff
 
-		expectedFragment := map[string]string{
-			"workflow:security-compliance":            "name: security-compliance",
-			"prompt:security-compliance/scan_secrets": "RESULT: CLEAN | FINDINGS | TOOLING-GAP",
-			"prompt:security-compliance/synthesize":   "ISSUES_CREATED:",
-			"source:security-compliance":              "workflow: security-compliance",
-		}[check.name]
-		if !strings.Contains(string(check.data), expectedFragment) {
-			t.Fatalf("%s = %q, want fragment %q", check.name, string(check.data), expectedFragment)
+		fresh, err := Compose("core")
+		if err != nil {
+			t.Fatalf("Compose(core) fresh call error = %v", err)
+		}
+
+		for _, want := range securityComplianceBundle(fresh) {
+			expectedFragment := securityComplianceExpectedFragments[want.name]
+			if len(want.data) == 0 {
+				t.Fatalf("%s missing or empty", want.name)
+			}
+			if !strings.Contains(string(want.data), expectedFragment) {
+				t.Fatalf("%s = %q, want fragment %q", want.name, string(want.data), expectedFragment)
+			}
 		}
 	})
+}
+
+func TestPropComposeSelfHostingXylemImplementHarnessWorkflowKeepsPRCreateContract(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		composed, err := Compose("core", "self-hosting-xylem")
+		if err != nil {
+			t.Fatalf("Compose(core, self-hosting-xylem) error = %v", err)
+		}
+
+		workflowData, ok := composed.Workflows["implement-harness"]
+		if !ok {
+			t.Fatal(`Compose(core, self-hosting-xylem) missing workflow "implement-harness"`)
+		}
+		if len(workflowData) == 0 {
+			t.Fatal(`Compose(core, self-hosting-xylem) returned empty workflow "implement-harness"`)
+		}
+
+		byteIndex := rapid.IntRange(0, len(workflowData)-1).Draw(t, "byteIndex")
+		workflowData[byteIndex] ^= 0xff
+
+		fresh, err := Compose("core", "self-hosting-xylem")
+		if err != nil {
+			t.Fatalf("Compose(core, self-hosting-xylem) fresh call error = %v", err)
+		}
+		freshWorkflowData, ok := fresh.Workflows["implement-harness"]
+		if !ok {
+			t.Fatal(`Compose(core, self-hosting-xylem) fresh call missing workflow "implement-harness"`)
+		}
+
+		for _, requiredFragment := range implementHarnessPRCreateContract {
+			if !strings.Contains(string(freshWorkflowData), requiredFragment) {
+				t.Fatalf("implement-harness workflow missing fragment %q", requiredFragment)
+			}
+		}
+	})
+}
+
+var securityComplianceExpectedFragments = map[string]string{
+	"workflow:security-compliance":            "name: security-compliance",
+	"prompt:security-compliance/scan_secrets": "RESULT: CLEAN | FINDINGS | TOOLING-GAP",
+	"prompt:security-compliance/synthesize":   "ISSUES_CREATED:",
+	"source:security-compliance":              "workflow: security-compliance",
+}
+
+var implementHarnessPRCreateContract = []string{
+	`gh pr create`,
+	`--repo nicholls-inc/xylem`,
+	`--label "harness-impl"`,
+	`--label "ready-to-merge"`,
 }
 
 type assetRef struct {
 	name string
 	data []byte
+}
+
+func securityComplianceBundle(composed *ComposedProfile) []assetRef {
+	return []assetRef{
+		{name: "workflow:security-compliance", data: composed.Workflows["security-compliance"]},
+		{name: "prompt:security-compliance/scan_secrets", data: composed.Prompts["security-compliance/scan_secrets"]},
+		{name: "prompt:security-compliance/synthesize", data: composed.Prompts["security-compliance/synthesize"]},
+		{name: "source:security-compliance", data: composed.Sources["security-compliance"]},
+	}
 }
 
 func composedSignature(composed *ComposedProfile) string {

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -129,6 +129,11 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	assert.Contains(t, sortedKeys(composed.Sources), "continuous-simplicity")
 	assert.Contains(t, sortedKeys(composed.Sources), "sota-gap")
 	require.Len(t, composed.ConfigOverlays, 2)
+
+	implementHarnessWorkflow := string(composed.Workflows["implement-harness"])
+	assert.Contains(t, implementHarnessWorkflow, `--repo nicholls-inc/xylem`)
+	assert.Contains(t, implementHarnessWorkflow, `--label "harness-impl"`)
+	assert.Contains(t, implementHarnessWorkflow, `--label "ready-to-merge"`)
 }
 
 func TestAdaptRepoWorkflowAssetParsesCleanly(t *testing.T) {

--- a/cli/internal/profiles/self-hosting-xylem/workflows/implement-harness.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/implement-harness.yaml
@@ -113,4 +113,5 @@ phases:
         --repo nicholls-inc/xylem \
         --title "$TITLE" \
         --body "$BODY" \
-        --label "harness-impl"
+        --label "harness-impl" \
+        --label "ready-to-merge"

--- a/cli/internal/workflow/implement_harness_workflow_test.go
+++ b/cli/internal/workflow/implement_harness_workflow_test.go
@@ -13,14 +13,17 @@ import (
 )
 
 const (
-	implementHarnessFetchMain = "git fetch origin main"
-	implementHarnessFetchHead = `git fetch origin main "$current_branch"`
-	implementHarnessMergeBase = "git merge-base --is-ancestor origin/main HEAD"
-	implementHarnessRemoteRef = `git rev-parse "origin/$current_branch"`
-	implementHarnessGoVet     = "go vet ./..."
-	implementHarnessGoBuild   = "go build ./cmd/xylem"
-	implementHarnessGoTest    = "go test ./..."
-	implementHarnessPRCreate  = "gh pr create"
+	implementHarnessFetchMain  = "git fetch origin main"
+	implementHarnessFetchHead  = `git fetch origin main "$current_branch"`
+	implementHarnessMergeBase  = "git merge-base --is-ancestor origin/main HEAD"
+	implementHarnessRemoteRef  = `git rev-parse "origin/$current_branch"`
+	implementHarnessGoVet      = "go vet ./..."
+	implementHarnessGoBuild    = "go build ./cmd/xylem"
+	implementHarnessGoTest     = "go test ./..."
+	implementHarnessPRCreate   = "gh pr create"
+	implementHarnessRepoFlag   = "--repo nicholls-inc/xylem"
+	implementHarnessPRLabel    = `--label "harness-impl"`
+	implementHarnessMergeLabel = `--label "ready-to-merge"`
 )
 
 func checkedInWorkflowPath(t *testing.T, name string) string {
@@ -110,8 +113,18 @@ func TestSmoke_S3_ImplementHarnessWorkflowChecksMainFreshnessBeforePRCreate(t *t
 	assert.Equal(t, "command", prCreate.Type)
 	assert.Contains(t, prCreate.Run, implementHarnessFetchMain)
 	assert.Contains(t, prCreate.Run, implementHarnessMergeBase)
+	assert.Contains(t, prCreate.Run, implementHarnessRepoFlag)
+	assert.Contains(t, prCreate.Run, implementHarnessPRLabel)
+	assert.Contains(t, prCreate.Run, implementHarnessMergeLabel)
 	assert.Contains(t, prCreate.Run, `ERROR: branch is behind origin/main; rebase before creating the PR`)
-	assert.True(t, commandContainsInOrder(prCreate.Run, implementHarnessFetchMain, implementHarnessMergeBase, implementHarnessPRCreate))
+	assert.True(t, commandContainsInOrder(
+		prCreate.Run,
+		implementHarnessFetchMain,
+		implementHarnessMergeBase,
+		implementHarnessPRCreate,
+		implementHarnessPRLabel,
+		implementHarnessMergeLabel,
+	))
 }
 
 func TestSmoke_S4_ImplementHarnessPRDraftPromptRequiresRebaseRetestAndForcePush(t *testing.T) {

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -789,6 +789,12 @@ phases:
     run: |
       set -euo pipefail
 
+      git fetch origin main
+      if ! git merge-base --is-ancestor origin/main HEAD; then
+        echo "ERROR: branch is behind origin/main; rebase before creating the PR"
+        exit 1
+      fi
+
       DRAFT_FILE="pr_draft.json"
       if [ ! -f "$DRAFT_FILE" ]; then
         echo "ERROR: pr_draft.json not found in worktree root"
@@ -811,10 +817,11 @@ phases:
         --repo nicholls-inc/xylem \
         --title "$TITLE" \
         --body "$BODY" \
-        --label "harness-impl"
+        --label "harness-impl" \
+        --label "ready-to-merge"
 ```
 
-Unlike the scaffolded `pr` prompt phases above, this repo-specific `pr_create` step is a deterministic command phase: it validates `pr_draft.json`, appends `Fixes #{{.Issue.Number}}` so GitHub auto-closes the issue, and targets `nicholls-inc/xylem` explicitly.
+Unlike the scaffolded `pr` prompt phases above, this repo-specific `pr_create` step is a deterministic command phase: it refuses to create the PR if the branch has fallen behind `origin/main`, validates `pr_draft.json`, appends `Fixes #{{.Issue.Number}}` so GitHub auto-closes the issue, targets `nicholls-inc/xylem` explicitly, and applies both `harness-impl` and `ready-to-merge` at PR creation so the merge workflow can pick the PR up immediately once checks are green.
 
 **Phase flow:**
 


### PR DESCRIPTION
## Summary
Implements [issue #283](https://github.com/nicholls-inc/xylem/issues/283) by adding the `ready-to-merge` label at `implement-harness` PR creation time so self-hosted harness PRs immediately satisfy the shared auto-admin-merge label contract.

## Smoke scenarios covered
- S1 - Compose core + self-hosting-xylem includes the seeded `implement-harness` workflow asset with both PR labels.
- S2 - `implement-harness` checks the rebased branch state before `pr_draft` completes.
- S3 - `implement-harness` checks `origin/main` freshness and applies both PR labels before `pr_create`.
- S4 - The `pr_draft` prompt requires rebase, retest, and `git push --force-with-lease` after rewritten history.

## Changes summary
- Modified `.xylem/workflows/implement-harness.yaml` and `cli/internal/profiles/self-hosting-xylem/workflows/implement-harness.yaml` so `gh pr create` applies both `harness-impl` and `ready-to-merge`.
- Expanded `cli/internal/workflow/implement_harness_workflow_test.go` to assert the `pr_create` command includes the repo target and both label flags via `implementHarnessRepoFlag`, `implementHarnessPRLabel`, and `implementHarnessMergeLabel`.
- Updated `cli/internal/profiles/profiles_test.go` and `cli/internal/profiles/profiles_prop_test.go` to verify the composed self-hosting profile preserves the implement-harness PR creation contract, including `securityComplianceBundle` and `implementHarnessPRCreateContract` helper coverage.
- Modified `docs/workflows.md` to document the `origin/main` freshness check and the dual-label PR creation behavior.

## Test plan
- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #283