### PR TITLE
fix: keep daemon startup alive when adapt-repo seeding hits gh v2.9 state limits

### DIFF
--- a/cli/cmd/xylem/adapt_repo_seed.go
+++ b/cli/cmd/xylem/adapt_repo_seed.go
@@ -158,20 +158,33 @@ func primaryGitHubRepo(cfg *config.Config) string {
 }
 
 func findExistingAdaptRepoIssue(ctx context.Context, runner adaptRepoSeedRunner, repo string) (*adaptRepoIssue, error) {
+	for _, state := range []string{"open", "closed"} {
+		issue, err := findAdaptRepoIssueByState(ctx, runner, repo, state)
+		if err != nil {
+			return nil, err
+		}
+		if issue != nil {
+			return issue, nil
+		}
+	}
+	return nil, nil
+}
+
+func findAdaptRepoIssueByState(ctx context.Context, runner adaptRepoSeedRunner, repo, state string) (*adaptRepoIssue, error) {
 	out, err := runner.Run(ctx, "gh", "search", "issues",
 		"--repo", repo,
-		"--state", "all",
+		"--state", state,
 		"--json", "number,title,url",
 		"--limit", "100",
 		"--search", adaptRepoIssueTitle,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("search adapt-repo seed issue: %w", err)
+		return nil, fmt.Errorf("search adapt-repo seed issue in %s state: %w", state, err)
 	}
 
 	var issues []adaptRepoIssue
 	if err := json.Unmarshal(out, &issues); err != nil {
-		return nil, fmt.Errorf("parse adapt-repo seed issue search output: %w", err)
+		return nil, fmt.Errorf("parse adapt-repo seed issue search output for %s state: %w", state, err)
 	}
 	for _, issue := range issues {
 		if issue.Title == adaptRepoIssueTitle {

--- a/cli/cmd/xylem/adapt_repo_seed_test.go
+++ b/cli/cmd/xylem/adapt_repo_seed_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func adaptRepoSearchCall(repo string) string {
-	return "gh search issues --repo " + repo + " --state all --json number,title,url --limit 100 --search " + adaptRepoIssueTitle
+func adaptRepoSearchCallForState(repo, state string) string {
+	return "gh search issues --repo " + repo + " --state " + state + " --json number,title,url --limit 100 --search " + adaptRepoIssueTitle
 }
 
 func adaptRepoCreateCall(repo string) string {
@@ -22,15 +22,22 @@ func adaptRepoCreateCall(repo string) string {
 type seedRunnerStub struct {
 	calls   [][]string
 	outputs map[string][]byte
+	errors  map[string]error
 }
 
 func (s *seedRunnerStub) Run(_ context.Context, name string, args ...string) ([]byte, error) {
 	call := append([]string{name}, args...)
 	s.calls = append(s.calls, call)
+	key := strings.Join(call, " ")
+	if s.errors != nil {
+		if err := s.errors[key]; err != nil {
+			return nil, err
+		}
+	}
 	if s.outputs == nil {
 		return nil, nil
 	}
-	return s.outputs[strings.Join(call, " ")], nil
+	return s.outputs[key], nil
 }
 
 func TestSmoke_S3_DaemonSeedingCreatesIssueAndMarkerOnFreshRepo(t *testing.T) {
@@ -45,8 +52,9 @@ func TestSmoke_S3_DaemonSeedingCreatesIssueAndMarkerOnFreshRepo(t *testing.T) {
 	}
 	runner := &seedRunnerStub{
 		outputs: map[string][]byte{
-			adaptRepoSearchCall("owner/repo"): []byte("[]"),
-			adaptRepoCreateCall("owner/repo"): []byte("https://github.com/owner/repo/issues/34\n"),
+			adaptRepoSearchCallForState("owner/repo", "open"):   []byte("[]"),
+			adaptRepoSearchCallForState("owner/repo", "closed"): []byte("[]"),
+			adaptRepoCreateCall("owner/repo"):                   []byte("https://github.com/owner/repo/issues/34\n"),
 		},
 	}
 
@@ -61,7 +69,7 @@ func TestSmoke_S3_DaemonSeedingCreatesIssueAndMarkerOnFreshRepo(t *testing.T) {
 	written, err := readAdaptRepoSeedMarker(filepath.Join(cfg.StateDir, "state", "bootstrap", "adapt-repo-seeded.json"))
 	require.NoError(t, err)
 	assert.Equal(t, marker, written)
-	assert.Len(t, runner.calls, 2)
+	assert.Len(t, runner.calls, 3)
 }
 
 func TestSmoke_S4_DaemonSeedingDedupesMatchingClosedIssueByTitle(t *testing.T) {
@@ -76,7 +84,8 @@ func TestSmoke_S4_DaemonSeedingDedupesMatchingClosedIssueByTitle(t *testing.T) {
 	}
 	runner := &seedRunnerStub{
 		outputs: map[string][]byte{
-			adaptRepoSearchCall("owner/repo"): []byte(`[{"number":21,"title":"[xylem] adapt harness to this repository","url":"https://github.com/owner/repo/issues/21"}]`),
+			adaptRepoSearchCallForState("owner/repo", "open"):   []byte("[]"),
+			adaptRepoSearchCallForState("owner/repo", "closed"): []byte(`[{"number":21,"title":"[xylem] adapt harness to this repository","url":"https://github.com/owner/repo/issues/21"}]`),
 		},
 	}
 
@@ -90,7 +99,7 @@ func TestSmoke_S4_DaemonSeedingDedupesMatchingClosedIssueByTitle(t *testing.T) {
 	written, err := readAdaptRepoSeedMarker(filepath.Join(cfg.StateDir, "state", "bootstrap", "adapt-repo-seeded.json"))
 	require.NoError(t, err)
 	assert.Equal(t, marker, written)
-	assert.Len(t, runner.calls, 1)
+	assert.Len(t, runner.calls, 2)
 }
 
 func TestSmoke_S5_AdaptRepoSeedMarkerPreventsReseedingOnSubsequentBoots(t *testing.T) {
@@ -105,21 +114,22 @@ func TestSmoke_S5_AdaptRepoSeedMarkerPreventsReseedingOnSubsequentBoots(t *testi
 	}
 	runner := &seedRunnerStub{
 		outputs: map[string][]byte{
-			adaptRepoSearchCall("owner/repo"): []byte("[]"),
-			adaptRepoCreateCall("owner/repo"): []byte("https://github.com/owner/repo/issues/34\n"),
+			adaptRepoSearchCallForState("owner/repo", "open"):   []byte("[]"),
+			adaptRepoSearchCallForState("owner/repo", "closed"): []byte("[]"),
+			adaptRepoCreateCall("owner/repo"):                   []byte("https://github.com/owner/repo/issues/34\n"),
 		},
 	}
 
 	marker, err := ensureAdaptRepoSeeded(context.Background(), cfg, runner, adaptRepoSeededByDaemon)
 	require.NoError(t, err)
 	require.NotNil(t, marker)
-	assert.Len(t, runner.calls, 2)
+	assert.Len(t, runner.calls, 3)
 
 	markerAgain, err := ensureAdaptRepoSeeded(context.Background(), cfg, runner, adaptRepoSeededByDaemon)
 	require.NoError(t, err)
 	require.NotNil(t, markerAgain)
 	assert.Equal(t, marker, markerAgain)
-	assert.Len(t, runner.calls, 2)
+	assert.Len(t, runner.calls, 3)
 }
 
 func TestEnsureAdaptRepoSeededSkipsConfigsWithoutGitHubRepo(t *testing.T) {
@@ -139,4 +149,18 @@ func TestEnsureAdaptRepoSeededSkipsConfigsWithoutGitHubRepo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, marker)
 	assert.Empty(t, runner.calls)
+}
+
+func TestFindExistingAdaptRepoIssueStopsAfterOpenMatch(t *testing.T) {
+	runner := &seedRunnerStub{
+		outputs: map[string][]byte{
+			adaptRepoSearchCallForState("owner/repo", "open"): []byte(`[{"number":13,"title":"[xylem] adapt harness to this repository","url":"https://github.com/owner/repo/issues/13"}]`),
+		},
+	}
+
+	issue, err := findExistingAdaptRepoIssue(context.Background(), runner, "owner/repo")
+	require.NoError(t, err)
+	require.NotNil(t, issue)
+	assert.Equal(t, 13, issue.Number)
+	assert.Len(t, runner.calls, 1)
 }

--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -83,10 +83,8 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	// P0-2: Reconcile any vessels left in running state from a previous daemon.
 	// The singleton lock guarantees no other daemon is running, so all running
 	// vessels are definitionally orphaned.
-	reconcileStaleVessels(q, wt)
-
-	if _, err := ensureAdaptRepoSeeded(context.Background(), cfg, newCmdRunner(cfg), adaptRepoSeededByDaemon); err != nil {
-		return fmt.Errorf("seed adapt-repo issue: %w", err)
+	if err := daemonStartup(context.Background(), cfg, q, wt, newCmdRunner(cfg)); err != nil {
+		return err
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -190,6 +188,15 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 
 	commandErr = daemonLoop(ctx, q, drainRunner, scan, drain, check, upgrade, tickHook, scanInterval, drainInterval, upgradeInterval)
 	return commandErr
+}
+
+func daemonStartup(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *worktree.Manager, seedRunner adaptRepoSeedRunner) error {
+	reconcileStaleVessels(q, wt)
+
+	if _, err := ensureAdaptRepoSeeded(ctx, cfg, seedRunner, adaptRepoSeededByDaemon); err != nil {
+		slog.Warn("seed adapt-repo issue failed, continuing", "error", err)
+	}
+	return nil
 }
 
 // parseUpgradeInterval returns the effective periodic upgrade interval. If

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -198,6 +198,73 @@ func (r daemonBacklogRunner) Run(_ context.Context, _ string, _ ...string) ([]by
 	return r.output, nil
 }
 
+func TestSmoke_S7_DaemonStartupContinuesWhenAdaptRepoSearchFails(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		StateDir: dir,
+		Sources: map[string]config.SourceConfig{
+			"issues": {
+				Type: "github",
+				Repo: "owner/repo",
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	logBuf := withBufferedDefaultLogger(t)
+	markerPath := adaptRepoSeedMarkerPath(cfg.StateDir)
+	runner := &seedRunnerStub{
+		errors: map[string]error{
+			adaptRepoSearchCallForState("owner/repo", "open"): fmt.Errorf("gh unavailable"),
+		},
+	}
+
+	err := daemonStartup(context.Background(), cfg, q, nil, runner)
+	require.NoError(t, err)
+	_, statErr := os.Stat(markerPath)
+	require.Error(t, statErr)
+	require.True(t, os.IsNotExist(statErr))
+	assert.Contains(t, logBuf.String(), "seed adapt-repo issue failed, continuing")
+	assert.Contains(t, logBuf.String(), "gh unavailable")
+	assert.Len(t, runner.calls, 1)
+}
+
+func TestSmoke_S8_DaemonStartupLeavesMarkerAbsentWhenAdaptRepoCreateFails(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		StateDir: dir,
+		Sources: map[string]config.SourceConfig{
+			"issues": {
+				Type: "github",
+				Repo: "owner/repo",
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	logBuf := withBufferedDefaultLogger(t)
+	runner := &seedRunnerStub{
+		outputs: map[string][]byte{
+			adaptRepoSearchCallForState("owner/repo", "open"):   []byte("[]"),
+			adaptRepoSearchCallForState("owner/repo", "closed"): []byte("[]"),
+		},
+		errors: map[string]error{
+			adaptRepoCreateCall("owner/repo"): fmt.Errorf("gh create failed"),
+		},
+	}
+	markerPath := adaptRepoSeedMarkerPath(cfg.StateDir)
+	_, statErr := os.Stat(markerPath)
+	require.Error(t, statErr)
+	require.True(t, os.IsNotExist(statErr))
+
+	err := daemonStartup(context.Background(), cfg, q, nil, runner)
+	require.NoError(t, err)
+	_, statErr = os.Stat(markerPath)
+	require.Error(t, statErr)
+	assert.True(t, os.IsNotExist(statErr))
+	assert.Contains(t, logBuf.String(), "seed adapt-repo issue failed, continuing")
+	assert.Contains(t, logBuf.String(), "gh create failed")
+	assert.Len(t, runner.calls, 3)
+}
+
 func TestDaemonLoopScheduledSourceRunsSingleTick(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -319,8 +319,9 @@ func TestSmoke_S6_InitSeedCreatesAdaptRepoMarkerSynchronously(t *testing.T) {
 
 	runner := &seedRunnerStub{
 		outputs: map[string][]byte{
-			adaptRepoSearchCall("owner/name"): []byte("[]"),
-			adaptRepoCreateCall("owner/name"): []byte("https://github.com/owner/name/issues/12\n"),
+			adaptRepoSearchCallForState("owner/name", "open"):   []byte("[]"),
+			adaptRepoSearchCallForState("owner/name", "closed"): []byte("[]"),
+			adaptRepoCreateCall("owner/name"):                   []byte("https://github.com/owner/name/issues/12\n"),
 		},
 	}
 
@@ -336,7 +337,7 @@ func TestSmoke_S6_InitSeedCreatesAdaptRepoMarkerSynchronously(t *testing.T) {
 	assert.Equal(t, "https://github.com/owner/name/issues/12", marker.IssueURL)
 	assert.Equal(t, adaptRepoSeededByInit, marker.SeededBy)
 	assert.Equal(t, 1, marker.ProfileVersion)
-	assert.Len(t, runner.calls, 2)
+	assert.Len(t, runner.calls, 3)
 }
 
 func TestInitSkipsExistingV2Files(t *testing.T) {


### PR DESCRIPTION
## Summary
+- Implements https://github.com/nicholls-inc/xylem/issues/259.
+- Replaces the unsupported `gh search issues --state all` lookup with an open-then-closed search flow so adapt-repo seeding still finds prior issues on GitHub CLI v2.9.
+- Moves daemon startup seeding behind `daemonStartup`, logging seeding failures and continuing startup instead of crashing the daemon before the main loop begins.
+
+## Smoke scenarios covered
+- `S3` — Daemon seeding creates issue and marker on fresh repo.
+- `S4` — Daemon seeding dedupes matching closed issue by title.
+- `S5` — Adapt-repo seed marker prevents reseeding on subsequent boots.
+- `S6` — Init seed creates adapt-repo marker synchronously.
+- `S7` — Daemon startup continues when adapt-repo search fails.
+- `S8` — Daemon startup leaves marker absent when adapt-repo create fails.
+
+## Changes summary
+- Modified `cli/cmd/xylem/adapt_repo_seed.go` to split adapt-repo issue discovery into `findExistingAdaptRepoIssue` plus `findAdaptRepoIssueByState`, searching `open` and `closed` separately and preserving the existing dedupe-by-title behavior.
+- Modified `cli/cmd/xylem/daemon.go` to route startup reconciliation and seed bootstrapping through `daemonStartup`, which warns and continues when `ensureAdaptRepoSeeded` fails.
+- Modified `cli/cmd/xylem/adapt_repo_seed_test.go` to model per-state `gh search issues` calls, cover the open-match short-circuit path, and keep marker/creation expectations aligned with the new search sequence.
+- Modified `cli/cmd/xylem/daemon_test.go` to add startup smoke coverage for search/create failures and verify the marker stays absent when seeding fails.
+- Modified `cli/cmd/xylem/init_test.go` to align init seeding expectations with the new open-then-closed lookup sequence.
+
+## Test plan
+- `cd cli && goimports -w . && goimports -l .`
+- `cd cli && golangci-lint run`
+- `cd cli && go vet ./...`
+- `cd cli && go build ./cmd/xylem`
+- `cd cli && go test ./...`
+

Fixes #259