### PR TITLE
feat(workflow): add continuous-improvement workflow

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -143,6 +143,16 @@ sources:
         workflow: continuous-simplicity
         ref: continuous-simplicity
 
+  continuous-improvement:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "@daily"
+    timeout: "90m"
+    tasks:
+      daily-rotation:
+        workflow: continuous-improvement
+        ref: continuous-improvement
+
   harness-gap-analysis:
     type: scheduled
     repo: nicholls-inc/xylem

--- a/.xylem/prompts/continuous-improvement/analyze.md
+++ b/.xylem/prompts/continuous-improvement/analyze.md
@@ -1,0 +1,22 @@
+This is a scheduled continuous-improvement run for `{{.Repo.Slug}}`. There is no triggering GitHub issue.
+
+## Focus brief
+{{.PreviousOutputs.select_focus}}
+
+Read the codebase and identify the best small improvement opportunity inside the selected focus area.
+
+Requirements:
+
+1. Read the relevant code, tests, and any directly related docs before concluding.
+2. Prefer one focused, mergeable improvement over a broad refactor.
+3. Weight repo-specific harness concerns higher than generic cleanup if both are similarly valuable.
+4. Avoid repeating the exact same improvement area covered in the recent history unless the current focus brief explicitly chose a revisit.
+
+If there is no worthwhile, low-risk change to ship for this focus area, output the exact standalone line `XYLEM_NOOP` and explain why.
+
+Otherwise, provide:
+
+- the specific problem to fix
+- the exact files likely involved
+- constraints, risks, and validation needs
+- why this is the highest-value improvement for this scheduled run

--- a/.xylem/prompts/continuous-improvement/implement.md
+++ b/.xylem/prompts/continuous-improvement/implement.md
@@ -1,0 +1,25 @@
+Implement the scheduled continuous-improvement plan.
+
+## Focus brief
+{{.PreviousOutputs.select_focus}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+{{if .GateResult}}
+## Previous gate failure
+The previous validation gate failed. Fix the issues below and continue:
+
+{{.GateResult}}
+{{end}}
+
+Rules:
+
+1. Keep the change set small, focused, and easy to review.
+2. Add or update tests for the chosen improvement.
+3. Do not widen scope into unrelated cleanup.
+4. Leave PR creation for the next phase.
+5. Run any narrow, local checks you need while editing; the workflow gate will run the full configured validation commands.

--- a/.xylem/prompts/continuous-improvement/plan.md
+++ b/.xylem/prompts/continuous-improvement/plan.md
@@ -1,0 +1,16 @@
+Create an implementation plan for this scheduled continuous-improvement run.
+
+## Focus brief
+{{.PreviousOutputs.select_focus}}
+
+## Previous analysis
+{{.PreviousOutputs.analyze}}
+
+Write a concrete plan that includes:
+
+1. file-by-file changes
+2. tests to add or update
+3. validation commands to rely on
+4. any edge cases or rollback risks
+
+If the analysis established that nothing safe and worthwhile should ship, output the exact standalone line `XYLEM_NOOP` and explain why.

--- a/.xylem/prompts/continuous-improvement/verify.md
+++ b/.xylem/prompts/continuous-improvement/verify.md
@@ -1,0 +1,29 @@
+Perform the final verification and ship this scheduled continuous-improvement change.
+
+## Focus brief
+{{.PreviousOutputs.select_focus}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+Review the final diff against the selected focus area and ensure the change is still small, coherent, and worth merging.
+
+If you make additional edits in this phase, rerun the relevant validation commands before committing.
+
+Then:
+
+1. commit the changes with a clear message
+2. push the branch
+3. create a pull request
+
+PR requirements:
+
+- Prefix the title with `[continuous-improvement]`
+- Mention the selected focus area in the body
+- Note that this came from a scheduled continuous-improvement run
+- Summarize the concrete improvement and the tests or validation performed
+
+In your final output, include the PR URL and a short summary of what shipped.

--- a/.xylem/workflows/continuous-improvement.yaml
+++ b/.xylem/workflows/continuous-improvement.yaml
@@ -1,0 +1,44 @@
+name: continuous-improvement
+class: harness-maintenance
+description: "Scheduled self-improvement loop for small, high-signal xylem maintenance changes"
+phases:
+  - name: select_focus
+    type: command
+    run: |
+      set -euo pipefail
+      go run ./cli/cmd/xylem --config .xylem.yml continuous-improvement select \
+        --state .xylem/state/continuous-improvement/state.json \
+        --selection .xylem/state/continuous-improvement/current-selection.json
+  - name: analyze
+    prompt_file: .xylem/prompts/continuous-improvement/analyze.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4
+    noop:
+      match: XYLEM_NOOP
+  - name: plan
+    prompt_file: .xylem/prompts/continuous-improvement/plan.md
+    max_turns: 30
+    llm: copilot
+    model: gpt-5.4
+    noop:
+      match: XYLEM_NOOP
+  - name: implement
+    prompt_file: .xylem/prompts/continuous-improvement/implement.md
+    max_turns: 80
+    llm: copilot
+    model: gpt-5.4
+    gate:
+      type: command
+      run: |
+        set -euo pipefail
+        {{if .Validation.Format}}{{.Validation.Format}}{{else}}true{{end}}
+        {{if .Validation.Lint}}{{.Validation.Lint}}{{end}}
+        {{if .Validation.Build}}{{.Validation.Build}}{{end}}
+        {{if .Validation.Test}}{{.Validation.Test}}{{else}}true{{end}}
+      retries: 2
+  - name: verify
+    prompt_file: .xylem/prompts/continuous-improvement/verify.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4

--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -37,7 +37,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "bootstrap", "continuous-simplicity", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "enqueue", "daemon", "retry", "visualize", "version"}
+	expected := []string{"init", "bootstrap", "continuous-improvement", "continuous-simplicity", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "enqueue", "daemon", "retry", "visualize", "version"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/continuous_improvement.go
+++ b/cli/cmd/xylem/continuous_improvement.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholls-inc/xylem/cli/internal/continuousimprovement"
+)
+
+var selectContinuousImprovement = continuousimprovement.SelectAndPersist
+
+func newContinuousImprovementCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "continuous-improvement",
+		Short: "Deterministic helpers for scheduled continuous improvement runs",
+	}
+	cmd.AddCommand(newContinuousImprovementSelectCmd())
+	return cmd
+}
+
+func newContinuousImprovementSelectCmd() *cobra.Command {
+	var statePath string
+	var selectionPath string
+	var nowRaw string
+	cmd := &cobra.Command{
+		Use:   "select",
+		Short: "Choose and persist the next continuous improvement focus area",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var now time.Time
+			if strings.TrimSpace(nowRaw) != "" {
+				parsed, err := time.Parse(time.RFC3339, nowRaw)
+				if err != nil {
+					return fmt.Errorf("parse --now: %w", err)
+				}
+				now = parsed
+			}
+			selection, err := cmdContinuousImprovementSelect(statePath, selectionPath, now)
+			if err != nil {
+				return err
+			}
+			fmt.Print(continuousimprovement.RenderMarkdown(selection))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&statePath, "state", "", "Path to the continuous-improvement rotation state JSON")
+	cmd.Flags().StringVar(&selectionPath, "selection", "", "Path to write the current selection JSON")
+	cmd.Flags().StringVar(&nowRaw, "now", "", "Optional RFC3339 timestamp override for deterministic runs")
+	return cmd
+}
+
+func cmdContinuousImprovementSelect(statePath, selectionPath string, now time.Time) (*continuousimprovement.Selection, error) {
+	if deps == nil || deps.cfg == nil {
+		return nil, fmt.Errorf("continuous-improvement select requires loaded config")
+	}
+	if strings.TrimSpace(statePath) == "" {
+		statePath = filepath.Join(deps.cfg.StateDir, "state", "continuous-improvement", "state.json")
+	}
+	if strings.TrimSpace(selectionPath) == "" {
+		selectionPath = filepath.Join(deps.cfg.StateDir, "state", "continuous-improvement", "current-selection.json")
+	}
+	selection, err := selectContinuousImprovement(continuousimprovement.Options{
+		Repo:          detectLessonsRepo(deps.cfg),
+		Now:           now,
+		StatePath:     statePath,
+		SelectionPath: selectionPath,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("select continuous improvement focus: %w", err)
+	}
+	return selection, nil
+}

--- a/cli/cmd/xylem/continuous_improvement_test.go
+++ b/cli/cmd/xylem/continuous_improvement_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/continuousimprovement"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSmoke_S2_SelectCommandWritesDefaultArtifactsAndSummary(t *testing.T) {
+	cfg := &config.Config{StateDir: t.TempDir(), Repo: "owner/repo"}
+	originalDeps := deps
+	t.Cleanup(func() { deps = originalDeps })
+	deps = &appDeps{cfg: cfg}
+
+	original := selectContinuousImprovement
+	t.Cleanup(func() { selectContinuousImprovement = original })
+	selectContinuousImprovement = continuousimprovement.SelectAndPersist
+
+	now := time.Date(2026, time.April, 10, 4, 0, 0, 0, time.UTC)
+	out := captureStdout(func() {
+		cmd := newContinuousImprovementSelectCmd()
+		cmd.SetArgs([]string{"--now", now.Format(time.RFC3339)})
+		require.NoError(t, cmd.Execute())
+	})
+
+	expectedStatePath := filepath.Join(cfg.StateDir, "state", "continuous-improvement", "state.json")
+	expectedSelectionPath := filepath.Join(cfg.StateDir, "state", "continuous-improvement", "current-selection.json")
+	assert.Contains(t, out, "Continuous Improvement Focus")
+	assert.Contains(t, out, "owner/repo")
+	assert.Contains(t, out, now.Format(time.RFC3339))
+
+	loadedState, err := continuousimprovement.LoadState(expectedStatePath)
+	require.NoError(t, err)
+	assert.Equal(t, 1, loadedState.Runs)
+	require.Len(t, loadedState.History, 1)
+	assert.Equal(t, now.Format(time.RFC3339), loadedState.History[0].SelectedAt)
+
+	selectionData, err := os.ReadFile(expectedSelectionPath)
+	require.NoError(t, err)
+	var persisted continuousimprovement.Selection
+	require.NoError(t, json.Unmarshal(selectionData, &persisted))
+	assert.Equal(t, "owner/repo", persisted.Repo)
+	assert.Equal(t, now.Format(time.RFC3339), persisted.GeneratedAt)
+	assert.Equal(t, expectedStatePath, persisted.StatePath)
+	assert.Equal(t, expectedSelectionPath, persisted.SelectionPath)
+	assert.NotEmpty(t, persisted.Focus.Key)
+	assert.Contains(t, out, persisted.Focus.Key)
+}
+
+func TestCmdContinuousImprovementSelectPrintsSelectionSummary(t *testing.T) {
+	cfg := &config.Config{StateDir: t.TempDir(), Repo: "owner/repo"}
+	originalDeps := deps
+	t.Cleanup(func() { deps = originalDeps })
+	deps = &appDeps{cfg: cfg}
+
+	customStatePath := filepath.Join(cfg.StateDir, "custom-state.json")
+	customSelectionPath := filepath.Join(cfg.StateDir, "custom-selection.json")
+	now := time.Date(2026, time.April, 10, 5, 6, 7, 0, time.UTC)
+
+	original := selectContinuousImprovement
+	t.Cleanup(func() { selectContinuousImprovement = original })
+	var gotOpts continuousimprovement.Options
+	selectContinuousImprovement = func(opts continuousimprovement.Options) (*continuousimprovement.Selection, error) {
+		gotOpts = opts
+		return &continuousimprovement.Selection{
+			Version:       continuousimprovement.StateVersion,
+			Repo:          opts.Repo,
+			GeneratedAt:   opts.Now.Format(time.RFC3339),
+			RotationSlot:  0,
+			RotationGroup: continuousimprovement.GroupRepoSpecific,
+			Focus: continuousimprovement.Focus{
+				Key:     "workflow-prompts-and-gates",
+				Title:   "Workflow prompts and gates",
+				Group:   continuousimprovement.GroupRepoSpecific,
+				Summary: "summary",
+			},
+			Reason:      "weighted repo-specific slot",
+			Fingerprint: "cafebabe",
+		}, nil
+	}
+
+	out := captureStdout(func() {
+		cmd := newContinuousImprovementSelectCmd()
+		cmd.SetArgs([]string{
+			"--state", customStatePath,
+			"--selection", customSelectionPath,
+			"--now", now.Format(time.RFC3339),
+		})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+	if gotOpts.Repo != cfg.Repo {
+		t.Fatalf("Repo = %q, want %q", gotOpts.Repo, cfg.Repo)
+	}
+	if gotOpts.StatePath != customStatePath {
+		t.Fatalf("StatePath = %q, want %q", gotOpts.StatePath, customStatePath)
+	}
+	if gotOpts.SelectionPath != customSelectionPath {
+		t.Fatalf("SelectionPath = %q, want %q", gotOpts.SelectionPath, customSelectionPath)
+	}
+	if !gotOpts.Now.Equal(now) {
+		t.Fatalf("Now = %s, want %s", gotOpts.Now.Format(time.RFC3339), now.Format(time.RFC3339))
+	}
+	if !strings.Contains(out, "Continuous Improvement Focus") {
+		t.Fatalf("output = %q, want rendered selection summary", out)
+	}
+	if !strings.Contains(out, "workflow-prompts-and-gates") {
+		t.Fatalf("output = %q, want focus key", out)
+	}
+	if !strings.Contains(out, now.Format(time.RFC3339)) {
+		t.Fatalf("output = %q, want generated timestamp", out)
+	}
+}
+
+func TestCmdContinuousImprovementSelectUsesDefaultPaths(t *testing.T) {
+	cfg := &config.Config{StateDir: t.TempDir(), Repo: "owner/repo"}
+	originalDeps := deps
+	t.Cleanup(func() { deps = originalDeps })
+	deps = &appDeps{cfg: cfg}
+
+	original := selectContinuousImprovement
+	t.Cleanup(func() { selectContinuousImprovement = original })
+	selectContinuousImprovement = continuousimprovement.SelectAndPersist
+
+	selection, err := cmdContinuousImprovementSelect("", "", time.Date(2026, time.April, 10, 4, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("cmdContinuousImprovementSelect() error = %v", err)
+	}
+	expectedStatePath := filepath.Join(cfg.StateDir, "state", "continuous-improvement", "state.json")
+	expectedSelectionPath := filepath.Join(cfg.StateDir, "state", "continuous-improvement", "current-selection.json")
+	if selection.StatePath != expectedStatePath {
+		t.Fatalf("StatePath = %q, want %q", selection.StatePath, expectedStatePath)
+	}
+	if selection.SelectionPath != expectedSelectionPath {
+		t.Fatalf("SelectionPath = %q, want %q", selection.SelectionPath, expectedSelectionPath)
+	}
+	if _, err := os.Stat(expectedStatePath); err != nil {
+		t.Fatalf("default state file missing: %v", err)
+	}
+	if _, err := os.Stat(expectedSelectionPath); err != nil {
+		t.Fatalf("default selection file missing: %v", err)
+	}
+}
+
+func TestContinuousImprovementSelectBypassesToolLookup(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".xylem.yml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+repo: owner/repo
+state_dir: ".xylem"
+providers:
+  claude:
+    kind: claude
+    command: "claude"
+    flags: "--dangerously-skip-permissions"
+    tiers:
+      high: "claude-opus-4-6"
+      med: "claude-sonnet-4-6"
+      low: "claude-haiku-4-5"
+    env:
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
+  copilot:
+    kind: copilot
+    command: "copilot"
+    flags: "--yolo --autopilot"
+    tiers:
+      high: "gpt-5.4"
+      med: "gpt-5.2-codex"
+      low: "gpt-5-mini"
+    env:
+      GITHUB_TOKEN: "${COPILOT_GITHUB_TOKEN}"
+llm_routing:
+  default_tier: med
+  tiers:
+    high:
+      providers: [claude]
+    med:
+      providers: [claude, copilot]
+    low:
+      providers: [copilot, claude]
+sources:
+  ci:
+    type: scheduled
+    repo: owner/repo
+    schedule: "@daily"
+    tasks:
+      daily:
+        workflow: continuous-improvement
+        ref: continuous-improvement
+`), 0o644))
+
+	orig, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(orig))
+	})
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"--config", configPath, "continuous-improvement", "select", "--now", "2026-04-10T04:00:00Z"})
+
+	out := captureStdout(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	assert.Contains(t, out, "Continuous Improvement Focus")
+	assert.FileExists(t, filepath.Join(dir, ".xylem", "state", "continuous-improvement", "state.json"))
+	assert.FileExists(t, filepath.Join(dir, ".xylem", "state", "continuous-improvement", "current-selection.json"))
+}

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -36,6 +36,7 @@ var expectedCoreWorkflows = []string{
 }
 
 var expectedSelfHostingWorkflows = []string{
+	"continuous-improvement",
 	"continuous-simplicity",
 	"diagnose-failures",
 	"implement-harness",

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -31,14 +31,19 @@ func newRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Name() == "init" || cmd.Name() == "shim-dispatch" || cmd.Name() == "version" || cmd.CommandPath() == "xylem dtu" || strings.HasPrefix(cmd.CommandPath(), "xylem dtu ") || cmd.CommandPath() == "xylem bootstrap" || strings.HasPrefix(cmd.CommandPath(), "xylem bootstrap ") {
+			commandPath := cmd.CommandPath()
+			if cmd.Name() == "init" || cmd.Name() == "shim-dispatch" || cmd.Name() == "version" || commandPath == "xylem dtu" || strings.HasPrefix(commandPath, "xylem dtu ") || commandPath == "xylem bootstrap" || strings.HasPrefix(commandPath, "xylem bootstrap ") {
 				return nil
 			}
 
 			// visualize (and its subcommands) and review are read-only commands
 			// that only parse config, workflow YAML, and local state; they
-			// don't shell out to git or gh.
-			skipTooling := cmd.Name() == "visualize" || strings.HasPrefix(cmd.CommandPath(), "xylem visualize") || cmd.Name() == "review"
+			// don't shell out to git or gh. continuous-improvement select is
+			// another local-only helper used by a command phase.
+			skipTooling := cmd.Name() == "visualize" ||
+				strings.HasPrefix(commandPath, "xylem visualize") ||
+				cmd.Name() == "review" ||
+				commandPath == "xylem continuous-improvement select"
 
 			if !skipTooling {
 				if _, err := exec.LookPath("git"); err != nil {
@@ -82,6 +87,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		newInitCmd(),
 		newBootstrapCmd(),
+		newContinuousImprovementCmd(),
 		newContinuousSimplicityCmd(),
 		newDtuCmd(),
 		newShimDispatchCmd(),

--- a/cli/internal/continuousimprovement/continuous_improvement.go
+++ b/cli/internal/continuousimprovement/continuous_improvement.go
@@ -1,0 +1,562 @@
+package continuousimprovement
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	StateVersion    = 1
+	MaxHistory      = 40
+	recentRunWindow = 5
+	rotationSlots   = 10
+)
+
+type Group string
+
+const (
+	GroupRepoSpecific Group = "repo-specific"
+	GroupStandard     Group = "standard"
+	GroupRevisit      Group = "revisit"
+)
+
+type Focus struct {
+	Key            string   `json:"key"`
+	Title          string   `json:"title"`
+	Group          Group    `json:"group"`
+	Summary        string   `json:"summary"`
+	CandidatePaths []string `json:"candidate_paths,omitempty"`
+}
+
+type HistoryEntry struct {
+	SelectedAt     string   `json:"selected_at"`
+	FocusKey       string   `json:"focus_key"`
+	FocusTitle     string   `json:"focus_title"`
+	Group          Group    `json:"group"`
+	RotationSlot   int      `json:"rotation_slot"`
+	CandidatePaths []string `json:"candidate_paths,omitempty"`
+}
+
+type State struct {
+	Version int            `json:"version"`
+	Runs    int            `json:"runs"`
+	Counts  map[string]int `json:"counts,omitempty"`
+	History []HistoryEntry `json:"history,omitempty"`
+}
+
+type Selection struct {
+	Version       int            `json:"version"`
+	Repo          string         `json:"repo,omitempty"`
+	GeneratedAt   string         `json:"generated_at"`
+	RotationSlot  int            `json:"rotation_slot"`
+	RotationGroup Group          `json:"rotation_group"`
+	Focus         Focus          `json:"focus"`
+	Reason        string         `json:"reason"`
+	RecentHistory []HistoryEntry `json:"recent_history,omitempty"`
+	StatePath     string         `json:"state_path,omitempty"`
+	SelectionPath string         `json:"selection_path,omitempty"`
+	Fingerprint   string         `json:"fingerprint,omitempty"`
+}
+
+type Options struct {
+	Repo          string
+	Now           time.Time
+	StatePath     string
+	SelectionPath string
+}
+
+var repoSpecificFocuses = []Focus{
+	{
+		Key:     "workflow-prompts-and-gates",
+		Title:   "Workflow prompts and gates",
+		Group:   GroupRepoSpecific,
+		Summary: "Tighten self-hosted workflow prompts, command phases, and gate behavior so recurring automation stays reliable.",
+		CandidatePaths: []string{
+			".xylem/workflows",
+			".xylem/prompts",
+			"cli/internal/workflow",
+			"cli/internal/phase",
+			"cli/internal/runner",
+		},
+	},
+	{
+		Key:     "scheduled-automation-and-daemon-ops",
+		Title:   "Scheduled automation and daemon operations",
+		Group:   GroupRepoSpecific,
+		Summary: "Improve the recurring automation loop around scheduled sources, daemon scans, built-in maintenance workflows, and queue orchestration.",
+		CandidatePaths: []string{
+			".xylem.yml",
+			"cli/cmd/xylem",
+			"cli/internal/source",
+			"cli/internal/scanner",
+			"cli/internal/runner",
+		},
+	},
+	{
+		Key:     "queue-runner-worktree-safety",
+		Title:   "Queue, runner, and worktree safety",
+		Group:   GroupRepoSpecific,
+		Summary: "Strengthen the vessel state machine, worktree lifecycle, and concurrency boundaries used by the self-hosted control plane.",
+		CandidatePaths: []string{
+			"cli/internal/queue",
+			"cli/internal/runner",
+			"cli/internal/worktree",
+			"cli/internal/gate",
+		},
+	},
+	{
+		Key:     "self-hosting-config-and-docs",
+		Title:   "Self-hosting config and docs alignment",
+		Group:   GroupRepoSpecific,
+		Summary: "Reduce drift between the checked-in .xylem assets, profile overlays, init scaffolding, and self-hosting documentation.",
+		CandidatePaths: []string{
+			".xylem.yml",
+			".xylem",
+			"cli/internal/profiles",
+			"docs/configuration.md",
+			"docs/workflows.md",
+		},
+	},
+}
+
+var standardFocuses = []Focus{
+	{
+		Key:     "dependency-hygiene",
+		Title:   "Dependency hygiene",
+		Group:   GroupStandard,
+		Summary: "Look for stale or unnecessary dependencies, narrow version constraints, and dead imports that can be removed safely.",
+		CandidatePaths: []string{
+			"cli/go.mod",
+			"cli/go.sum",
+			"cli/internal",
+			"cli/cmd",
+		},
+	},
+	{
+		Key:     "type-safety",
+		Title:   "Type safety",
+		Group:   GroupStandard,
+		Summary: "Replace loosely typed plumbing with clearer concrete types, stronger validation, and safer helper boundaries.",
+		CandidatePaths: []string{
+			"cli/internal",
+			"cli/cmd",
+		},
+	},
+	{
+		Key:     "code-quality",
+		Title:   "Code quality",
+		Group:   GroupStandard,
+		Summary: "Pay down small correctness or maintainability issues that make future changes harder than they need to be.",
+		CandidatePaths: []string{
+			"cli/internal",
+			"cli/cmd",
+			"docs",
+		},
+	},
+	{
+		Key:     "test-coverage",
+		Title:   "Test coverage",
+		Group:   GroupStandard,
+		Summary: "Tighten unit and property coverage around existing behavior gaps, especially for error handling and scheduling edges.",
+		CandidatePaths: []string{
+			"cli/internal",
+			"cli/cmd",
+		},
+	},
+	{
+		Key:     "documentation",
+		Title:   "Documentation",
+		Group:   GroupStandard,
+		Summary: "Close code-to-doc drift so self-hosting operators and contributors can trust the documented behavior.",
+		CandidatePaths: []string{
+			"README.md",
+			"docs",
+			".xylem.yml",
+		},
+	},
+	{
+		Key:     "performance",
+		Title:   "Performance",
+		Group:   GroupStandard,
+		Summary: "Trim unnecessary work in scans, queue traversals, workflow execution, or repeated file-system operations.",
+		CandidatePaths: []string{
+			"cli/internal/runner",
+			"cli/internal/source",
+			"cli/internal/queue",
+		},
+	},
+	{
+		Key:     "security",
+		Title:   "Security",
+		Group:   GroupStandard,
+		Summary: "Harden command execution, path handling, or config-driven behavior that crosses trust boundaries in the harness.",
+		CandidatePaths: []string{
+			"cli/internal/runner",
+			"cli/internal/config",
+			"cli/internal/intermediary",
+			"cli/internal/worktree",
+		},
+	},
+}
+
+func SelectAndPersist(opts Options) (*Selection, error) {
+	if opts.Now.IsZero() {
+		opts.Now = time.Now().UTC()
+	}
+
+	state, err := LoadState(opts.StatePath)
+	if err != nil {
+		return nil, err
+	}
+	selection, nextState, err := GenerateSelection(state, opts)
+	if err != nil {
+		return nil, err
+	}
+	if err := SaveState(opts.StatePath, nextState); err != nil {
+		return nil, err
+	}
+	selection.StatePath = opts.StatePath
+	selection.SelectionPath = opts.SelectionPath
+	if strings.TrimSpace(opts.SelectionPath) != "" {
+		if err := SaveSelection(opts.SelectionPath, selection); err != nil {
+			return nil, err
+		}
+	}
+	return selection, nil
+}
+
+func GenerateSelection(state *State, opts Options) (*Selection, *State, error) {
+	if state == nil {
+		state = defaultState()
+	}
+	now := opts.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	nextState := cloneState(state)
+	if nextState.Version == 0 {
+		nextState.Version = StateVersion
+	}
+	if nextState.Counts == nil {
+		nextState.Counts = make(map[string]int)
+	}
+
+	slot := nextState.Runs % rotationSlots
+	targetGroup := groupForSlot(slot)
+	focus, actualGroup, reason := chooseFocus(nextState, targetGroup, slot)
+
+	entry := HistoryEntry{
+		SelectedAt:     now.Format(time.RFC3339),
+		FocusKey:       focus.Key,
+		FocusTitle:     focus.Title,
+		Group:          actualGroup,
+		RotationSlot:   slot,
+		CandidatePaths: append([]string(nil), focus.CandidatePaths...),
+	}
+	nextState.Runs++
+	nextState.Counts[focus.Key]++
+	nextState.History = append(nextState.History, entry)
+	if len(nextState.History) > MaxHistory {
+		nextState.History = append([]HistoryEntry(nil), nextState.History[len(nextState.History)-MaxHistory:]...)
+	}
+
+	selection := &Selection{
+		Version:       StateVersion,
+		Repo:          strings.TrimSpace(opts.Repo),
+		GeneratedAt:   now.Format(time.RFC3339),
+		RotationSlot:  slot,
+		RotationGroup: actualGroup,
+		Focus:         focus,
+		Reason:        reason,
+		RecentHistory: recentHistory(state.History),
+		Fingerprint:   selectionFingerprint(opts.Repo, slot, focus.Key, now),
+	}
+	return selection, nextState, nil
+}
+
+func LoadState(path string) (*State, error) {
+	if strings.TrimSpace(path) == "" {
+		return defaultState(), nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return defaultState(), nil
+		}
+		return nil, fmt.Errorf("read continuous improvement state %q: %w", path, err)
+	}
+
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("parse continuous improvement state %q: %w", path, err)
+	}
+	if state.Version == 0 {
+		state.Version = StateVersion
+	}
+	if state.Counts == nil {
+		state.Counts = make(map[string]int)
+	}
+	if state.History == nil {
+		state.History = []HistoryEntry{}
+	}
+	return &state, nil
+}
+
+func SaveState(path string, state *State) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	if state == nil {
+		state = defaultState()
+	}
+	return writeJSON(path, state, "continuous improvement state")
+}
+
+func SaveSelection(path string, selection *Selection) error {
+	if strings.TrimSpace(path) == "" || selection == nil {
+		return nil
+	}
+	return writeJSON(path, selection, "continuous improvement selection")
+}
+
+func RenderMarkdown(selection *Selection) string {
+	if selection == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("# Continuous Improvement Focus\n\n")
+	if strings.TrimSpace(selection.Repo) != "" {
+		fmt.Fprintf(&b, "- **Repo:** `%s`\n", selection.Repo)
+	}
+	fmt.Fprintf(&b, "- **Rotation slot:** %d/10\n", selection.RotationSlot+1)
+	fmt.Fprintf(&b, "- **Rotation group:** %s\n", selection.RotationGroup)
+	fmt.Fprintf(&b, "- **Focus area:** %s (`%s`)\n", selection.Focus.Title, selection.Focus.Key)
+	fmt.Fprintf(&b, "- **Generated at:** %s\n", selection.GeneratedAt)
+	fmt.Fprintf(&b, "- **Fingerprint:** `%s`\n", selection.Fingerprint)
+	b.WriteString("\n## Why this focus now\n")
+	b.WriteString(selection.Reason)
+	b.WriteString("\n")
+	if len(selection.Focus.CandidatePaths) > 0 {
+		b.WriteString("\n## Candidate paths\n")
+		for _, p := range selection.Focus.CandidatePaths {
+			fmt.Fprintf(&b, "- `%s`\n", p)
+		}
+	}
+	if len(selection.RecentHistory) > 0 {
+		b.WriteString("\n## Recent focus history\n")
+		for _, entry := range selection.RecentHistory {
+			fmt.Fprintf(&b, "- %s — %s (%s)\n", entry.SelectedAt, entry.FocusTitle, entry.Group)
+		}
+	}
+	b.WriteString("\n## Operator constraints\n")
+	b.WriteString("- Prefer one small, mergeable improvement rather than a batch of unrelated edits.\n")
+	b.WriteString("- Bias toward repo-specific harness concerns before generic cleanup when multiple options look similar.\n")
+	b.WriteString("- Avoid immediately repeating the most recent focus area unless the revisit slot explicitly selected it.\n")
+	return b.String()
+}
+
+func KnownFocuses() []Focus {
+	out := make([]Focus, 0, len(repoSpecificFocuses)+len(standardFocuses))
+	out = append(out, repoSpecificFocuses...)
+	out = append(out, standardFocuses...)
+	return out
+}
+
+func chooseFocus(state *State, targetGroup Group, slot int) (Focus, Group, string) {
+	switch targetGroup {
+	case GroupRepoSpecific:
+		focus := rankedFocus(repoSpecificFocuses, state)
+		return focus, GroupRepoSpecific, fmt.Sprintf("Weighted slot %d targets repo-specific harness work (60%% of runs). %s", slot+1, rankedReason(state, focus))
+	case GroupStandard:
+		focus := rankedFocus(standardFocuses, state)
+		return focus, GroupStandard, fmt.Sprintf("Weighted slot %d targets a standard improvement category (30%% of runs). %s", slot+1, rankedReason(state, focus))
+	default:
+		revisitPool := revisitCandidates(state)
+		if len(revisitPool) > 0 {
+			focus := rankedFocus(revisitPool, state)
+			return focus, GroupRevisit, fmt.Sprintf("Weighted slot %d is reserved for revisits (10%% of runs). Revisiting an older focus keeps long-lived concerns from going stale. %s", slot+1, rankedReason(state, focus))
+		}
+		focus := rankedFocus(repoSpecificFocuses, state)
+		return focus, GroupRepoSpecific, fmt.Sprintf("Weighted slot %d would revisit a prior focus, but the history is empty, so it falls back to repo-specific work. %s", slot+1, rankedReason(state, focus))
+	}
+}
+
+func rankedReason(state *State, focus Focus) string {
+	count := 0
+	if state != nil && state.Counts != nil {
+		count = state.Counts[focus.Key]
+	}
+	lastSeen := "never selected before"
+	if idx := lastSelectedIndex(state, focus.Key); idx >= 0 && idx < len(state.History) {
+		lastSeen = "last selected at " + state.History[idx].SelectedAt
+	}
+	return fmt.Sprintf("%q has the lightest recent coverage (%d prior selections; %s).", focus.Title, count, lastSeen)
+}
+
+func rankedFocus(pool []Focus, state *State) Focus {
+	if len(pool) == 0 {
+		return Focus{
+			Key:     "general-maintenance",
+			Title:   "General maintenance",
+			Group:   GroupStandard,
+			Summary: "Fallback improvement category when no explicit focus areas are available.",
+		}
+	}
+
+	filtered := append([]Focus(nil), pool...)
+	if len(filtered) > 1 && state != nil && len(state.History) > 0 {
+		last := state.History[len(state.History)-1].FocusKey
+		next := filtered[:0]
+		for _, focus := range filtered {
+			if focus.Key == last {
+				continue
+			}
+			next = append(next, focus)
+		}
+		if len(next) > 0 {
+			filtered = next
+		}
+	}
+
+	sort.SliceStable(filtered, func(i, j int) bool {
+		leftCount := selectionCount(state, filtered[i].Key)
+		rightCount := selectionCount(state, filtered[j].Key)
+		if leftCount != rightCount {
+			return leftCount < rightCount
+		}
+		leftIndex := lastSelectedIndex(state, filtered[i].Key)
+		rightIndex := lastSelectedIndex(state, filtered[j].Key)
+		if leftIndex != rightIndex {
+			return leftIndex < rightIndex
+		}
+		return filtered[i].Key < filtered[j].Key
+	})
+	return filtered[0]
+}
+
+func revisitCandidates(state *State) []Focus {
+	if state == nil || len(state.History) == 0 {
+		return nil
+	}
+	known := make(map[string]Focus, len(KnownFocuses()))
+	for _, focus := range KnownFocuses() {
+		known[focus.Key] = focus
+	}
+
+	seen := make(map[string]struct{})
+	candidates := make([]Focus, 0, len(known))
+	for i := 0; i < len(state.History); i++ {
+		entry := state.History[i]
+		focus, ok := known[entry.FocusKey]
+		if !ok {
+			continue
+		}
+		if _, exists := seen[focus.Key]; exists {
+			continue
+		}
+		seen[focus.Key] = struct{}{}
+		focus.Group = GroupRevisit
+		candidates = append(candidates, focus)
+	}
+	return candidates
+}
+
+func groupForSlot(slot int) Group {
+	switch {
+	case slot < 6:
+		return GroupRepoSpecific
+	case slot < 9:
+		return GroupStandard
+	default:
+		return GroupRevisit
+	}
+}
+
+func selectionCount(state *State, key string) int {
+	if state == nil || state.Counts == nil {
+		return 0
+	}
+	return state.Counts[key]
+}
+
+func lastSelectedIndex(state *State, key string) int {
+	if state == nil {
+		return -1
+	}
+	for i := len(state.History) - 1; i >= 0; i-- {
+		if state.History[i].FocusKey == key {
+			return i
+		}
+	}
+	return -1
+}
+
+func recentHistory(history []HistoryEntry) []HistoryEntry {
+	if len(history) == 0 {
+		return nil
+	}
+	if len(history) <= recentRunWindow {
+		return append([]HistoryEntry(nil), history...)
+	}
+	return append([]HistoryEntry(nil), history[len(history)-recentRunWindow:]...)
+}
+
+func cloneState(state *State) *State {
+	if state == nil {
+		return defaultState()
+	}
+	cloned := &State{
+		Version: state.Version,
+		Runs:    state.Runs,
+		Counts:  make(map[string]int, len(state.Counts)),
+		History: append([]HistoryEntry(nil), state.History...),
+	}
+	for key, count := range state.Counts {
+		cloned.Counts[key] = count
+	}
+	return cloned
+}
+
+func defaultState() *State {
+	return &State{
+		Version: StateVersion,
+		Counts:  make(map[string]int),
+		History: []HistoryEntry{},
+	}
+}
+
+func writeJSON(path string, payload any, label string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create %s dir for %q: %w", label, path, err)
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s %q: %w", label, path, err)
+	}
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("write %s temp file %q: %w", label, tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace %s %q: %w", label, path, err)
+	}
+	return nil
+}
+
+func selectionFingerprint(repo string, slot int, focusKey string, now time.Time) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		strings.TrimSpace(repo),
+		fmt.Sprintf("%d", slot),
+		focusKey,
+		now.UTC().Format(time.RFC3339),
+	}, "\n")))
+	return fmt.Sprintf("%x", sum[:8])
+}

--- a/cli/internal/continuousimprovement/continuous_improvement_prop_test.go
+++ b/cli/internal/continuousimprovement/continuous_improvement_prop_test.go
@@ -1,0 +1,52 @@
+package continuousimprovement
+
+import (
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropGenerateSelectionMaintainsBoundedHistoryAndKnownFocuses(t *testing.T) {
+	t.Parallel()
+
+	known := make(map[string]struct{}, len(KnownFocuses()))
+	for _, focus := range KnownFocuses() {
+		known[focus.Key] = struct{}{}
+	}
+
+	rapid.Check(t, func(t *rapid.T) {
+		steps := rapid.IntRange(1, 120).Draw(t, "steps")
+		state := defaultState()
+
+		for step := 0; step < steps; step++ {
+			selection, nextState, err := GenerateSelection(state, Options{
+				Repo: "owner/repo",
+				Now:  time.Date(2026, time.April, 10, 0, 0, step, 0, time.UTC),
+			})
+			if err != nil {
+				t.Fatalf("GenerateSelection() error = %v", err)
+			}
+			if _, ok := known[selection.Focus.Key]; !ok {
+				t.Fatalf("selected unknown focus key %q", selection.Focus.Key)
+			}
+			if nextState.Runs != state.Runs+1 {
+				t.Fatalf("Runs = %d, want %d", nextState.Runs, state.Runs+1)
+			}
+			if nextState.Counts[selection.Focus.Key] <= state.Counts[selection.Focus.Key] {
+				t.Fatalf("Counts[%q] did not increase", selection.Focus.Key)
+			}
+			if len(nextState.History) == 0 {
+				t.Fatal("history is empty after selection")
+			}
+			if len(nextState.History) > MaxHistory {
+				t.Fatalf("history length = %d, want <= %d", len(nextState.History), MaxHistory)
+			}
+			last := nextState.History[len(nextState.History)-1]
+			if last.FocusKey != selection.Focus.Key {
+				t.Fatalf("last history key = %q, want %q", last.FocusKey, selection.Focus.Key)
+			}
+			state = nextState
+		}
+	})
+}

--- a/cli/internal/continuousimprovement/continuous_improvement_test.go
+++ b/cli/internal/continuousimprovement/continuous_improvement_test.go
@@ -1,0 +1,231 @@
+package continuousimprovement
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSmoke_S1_SelectAndPersistRotatesRepoSpecificFocusAndPersistsState(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	selectionPath := filepath.Join(dir, "selection.json")
+	previous := HistoryEntry{
+		SelectedAt: "2026-04-09T00:00:00Z",
+		FocusKey:   repoSpecificFocuses[0].Key,
+		FocusTitle: repoSpecificFocuses[0].Title,
+		Group:      GroupRepoSpecific,
+	}
+	require.NoError(t, SaveState(statePath, &State{
+		Version: StateVersion,
+		Counts: map[string]int{
+			repoSpecificFocuses[0].Key: 1,
+		},
+		History: []HistoryEntry{previous},
+	}))
+
+	selection, err := SelectAndPersist(Options{
+		Repo:          "owner/repo",
+		Now:           time.Date(2026, time.April, 10, 3, 0, 0, 0, time.UTC),
+		StatePath:     statePath,
+		SelectionPath: selectionPath,
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, selection)
+	assert.Equal(t, GroupRepoSpecific, selection.RotationGroup)
+	assert.Equal(t, "owner/repo", selection.Repo)
+	assert.NotEmpty(t, selection.Focus.Key)
+	assert.NotEqual(t, previous.FocusKey, selection.Focus.Key)
+	assert.Contains(t, selection.Reason, "repo-specific")
+	require.Len(t, selection.RecentHistory, 1)
+	assert.Equal(t, previous.FocusKey, selection.RecentHistory[0].FocusKey)
+	assert.Equal(t, statePath, selection.StatePath)
+	assert.Equal(t, selectionPath, selection.SelectionPath)
+
+	loadedState, err := LoadState(statePath)
+	require.NoError(t, err)
+	assert.Equal(t, 1, loadedState.Runs)
+	assert.Equal(t, 1, loadedState.Counts[previous.FocusKey])
+	assert.Equal(t, 1, loadedState.Counts[selection.Focus.Key])
+	require.Len(t, loadedState.History, 2)
+	assert.Equal(t, previous.FocusKey, loadedState.History[0].FocusKey)
+	assert.Equal(t, selection.Focus.Key, loadedState.History[1].FocusKey)
+	assert.Equal(t, selection.GeneratedAt, loadedState.History[1].SelectedAt)
+
+	selectionData, err := os.ReadFile(selectionPath)
+	require.NoError(t, err)
+	var persisted Selection
+	require.NoError(t, json.Unmarshal(selectionData, &persisted))
+	assert.Equal(t, selection.Focus.Key, persisted.Focus.Key)
+	assert.Equal(t, selection.Fingerprint, persisted.Fingerprint)
+	assert.Equal(t, selectionPath, persisted.SelectionPath)
+}
+
+func TestGenerateSelectionUsesWeightedGroups(t *testing.T) {
+	baseState := defaultState()
+	baseState.History = append(baseState.History, HistoryEntry{
+		SelectedAt: "2026-04-01T00:00:00Z",
+		FocusKey:   repoSpecificFocuses[0].Key,
+		FocusTitle: repoSpecificFocuses[0].Title,
+		Group:      GroupRepoSpecific,
+	})
+	baseState.Counts[repoSpecificFocuses[0].Key] = 1
+
+	repoSelection, _, err := GenerateSelection(baseState, Options{
+		Repo: "owner/repo",
+		Now:  time.Date(2026, time.April, 10, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("GenerateSelection(repo) error = %v", err)
+	}
+	if repoSelection.RotationGroup != GroupRepoSpecific {
+		t.Fatalf("RotationGroup = %q, want %q", repoSelection.RotationGroup, GroupRepoSpecific)
+	}
+
+	standardState := cloneState(baseState)
+	standardState.Runs = 6
+	standardSelection, _, err := GenerateSelection(standardState, Options{
+		Repo: "owner/repo",
+		Now:  time.Date(2026, time.April, 10, 1, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("GenerateSelection(standard) error = %v", err)
+	}
+	if standardSelection.RotationGroup != GroupStandard {
+		t.Fatalf("RotationGroup = %q, want %q", standardSelection.RotationGroup, GroupStandard)
+	}
+
+	revisitState := cloneState(baseState)
+	revisitState.Runs = 9
+	revisitSelection, _, err := GenerateSelection(revisitState, Options{
+		Repo: "owner/repo",
+		Now:  time.Date(2026, time.April, 10, 2, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("GenerateSelection(revisit) error = %v", err)
+	}
+	if revisitSelection.RotationGroup != GroupRevisit {
+		t.Fatalf("RotationGroup = %q, want %q", revisitSelection.RotationGroup, GroupRevisit)
+	}
+}
+
+func TestGenerateSelectionAvoidsImmediateRepeatWhenAlternativesExist(t *testing.T) {
+	state := defaultState()
+	state.History = append(state.History, HistoryEntry{
+		SelectedAt: "2026-04-01T00:00:00Z",
+		FocusKey:   repoSpecificFocuses[0].Key,
+		FocusTitle: repoSpecificFocuses[0].Title,
+		Group:      GroupRepoSpecific,
+	})
+	state.Counts[repoSpecificFocuses[0].Key] = 1
+
+	selection, _, err := GenerateSelection(state, Options{
+		Repo: "owner/repo",
+		Now:  time.Date(2026, time.April, 10, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("GenerateSelection() error = %v", err)
+	}
+	if selection.Focus.Key == repoSpecificFocuses[0].Key {
+		t.Fatalf("Focus.Key = %q, want a different repo-specific focus when alternatives exist", selection.Focus.Key)
+	}
+}
+
+func TestSelectAndPersistWritesStateAndSelection(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	selectionPath := filepath.Join(dir, "selection.json")
+
+	selection, err := SelectAndPersist(Options{
+		Repo:          "owner/repo",
+		Now:           time.Date(2026, time.April, 10, 3, 0, 0, 0, time.UTC),
+		StatePath:     statePath,
+		SelectionPath: selectionPath,
+	})
+	if err != nil {
+		t.Fatalf("SelectAndPersist() error = %v", err)
+	}
+	if selection.Focus.Key == "" {
+		t.Fatal("selection focus key = empty, want non-empty")
+	}
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("state file missing: %v", err)
+	}
+	if _, err := os.Stat(selectionPath); err != nil {
+		t.Fatalf("selection file missing: %v", err)
+	}
+	loaded, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if loaded.Runs != 1 {
+		t.Fatalf("Runs = %d, want 1", loaded.Runs)
+	}
+	if loaded.Counts[selection.Focus.Key] != 1 {
+		t.Fatalf("Counts[%q] = %d, want 1", selection.Focus.Key, loaded.Counts[selection.Focus.Key])
+	}
+
+	selectionData, err := os.ReadFile(selectionPath)
+	if err != nil {
+		t.Fatalf("ReadFile(selectionPath) error = %v", err)
+	}
+	var persisted Selection
+	if err := json.Unmarshal(selectionData, &persisted); err != nil {
+		t.Fatalf("Unmarshal(selectionPath) error = %v", err)
+	}
+	if persisted.Focus.Key != selection.Focus.Key {
+		t.Fatalf("persisted focus key = %q, want %q", persisted.Focus.Key, selection.Focus.Key)
+	}
+	if persisted.StatePath != statePath {
+		t.Fatalf("persisted state path = %q, want %q", persisted.StatePath, statePath)
+	}
+	if persisted.SelectionPath != selectionPath {
+		t.Fatalf("persisted selection path = %q, want %q", persisted.SelectionPath, selectionPath)
+	}
+}
+
+func TestLoadStateMissingFileReturnsDefault(t *testing.T) {
+	state, err := LoadState(filepath.Join(t.TempDir(), "missing.json"))
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if state.Version != StateVersion {
+		t.Fatalf("Version = %d, want %d", state.Version, StateVersion)
+	}
+	if state.Runs != 0 {
+		t.Fatalf("Runs = %d, want 0", state.Runs)
+	}
+}
+
+func TestRenderMarkdownIncludesSelectionSummary(t *testing.T) {
+	selection := &Selection{
+		Version:       StateVersion,
+		Repo:          "owner/repo",
+		GeneratedAt:   "2026-04-10T00:00:00Z",
+		RotationSlot:  0,
+		RotationGroup: GroupRepoSpecific,
+		Focus:         repoSpecificFocuses[0],
+		Reason:        "Because it is the next repo-specific slot.",
+		Fingerprint:   "deadbeefcafebabe",
+	}
+
+	rendered := RenderMarkdown(selection)
+	if !strings.Contains(rendered, "# Continuous Improvement Focus") {
+		t.Fatalf("rendered markdown missing heading: %q", rendered)
+	}
+	if !strings.Contains(rendered, repoSpecificFocuses[0].Title) {
+		t.Fatalf("rendered markdown missing focus title: %q", rendered)
+	}
+	if !strings.Contains(rendered, "deadbeefcafebabe") {
+		t.Fatalf("rendered markdown missing fingerprint: %q", rendered)
+	}
+}

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -8,9 +8,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	workflowpkg "github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestSmoke_S1_LoadCoreProfileReturnsEmbeddedAssets(t *testing.T) {
@@ -119,13 +121,16 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, sortedKeys(composed.Workflows), "implement-harness")
+	assert.Contains(t, sortedKeys(composed.Workflows), "continuous-improvement")
 	assert.Contains(t, sortedKeys(composed.Workflows), "continuous-simplicity")
 	assert.Contains(t, sortedKeys(composed.Workflows), "sota-gap-analysis")
 	assert.Contains(t, sortedKeys(composed.Workflows), "unblock-wave")
 	assert.Contains(t, sortedKeys(composed.Workflows), "diagnose-failures")
 	assert.Contains(t, sortedKeys(composed.Prompts), "implement-harness/pr_draft")
+	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/verify")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-impl")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-pr-lifecycle")
+	assert.Contains(t, sortedKeys(composed.Sources), "continuous-improvement")
 	assert.Contains(t, sortedKeys(composed.Sources), "continuous-simplicity")
 	assert.Contains(t, sortedKeys(composed.Sources), "sota-gap")
 	require.Len(t, composed.ConfigOverlays, 2)
@@ -134,6 +139,43 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	assert.Contains(t, implementHarnessWorkflow, `--repo nicholls-inc/xylem`)
 	assert.Contains(t, implementHarnessWorkflow, `--label "harness-impl"`)
 	assert.Contains(t, implementHarnessWorkflow, `--label "ready-to-merge"`)
+}
+
+func TestSmoke_S3_SelfHostingProfileScaffoldsContinuousImprovementScheduledWorkflow(t *testing.T) {
+	t.Parallel()
+
+	composed, err := Compose("core", "self-hosting-xylem")
+	require.NoError(t, err)
+
+	var source config.SourceConfig
+	require.NoError(t, yaml.Unmarshal(composed.Sources["continuous-improvement"], &source))
+	assert.Equal(t, "scheduled", source.Type)
+	assert.Equal(t, "{{ .Repo }}", source.Repo)
+	assert.Equal(t, "@daily", source.Schedule)
+	require.Contains(t, source.Tasks, "daily-rotation")
+	assert.Equal(t, "continuous-improvement", source.Tasks["daily-rotation"].Workflow)
+	assert.Equal(t, "continuous-improvement", source.Tasks["daily-rotation"].Ref)
+
+	var wf workflowpkg.Workflow
+	require.NoError(t, yaml.Unmarshal(composed.Workflows["continuous-improvement"], &wf))
+	assert.Equal(t, "continuous-improvement", wf.Name)
+	assert.Equal(t, workflowpkg.ClassHarnessMaintenance, wf.Class)
+	require.Len(t, wf.Phases, 5)
+	assert.Equal(t, "select_focus", wf.Phases[0].Name)
+	assert.Equal(t, "command", wf.Phases[0].Type)
+	assert.Contains(t, wf.Phases[0].Run, "continuous-improvement select")
+	assert.Equal(t, ".xylem/prompts/continuous-improvement/analyze.md", wf.Phases[1].PromptFile)
+	assert.Equal(t, ".xylem/prompts/continuous-improvement/verify.md", wf.Phases[4].PromptFile)
+	require.NotNil(t, wf.Phases[3].Gate)
+	assert.Equal(t, "command", wf.Phases[3].Gate.Type)
+	assert.Equal(t, 2, wf.Phases[3].Gate.Retries)
+	assert.Contains(t, wf.Phases[3].Gate.Run, ".Validation.Format")
+	assert.Contains(t, wf.Phases[3].Gate.Run, ".Validation.Test")
+
+	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/analyze")
+	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/plan")
+	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/implement")
+	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/verify")
 }
 
 func TestAdaptRepoWorkflowAssetParsesCleanly(t *testing.T) {

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-improvement/analyze.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-improvement/analyze.md
@@ -1,0 +1,22 @@
+This is a scheduled continuous-improvement run for `{{.Repo.Slug}}`. There is no triggering GitHub issue.
+
+## Focus brief
+{{.PreviousOutputs.select_focus}}
+
+Read the codebase and identify the best small improvement opportunity inside the selected focus area.
+
+Requirements:
+
+1. Read the relevant code, tests, and any directly related docs before concluding.
+2. Prefer one focused, mergeable improvement over a broad refactor.
+3. Weight repo-specific harness concerns higher than generic cleanup if both are similarly valuable.
+4. Avoid repeating the exact same improvement area covered in the recent history unless the current focus brief explicitly chose a revisit.
+
+If there is no worthwhile, low-risk change to ship for this focus area, output the exact standalone line `XYLEM_NOOP` and explain why.
+
+Otherwise, provide:
+
+- the specific problem to fix
+- the exact files likely involved
+- constraints, risks, and validation needs
+- why this is the highest-value improvement for this scheduled run

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-improvement/implement.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-improvement/implement.md
@@ -1,0 +1,25 @@
+Implement the scheduled continuous-improvement plan.
+
+## Focus brief
+{{.PreviousOutputs.select_focus}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+{{if .GateResult}}
+## Previous gate failure
+The previous validation gate failed. Fix the issues below and continue:
+
+{{.GateResult}}
+{{end}}
+
+Rules:
+
+1. Keep the change set small, focused, and easy to review.
+2. Add or update tests for the chosen improvement.
+3. Do not widen scope into unrelated cleanup.
+4. Leave PR creation for the next phase.
+5. Run any narrow, local checks you need while editing; the workflow gate will run the full configured validation commands.

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-improvement/plan.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-improvement/plan.md
@@ -1,0 +1,16 @@
+Create an implementation plan for this scheduled continuous-improvement run.
+
+## Focus brief
+{{.PreviousOutputs.select_focus}}
+
+## Previous analysis
+{{.PreviousOutputs.analyze}}
+
+Write a concrete plan that includes:
+
+1. file-by-file changes
+2. tests to add or update
+3. validation commands to rely on
+4. any edge cases or rollback risks
+
+If the analysis established that nothing safe and worthwhile should ship, output the exact standalone line `XYLEM_NOOP` and explain why.

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-improvement/verify.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-improvement/verify.md
@@ -1,0 +1,29 @@
+Perform the final verification and ship this scheduled continuous-improvement change.
+
+## Focus brief
+{{.PreviousOutputs.select_focus}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+Review the final diff against the selected focus area and ensure the change is still small, coherent, and worth merging.
+
+If you make additional edits in this phase, rerun the relevant validation commands before committing.
+
+Then:
+
+1. commit the changes with a clear message
+2. push the branch
+3. create a pull request
+
+PR requirements:
+
+- Prefix the title with `[continuous-improvement]`
+- Mention the selected focus area in the body
+- Note that this came from a scheduled continuous-improvement run
+- Summarize the concrete improvement and the tests or validation performed
+
+In your final output, include the PR URL and a short summary of what shipped.

--- a/cli/internal/profiles/self-hosting-xylem/workflows/continuous-improvement.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/continuous-improvement.yaml
@@ -1,0 +1,44 @@
+name: continuous-improvement
+class: harness-maintenance
+description: "Scheduled self-improvement loop for small, high-signal xylem maintenance changes"
+phases:
+  - name: select_focus
+    type: command
+    run: |
+      set -euo pipefail
+      go run ./cli/cmd/xylem --config .xylem.yml continuous-improvement select \
+        --state .xylem/state/continuous-improvement/state.json \
+        --selection .xylem/state/continuous-improvement/current-selection.json
+  - name: analyze
+    prompt_file: .xylem/prompts/continuous-improvement/analyze.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4
+    noop:
+      match: XYLEM_NOOP
+  - name: plan
+    prompt_file: .xylem/prompts/continuous-improvement/plan.md
+    max_turns: 30
+    llm: copilot
+    model: gpt-5.4
+    noop:
+      match: XYLEM_NOOP
+  - name: implement
+    prompt_file: .xylem/prompts/continuous-improvement/implement.md
+    max_turns: 80
+    llm: copilot
+    model: gpt-5.4
+    gate:
+      type: command
+      run: |
+        set -euo pipefail
+        {{if .Validation.Format}}{{.Validation.Format}}{{else}}true{{end}}
+        {{if .Validation.Lint}}{{.Validation.Lint}}{{end}}
+        {{if .Validation.Build}}{{.Validation.Build}}{{end}}
+        {{if .Validation.Test}}{{.Validation.Test}}{{else}}true{{end}}
+      retries: 2
+  - name: verify
+    prompt_file: .xylem/prompts/continuous-improvement/verify.md
+    max_turns: 40
+    llm: copilot
+    model: gpt-5.4

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -68,6 +68,15 @@ sources:
       weekly-continuous-simplicity:
         workflow: continuous-simplicity
         ref: continuous-simplicity
+  continuous-improvement:
+    type: scheduled
+    repo: "{{ .Repo }}"
+    schedule: "@daily"
+    timeout: "90m"
+    tasks:
+      daily-rotation:
+        workflow: continuous-improvement
+        ref: continuous-improvement
   harness-post-merge:
     type: github-merge
     repo: "{{ .Repo }}"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -258,7 +258,22 @@ sources:
         ref: harness-gap-analysis
 ```
 
-To opt out, omit or delete the scheduled `harness-gap-analysis` source from your config; no separate feature flag is required.
+`continuous-improvement` is another scheduled self-hosting workflow. It runs a deterministic rotation helper before the prompt phases, persists its focus history under `<state_dir>/state/continuous-improvement/state.json`, writes the current focus brief to `<state_dir>/state/continuous-improvement/current-selection.json`, and then drives a small improvement PR through the normal workflow pipeline.
+
+```yaml
+sources:
+  continuous-improvement:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "@daily"
+    tasks:
+      daily-rotation:
+        workflow: continuous-improvement
+        ref: continuous-improvement
+```
+
+To opt out, omit or delete the scheduled `continuous-improvement` source from your config; likewise, omit `harness-gap-analysis` if you do not want the sibling scheduled review. No separate feature flag is required.
+
 ### `status_labels`
 
 When `status_labels` is set, xylem records the configured labels in vessel metadata and applies them during source lifecycle hooks.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -27,7 +27,9 @@ Workflow (YAML definition)
 
 Each phase produces output that subsequent phases can reference. Gates act as checkpoints -- if a gate fails and retries are exhausted, the vessel is marked as failed. If a gate is a label gate, the vessel enters a `waiting` state until a human applies the required label on GitHub. Live gates also persist step evidence under `.xylem/phases/<vessel-id>/evidence/`.
 
-The built-in workflows scaffolded by `xylem init` are profile-driven. The core profile seeds delivery workflows such as `fix-bug` and `implement-feature`, plus recurring operator workflows such as `lessons`, `context-weight-audit`, `workflow-health-report`, and `security-compliance`. Repo-specific overlays such as `implement-harness` are not part of the base core scaffold and must be added through an overlay profile or checked-in repo assets. The workflow format also supports `type: command` phases for deterministic shell steps inside the same execution pipeline.
+The built-in workflows scaffolded by `xylem init` are profile-driven. The core profile seeds delivery workflows such as `fix-bug` and `implement-feature`, plus recurring operator workflows such as `lessons`, `context-weight-audit`, `workflow-health-report`, and `security-compliance`. Repo-specific overlays such as `implement-harness` and `continuous-improvement` are not part of the base core scaffold and must be added through an overlay profile or checked-in repo assets. The workflow format also supports `type: command` phases for deterministic shell steps inside the same execution pipeline.
+
+In this repository, `continuous-improvement` is a concrete example of mixing both styles: a deterministic `select_focus` command phase picks the next focus area and persists rotation state, then prompt phases analyze, plan, implement, and verify one small scheduled improvement.
 
 ## Workflow YAML format
 
@@ -722,6 +724,73 @@ sources:
     type: schedule
     cadence: "@daily"
     workflow: security-compliance
+```
+
+### continuous-improvement (repo-specific)
+
+Runs a scheduled self-hosting maintenance loop in 5 phases. The first phase is deterministic: it rotates through repo-specific, standard, and revisit focus buckets, persists durable state, and emits a focus brief for the later prompt phases.
+
+```yaml
+name: continuous-improvement
+class: harness-maintenance
+description: "Scheduled self-improvement loop for small, high-signal xylem maintenance changes"
+phases:
+  - name: select_focus
+    type: command
+    run: |
+      set -euo pipefail
+      go run ./cli/cmd/xylem --config .xylem.yml continuous-improvement select \
+        --state .xylem/state/continuous-improvement/state.json \
+        --selection .xylem/state/continuous-improvement/current-selection.json
+  - name: analyze
+    prompt_file: .xylem/prompts/continuous-improvement/analyze.md
+    max_turns: 40
+    noop:
+      match: XYLEM_NOOP
+  - name: plan
+    prompt_file: .xylem/prompts/continuous-improvement/plan.md
+    max_turns: 30
+    noop:
+      match: XYLEM_NOOP
+  - name: implement
+    prompt_file: .xylem/prompts/continuous-improvement/implement.md
+    max_turns: 80
+    gate:
+      type: command
+      run: |
+        set -euo pipefail
+        {{if .Validation.Format}}{{.Validation.Format}}{{else}}true{{end}}
+        {{if .Validation.Lint}}{{.Validation.Lint}}{{end}}
+        {{if .Validation.Build}}{{.Validation.Build}}{{end}}
+        {{if .Validation.Test}}{{.Validation.Test}}{{else}}true{{end}}
+      retries: 2
+  - name: verify
+    prompt_file: .xylem/prompts/continuous-improvement/verify.md
+    max_turns: 40
+```
+
+**Phase flow:**
+
+1. **select_focus** -- Runs `xylem continuous-improvement select`, applies the 60/30/10 weighting across repo-specific, standard, and revisit buckets, persists durable state under `.xylem/state/continuous-improvement/`, and prints the markdown brief consumed by later phases.
+2. **analyze** -- Reads the focus brief plus the codebase, then chooses one small, mergeable improvement inside that slice. It can exit early with `XYLEM_NOOP` when the selected area has nothing safe and worthwhile to ship.
+3. **plan** -- Converts the selected improvement into a file-by-file implementation plan and test strategy, again allowing `XYLEM_NOOP` if the analysis already established that the run should skip publication.
+4. **implement** -- Makes the focused change and passes a command gate that reuses the repo's configured format/lint/build/test validation commands.
+5. **verify** -- Rechecks that the diff still matches the selected focus, then commits, pushes, and opens the scheduled maintenance PR.
+
+**Rotation strategy:** The selector keeps a durable history in `.xylem/state/continuous-improvement/state.json`, chooses repo-specific focus areas for 6 of every 10 runs, standard categories for 3 of every 10 runs, and a revisit slot for the 10th run. Candidate focus areas are part of the checked-in helper so the schedule can rotate predictably without needing a triggering GitHub issue.
+
+**Configuration example:**
+
+```yaml
+sources:
+  continuous-improvement:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "@daily"
+    tasks:
+      daily-rotation:
+        workflow: continuous-improvement
+        ref: continuous-improvement
 ```
 
 ### implement-harness (repo-specific)


### PR DESCRIPTION
## Summary
- add the scheduled continuous-improvement workflow, prompts, and self-hosting profile scaffolding
- add a deterministic `xylem continuous-improvement select` helper with persistent rotation state and tests
- document the rotation strategy and scheduled source wiring

Closes #274

Issue: https://github.com/nicholls-inc/xylem/issues/274