### PR TITLE
fix(runner): hydrate Issue data for manual vessels + fix CI workflow

### DIFF
--- a/.xylem/workflows/continuous-improvement.yaml
+++ b/.xylem/workflows/continuous-improvement.yaml
@@ -6,9 +6,10 @@ phases:
     type: command
     run: |
       set -euo pipefail
-      go run ./cli/cmd/xylem --config .xylem.yml continuous-improvement select \
-        --state .xylem/state/continuous-improvement/state.json \
-        --selection .xylem/state/continuous-improvement/current-selection.json
+      cd cli
+      go run ./cmd/xylem --config ../.xylem.yml continuous-improvement select \
+        --state ../.xylem/state/continuous-improvement/state.json \
+        --selection ../.xylem/state/continuous-improvement/current-selection.json
   - name: analyze
     prompt_file: .xylem/prompts/continuous-improvement/analyze.md
     max_turns: 40

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -3414,14 +3414,58 @@ func (r *Runner) readHarness() string {
 	return string(data)
 }
 
+// githubIssueURLRe matches GitHub issue URLs and captures owner/repo and number.
+var githubIssueURLRe = regexp.MustCompile(`^https?://github\.com/([^/]+/[^/]+)/issues/(\d+)`)
+
+// githubPRURLRe matches GitHub pull request URLs and captures owner/repo and number.
+var githubPRURLRe = regexp.MustCompile(`^https?://github\.com/([^/]+/[^/]+)/pull/(\d+)`)
+
 func (r *Runner) fetchIssueData(ctx context.Context, vessel *queue.Vessel) phase.IssueData {
 	switch vessel.Source {
 	case "github-issue":
 		return r.fetchGitHubData(ctx, vessel, "issue", "issue")
 	case "github-pr", "github-pr-events", "github-merge":
 		return r.fetchGitHubData(ctx, vessel, "pr", "pr")
+	case "manual":
+		return r.fetchManualIssueData(ctx, vessel)
 	default:
 		return phase.IssueData{}
+	}
+}
+
+// fetchManualIssueData hydrates issue data for manual vessels whose ref
+// matches a GitHub issue or PR URL pattern.
+func (r *Runner) fetchManualIssueData(ctx context.Context, vessel *queue.Vessel) phase.IssueData {
+	if vessel.Ref == "" {
+		return phase.IssueData{}
+	}
+
+	if m := githubIssueURLRe.FindStringSubmatch(vessel.Ref); m != nil {
+		repo, numStr := m[1], m[2]
+		r.hydrateManualMeta(vessel, "issue_num", numStr, repo)
+		return r.fetchGitHubData(ctx, vessel, "issue", "issue")
+	}
+
+	if m := githubPRURLRe.FindStringSubmatch(vessel.Ref); m != nil {
+		repo, numStr := m[1], m[2]
+		r.hydrateManualMeta(vessel, "pr_num", numStr, repo)
+		return r.fetchGitHubData(ctx, vessel, "pr", "pr")
+	}
+
+	return phase.IssueData{}
+}
+
+// hydrateManualMeta sets the issue/PR number and source_repo in the vessel's
+// Meta map so that parseIssueNum and resolveRepo can find them.
+func (r *Runner) hydrateManualMeta(vessel *queue.Vessel, numKey, numStr, repo string) {
+	if vessel.Meta == nil {
+		vessel.Meta = make(map[string]string)
+	}
+	if vessel.Meta[numKey] == "" {
+		vessel.Meta[numKey] = numStr
+	}
+	if vessel.Meta["source_repo"] == "" {
+		vessel.Meta["source_repo"] = repo
 	}
 }
 
@@ -3682,6 +3726,9 @@ func (r *Runner) resolveRepo(vessel queue.Vessel) string {
 	case *source.Scheduled:
 		return s.Repo
 	default:
+		if vessel.Meta != nil && vessel.Meta["source_repo"] != "" {
+			return vessel.Meta["source_repo"]
+		}
 		return ""
 	}
 }

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -7092,6 +7092,181 @@ func TestValidateIssueDataForWorkflow_NilWorkflow(t *testing.T) {
 	}
 }
 
+func TestGitHubIssueURLRegex(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantOK  bool
+		wantNum string
+	}{
+		{"standard issue URL", "https://github.com/owner/repo/issues/42", true, "42"},
+		{"http issue URL", "http://github.com/owner/repo/issues/1", true, "1"},
+		{"PR URL does not match issue regex", "https://github.com/owner/repo/pull/42", false, ""},
+		{"non-GitHub URL", "https://example.com/issues/42", false, ""},
+		{"no number", "https://github.com/owner/repo/issues/", false, ""},
+		{"issue URL with trailing path", "https://github.com/owner/repo/issues/42#comment", true, "42"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := githubIssueURLRe.FindStringSubmatch(tt.url)
+			if tt.wantOK {
+				require.NotNil(t, m, "expected match for %s", tt.url)
+				assert.Equal(t, tt.wantNum, m[2])
+			} else {
+				assert.Nil(t, m, "expected no match for %s", tt.url)
+			}
+		})
+	}
+}
+
+func TestGitHubPRURLRegex(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantOK  bool
+		wantNum string
+	}{
+		{"standard PR URL", "https://github.com/owner/repo/pull/99", true, "99"},
+		{"issue URL does not match PR regex", "https://github.com/owner/repo/issues/42", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := githubPRURLRe.FindStringSubmatch(tt.url)
+			if tt.wantOK {
+				require.NotNil(t, m, "expected match for %s", tt.url)
+				assert.Equal(t, tt.wantNum, m[2])
+			} else {
+				assert.Nil(t, m, "expected no match for %s", tt.url)
+			}
+		})
+	}
+}
+
+func TestFetchManualIssueData_GitHubIssueRef(t *testing.T) {
+	issueJSON := `{"title":"Fix the bug","body":"Something is broken","url":"https://github.com/nicholls-inc/xylem/issues/230","labels":[{"name":"bug"}]}`
+	cmdRunner := &mockCmdRunner{
+		outputData: []byte(issueJSON),
+	}
+	r := &Runner{
+		Runner: cmdRunner,
+		Sources: map[string]source.Source{
+			"manual": &source.Manual{},
+		},
+	}
+
+	vessel := queue.Vessel{
+		ID:     "issue-230-fresh",
+		Source: "manual",
+		Ref:    "https://github.com/nicholls-inc/xylem/issues/230",
+	}
+
+	data := r.fetchIssueData(context.Background(), &vessel)
+
+	assert.Equal(t, 230, data.Number)
+	assert.Equal(t, "Fix the bug", data.Title)
+	assert.Equal(t, "Something is broken", data.Body)
+	assert.Contains(t, data.Labels, "bug")
+
+	// Verify meta was hydrated
+	assert.Equal(t, "230", vessel.Meta["issue_num"])
+	assert.Equal(t, "nicholls-inc/xylem", vessel.Meta["source_repo"])
+}
+
+func TestFetchManualIssueData_GitHubPRRef(t *testing.T) {
+	prJSON := `{"title":"Add feature","body":"New feature","url":"https://github.com/owner/repo/pull/55","labels":[]}`
+	cmdRunner := &mockCmdRunner{
+		outputData: []byte(prJSON),
+	}
+	r := &Runner{
+		Runner: cmdRunner,
+		Sources: map[string]source.Source{
+			"manual": &source.Manual{},
+		},
+	}
+
+	vessel := queue.Vessel{
+		ID:     "pr-55",
+		Source: "manual",
+		Ref:    "https://github.com/owner/repo/pull/55",
+	}
+
+	data := r.fetchIssueData(context.Background(), &vessel)
+
+	assert.Equal(t, 55, data.Number)
+	assert.Equal(t, "Add feature", data.Title)
+	assert.Equal(t, "55", vessel.Meta["pr_num"])
+	assert.Equal(t, "owner/repo", vessel.Meta["source_repo"])
+}
+
+func TestFetchManualIssueData_NonGitHubRef(t *testing.T) {
+	r := &Runner{
+		Runner:  &mockCmdRunner{},
+		Sources: map[string]source.Source{"manual": &source.Manual{}},
+	}
+
+	vessel := queue.Vessel{
+		ID:     "task-1",
+		Source: "manual",
+		Ref:    "just a description",
+	}
+
+	data := r.fetchIssueData(context.Background(), &vessel)
+	assert.Equal(t, 0, data.Number)
+	assert.Empty(t, data.Title)
+}
+
+func TestFetchManualIssueData_EmptyRef(t *testing.T) {
+	r := &Runner{
+		Runner:  &mockCmdRunner{},
+		Sources: map[string]source.Source{"manual": &source.Manual{}},
+	}
+
+	vessel := queue.Vessel{
+		ID:     "task-2",
+		Source: "manual",
+		Ref:    "",
+	}
+
+	data := r.fetchIssueData(context.Background(), &vessel)
+	assert.Equal(t, 0, data.Number)
+}
+
+func TestResolveRepo_ManualWithSourceRepo(t *testing.T) {
+	r := &Runner{
+		Sources: map[string]source.Source{"manual": &source.Manual{}},
+	}
+
+	vessel := queue.Vessel{
+		Source: "manual",
+		Meta:   map[string]string{"source_repo": "nicholls-inc/xylem"},
+	}
+	got := r.resolveRepo(vessel)
+	assert.Equal(t, "nicholls-inc/xylem", got)
+}
+
+func TestResolveRepo_ManualWithoutSourceRepo(t *testing.T) {
+	r := &Runner{
+		Sources: map[string]source.Source{"manual": &source.Manual{}},
+	}
+
+	vessel := queue.Vessel{Source: "manual"}
+	got := r.resolveRepo(vessel)
+	assert.Equal(t, "", got)
+}
+
+func TestHydrateManualMeta_DoesNotOverwrite(t *testing.T) {
+	r := &Runner{}
+	vessel := &queue.Vessel{
+		Meta: map[string]string{
+			"issue_num":   "99",
+			"source_repo": "existing/repo",
+		},
+	}
+	r.hydrateManualMeta(vessel, "issue_num", "230", "new/repo")
+	assert.Equal(t, "99", vessel.Meta["issue_num"])
+	assert.Equal(t, "existing/repo", vessel.Meta["source_repo"])
+}
+
 func TestDrainCommandPhaseTemplateValidation(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 2)


### PR DESCRIPTION
## Summary
- **Manual enqueue hydration**: Vessels with `source: manual` and a GitHub issue/PR URL as `ref` now parse the URL, extract owner/repo + number, and hydrate `.Issue` via `gh issue view` / `gh pr view`. Fixes the "Number is 0" template failures that caused 4 vessels to fail instantly.
- **Continuous-improvement workflow**: Added missing `cd cli` before `go run` in `select_focus` phase and adjusted paths. Matches pattern used by all other workflows (sota-gap-analysis, continuous-simplicity, etc).

## Changes
- `cli/internal/runner/runner.go` — Added `manual` case to `fetchIssueData`, new `fetchManualIssueData` + `hydrateManualMeta` helpers, `resolveRepo` fallback for `source_repo` meta
- `cli/internal/runner/runner_test.go` — 9 new tests covering URL regex, manual hydration, resolveRepo, and no-overwrite behavior
- `.xylem/workflows/continuous-improvement.yaml` — Fixed `select_focus` phase to use `cd cli` + relative paths

## Test plan
- [x] `go test ./internal/runner/...` passes (9 new tests)
- [x] `go build ./cmd/xylem` clean
- [x] `goimports -l .` clean
- [ ] Daemon restart picks up fix; manually-enqueued vessels with issue URLs succeed
- [ ] Continuous-improvement scheduled vessel no longer fails at select_focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)