### PR TITLE
feat: support scheduled workflow-health doctor vessels across schedule sources

### DIFF
--- a/cli/cmd/xylem/builtin_audit.go
+++ b/cli/cmd/xylem/builtin_audit.go
@@ -25,7 +25,7 @@ func runBuiltInScheduledVessels(ctx context.Context, cfg *config.Config, q *queu
 
 	var result runner.DrainResult
 	for _, vessel := range pending {
-		if vessel.Source != "scheduled" || !isBuiltInScheduledWorkflow(vessel.Workflow) {
+		if !isBuiltInScheduledVessel(cfg, vessel) {
 			continue
 		}
 		result.Launched++
@@ -80,6 +80,28 @@ func isBuiltInScheduledWorkflow(workflow string) bool {
 	}
 }
 
+func isBuiltInScheduledVessel(cfg *config.Config, vessel queue.Vessel) bool {
+	if !isBuiltInScheduledWorkflow(vessel.Workflow) {
+		return false
+	}
+	switch vessel.Source {
+	case "scheduled", "schedule":
+		return true
+	}
+	if cfg == nil || vessel.Meta == nil {
+		return false
+	}
+	name := strings.TrimSpace(vessel.Meta["config_source"])
+	if name == "" {
+		return false
+	}
+	srcCfg, ok := cfg.Sources[name]
+	if !ok {
+		return false
+	}
+	return srcCfg.Type == "scheduled" || srcCfg.Type == "schedule"
+}
+
 func runBuiltInScheduledWorkflow(ctx context.Context, cfg *config.Config, workflowName, repo string, cmdRunner auditCommandRunner) error {
 	now := time.Now().UTC()
 	switch workflowName {
@@ -117,14 +139,16 @@ func resolveScheduledAuditRepo(cfg *config.Config, vessel queue.Vessel) string {
 	if vessel.Meta != nil {
 		if name := strings.TrimSpace(vessel.Meta["config_source"]); name != "" {
 			if srcCfg, ok := cfg.Sources[name]; ok {
-				return strings.TrimSpace(srcCfg.Repo)
+				if repo := strings.TrimSpace(srcCfg.Repo); repo != "" {
+					return repo
+				}
 			}
 		}
 		if repo := strings.TrimSpace(vessel.Meta["scheduled_repo"]); repo != "" {
 			return repo
 		}
 	}
-	return ""
+	return detectLessonsRepo(cfg)
 }
 
 func persistBuiltInAuditSummary(cfg *config.Config, vessel queue.Vessel) error {

--- a/cli/cmd/xylem/builtin_audit_prop_test.go
+++ b/cli/cmd/xylem/builtin_audit_prop_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	reviewpkg "github.com/nicholls-inc/xylem/cli/internal/review"
+	"pgregory.net/rapid"
+)
+
+func TestPropResolveScheduledAuditRepoPrefersSourceThenMetadataThenFallback(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		sourceRepo := rapid.SampledFrom([]string{"", "owner/source", "team/service"}).Draw(t, "sourceRepo")
+		metaRepo := rapid.SampledFrom([]string{"", "owner/meta", "ops/weekly"}).Draw(t, "metaRepo")
+		cfgRepo := rapid.SampledFrom([]string{"", "owner/cfg", "platform/xylem"}).Draw(t, "cfgRepo")
+		fallbackRepo := rapid.SampledFrom([]string{"", "owner/fallback", "core/repo"}).Draw(t, "fallbackRepo")
+
+		cfg := &config.Config{
+			Repo: cfgRepo,
+			Sources: map[string]config.SourceConfig{
+				"doctor": {
+					Type: "scheduled",
+					Repo: sourceRepo,
+				},
+			},
+		}
+		if fallbackRepo != "" {
+			cfg.Sources["bugs"] = config.SourceConfig{
+				Type: "github",
+				Repo: fallbackRepo,
+			}
+		}
+
+		vessel := queue.Vessel{
+			Source:   "schedule",
+			Workflow: reviewpkg.WorkflowHealthReportWorkflow,
+			Meta: map[string]string{
+				"config_source":  "doctor",
+				"scheduled_repo": metaRepo,
+			},
+		}
+
+		want := sourceRepo
+		switch {
+		case want != "":
+		case metaRepo != "":
+			want = metaRepo
+		case cfgRepo != "":
+			want = cfgRepo
+		default:
+			want = fallbackRepo
+		}
+
+		if got := resolveScheduledAuditRepo(cfg, vessel); got != want {
+			t.Fatalf("resolveScheduledAuditRepo() = %q, want %q", got, want)
+		}
+	})
+}

--- a/cli/cmd/xylem/builtin_audit_test.go
+++ b/cli/cmd/xylem/builtin_audit_test.go
@@ -59,7 +59,10 @@ func TestRunBuiltInScheduledVesselsCompletesBuiltInAudits(t *testing.T) {
 	testCases := []struct {
 		name             string
 		sourceName       string
+		sourceType       string
+		vesselSource     string
 		schedule         string
+		cadence          string
 		taskName         string
 		vesselID         string
 		workflow         string
@@ -70,6 +73,8 @@ func TestRunBuiltInScheduledVesselsCompletesBuiltInAudits(t *testing.T) {
 		{
 			name:            "context-weight-audit",
 			sourceName:      "scheduled-audit",
+			sourceType:      "scheduled",
+			vesselSource:    "scheduled",
 			schedule:        "24h",
 			taskName:        "context",
 			vesselID:        "scheduled-audit-1",
@@ -80,12 +85,28 @@ func TestRunBuiltInScheduledVesselsCompletesBuiltInAudits(t *testing.T) {
 		{
 			name:            "harness-gap-analysis",
 			sourceName:      "harness-gap",
+			sourceType:      "scheduled",
+			vesselSource:    "scheduled",
 			schedule:        "4h",
 			taskName:        "analyze-gaps",
 			vesselID:        "scheduled-gap-1",
 			workflow:        reviewpkg.HarnessGapAnalysisWorkflow,
 			reportFile:      "harness-gap-analysis.json",
 			wantCreateCount: 0,
+		},
+		{
+			name:            "workflow-health-report-schedule-source",
+			sourceName:      "workflow-health",
+			sourceType:      "schedule",
+			vesselSource:    "schedule",
+			cadence:         "@weekly",
+			vesselID:        "schedule-workflow-health-1",
+			workflow:        reviewpkg.WorkflowHealthReportWorkflow,
+			reportFile:      "workflow-health-report.json",
+			wantCreateCount: 1,
+			wantCreatePrefix: []string{
+				"gh", "issue", "create", "--repo", "owner/repo", "--title", "[xylem] weekly workflow health",
+			},
 		},
 	}
 
@@ -96,37 +117,51 @@ func TestRunBuiltInScheduledVesselsCompletesBuiltInAudits(t *testing.T) {
 
 			dir := t.TempDir()
 			cfg := &config.Config{
+				Repo:     "owner/repo",
 				StateDir: dir,
 				Claude: config.ClaudeConfig{
 					Command:      "claude",
 					DefaultModel: "claude-sonnet-4-6",
 				},
-				Sources: map[string]config.SourceConfig{
-					tc.sourceName: {
-						Type:     "scheduled",
-						Repo:     "owner/repo",
-						Schedule: tc.schedule,
-						Tasks: map[string]config.Task{
-							tc.taskName: {Workflow: tc.workflow},
-						},
+				Sources: map[string]config.SourceConfig{},
+			}
+			switch tc.sourceType {
+			case "scheduled":
+				cfg.Sources[tc.sourceName] = config.SourceConfig{
+					Type:     "scheduled",
+					Repo:     "owner/repo",
+					Schedule: tc.schedule,
+					Tasks: map[string]config.Task{
+						tc.taskName: {Workflow: tc.workflow},
 					},
-				},
+				}
+			case "schedule":
+				cfg.Sources[tc.sourceName] = config.SourceConfig{
+					Type:     "schedule",
+					Cadence:  tc.cadence,
+					Workflow: tc.workflow,
+				}
+			default:
+				t.Fatalf("unexpected sourceType %q", tc.sourceType)
 			}
 
 			q := queue.New(filepath.Join(dir, "queue.jsonl"))
+			meta := map[string]string{
+				"config_source": tc.sourceName,
+			}
+			if tc.sourceType == "scheduled" {
+				meta["scheduled_task_name"] = tc.taskName
+				meta["scheduled_bucket"] = "1"
+				meta["scheduled_config_name"] = tc.sourceName
+			}
 			_, err := q.Enqueue(queue.Vessel{
 				ID:        tc.vesselID,
-				Source:    "scheduled",
-				Ref:       "scheduled://" + tc.sourceName + "/" + tc.taskName + "@1",
+				Source:    tc.vesselSource,
+				Ref:       builtInAuditTestRef(tc.sourceType, tc.sourceName, tc.taskName),
 				Workflow:  tc.workflow,
 				State:     queue.StatePending,
 				CreatedAt: time.Now().UTC(),
-				Meta: map[string]string{
-					"config_source":         tc.sourceName,
-					"scheduled_task_name":   tc.taskName,
-					"scheduled_bucket":      "1",
-					"scheduled_config_name": tc.sourceName,
-				},
+				Meta:      meta,
 			})
 			if err != nil {
 				t.Fatalf("Enqueue() error = %v", err)
@@ -166,6 +201,46 @@ func TestRunBuiltInScheduledVesselsCompletesBuiltInAudits(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunBuiltInScheduledVesselsFailsWithoutRepoFallback(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &config.Config{
+		StateDir: dir,
+		Sources: map[string]config.SourceConfig{
+			"workflow-health": {
+				Type:     "schedule",
+				Cadence:  "@weekly",
+				Workflow: reviewpkg.WorkflowHealthReportWorkflow,
+			},
+		},
+	}
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "schedule-workflow-health-missing-repo",
+		Source:    "schedule",
+		Ref:       "schedule://workflow-health/2026-04-10T00:00:00Z",
+		Workflow:  reviewpkg.WorkflowHealthReportWorkflow,
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+		Meta: map[string]string{
+			"config_source": "workflow-health",
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := runBuiltInScheduledVessels(context.Background(), cfg, q, &auditTestRunner{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+	assert.Zero(t, result.Completed)
+
+	vessel, err := q.FindByID("schedule-workflow-health-missing-repo")
+	require.NoError(t, err)
+	assert.Equal(t, queue.StateFailed, vessel.State)
+	assert.Contains(t, vessel.Error, "requires a source repo")
 }
 
 func TestSmoke_S4_ScheduledWorkflowHealthVesselPublishesWeeklyReport(t *testing.T) {
@@ -224,4 +299,11 @@ func TestSmoke_S4_ScheduledWorkflowHealthVesselPublishesWeeklyReport(t *testing.
 	require.NoError(t, err)
 	_, err = os.Stat(filepath.Join(dir, "phases", "scheduled-health-1", "summary.json"))
 	require.NoError(t, err)
+}
+
+func builtInAuditTestRef(sourceType, sourceName, taskName string) string {
+	if sourceType == "schedule" {
+		return "schedule://" + sourceName + "/2026-04-10T00:00:00Z"
+	}
+	return "scheduled://" + sourceName + "/" + taskName + "@1"
 }


### PR DESCRIPTION
## Summary
- Implements https://github.com/nicholls-inc/xylem/issues/154.
- Extends the built-in scheduled audit path so workflow-health doctor vessels run for both `scheduled` and legacy `schedule` sources, and so they can resolve a GitHub repo from source config, vessel metadata, or the lessons repo fallback before filing weekly issues.

## Smoke scenarios covered
- S4 — Scheduled workflow health vessel publishes weekly report

## Changes summary
- `cli/cmd/xylem/builtin_audit.go` (modified): taught `runBuiltInScheduledVessels` to route built-in audits through the new `isBuiltInScheduledVessel` predicate, accept both `scheduled` and `schedule` source types, and let `resolveScheduledAuditRepo` fall back to the lessons repo when source-level repo config is absent.
- `cli/cmd/xylem/builtin_audit_test.go` (modified): expanded table coverage for both source styles, added the missing-repo failure case, and kept the weekly workflow-health smoke scenario aligned with the new scheduling path.
- `cli/cmd/xylem/builtin_audit_prop_test.go` (added): added `TestPropResolveScheduledAuditRepoPrefersSourceThenMetadataThenFallback` to lock in repo resolution precedence.

## Test plan
- `cd cli && goimports -w .`
- `cd cli && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #154