### PR TITLE
feat(cmd,runner): add doctor CLI + auto-cancel stale PR vessels

### DIFF
--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -37,7 +37,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "bootstrap", "continuous-improvement", "continuous-simplicity", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "enqueue", "daemon", "retry", "visualize", "version"}
+	expected := []string{"init", "bootstrap", "continuous-improvement", "continuous-simplicity", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "retry", "visualize", "version"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -153,6 +153,9 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		stallChecks = daemonChecksFromFindings(findings, daemonNow())
 		drainRunner.CheckWaitingVessels(ctx)
 		drainRunner.CheckHungVessels(ctx)
+		// Cancel pending vessels whose PRs are already merged/closed,
+		// freeing concurrency slots for real work.
+		drainRunner.CancelStalePRVessels(ctx)
 		// Auto-merge: best-effort request copilot review on merge-ready
 		// harness PRs, then admin-merge once deterministic safety checks
 		// are green.

--- a/cli/cmd/xylem/doctor.go
+++ b/cli/cmd/xylem/doctor.go
@@ -1,0 +1,404 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/daemonhealth"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+	"github.com/nicholls-inc/xylem/cli/internal/worktree"
+)
+
+func newDoctorCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Diagnose queue, daemon, and vessel health issues",
+		Long: `Run deterministic health checks against the xylem control plane.
+
+Checks performed:
+  - Daemon liveness (PID file + process signal)
+  - Zombie vessels (running state with no live daemon)
+  - Stale worktrees (registered but associated with terminal vessels)
+  - Queue integrity (malformed entries, duplicate IDs)
+  - Fleet health summary (failure rate, timeout rate)
+
+Use --fix to automatically remediate safe issues (e.g., reap zombie vessels).
+Use --json for machine-readable output.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fix, _ := cmd.Flags().GetBool("fix")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			return cmdDoctor(deps.cfg, deps.q, deps.wt, fix, jsonMode)
+		},
+	}
+	cmd.Flags().Bool("fix", false, "Automatically remediate safe issues")
+	cmd.Flags().Bool("json", false, "Output as JSON")
+	return cmd
+}
+
+// doctorCheck represents a single diagnostic finding.
+type doctorCheck struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"` // "ok", "warn", "fail"
+	Message string `json:"message"`
+	Fixed   bool   `json:"fixed,omitempty"`
+}
+
+// doctorReport aggregates all diagnostic checks.
+type doctorReport struct {
+	Checks  []doctorCheck `json:"checks"`
+	Summary struct {
+		OK   int `json:"ok"`
+		Warn int `json:"warn"`
+		Fail int `json:"fail"`
+	} `json:"summary"`
+}
+
+func (r *doctorReport) add(name, status, message string) {
+	r.Checks = append(r.Checks, doctorCheck{
+		Name:    name,
+		Status:  status,
+		Message: message,
+	})
+	switch status {
+	case "ok":
+		r.Summary.OK++
+	case "warn":
+		r.Summary.Warn++
+	case "fail":
+		r.Summary.Fail++
+	}
+}
+
+func (r *doctorReport) addFixed(name, message string) {
+	r.Checks = append(r.Checks, doctorCheck{
+		Name:    name,
+		Status:  "ok",
+		Message: message,
+		Fixed:   true,
+	})
+	r.Summary.OK++
+}
+
+func cmdDoctor(cfg *config.Config, q *queue.Queue, wt *worktree.Manager, fix, jsonMode bool) error {
+	report := &doctorReport{}
+
+	checkDaemonLiveness(cfg, report)
+	daemonAlive := isDaemonAlive(cfg)
+	checkZombieVessels(cfg, q, wt, report, fix, daemonAlive)
+	checkStaleWorktrees(wt, q, report, fix)
+	checkQueueHealth(q, report)
+	checkFleetHealth(cfg, q, report)
+	checkConfig(cfg, report)
+
+	if jsonMode {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+
+	renderDoctorReport(report)
+	return nil
+}
+
+func checkDaemonLiveness(cfg *config.Config, report *doctorReport) {
+	snapshot, err := daemonhealth.Load(cfg.StateDir)
+	if err != nil {
+		report.add("daemon", "warn", "No daemon health snapshot found (daemon may have never run)")
+		return
+	}
+
+	if daemonProcessAlive(snapshot.PID) {
+		uptime := time.Since(snapshot.StartedAt).Round(time.Second)
+		report.add("daemon", "ok", fmt.Sprintf("Daemon alive (pid=%d, uptime=%s, binary=%s)", snapshot.PID, uptime, snapshot.Binary))
+
+		// Check for stale heartbeat even if process is alive
+		heartbeatAge := time.Since(snapshot.UpdatedAt)
+		if heartbeatAge > 5*time.Minute {
+			report.add("daemon_heartbeat", "warn", fmt.Sprintf("Daemon heartbeat stale (%s ago)", heartbeatAge.Round(time.Second)))
+		}
+	} else {
+		lastSeen := snapshot.UpdatedAt.UTC().Format("2006-01-02 15:04:05 UTC")
+		report.add("daemon", "fail", fmt.Sprintf("Daemon not running (pid=%d last seen %s)", snapshot.PID, lastSeen))
+	}
+
+	// Report daemon health checks
+	for _, check := range snapshot.Checks {
+		status := "ok"
+		switch check.Level {
+		case daemonhealth.LevelWarning:
+			status = "warn"
+		case daemonhealth.LevelCritical:
+			status = "fail"
+		}
+		report.add("daemon_check_"+check.Code, status, check.Message)
+	}
+}
+
+func isDaemonAlive(cfg *config.Config) bool {
+	snapshot, err := daemonhealth.Load(cfg.StateDir)
+	if err != nil {
+		return false
+	}
+	return daemonProcessAlive(snapshot.PID)
+}
+
+func checkZombieVessels(cfg *config.Config, q *queue.Queue, wt *worktree.Manager, report *doctorReport, fix, daemonAlive bool) {
+	running, err := q.ListByState(queue.StateRunning)
+	if err != nil {
+		report.add("zombie_vessels", "warn", fmt.Sprintf("Failed to list running vessels: %v", err))
+		return
+	}
+
+	if len(running) == 0 {
+		report.add("zombie_vessels", "ok", "No running vessels")
+		return
+	}
+
+	timeout, _ := time.ParseDuration(cfg.Timeout)
+	if timeout == 0 {
+		timeout = 45 * time.Minute // fallback default
+	}
+
+	var zombies []queue.Vessel
+	for _, v := range running {
+		if v.StartedAt == nil {
+			zombies = append(zombies, v)
+			continue
+		}
+		elapsed := time.Since(*v.StartedAt)
+		// A vessel is a zombie if:
+		// 1. The daemon is dead and the vessel is running, OR
+		// 2. The vessel has been running for > 2x the timeout
+		if !daemonAlive || elapsed > 2*timeout {
+			zombies = append(zombies, v)
+		}
+	}
+
+	if len(zombies) == 0 {
+		report.add("zombie_vessels", "ok", fmt.Sprintf("%d running vessel(s), none are zombies", len(running)))
+		return
+	}
+
+	if !fix {
+		ids := make([]string, len(zombies))
+		for i, v := range zombies {
+			elapsed := "unknown"
+			if v.StartedAt != nil {
+				elapsed = time.Since(*v.StartedAt).Round(time.Second).String()
+			}
+			ids[i] = fmt.Sprintf("%s (running %s)", v.ID, elapsed)
+		}
+		report.add("zombie_vessels", "fail", fmt.Sprintf("%d zombie vessel(s) found: %s. Run with --fix to reap", len(zombies), strings.Join(ids, ", ")))
+		return
+	}
+
+	// Fix: transition zombies to timed_out
+	reaped := 0
+	for _, v := range zombies {
+		errMsg := "reaped by xylem doctor --fix (orphaned vessel)"
+		if err := q.Update(v.ID, queue.StateTimedOut, errMsg); err != nil {
+			report.add("zombie_reap_"+v.ID, "warn", fmt.Sprintf("Failed to reap %s: %v", v.ID, err))
+			continue
+		}
+		reaped++
+
+		// Best-effort worktree cleanup
+		if v.WorktreePath != "" && wt != nil {
+			_ = wt.Remove(context.Background(), v.WorktreePath)
+		}
+	}
+	report.addFixed("zombie_vessels", fmt.Sprintf("Reaped %d/%d zombie vessel(s)", reaped, len(zombies)))
+}
+
+func checkStaleWorktrees(wt *worktree.Manager, q *queue.Queue, report *doctorReport, fix bool) {
+	ctx := context.Background()
+	trees, err := wt.ListXylem(ctx)
+	if err != nil {
+		report.add("worktrees", "warn", fmt.Sprintf("Failed to list worktrees: %v", err))
+		return
+	}
+
+	if len(trees) == 0 {
+		report.add("worktrees", "ok", "No xylem worktrees")
+		return
+	}
+
+	// Build set of worktree paths for non-terminal vessels
+	vessels, err := q.List()
+	if err != nil {
+		report.add("worktrees", "warn", fmt.Sprintf("Failed to list vessels for worktree check: %v", err))
+		return
+	}
+	activeWorktrees := make(map[string]bool)
+	for _, v := range vessels {
+		if !v.State.IsTerminal() && v.WorktreePath != "" {
+			activeWorktrees[v.WorktreePath] = true
+		}
+	}
+
+	var stale []worktree.WorktreeInfo
+	for _, t := range trees {
+		if !activeWorktrees[t.Path] {
+			stale = append(stale, t)
+		}
+	}
+
+	if len(stale) == 0 {
+		report.add("worktrees", "ok", fmt.Sprintf("%d worktree(s), all active", len(trees)))
+		return
+	}
+
+	if !fix {
+		report.add("worktrees", "warn", fmt.Sprintf("%d stale worktree(s) of %d total. Run xylem cleanup or doctor --fix to remove", len(stale), len(trees)))
+		return
+	}
+
+	removed := 0
+	for _, t := range stale {
+		if err := wt.Remove(ctx, t.Path); err != nil {
+			continue
+		}
+		removed++
+	}
+	report.addFixed("worktrees", fmt.Sprintf("Removed %d/%d stale worktree(s)", removed, len(stale)))
+}
+
+func checkQueueHealth(q *queue.Queue, report *doctorReport) {
+	vessels, err := q.List()
+	if err != nil {
+		report.add("queue", "fail", fmt.Sprintf("Failed to read queue: %v", err))
+		return
+	}
+
+	// Check for duplicate IDs (non-terminal)
+	seen := make(map[string]int)
+	for _, v := range vessels {
+		if !v.State.IsTerminal() {
+			seen[v.ID]++
+		}
+	}
+	var dupes []string
+	for id, count := range seen {
+		if count > 1 {
+			dupes = append(dupes, fmt.Sprintf("%s (x%d)", id, count))
+		}
+	}
+	if len(dupes) > 0 {
+		report.add("queue_duplicates", "warn", fmt.Sprintf("Duplicate active vessel IDs: %s", strings.Join(dupes, ", ")))
+	}
+
+	// Check queue compaction potential
+	compactable, err := q.CompactDryRun()
+	if err == nil && compactable > 0 {
+		report.add("queue_compaction", "warn", fmt.Sprintf("%d stale queue records could be compacted. Run xylem cleanup", compactable))
+	} else {
+		report.add("queue_compaction", "ok", "Queue is compact")
+	}
+
+	report.add("queue", "ok", fmt.Sprintf("%d vessel(s) in queue", len(vessels)))
+}
+
+func checkFleetHealth(cfg *config.Config, q *queue.Queue, report *doctorReport) {
+	vessels, err := q.List()
+	if err != nil {
+		return
+	}
+
+	ids := make([]string, len(vessels))
+	for i, v := range vessels {
+		ids[i] = v.ID
+	}
+	summaries, _ := runner.LoadVesselSummaries(cfg.StateDir, ids)
+	fleet := runner.AnalyzeFleetStatus(vessels, summaries)
+
+	total := fleet.Healthy + fleet.Degraded + fleet.Unhealthy
+	if total == 0 {
+		return
+	}
+
+	failRate := float64(fleet.Unhealthy) / float64(total) * 100
+	if failRate > 40 {
+		report.add("fleet_health", "fail", fmt.Sprintf("%.0f%% unhealthy (%d/%d vessels)", failRate, fleet.Unhealthy, total))
+	} else if failRate > 20 {
+		report.add("fleet_health", "warn", fmt.Sprintf("%.0f%% unhealthy (%d/%d vessels)", failRate, fleet.Unhealthy, total))
+	} else {
+		report.add("fleet_health", "ok", fmt.Sprintf("%.0f%% healthy (%d/%d vessels)", float64(fleet.Healthy)/float64(total)*100, fleet.Healthy, total))
+	}
+
+	// Check for dominant failure patterns
+	for _, p := range fleet.Patterns {
+		if p.Count >= 5 {
+			pct := float64(p.Count) / float64(total) * 100
+			report.add("fleet_pattern_"+p.Code, "warn", fmt.Sprintf("Recurring pattern: %s (%d vessels, %.0f%%)", p.Code, p.Count, pct))
+		}
+	}
+
+	// Check pending backlog
+	counts := map[queue.VesselState]int{}
+	for _, v := range vessels {
+		counts[v.State]++
+	}
+	if counts[queue.StatePending] > 10 {
+		report.add("pending_backlog", "warn", fmt.Sprintf("%d pending vessels in backlog", counts[queue.StatePending]))
+	}
+}
+
+func checkConfig(cfg *config.Config, report *doctorReport) {
+	// Check timeout is parseable
+	if cfg.Timeout != "" {
+		if _, err := time.ParseDuration(cfg.Timeout); err != nil {
+			report.add("config_timeout", "fail", fmt.Sprintf("Invalid timeout %q: %v", cfg.Timeout, err))
+		}
+	}
+
+	// Check concurrency
+	if cfg.Concurrency <= 0 {
+		report.add("config_concurrency", "warn", "Concurrency not set or zero (defaults to 1)")
+	}
+
+	// Check stall monitor
+	if cfg.Daemon.StallMonitor.PhaseStallThreshold == "" {
+		report.add("config_stall_monitor", "warn", "Phase stall threshold not configured (stall detection disabled)")
+	}
+
+	// Check auto-upgrade
+	if !cfg.Daemon.AutoUpgrade {
+		report.add("config_auto_upgrade", "warn", "Daemon auto-upgrade is disabled")
+	}
+}
+
+func renderDoctorReport(report *doctorReport) {
+	for _, check := range report.Checks {
+		icon := checkIcon(check.Status)
+		suffix := ""
+		if check.Fixed {
+			suffix = " [FIXED]"
+		}
+		fmt.Printf("  %s %s%s\n", icon, check.Message, suffix)
+	}
+
+	fmt.Printf("\n%d ok, %d warnings, %d failures\n", report.Summary.OK, report.Summary.Warn, report.Summary.Fail)
+
+	if report.Summary.Fail > 0 {
+		fmt.Println("\nRun with --fix to attempt automatic remediation of fixable issues.")
+	}
+}
+
+func checkIcon(status string) string {
+	switch status {
+	case "warn":
+		return "!"
+	case "fail":
+		return "X"
+	default:
+		return "."
+	}
+}

--- a/cli/cmd/xylem/doctor_test.go
+++ b/cli/cmd/xylem/doctor_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/daemonhealth"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+func TestDoctorDetectsZombieVessels(t *testing.T) {
+	dir := t.TempDir()
+	qPath := filepath.Join(dir, "queue.jsonl")
+	q := queue.New(qPath)
+
+	started := time.Now().Add(-2 * time.Hour)
+	v := queue.Vessel{
+		ID:        "zombie-1",
+		Source:    "github-issue",
+		Workflow:  "implement-feature",
+		State:     queue.StatePending,
+		CreatedAt: started,
+	}
+	if _, err := q.Enqueue(v); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Update("zombie-1", queue.StateRunning, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Timeout:  "45m",
+		StateDir: dir,
+	}
+
+	report := &doctorReport{}
+	checkZombieVessels(cfg, q, nil, report, false, false)
+
+	found := false
+	for _, c := range report.Checks {
+		if c.Name == "zombie_vessels" && c.Status == "fail" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected zombie_vessels fail check")
+	}
+}
+
+func TestDoctorFixReapsZombies(t *testing.T) {
+	dir := t.TempDir()
+	qPath := filepath.Join(dir, "queue.jsonl")
+	q := queue.New(qPath)
+
+	started := time.Now().Add(-2 * time.Hour)
+	v := queue.Vessel{
+		ID:        "zombie-fix",
+		Source:    "github-issue",
+		Workflow:  "implement-feature",
+		State:     queue.StatePending,
+		CreatedAt: started,
+	}
+	if _, err := q.Enqueue(v); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Update("zombie-fix", queue.StateRunning, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Timeout:  "45m",
+		StateDir: dir,
+	}
+
+	report := &doctorReport{}
+	checkZombieVessels(cfg, q, nil, report, true, false)
+
+	vessel, err := q.FindByID("zombie-fix")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vessel.State != queue.StateTimedOut {
+		t.Errorf("expected timed_out, got %s", vessel.State)
+	}
+
+	found := false
+	for _, c := range report.Checks {
+		if c.Name == "zombie_vessels" && c.Fixed {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected zombie_vessels fixed check")
+	}
+}
+
+func TestDoctorDetectsDeadDaemon(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "state")
+	os.MkdirAll(stateDir, 0o755)
+
+	snapshot := daemonhealth.Snapshot{
+		PID:       99999,
+		StartedAt: time.Now().Add(-24 * time.Hour),
+		UpdatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	if err := daemonhealth.Save(dir, snapshot); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		StateDir: dir,
+	}
+
+	report := &doctorReport{}
+	checkDaemonLiveness(cfg, report)
+
+	found := false
+	for _, c := range report.Checks {
+		if c.Name == "daemon" && c.Status == "fail" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected daemon fail check for dead process")
+	}
+}
+
+func TestDoctorQueueHealth(t *testing.T) {
+	dir := t.TempDir()
+	qPath := filepath.Join(dir, "queue.jsonl")
+	q := queue.New(qPath)
+
+	v := queue.Vessel{
+		ID:        "done-1",
+		Source:    "github-issue",
+		Workflow:  "implement-feature",
+		State:     queue.StatePending,
+		CreatedAt: time.Now(),
+	}
+	if _, err := q.Enqueue(v); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Update("done-1", queue.StateRunning, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Update("done-1", queue.StateCompleted, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	report := &doctorReport{}
+	checkQueueHealth(q, report)
+
+	if report.Summary.Fail > 0 {
+		t.Error("expected no failures for healthy queue")
+	}
+}
+
+func TestDoctorJSONOutput(t *testing.T) {
+	report := &doctorReport{}
+	report.add("test_check", "ok", "All good")
+	report.add("test_warn", "warn", "Minor issue")
+
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded doctorReport
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Checks) != 2 {
+		t.Errorf("expected 2 checks, got %d", len(decoded.Checks))
+	}
+}

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -102,6 +102,7 @@ func newRootCmd() *cobra.Command {
 		newResumeCmd(),
 		newCancelCmd(),
 		newCleanupCmd(),
+		newDoctorCmd(),
 		newDaemonCmd(),
 		newRetryCmd(),
 		newVisualizeCmd(),

--- a/cli/internal/runner/stale_cancel.go
+++ b/cli/internal/runner/stale_cancel.go
@@ -1,0 +1,114 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+// prRefPattern matches GitHub PR URLs and extracts the PR number.
+var prRefPattern = regexp.MustCompile(`/pull/(\d+)`)
+
+// prSources are the vessel source types that reference pull requests.
+var prSources = map[string]bool{
+	"github-pr":        true,
+	"github-pr-events": true,
+	"github-merge":     true,
+}
+
+// CancelStalePRVessels checks pending vessels that reference pull requests and
+// cancels those whose PRs are already merged or closed. This prevents wasting
+// concurrency slots on work that can never succeed (e.g., merging an already-
+// merged PR, resolving conflicts on a closed PR).
+//
+// Returns the number of vessels cancelled.
+func (r *Runner) CancelStalePRVessels(ctx context.Context) int {
+	pending, err := r.Queue.ListByState(queue.StatePending)
+	if err != nil {
+		log.Printf("warn: cancel stale PR vessels: list pending: %v", err)
+		return 0
+	}
+
+	cancelled := 0
+	for _, vessel := range pending {
+		if !prSources[vessel.Source] {
+			continue
+		}
+
+		prNum := extractPRNumber(vessel)
+		if prNum == 0 {
+			continue
+		}
+
+		repo := r.resolveRepo(vessel)
+		if repo == "" {
+			continue
+		}
+
+		state, err := r.checkPRState(ctx, repo, prNum)
+		if err != nil {
+			log.Printf("warn: cancel stale PR vessels: check PR %d state: %v", prNum, err)
+			continue
+		}
+
+		if state == "OPEN" {
+			continue
+		}
+
+		reason := fmt.Sprintf("PR #%d is %s", prNum, strings.ToLower(state))
+		log.Printf("cancel stale vessel %s: %s", vessel.ID, reason)
+		if err := r.Queue.Cancel(vessel.ID); err != nil {
+			log.Printf("warn: cancel stale vessel %s: %v", vessel.ID, err)
+			continue
+		}
+		cancelled++
+	}
+
+	if cancelled > 0 {
+		log.Printf("cancelled %d stale PR vessel(s)", cancelled)
+	}
+	return cancelled
+}
+
+// extractPRNumber gets the PR number from a vessel's metadata or ref URL.
+func extractPRNumber(v queue.Vessel) int {
+	if num, ok := v.Meta["pr_num"]; ok {
+		if n, err := strconv.Atoi(num); err == nil {
+			return n
+		}
+	}
+	matches := prRefPattern.FindStringSubmatch(v.Ref)
+	if len(matches) >= 2 {
+		if n, err := strconv.Atoi(matches[1]); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+// checkPRState queries the GitHub API for a PR's state.
+// Returns "OPEN", "MERGED", or "CLOSED".
+func (r *Runner) checkPRState(ctx context.Context, repo string, prNum int) (string, error) {
+	out, err := r.Runner.RunOutput(ctx, "gh", "pr", "view",
+		strconv.Itoa(prNum),
+		"--repo", repo,
+		"--json", "state",
+	)
+	if err != nil {
+		return "", fmt.Errorf("gh pr view %d: %w", prNum, err)
+	}
+
+	var resp struct {
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return "", fmt.Errorf("parse PR state: %w", err)
+	}
+	return resp.State, nil
+}

--- a/cli/internal/runner/stale_cancel_test.go
+++ b/cli/internal/runner/stale_cancel_test.go
@@ -1,0 +1,272 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/source"
+)
+
+func TestCancelStalePRVessels_CancelsMerged(t *testing.T) {
+	dir := t.TempDir()
+	qPath := filepath.Join(dir, "queue.jsonl")
+	q := queue.New(qPath)
+
+	v := queue.Vessel{
+		ID:        "merge-pr-42",
+		Source:    "github-pr",
+		Ref:       "https://github.com/owner/repo/pull/42",
+		Workflow:  "merge-pr",
+		State:     queue.StatePending,
+		CreatedAt: time.Now(),
+		Meta:      map[string]string{"pr_num": "42", "config_source": "prs"},
+	}
+	if _, err := q.Enqueue(v); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _ := json.Marshal(map[string]string{"state": "MERGED"})
+	mock := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name == "gh" && len(args) >= 2 && args[0] == "pr" && args[1] == "view" {
+				return resp, nil, true
+			}
+			return nil, nil, false
+		},
+	}
+
+	cfg := &config.Config{
+		Timeout:  "45m",
+		StateDir: dir,
+		Sources: map[string]config.SourceConfig{
+			"prs": {Type: "github-pr", Repo: "owner/repo"},
+		},
+	}
+
+	r := &Runner{
+		Config: cfg,
+		Queue:  q,
+		Runner: mock,
+		Sources: map[string]source.Source{
+			"github-pr": &source.GitHubPR{Repo: "owner/repo"},
+		},
+	}
+
+	cancelled := r.CancelStalePRVessels(context.Background())
+	if cancelled != 1 {
+		t.Errorf("expected 1 cancelled, got %d", cancelled)
+	}
+
+	vessel, err := q.FindByID("merge-pr-42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vessel.State != queue.StateCancelled {
+		t.Errorf("expected cancelled, got %s", vessel.State)
+	}
+}
+
+func TestCancelStalePRVessels_KeepsOpen(t *testing.T) {
+	dir := t.TempDir()
+	qPath := filepath.Join(dir, "queue.jsonl")
+	q := queue.New(qPath)
+
+	v := queue.Vessel{
+		ID:        "merge-pr-43",
+		Source:    "github-pr",
+		Ref:       "https://github.com/owner/repo/pull/43",
+		Workflow:  "merge-pr",
+		State:     queue.StatePending,
+		CreatedAt: time.Now(),
+		Meta:      map[string]string{"pr_num": "43", "config_source": "prs"},
+	}
+	if _, err := q.Enqueue(v); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _ := json.Marshal(map[string]string{"state": "OPEN"})
+	mock := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name == "gh" {
+				return resp, nil, true
+			}
+			return nil, nil, false
+		},
+	}
+
+	cfg := &config.Config{
+		Timeout:  "45m",
+		StateDir: dir,
+		Sources: map[string]config.SourceConfig{
+			"prs": {Type: "github-pr", Repo: "owner/repo"},
+		},
+	}
+
+	r := &Runner{
+		Config: cfg,
+		Queue:  q,
+		Runner: mock,
+		Sources: map[string]source.Source{
+			"github-pr": &source.GitHubPR{Repo: "owner/repo"},
+		},
+	}
+
+	cancelled := r.CancelStalePRVessels(context.Background())
+	if cancelled != 0 {
+		t.Errorf("expected 0 cancelled, got %d", cancelled)
+	}
+
+	vessel, err := q.FindByID("merge-pr-43")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vessel.State != queue.StatePending {
+		t.Errorf("expected pending, got %s", vessel.State)
+	}
+}
+
+func TestCancelStalePRVessels_SkipsNonPRSources(t *testing.T) {
+	dir := t.TempDir()
+	qPath := filepath.Join(dir, "queue.jsonl")
+	q := queue.New(qPath)
+
+	v := queue.Vessel{
+		ID:        "issue-99",
+		Source:    "github-issue",
+		Ref:       "https://github.com/owner/repo/issues/99",
+		Workflow:  "implement-feature",
+		State:     queue.StatePending,
+		CreatedAt: time.Now(),
+	}
+	if _, err := q.Enqueue(v); err != nil {
+		t.Fatal(err)
+	}
+
+	ghCalled := false
+	mock := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name == "gh" {
+				ghCalled = true
+			}
+			return nil, nil, false
+		},
+	}
+
+	cfg := &config.Config{
+		Timeout:  "45m",
+		StateDir: dir,
+	}
+
+	r := &Runner{
+		Config: cfg,
+		Queue:  q,
+		Runner: mock,
+	}
+
+	cancelled := r.CancelStalePRVessels(context.Background())
+	if cancelled != 0 {
+		t.Errorf("expected 0 cancelled, got %d", cancelled)
+	}
+	if ghCalled {
+		t.Error("gh should not be called for non-PR sources")
+	}
+}
+
+func TestCancelStalePRVessels_CancelsClosed(t *testing.T) {
+	dir := t.TempDir()
+	qPath := filepath.Join(dir, "queue.jsonl")
+	q := queue.New(qPath)
+
+	v := queue.Vessel{
+		ID:        "resolve-pr-50",
+		Source:    "github-pr-events",
+		Ref:       "https://github.com/owner/repo/pull/50#checks-failed-abc",
+		Workflow:  "fix-pr-checks",
+		State:     queue.StatePending,
+		CreatedAt: time.Now(),
+		Meta:      map[string]string{"pr_num": "50", "config_source": "pr-events"},
+	}
+	if _, err := q.Enqueue(v); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _ := json.Marshal(map[string]string{"state": "CLOSED"})
+	mock := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name == "gh" {
+				return resp, nil, true
+			}
+			return nil, nil, false
+		},
+	}
+
+	cfg := &config.Config{
+		Timeout:  "45m",
+		StateDir: dir,
+		Sources: map[string]config.SourceConfig{
+			"pr-events": {Type: "github-pr-events", Repo: "owner/repo"},
+		},
+	}
+
+	r := &Runner{
+		Config: cfg,
+		Queue:  q,
+		Runner: mock,
+		Sources: map[string]source.Source{
+			"github-pr-events": &source.GitHubPREvents{Repo: "owner/repo"},
+		},
+	}
+
+	cancelled := r.CancelStalePRVessels(context.Background())
+	if cancelled != 1 {
+		t.Errorf("expected 1 cancelled, got %d", cancelled)
+	}
+}
+
+func TestExtractPRNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		vessel   queue.Vessel
+		expected int
+	}{
+		{
+			name:     "from meta",
+			vessel:   queue.Vessel{Meta: map[string]string{"pr_num": "42"}},
+			expected: 42,
+		},
+		{
+			name:     "from ref",
+			vessel:   queue.Vessel{Ref: "https://github.com/owner/repo/pull/99"},
+			expected: 99,
+		},
+		{
+			name:     "from ref with fragment",
+			vessel:   queue.Vessel{Ref: "https://github.com/owner/repo/pull/55#merge-abc123"},
+			expected: 55,
+		},
+		{
+			name:     "no pr number",
+			vessel:   queue.Vessel{Ref: "https://github.com/owner/repo/issues/10"},
+			expected: 0,
+		},
+		{
+			name:     "meta takes precedence",
+			vessel:   queue.Vessel{Meta: map[string]string{"pr_num": "7"}, Ref: "https://github.com/owner/repo/pull/99"},
+			expected: 7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractPRNumber(tt.vessel)
+			if got != tt.expected {
+				t.Errorf("extractPRNumber() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `xylem doctor` CLI command with deterministic health checks (daemon liveness, zombie vessels, stale worktrees, queue integrity, fleet health, config validation). Supports `--fix` to auto-remediate and `--json` for machine output.
- Adds `CancelStalePRVessels` to the runner, integrated into the daemon tick loop. Auto-cancels pending vessels whose referenced PRs are already merged/closed, freeing concurrency slots for real work.
- Closes #280

## Motivation
Two zombie vessels were stuck "running" for 35+ hours with no live daemon, blocking 4 pending vessels. Loop 34 found 50% of pending vessels were stale PR references. These features close both gaps: `doctor --fix` reaps zombies immediately, and the daemon now auto-cancels stale PR vessels every tick.

## Test plan
- [x] `TestDoctorDetectsZombieVessels` — zombie detection when daemon is dead
- [x] `TestDoctorFixReapsZombies` — --fix transitions zombies to timed_out
- [x] `TestDoctorDetectsDeadDaemon` — daemon liveness check with dead PID
- [x] `TestDoctorQueueHealth` — queue integrity checks
- [x] `TestDoctorJSONOutput` — JSON serialization
- [x] `TestCancelStalePRVessels_CancelsMerged` — cancels merged PR vessels
- [x] `TestCancelStalePRVessels_KeepsOpen` — keeps open PR vessels
- [x] `TestCancelStalePRVessels_SkipsNonPRSources` — skips issue vessels
- [x] `TestCancelStalePRVessels_CancelsClosed` — cancels closed PR vessels
- [x] `TestExtractPRNumber` — PR number extraction from meta/ref
- [x] Full test suite passes (37 packages)
- [x] All pre-commit hooks pass (goimports, golangci-lint, go build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)