### PR TITLE
fix(doctor): guard worktree cleanup to only remove .claude/worktrees/ paths

### DIFF
--- a/cli/cmd/xylem/doctor.go
+++ b/cli/cmd/xylem/doctor.go
@@ -210,8 +210,10 @@ func checkZombieVessels(cfg *config.Config, q *queue.Queue, wt *worktree.Manager
 		}
 		reaped++
 
-		// Best-effort worktree cleanup
-		if v.WorktreePath != "" && wt != nil {
+		// Best-effort worktree cleanup — only remove vessel worktrees
+		// under .claude/worktrees/ to avoid destroying the daemon root
+		// or other important worktrees.
+		if v.WorktreePath != "" && wt != nil && strings.Contains(v.WorktreePath, ".claude/worktrees/") {
 			_ = wt.Remove(context.Background(), v.WorktreePath)
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixes a critical bug where `doctor --fix` zombie vessel cleanup removed worktrees at arbitrary paths, including `.daemon-root/`, destroying the daemon's entire runtime state (queue, phases, audit log)
- Now only removes worktree paths containing `.claude/worktrees/` — matching the same guard used by `ListXylem`

## Root cause
The zombie vessel reap logic called `wt.Remove()` on whatever path was in `vessel.WorktreePath`, which could be `.daemon-root/` or any other non-vessel worktree. This was a latent bug in PR #298 that manifested when `doctor --fix` was run against a queue with zombie vessels whose worktree paths pointed outside the standard `.claude/worktrees/` directory.

## Test plan
- [x] Existing doctor tests still pass
- [x] All pre-commit hooks pass
- [x] Manual verification: `doctor --fix` no longer removes non-vessel worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)