### PR TITLE
fix(cmd,profiles): fix scheduled workflow command-phase failures in worktrees

### DIFF
--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -32,7 +32,7 @@ func newRootCmd() *cobra.Command {
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			commandPath := cmd.CommandPath()
-			if cmd.Name() == "init" || cmd.Name() == "shim-dispatch" || cmd.Name() == "version" || commandPath == "xylem dtu" || strings.HasPrefix(commandPath, "xylem dtu ") || commandPath == "xylem bootstrap" || strings.HasPrefix(commandPath, "xylem bootstrap ") {
+			if cmd.Name() == "init" || cmd.Name() == "shim-dispatch" || cmd.Name() == "version" || commandPath == "xylem dtu" || strings.HasPrefix(commandPath, "xylem dtu ") || commandPath == "xylem bootstrap" || strings.HasPrefix(commandPath, "xylem bootstrap ") || strings.HasPrefix(commandPath, "xylem continuous-simplicity") {
 				return nil
 			}
 

--- a/cli/internal/profiles/self-hosting-xylem/workflows/continuous-improvement.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/continuous-improvement.yaml
@@ -6,9 +6,10 @@ phases:
     type: command
     run: |
       set -euo pipefail
-      go run ./cli/cmd/xylem --config .xylem.yml continuous-improvement select \
-        --state .xylem/state/continuous-improvement/state.json \
-        --selection .xylem/state/continuous-improvement/current-selection.json
+      cd cli
+      go run ./cmd/xylem --config ../.xylem.yml continuous-improvement select \
+        --state ../.xylem/state/continuous-improvement/state.json \
+        --selection ../.xylem/state/continuous-improvement/current-selection.json
   - name: analyze
     prompt_file: .xylem/prompts/continuous-improvement/analyze.md
     max_turns: 40


### PR DESCRIPTION
## Summary
- Fixes `continuous-simplicity` scheduled workflow failing with "error loading config .xylem.yml" by skipping config loading for subcommands that don't need it
- Fixes `continuous-improvement` scheduled workflow failing with "cannot find main module" by running from `cli/` with explicit `--config ../.xylem.yml`
- Both self-improvement workflows were failing at phase 1 on every daemon tick

## Root cause
Command phases in scheduled vessel worktrees run Go subcommands that load `.xylem.yml` relative to CWD. When CWD is `cli/` (for go.mod), config is at `../.xylem.yml`, not `./.xylem.yml`. When CWD is repo root (no go.mod), Go can't find the module.

## Test plan
- [x] `continuous-simplicity scan-changes` works from `cli/` without config
- [x] Full test suite passes (37 packages)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)