### PR TITLE
feat(config): switch default LLM to claude, protect .daemon-root

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -33,8 +33,6 @@ sources:
     repo: nicholls-inc/xylem
     exclude:
       [wontfix, duplicate, in-progress, no-bot, needs-refinement, xylem-failed]
-    llm: copilot
-    model: gpt-5-mini
     tasks:
       triage-issues:
         labels: [needs-triage]
@@ -199,8 +197,8 @@ timeout: "45m"
 state_dir: ".xylem"
 
 # llm selects the global default LLM provider: "claude" (default) or "copilot"
-llm: copilot
-model: gpt-5.4
+llm: claude
+model: claude-sonnet-4-6
 
 claude:
   command: "claude"

--- a/.xylem/workflows/continuous-improvement.yaml
+++ b/.xylem/workflows/continuous-improvement.yaml
@@ -12,22 +12,16 @@ phases:
   - name: analyze
     prompt_file: .xylem/prompts/continuous-improvement/analyze.md
     max_turns: 40
-    llm: copilot
-    model: gpt-5.4
     noop:
       match: XYLEM_NOOP
   - name: plan
     prompt_file: .xylem/prompts/continuous-improvement/plan.md
     max_turns: 30
-    llm: copilot
-    model: gpt-5.4
     noop:
       match: XYLEM_NOOP
   - name: implement
     prompt_file: .xylem/prompts/continuous-improvement/implement.md
     max_turns: 80
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: |
@@ -40,5 +34,3 @@ phases:
   - name: verify
     prompt_file: .xylem/prompts/continuous-improvement/verify.md
     max_turns: 40
-    llm: copilot
-    model: gpt-5.4

--- a/.xylem/workflows/continuous-simplicity.yaml
+++ b/.xylem/workflows/continuous-simplicity.yaml
@@ -13,13 +13,9 @@ phases:
   - name: simplify
     prompt_file: .xylem/prompts/continuous-simplicity/simplify.md
     max_turns: 40
-    llm: copilot
-    model: gpt-5.4
   - name: dedup
     prompt_file: .xylem/prompts/continuous-simplicity/dedup.md
     max_turns: 50
-    llm: copilot
-    model: gpt-5.4
   - name: plan_prs
     type: command
     run: |
@@ -32,8 +28,6 @@ phases:
   - name: apply
     prompt_file: .xylem/prompts/continuous-simplicity/apply.md
     max_turns: 80
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: |

--- a/.xylem/workflows/fix-pr-checks.yaml
+++ b/.xylem/workflows/fix-pr-checks.yaml
@@ -4,15 +4,11 @@ phases:
   - name: diagnose
     prompt_file: .xylem/prompts/fix-pr-checks/diagnose.md
     max_turns: 30
-    llm: copilot
-    model: gpt-5.4
     noop:
       match: XYLEM_NOOP
   - name: fix
     prompt_file: .xylem/prompts/fix-pr-checks/fix.md
     max_turns: 60
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: |
@@ -25,5 +21,3 @@ phases:
   - name: push
     prompt_file: .xylem/prompts/fix-pr-checks/push.md
     max_turns: 10
-    llm: copilot
-    model: gpt-5-mini

--- a/.xylem/workflows/implement-harness.yaml
+++ b/.xylem/workflows/implement-harness.yaml
@@ -4,19 +4,14 @@ phases:
   - name: analyze
     prompt_file: .xylem/prompts/implement-harness/analyze.md
     max_turns: 30
-    llm: copilot
-    model: gpt-5.4
     noop:
       match: XYLEM_NOOP
   - name: plan
     prompt_file: .xylem/prompts/implement-harness/plan.md
     max_turns: 30
-    llm: copilot
   - name: implement
     prompt_file: .xylem/prompts/implement-harness/implement.md
     max_turns: 80
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: "cd cli && go vet ./... && go build ./cmd/xylem && go test ./..."
@@ -24,7 +19,6 @@ phases:
   - name: verify
     prompt_file: .xylem/prompts/implement-harness/verify.md
     max_turns: 80
-    llm: copilot
     gate:
       type: command
       run: "cd cli && go test ./..."
@@ -32,8 +26,6 @@ phases:
   - name: test_critic
     prompt_file: .xylem/prompts/implement-harness/test_critic.md
     max_turns: 30
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: "cd cli && go test ./..."
@@ -41,8 +33,6 @@ phases:
   - name: smoke
     prompt_file: .xylem/prompts/implement-harness/smoke.md
     max_turns: 60
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: "cd cli && go test ./..."
@@ -50,8 +40,6 @@ phases:
   - name: pr_draft
     prompt_file: .xylem/prompts/implement-harness/pr_draft.md
     max_turns: 15
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: |

--- a/.xylem/workflows/resolve-conflicts.yaml
+++ b/.xylem/workflows/resolve-conflicts.yaml
@@ -34,13 +34,9 @@ phases:
   - name: analyze
     prompt_file: .xylem/prompts/resolve-conflicts/analyze.md
     max_turns: 20
-    llm: copilot
-    model: gpt-5.4
   - name: resolve
     prompt_file: .xylem/prompts/resolve-conflicts/resolve.md
     max_turns: 40
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: |
@@ -56,5 +52,3 @@ phases:
   - name: push
     prompt_file: .xylem/prompts/resolve-conflicts/push.md
     max_turns: 10
-    llm: copilot
-    model: gpt-5-mini

--- a/.xylem/workflows/respond-to-pr-review.yaml
+++ b/.xylem/workflows/respond-to-pr-review.yaml
@@ -4,15 +4,11 @@ phases:
   - name: analyze
     prompt_file: .xylem/prompts/respond-to-pr-review/analyze.md
     max_turns: 20
-    llm: copilot
-    model: gpt-5.4
     noop:
       match: XYLEM_NOOP
   - name: respond
     prompt_file: .xylem/prompts/respond-to-pr-review/respond.md
     max_turns: 60
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: "cd cli && go vet ./... && go build ./cmd/xylem && go test ./..."
@@ -20,5 +16,3 @@ phases:
   - name: push
     prompt_file: .xylem/prompts/respond-to-pr-review/push.md
     max_turns: 10
-    llm: copilot
-    model: gpt-5-mini

--- a/.xylem/workflows/sota-gap-analysis.yaml
+++ b/.xylem/workflows/sota-gap-analysis.yaml
@@ -4,13 +4,9 @@ phases:
   - name: ingest
     prompt_file: .xylem/prompts/sota-gap-analysis/ingest.md
     max_turns: 30
-    llm: copilot
-    model: gpt-5.4
   - name: survey
     prompt_file: .xylem/prompts/sota-gap-analysis/survey.md
     max_turns: 60
-    llm: copilot
-    model: gpt-5.4
   - name: diff
     type: command
     run: |
@@ -24,8 +20,6 @@ phases:
   - name: report
     prompt_file: .xylem/prompts/sota-gap-analysis/report.md
     max_turns: 40
-    llm: copilot
-    model: gpt-5.4
   - name: file_issues
     type: command
     run: |

--- a/.xylem/workflows/unblock-wave.yaml
+++ b/.xylem/workflows/unblock-wave.yaml
@@ -4,7 +4,5 @@ phases:
   - name: check_deps
     prompt_file: .xylem/prompts/unblock-wave/check_deps.md
     max_turns: 20
-    llm: copilot
-    model: gpt-5-mini
     noop:
       match: XYLEM_NOOP

--- a/cli/internal/profiles/core/workflows/fix-pr-checks.yaml
+++ b/cli/internal/profiles/core/workflows/fix-pr-checks.yaml
@@ -4,15 +4,11 @@ phases:
   - name: diagnose
     prompt_file: .xylem/prompts/fix-pr-checks/diagnose.md
     max_turns: 30
-    llm: copilot
-    model: gpt-5.4
     noop:
       match: XYLEM_NOOP
   - name: fix
     prompt_file: .xylem/prompts/fix-pr-checks/fix.md
     max_turns: 60
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: "true"
@@ -20,5 +16,3 @@ phases:
   - name: push
     prompt_file: .xylem/prompts/fix-pr-checks/push.md
     max_turns: 10
-    llm: copilot
-    model: gpt-5-mini

--- a/cli/internal/profiles/core/workflows/resolve-conflicts.yaml
+++ b/cli/internal/profiles/core/workflows/resolve-conflicts.yaml
@@ -4,15 +4,11 @@ phases:
   - name: analyze
     prompt_file: .xylem/prompts/resolve-conflicts/analyze.md
     max_turns: 20
-    llm: copilot
-    model: gpt-5.4
     noop:
       match: XYLEM_NOOP
   - name: resolve
     prompt_file: .xylem/prompts/resolve-conflicts/resolve.md
     max_turns: 40
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: "git fetch origin main && test \"$(git branch --show-current)\" = \"$(gh pr view {{.Issue.Number}} --json headRefName --jq '.headRefName')\" && git merge-base --is-ancestor origin/main HEAD"
@@ -20,5 +16,3 @@ phases:
   - name: push
     prompt_file: .xylem/prompts/resolve-conflicts/push.md
     max_turns: 10
-    llm: copilot
-    model: gpt-5-mini

--- a/cli/internal/profiles/core/workflows/respond-to-pr-review.yaml
+++ b/cli/internal/profiles/core/workflows/respond-to-pr-review.yaml
@@ -4,15 +4,11 @@ phases:
   - name: analyze
     prompt_file: .xylem/prompts/respond-to-pr-review/analyze.md
     max_turns: 20
-    llm: copilot
-    model: gpt-5.4
     noop:
       match: XYLEM_NOOP
   - name: respond
     prompt_file: .xylem/prompts/respond-to-pr-review/respond.md
     max_turns: 60
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: "true"
@@ -20,5 +16,3 @@ phases:
   - name: push
     prompt_file: .xylem/prompts/respond-to-pr-review/push.md
     max_turns: 10
-    llm: copilot
-    model: gpt-5-mini

--- a/cli/internal/profiles/self-hosting-xylem/workflows/continuous-improvement.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/continuous-improvement.yaml
@@ -13,22 +13,16 @@ phases:
   - name: analyze
     prompt_file: .xylem/prompts/continuous-improvement/analyze.md
     max_turns: 40
-    llm: copilot
-    model: gpt-5.4
     noop:
       match: XYLEM_NOOP
   - name: plan
     prompt_file: .xylem/prompts/continuous-improvement/plan.md
     max_turns: 30
-    llm: copilot
-    model: gpt-5.4
     noop:
       match: XYLEM_NOOP
   - name: implement
     prompt_file: .xylem/prompts/continuous-improvement/implement.md
     max_turns: 80
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: |
@@ -41,5 +35,3 @@ phases:
   - name: verify
     prompt_file: .xylem/prompts/continuous-improvement/verify.md
     max_turns: 40
-    llm: copilot
-    model: gpt-5.4

--- a/cli/internal/profiles/self-hosting-xylem/workflows/continuous-simplicity.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/continuous-simplicity.yaml
@@ -13,13 +13,9 @@ phases:
   - name: simplify
     prompt_file: .xylem/prompts/continuous-simplicity/simplify.md
     max_turns: 40
-    llm: copilot
-    model: gpt-5.4
   - name: dedup
     prompt_file: .xylem/prompts/continuous-simplicity/dedup.md
     max_turns: 50
-    llm: copilot
-    model: gpt-5.4
   - name: plan_prs
     type: command
     run: |
@@ -32,8 +28,6 @@ phases:
   - name: apply
     prompt_file: .xylem/prompts/continuous-simplicity/apply.md
     max_turns: 80
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: |

--- a/cli/internal/profiles/self-hosting-xylem/workflows/implement-harness.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/implement-harness.yaml
@@ -4,19 +4,14 @@ phases:
   - name: analyze
     prompt_file: .xylem/prompts/implement-harness/analyze.md
     max_turns: 30
-    llm: copilot
-    model: gpt-5.4
     noop:
       match: XYLEM_NOOP
   - name: plan
     prompt_file: .xylem/prompts/implement-harness/plan.md
     max_turns: 30
-    llm: copilot
   - name: implement
     prompt_file: .xylem/prompts/implement-harness/implement.md
     max_turns: 80
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: "cd cli && go vet ./... && go build ./cmd/xylem && go test ./..."
@@ -24,7 +19,6 @@ phases:
   - name: verify
     prompt_file: .xylem/prompts/implement-harness/verify.md
     max_turns: 80
-    llm: copilot
     gate:
       type: command
       run: "cd cli && go test ./..."
@@ -32,8 +26,6 @@ phases:
   - name: test_critic
     prompt_file: .xylem/prompts/implement-harness/test_critic.md
     max_turns: 30
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: "cd cli && go test ./..."
@@ -41,8 +33,6 @@ phases:
   - name: smoke
     prompt_file: .xylem/prompts/implement-harness/smoke.md
     max_turns: 60
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: "cd cli && go test ./..."
@@ -50,8 +40,6 @@ phases:
   - name: pr_draft
     prompt_file: .xylem/prompts/implement-harness/pr_draft.md
     max_turns: 15
-    llm: copilot
-    model: gpt-5.4
     gate:
       type: command
       run: |

--- a/cli/internal/profiles/self-hosting-xylem/workflows/sota-gap-analysis.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/sota-gap-analysis.yaml
@@ -4,13 +4,9 @@ phases:
   - name: ingest
     prompt_file: .xylem/prompts/sota-gap-analysis/ingest.md
     max_turns: 30
-    llm: copilot
-    model: gpt-5.4
   - name: survey
     prompt_file: .xylem/prompts/sota-gap-analysis/survey.md
     max_turns: 60
-    llm: copilot
-    model: gpt-5.4
   - name: diff
     type: command
     run: |
@@ -24,8 +20,6 @@ phases:
   - name: report
     prompt_file: .xylem/prompts/sota-gap-analysis/report.md
     max_turns: 40
-    llm: copilot
-    model: gpt-5.4
   - name: file_issues
     type: command
     run: |

--- a/cli/internal/profiles/self-hosting-xylem/workflows/unblock-wave.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/unblock-wave.yaml
@@ -4,7 +4,5 @@ phases:
   - name: check_deps
     prompt_file: .xylem/prompts/unblock-wave/check_deps.md
     max_turns: 20
-    llm: copilot
-    model: gpt-5-mini
     noop:
       match: XYLEM_NOOP

--- a/cli/internal/worktree/worktree.go
+++ b/cli/internal/worktree/worktree.go
@@ -345,6 +345,12 @@ func protectXylemSurfaces(worktreePath string, patterns []string) error {
 // It looks up the branch name from `git worktree list --porcelain` before removal
 // to correctly handle branch names containing path separators (e.g., "fix/issue-42").
 func (m *Manager) Remove(ctx context.Context, worktreePath string) error {
+	// Safety: never remove the daemon root worktree.
+	if strings.HasSuffix(filepath.ToSlash(worktreePath), ".daemon-root") ||
+		strings.Contains(filepath.ToSlash(worktreePath), ".daemon-root/") {
+		return fmt.Errorf("refusing to remove daemon root worktree: %s", worktreePath)
+	}
+
 	span := observability.StartGlobalSpan(ctx, "worktree:remove", observability.WorktreeSpanAttributes(observability.WorktreeSpanData{
 		Action: "remove",
 		Path:   worktreePath,


### PR DESCRIPTION
## Summary
- Switches global default LLM from copilot (out of credits, causing "Credit balance is too low" failures) to claude
- Removes all per-phase `llm: copilot` / `model: gpt-5.4` overrides from workflow YAMLs and embedded profiles so phases inherit the global default
- Adds safety guard in `worktree.Remove()` to refuse removal of `.daemon-root` paths, preventing the bug from loop 42 where `doctor --fix` destroyed the daemon's runtime state

## Test plan
- [x] Full test suite passes (37 packages)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)