### PR TITLE
fix(workflows): increase max_turns on pr/push phases from 10 to 25

### DIFF
--- a/.xylem/workflows/fix-bug.yaml
+++ b/.xylem/workflows/fix-bug.yaml
@@ -25,4 +25,4 @@ phases:
       retries: 1
   - name: pr
     prompt_file: .xylem/prompts/fix-bug/pr.md
-    max_turns: 10
+    max_turns: 25

--- a/.xylem/workflows/fix-pr-checks.yaml
+++ b/.xylem/workflows/fix-pr-checks.yaml
@@ -20,4 +20,4 @@ phases:
       retries: 3
   - name: push
     prompt_file: .xylem/prompts/fix-pr-checks/push.md
-    max_turns: 10
+    max_turns: 25

--- a/.xylem/workflows/implement-feature.yaml
+++ b/.xylem/workflows/implement-feature.yaml
@@ -25,4 +25,4 @@ phases:
       retries: 1
   - name: pr
     prompt_file: .xylem/prompts/implement-feature/pr.md
-    max_turns: 10
+    max_turns: 25

--- a/.xylem/workflows/resolve-conflicts.yaml
+++ b/.xylem/workflows/resolve-conflicts.yaml
@@ -51,4 +51,4 @@ phases:
       retries: 2
   - name: push
     prompt_file: .xylem/prompts/resolve-conflicts/push.md
-    max_turns: 10
+    max_turns: 25

--- a/.xylem/workflows/respond-to-pr-review.yaml
+++ b/.xylem/workflows/respond-to-pr-review.yaml
@@ -15,4 +15,4 @@ phases:
       retries: 2
   - name: push
     prompt_file: .xylem/prompts/respond-to-pr-review/push.md
-    max_turns: 10
+    max_turns: 25

--- a/cli/internal/profiles/core/workflows/fix-bug.yaml
+++ b/cli/internal/profiles/core/workflows/fix-bug.yaml
@@ -25,4 +25,4 @@ phases:
       retries: 1
   - name: pr
     prompt_file: .xylem/prompts/fix-bug/pr.md
-    max_turns: 10
+    max_turns: 25

--- a/cli/internal/profiles/core/workflows/fix-pr-checks.yaml
+++ b/cli/internal/profiles/core/workflows/fix-pr-checks.yaml
@@ -15,4 +15,4 @@ phases:
       retries: 3
   - name: push
     prompt_file: .xylem/prompts/fix-pr-checks/push.md
-    max_turns: 10
+    max_turns: 25

--- a/cli/internal/profiles/core/workflows/implement-feature.yaml
+++ b/cli/internal/profiles/core/workflows/implement-feature.yaml
@@ -25,4 +25,4 @@ phases:
       retries: 1
   - name: pr
     prompt_file: .xylem/prompts/implement-feature/pr.md
-    max_turns: 10
+    max_turns: 25

--- a/cli/internal/profiles/core/workflows/resolve-conflicts.yaml
+++ b/cli/internal/profiles/core/workflows/resolve-conflicts.yaml
@@ -15,4 +15,4 @@ phases:
       retries: 2
   - name: push
     prompt_file: .xylem/prompts/resolve-conflicts/push.md
-    max_turns: 10
+    max_turns: 25

--- a/cli/internal/profiles/core/workflows/respond-to-pr-review.yaml
+++ b/cli/internal/profiles/core/workflows/respond-to-pr-review.yaml
@@ -15,4 +15,4 @@ phases:
       retries: 2
   - name: push
     prompt_file: .xylem/prompts/respond-to-pr-review/push.md
-    max_turns: 10
+    max_turns: 25


### PR DESCRIPTION
## Summary
- Increases `max_turns` from 10 to 25 on all pr/push phases across fix-bug, implement-feature, fix-pr-checks, resolve-conflicts, and respond-to-pr-review workflows
- Vessels were completing all work (analyze→plan→implement→verify) but then failing at the final step with "Reached max turns (10)", wasting all preceding effort
- Observed on issues #275 and #273 in loop 45 — both hit the limit at PR creation

## Test plan
- [x] All 37 packages pass
- [x] All pre-commit hooks pass
- [x] Only YAML changes (no Go code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)