### PR TITLE
fix(daemon): detect phantom in_flight and force upgrade after 30 minutes

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -374,21 +374,36 @@ func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, sc
 			lastUpgrade = now
 			upgrade()
 		} else if upgradeOverdue && drainIdle && inFlight > 0 {
-			// Overdue: log that we're pausing new dequeue to let in-flight
-			// vessels drain naturally, creating an idle window for the
-			// normal upgrade path on a subsequent tick. This does NOT kill
-			// running vessels — we wait for them to complete on their own.
-			slog.Warn("daemon auto-upgrade overdue; pausing new drain dequeue until idle",
-				"elapsed", upgradeElapsed,
-				"in_flight", inFlight)
+			// Check for phantom in_flight: the runner's atomic counter can
+			// get stuck when a goroutine is blocked on a killed subprocess
+			// whose grandchildren hold stdout/stderr open. Detect by
+			// comparing in_flight against actual queue state, but only
+			// after a longer grace period (2x overdue = 6x upgrade
+			// interval) to avoid racing with legitimate drain completions.
+			// Phantom threshold: 30 minutes of overdue with 0 queue running.
+			// This is deliberately long to avoid false positives during
+			// legitimate drain wind-down (the S39 test scenario).
+			phantomThreshold := 30 * time.Minute
+			if upgradeElapsed >= phantomThreshold && daemonQueueCounts(q).running == 0 {
+				slog.Warn("daemon auto-upgrade forcing past phantom in_flight",
+					"elapsed", upgradeElapsed,
+					"in_flight", inFlight,
+					"queue_running", 0)
+				lastUpgrade = now
+				upgrade()
+			} else {
+				slog.Warn("daemon auto-upgrade overdue; pausing new drain dequeue until idle",
+					"elapsed", upgradeElapsed,
+					"in_flight", inFlight)
+			}
 		}
 
 		// Drain dequeue is suppressed while an upgrade is overdue and
-		// in-flight vessels still exist. This creates the idle window the
-		// normal upgrade path needs, without exec()ing while subprocesses
-		// are alive. When in_flight reaches zero, the next tick fires the
-		// normal upgrade path above and dequeue resumes.
-		drainPaused := upgradeOverdue && inFlight > 0
+		// real in-flight vessels still exist. Once the phantom threshold
+		// fires (6x upgrade interval with 0 queue running), the forced
+		// upgrade above handles recovery via exec().
+		phantomInFlight := upgradeElapsed >= 30*time.Minute && inFlight > 0 && daemonQueueCounts(q).running == 0
+		drainPaused := upgradeOverdue && inFlight > 0 && !phantomInFlight
 		if !drainPaused && now.Sub(lastDrain) >= drainInterval {
 			if atomic.CompareAndSwapInt32(&draining, 0, 1) {
 				lastDrain = now


### PR DESCRIPTION
## Summary
- Detects stuck in_flight counter (goroutine blocked on killed subprocess with grandchildren holding stdout) by comparing atomic counter against queue state
- After 30 minutes of overdue upgrade with in_flight > 0 and 0 queue running, forces upgrade via exec()
- Also resumes drain when phantom is detected so pending vessels aren't blocked
- This was the #1 autonomy blocker — the daemon got stuck every session requiring manual restart

## Root cause
When the stall monitor kills a vessel subprocess (SIGTERM), the subprocess's grandchildren (e.g., LLM session child processes) can hold stdout/stderr open. The runner's `RunPhase` blocks on `cmd.Wait()` which waits for stdout/stderr to close. The goroutine never returns, the `defer r.inFlight.Add(-1)` never fires, and the daemon permanently pauses drain to wait for an idle window that never comes.

## Test plan
- [x] All daemon loop tests pass (S39, overdue, normal upgrade)
- [x] Full test suite passes (37 packages)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)