### PR TITLE
fix(workflows): increase implement-harness pr_draft max_turns from 15 to 30

### DIFF
--- a/.xylem/workflows/implement-harness.yaml
+++ b/.xylem/workflows/implement-harness.yaml
@@ -39,7 +39,7 @@ phases:
       retries: 2
   - name: pr_draft
     prompt_file: .xylem/prompts/implement-harness/pr_draft.md
-    max_turns: 15
+    max_turns: 30
     gate:
       type: command
       run: |

--- a/cli/internal/profiles/self-hosting-xylem/workflows/implement-harness.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/implement-harness.yaml
@@ -39,7 +39,7 @@ phases:
       retries: 2
   - name: pr_draft
     prompt_file: .xylem/prompts/implement-harness/pr_draft.md
-    max_turns: 15
+    max_turns: 30
     gate:
       type: command
       run: |


### PR DESCRIPTION
## Summary
- Bumps `pr_draft` phase in implement-harness workflow from 15 to 30 max_turns
- Issues #269 and #272 both completed all 6 preceding phases (analyze→plan→implement→verify→test_critic→smoke, all gates passed) but failed at the final PR creation step with "Reached max turns (15)"
- This is the same class of fix as PR #303 (which bumped fix-bug/implement-feature pr phases to 25)

## Impact
Each pr_draft failure wastes ~$0.18 of successfully completed work across 6 phases. Two vessels hit this in the current daemon session.

## Test plan
- [x] YAML-only change, no Go code

🤖 Generated with [Claude Code](https://claude.com/claude-code)