### PR TITLE
revert(config): restore copilot as default LLM provider

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -197,8 +197,8 @@ timeout: "45m"
 state_dir: ".xylem"
 
 # llm selects the global default LLM provider: "claude" (default) or "copilot"
-llm: claude
-model: claude-sonnet-4-6
+llm: copilot
+model: gpt-5.4
 
 claude:
   command: "claude"


### PR DESCRIPTION
## Summary
Restores `llm: copilot` / `model: gpt-5.4` as the default. The switch to claude in PR #301 was based on a misdiagnosis — the errors were from an incorrect copilot token, not exhausted credits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)