### PR TITLE
refactor(init): extract profile asset sync helper for daemon upgrade reuse

### DIFF
--- a/cli/cmd/xylem/init.go
+++ b/cli/cmd/xylem/init.go
@@ -138,18 +138,8 @@ func cmdInitWithProfileAndOptions(configPath string, force bool, profileValue st
 		return err
 	}
 
-	workflowNames := sortedKeys(composed.Workflows)
-	for _, name := range workflowNames {
-		if err := writeFileIfNeeded(filepath.Join(defaultStateDir, "workflows", name+".yaml"), composed.Workflows[name], force); err != nil {
-			return err
-		}
-	}
-
-	promptNames := sortedKeys(composed.Prompts)
-	for _, name := range promptNames {
-		if err := writeFileIfNeeded(filepath.Join(defaultStateDir, "prompts", filepath.FromSlash(name)+".md"), composed.Prompts[name], force); err != nil {
-			return err
-		}
+	if err := syncProfileAssets(defaultStateDir, composed, force); err != nil {
+		return err
 	}
 
 	if seed {
@@ -215,6 +205,26 @@ func writeFileIfNeeded(path string, content []byte, force bool) error {
 		return fmt.Errorf("write %s: %w", path, err)
 	}
 	fmt.Printf("Created %s\n", path)
+	return nil
+}
+
+func syncProfileAssets(stateDir string, composed *profiles.ComposedProfile, force bool) error {
+	if composed == nil {
+		return fmt.Errorf("sync profile assets: composed profile is required")
+	}
+
+	for _, name := range sortedKeys(composed.Workflows) {
+		if err := writeFileIfNeeded(filepath.Join(stateDir, "workflows", name+".yaml"), composed.Workflows[name], force); err != nil {
+			return fmt.Errorf("sync workflow %q: %w", name, err)
+		}
+	}
+
+	for _, name := range sortedKeys(composed.Prompts) {
+		if err := writeFileIfNeeded(filepath.Join(stateDir, "prompts", filepath.FromSlash(name)+".md"), composed.Prompts[name], force); err != nil {
+			return fmt.Errorf("sync prompt %q: %w", name, err)
+		}
+	}
+
 	return nil
 }
 

--- a/cli/cmd/xylem/init_prop_test.go
+++ b/cli/cmd/xylem/init_prop_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/nicholls-inc/xylem/cli/internal/profiles"
 	"pgregory.net/rapid"
 )
 
@@ -67,4 +70,168 @@ func expectedProfiles(raw string) ([]string, bool) {
 	default:
 		return nil, true
 	}
+}
+
+func TestPropSyncProfileAssetsPreservesExistingFilesWhenForceFalse(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		stateDir, err := os.MkdirTemp("", "xylem-sync-assets-*")
+		if err != nil {
+			rt.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(stateDir)
+
+		composed := &profiles.ComposedProfile{
+			Workflows: rapidWorkflowMap(rt, "workflow"),
+			Prompts:   rapidPromptMap(rt, "prompt"),
+		}
+
+		existingWorkflows := make(map[string][]byte)
+		for _, name := range sortedKeys(composed.Workflows) {
+			if !rapid.Bool().Draw(rt, "existing-workflow-"+name) {
+				continue
+			}
+			content := []byte(rapid.StringMatching(`[a-z0-9 -]{0,24}`).Draw(rt, "existing-workflow-content-"+name))
+			path := filepath.Join(stateDir, "workflows", name+".yaml")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				rt.Fatalf("MkdirAll(%q) error = %v", path, err)
+			}
+			if err := os.WriteFile(path, content, 0o644); err != nil {
+				rt.Fatalf("WriteFile(%q) error = %v", path, err)
+			}
+			existingWorkflows[name] = content
+		}
+
+		existingPrompts := make(map[string][]byte)
+		for _, name := range sortedKeys(composed.Prompts) {
+			if !rapid.Bool().Draw(rt, "existing-prompt-"+name) {
+				continue
+			}
+			content := []byte(rapid.StringMatching(`[a-z0-9 -]{0,24}`).Draw(rt, "existing-prompt-content-"+name))
+			path := filepath.Join(stateDir, "prompts", filepath.FromSlash(name)+".md")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				rt.Fatalf("MkdirAll(%q) error = %v", path, err)
+			}
+			if err := os.WriteFile(path, content, 0o644); err != nil {
+				rt.Fatalf("WriteFile(%q) error = %v", path, err)
+			}
+			existingPrompts[name] = content
+		}
+
+		if err := syncProfileAssets(stateDir, composed, false); err != nil {
+			rt.Fatalf("syncProfileAssets() error = %v", err)
+		}
+
+		for name, want := range composed.Workflows {
+			got, err := os.ReadFile(filepath.Join(stateDir, "workflows", name+".yaml"))
+			if err != nil {
+				rt.Fatalf("ReadFile(workflow %q) error = %v", name, err)
+			}
+			if existing, ok := existingWorkflows[name]; ok {
+				if string(got) != string(existing) {
+					rt.Fatalf("workflow %q = %q, want preserved %q", name, string(got), string(existing))
+				}
+				continue
+			}
+			if string(got) != string(want) {
+				rt.Fatalf("workflow %q = %q, want %q", name, string(got), string(want))
+			}
+		}
+
+		for name, want := range composed.Prompts {
+			got, err := os.ReadFile(filepath.Join(stateDir, "prompts", filepath.FromSlash(name)+".md"))
+			if err != nil {
+				rt.Fatalf("ReadFile(prompt %q) error = %v", name, err)
+			}
+			if existing, ok := existingPrompts[name]; ok {
+				if string(got) != string(existing) {
+					rt.Fatalf("prompt %q = %q, want preserved %q", name, string(got), string(existing))
+				}
+				continue
+			}
+			if string(got) != string(want) {
+				rt.Fatalf("prompt %q = %q, want %q", name, string(got), string(want))
+			}
+		}
+	})
+}
+
+func TestPropSyncProfileAssetsMaterializesComposedAssetsWhenForceTrue(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		stateDir, err := os.MkdirTemp("", "xylem-sync-assets-*")
+		if err != nil {
+			rt.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(stateDir)
+
+		composed := &profiles.ComposedProfile{
+			Workflows: rapidWorkflowMap(rt, "workflow"),
+			Prompts:   rapidPromptMap(rt, "prompt"),
+		}
+
+		for _, name := range sortedKeys(composed.Workflows) {
+			path := filepath.Join(stateDir, "workflows", name+".yaml")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				rt.Fatalf("MkdirAll(%q) error = %v", path, err)
+			}
+			oldContent := []byte(rapid.StringMatching(`[a-z0-9 -]{0,24}`).Draw(rt, "old-workflow-content-"+name))
+			if err := os.WriteFile(path, oldContent, 0o644); err != nil {
+				rt.Fatalf("WriteFile(%q) error = %v", path, err)
+			}
+		}
+
+		for _, name := range sortedKeys(composed.Prompts) {
+			path := filepath.Join(stateDir, "prompts", filepath.FromSlash(name)+".md")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				rt.Fatalf("MkdirAll(%q) error = %v", path, err)
+			}
+			oldContent := []byte(rapid.StringMatching(`[a-z0-9 -]{0,24}`).Draw(rt, "old-prompt-content-"+name))
+			if err := os.WriteFile(path, oldContent, 0o644); err != nil {
+				rt.Fatalf("WriteFile(%q) error = %v", path, err)
+			}
+		}
+
+		if err := syncProfileAssets(stateDir, composed, true); err != nil {
+			rt.Fatalf("syncProfileAssets() error = %v", err)
+		}
+
+		for name, want := range composed.Workflows {
+			got, err := os.ReadFile(filepath.Join(stateDir, "workflows", name+".yaml"))
+			if err != nil {
+				rt.Fatalf("ReadFile(workflow %q) error = %v", name, err)
+			}
+			if string(got) != string(want) {
+				rt.Fatalf("workflow %q = %q, want %q", name, string(got), string(want))
+			}
+		}
+
+		for name, want := range composed.Prompts {
+			got, err := os.ReadFile(filepath.Join(stateDir, "prompts", filepath.FromSlash(name)+".md"))
+			if err != nil {
+				rt.Fatalf("ReadFile(prompt %q) error = %v", name, err)
+			}
+			if string(got) != string(want) {
+				rt.Fatalf("prompt %q = %q, want %q", name, string(got), string(want))
+			}
+		}
+	})
+}
+
+func rapidWorkflowMap(rt *rapid.T, label string) map[string][]byte {
+	count := rapid.IntRange(0, 4).Draw(rt, label+"-count")
+	assets := make(map[string][]byte, count)
+	for len(assets) < count {
+		name := rapid.StringMatching(`[a-z0-9-]{1,8}`).Draw(rt, label+"-name")
+		assets[name] = []byte(rapid.StringMatching(`[a-z0-9 -]{0,24}`).Draw(rt, label+"-content-"+name))
+	}
+	return assets
+}
+
+func rapidPromptMap(rt *rapid.T, label string) map[string][]byte {
+	count := rapid.IntRange(0, 4).Draw(rt, label+"-count")
+	assets := make(map[string][]byte, count)
+	for len(assets) < count {
+		name := rapid.StringMatching(`[a-z0-9-]{1,8}/[a-z0-9-]{1,8}`).Draw(rt, label+"-name")
+		assets[name] = []byte(rapid.StringMatching(`[a-z0-9 -]{0,24}`).Draw(rt, label+"-content-"+name))
+	}
+	return assets
 }

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/profiles"
 	toml "github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -272,6 +273,115 @@ func TestResolveProfiles(t *testing.T) {
 	profiles, err := resolveProfiles("core,self-hosting-xylem")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"core", "self-hosting-xylem"}, profiles)
+}
+
+func TestSyncProfileAssetsWritesMissingWorkflowAndPromptFiles(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+	composed := &profiles.ComposedProfile{
+		Workflows: map[string][]byte{
+			"merge-pr": []byte("run: gh pr merge\n"),
+		},
+		Prompts: map[string][]byte{
+			"merge-pr/check": []byte("review the merge preconditions\n"),
+		},
+	}
+
+	require.NoError(t, syncProfileAssets(stateDir, composed, false))
+
+	workflowData, err := os.ReadFile(filepath.Join(stateDir, "workflows", "merge-pr.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, composed.Workflows["merge-pr"], workflowData)
+
+	promptData, err := os.ReadFile(filepath.Join(stateDir, "prompts", "merge-pr", "check.md"))
+	require.NoError(t, err)
+	assert.Equal(t, composed.Prompts["merge-pr/check"], promptData)
+}
+
+func TestSyncProfileAssetsSkipsExistingFilesWithoutForce(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+	workflowPath := filepath.Join(stateDir, "workflows", "merge-pr.yaml")
+	promptPath := filepath.Join(stateDir, "prompts", "merge-pr", "check.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(workflowPath), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
+	require.NoError(t, os.WriteFile(workflowPath, []byte("existing workflow\n"), 0o644))
+	require.NoError(t, os.WriteFile(promptPath, []byte("existing prompt\n"), 0o644))
+
+	composed := &profiles.ComposedProfile{
+		Workflows: map[string][]byte{
+			"merge-pr": []byte("new workflow\n"),
+			"triage":   []byte("triage workflow\n"),
+		},
+		Prompts: map[string][]byte{
+			"merge-pr/check":     []byte("new prompt\n"),
+			"merge-pr/summarize": []byte("summarize prompt\n"),
+		},
+	}
+
+	require.NoError(t, syncProfileAssets(stateDir, composed, false))
+
+	workflowData, err := os.ReadFile(workflowPath)
+	require.NoError(t, err)
+	assert.Equal(t, "existing workflow\n", string(workflowData))
+
+	promptData, err := os.ReadFile(promptPath)
+	require.NoError(t, err)
+	assert.Equal(t, "existing prompt\n", string(promptData))
+
+	missingWorkflowData, err := os.ReadFile(filepath.Join(stateDir, "workflows", "triage.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, composed.Workflows["triage"], missingWorkflowData)
+
+	missingPromptData, err := os.ReadFile(filepath.Join(stateDir, "prompts", "merge-pr", "summarize.md"))
+	require.NoError(t, err)
+	assert.Equal(t, composed.Prompts["merge-pr/summarize"], missingPromptData)
+}
+
+func TestSyncProfileAssetsForceOverwritesExistingFiles(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+	workflowPath := filepath.Join(stateDir, "workflows", "merge-pr.yaml")
+	promptPath := filepath.Join(stateDir, "prompts", "merge-pr", "check.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(workflowPath), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
+	require.NoError(t, os.WriteFile(workflowPath, []byte("existing workflow\n"), 0o644))
+	require.NoError(t, os.WriteFile(promptPath, []byte("existing prompt\n"), 0o644))
+
+	composed := &profiles.ComposedProfile{
+		Workflows: map[string][]byte{
+			"merge-pr": []byte("new workflow\n"),
+		},
+		Prompts: map[string][]byte{
+			"merge-pr/check": []byte("new prompt\n"),
+		},
+	}
+
+	require.NoError(t, syncProfileAssets(stateDir, composed, true))
+
+	workflowData, err := os.ReadFile(workflowPath)
+	require.NoError(t, err)
+	assert.Equal(t, composed.Workflows["merge-pr"], workflowData)
+
+	promptData, err := os.ReadFile(promptPath)
+	require.NoError(t, err)
+	assert.Equal(t, composed.Prompts["merge-pr/check"], promptData)
+}
+
+func TestSyncProfileAssetsRejectsNilProfile(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+
+	err := syncProfileAssets(stateDir, nil, false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "composed profile is required")
+	assert.NoDirExists(t, filepath.Join(stateDir, "workflows"))
+	assert.NoDirExists(t, filepath.Join(stateDir, "prompts"))
+}
+
+func TestSyncProfileAssetsAllowsEmptyAssets(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+
+	require.NoError(t, syncProfileAssets(stateDir, &profiles.ComposedProfile{}, false))
+	assert.NoDirExists(t, filepath.Join(stateDir, "workflows"))
+	assert.NoDirExists(t, filepath.Join(stateDir, "prompts"))
 }
 
 func TestInitCreatesV2Files(t *testing.T) {


### PR DESCRIPTION
## Summary
- Refactors init asset syncing to extract reusable profile asset synchronization logic for daemon upgrade follow-on work.
- Keeps `xylem init` behavior intact while preparing the control-plane asset sync path for reuse in later upgrade wiring.
- Issue: https://github.com/nicholls-inc/xylem/issues/308

## Smoke scenarios covered
- `S4` — `CoreInitScaffoldsTrackedControlPlane`
- `S5` — `CorePlusSelfHostingOverlayScaffoldsOverlayWorkflows`
- `S37` — `DaemonAutoUpgradeSyncsDaemonWorktreeControlPlaneFiles`

## Changes summary
- Modified `cli/cmd/xylem/init.go` to replace inline workflow/prompt sync loops with `syncProfileAssets(stateDir string, composed *profiles.ComposedProfile, force bool) error`, including asset-specific error wrapping for workflows and prompts.
- Modified `cli/cmd/xylem/init_test.go` to add focused coverage for writing missing assets, preserving existing assets without force, overwriting with force, rejecting a nil composed profile, and allowing empty asset sets.
- Modified `cli/cmd/xylem/init_prop_test.go` to add property-based coverage for force and non-force sync behavior plus reusable `rapidWorkflowMap` / `rapidPromptMap` generators.

## Test plan
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #308