### PR TITLE
fix: add --root support to xylem doctor for alternate state directories

### DIFF
--- a/cli/cmd/xylem/doctor.go
+++ b/cli/cmd/xylem/doctor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -31,16 +32,46 @@ Checks performed:
   - Fleet health summary (failure rate, timeout rate)
 
 Use --fix to automatically remediate safe issues (e.g., reap zombie vessels).
-Use --json for machine-readable output.`,
+Use --json for machine-readable output.
+Use --root to inspect another checkout or daemon root.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fix, _ := cmd.Flags().GetBool("fix")
 			jsonMode, _ := cmd.Flags().GetBool("json")
-			return cmdDoctor(deps.cfg, deps.q, deps.wt, fix, jsonMode)
+			root, _ := cmd.Flags().GetString("root")
+			scopedDeps, err := doctorDepsForRoot(deps, root)
+			if err != nil {
+				return err
+			}
+			return cmdDoctor(scopedDeps.cfg, scopedDeps.q, scopedDeps.wt, fix, jsonMode)
 		},
 	}
 	cmd.Flags().Bool("fix", false, "Automatically remediate safe issues")
 	cmd.Flags().Bool("json", false, "Output as JSON")
+	cmd.Flags().String("root", "", "Run checks against the xylem state rooted at this directory")
 	return cmd
+}
+
+func doctorDepsForRoot(base *appDeps, root string) (*appDeps, error) {
+	if base == nil || base.cfg == nil {
+		return nil, fmt.Errorf("doctor dependencies not initialized")
+	}
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return base, nil
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve doctor root %q: %w", root, err)
+	}
+	cfg := *base.cfg
+	cfg.StateDir = config.ResolveStateDir(absRoot, cfg.StateDir)
+	wt := worktree.New(absRoot, &realCmdRunner{})
+	wt.DefaultBranch = cfg.DefaultBranch
+	return &appDeps{
+		cfg: &cfg,
+		q:   queue.New(filepath.Join(cfg.StateDir, "queue.jsonl")),
+		wt:  wt,
+	}, nil
 }
 
 // doctorCheck represents a single diagnostic finding.

--- a/cli/cmd/xylem/doctor_test.go
+++ b/cli/cmd/xylem/doctor_test.go
@@ -1,16 +1,60 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/daemonhealth"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/worktree"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type doctorStubRunner struct {
+	outputs map[string][]byte
+}
+
+func (r *doctorStubRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	key := strings.Join(append([]string{name}, args...), " ")
+	if out, ok := r.outputs[key]; ok {
+		return out, nil
+	}
+	return []byte{}, nil
+}
+
+func captureDoctorStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	defer r.Close()
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return string(data)
+}
 
 func TestDoctorDetectsZombieVessels(t *testing.T) {
 	dir := t.TempDir()
@@ -160,21 +204,249 @@ func TestDoctorQueueHealth(t *testing.T) {
 	}
 }
 
-func TestDoctorJSONOutput(t *testing.T) {
+func TestDoctorReportTracksSummaryAndFixedChecks(t *testing.T) {
 	report := &doctorReport{}
 	report.add("test_check", "ok", "All good")
 	report.add("test_warn", "warn", "Minor issue")
+	report.addFixed("test_fix", "Fixed issue")
 
-	data, err := json.Marshal(report)
+	if got, want := len(report.Checks), 3; got != want {
+		t.Fatalf("len(report.Checks) = %d, want %d", got, want)
+	}
+	if got, want := report.Summary.OK, 2; got != want {
+		t.Fatalf("report.Summary.OK = %d, want %d", got, want)
+	}
+	if got, want := report.Summary.Warn, 1; got != want {
+		t.Fatalf("report.Summary.Warn = %d, want %d", got, want)
+	}
+	if got, want := report.Summary.Fail, 0; got != want {
+		t.Fatalf("report.Summary.Fail = %d, want %d", got, want)
+	}
+	if got := report.Checks[2]; !got.Fixed || got.Status != "ok" || got.Name != "test_fix" {
+		t.Fatalf("fixed check = %#v, want fixed ok check named test_fix", got)
+	}
+}
+
+func TestDoctorDepsForRootRebasesStateDir(t *testing.T) {
+	root := t.TempDir()
+	base := &appDeps{
+		cfg: &config.Config{
+			StateDir:      ".xylem",
+			DefaultBranch: "main",
+		},
+	}
+
+	scoped, err := doctorDepsForRoot(base, root)
 	if err != nil {
+		t.Fatalf("doctorDepsForRoot() error = %v", err)
+	}
+
+	if scoped == base {
+		t.Fatal("doctorDepsForRoot() returned the original dependencies")
+	}
+	if got, want := scoped.cfg.StateDir, filepath.Join(root, ".xylem"); got != want {
+		t.Fatalf("scoped cfg.StateDir = %q, want %q", got, want)
+	}
+	if got, want := scoped.wt.RepoRoot, root; got != want {
+		t.Fatalf("scoped wt.RepoRoot = %q, want %q", got, want)
+	}
+	if got, want := scoped.wt.DefaultBranch, "main"; got != want {
+		t.Fatalf("scoped wt.DefaultBranch = %q, want %q", got, want)
+	}
+	if got := base.cfg.StateDir; got != ".xylem" {
+		t.Fatalf("base cfg.StateDir mutated to %q", got)
+	}
+}
+
+func TestDoctorJSONOutputUsesRootStateDir(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".xylem")
+	snapshot := daemonhealth.Snapshot{
+		PID:       99999,
+		StartedAt: time.Now().Add(-24 * time.Hour),
+		UpdatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	if err := daemonhealth.Save(stateDir, snapshot); err != nil {
 		t.Fatal(err)
 	}
+
+	scoped, err := doctorDepsForRoot(&appDeps{
+		cfg: &config.Config{
+			StateDir:    ".xylem",
+			Timeout:     "45m",
+			Concurrency: 1,
+			Daemon: config.DaemonConfig{
+				StallMonitor: config.StallMonitorConfig{
+					PhaseStallThreshold: "10m",
+				},
+				AutoUpgrade: true,
+			},
+		},
+	}, root)
+	if err != nil {
+		t.Fatalf("doctorDepsForRoot() error = %v", err)
+	}
+
+	wt := worktree.New(root, &doctorStubRunner{
+		outputs: map[string][]byte{
+			"git worktree list --porcelain": []byte{},
+		},
+	})
+	output := captureDoctorStdout(t, func() {
+		if err := cmdDoctor(scoped.cfg, scoped.q, wt, false, true); err != nil {
+			t.Fatalf("cmdDoctor() error = %v", err)
+		}
+	})
 
 	var decoded doctorReport
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		t.Fatal(err)
+	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
-	if len(decoded.Checks) != 2 {
-		t.Errorf("expected 2 checks, got %d", len(decoded.Checks))
+
+	found := false
+	for _, check := range decoded.Checks {
+		if check.Name == "daemon" && check.Status == "fail" {
+			found = true
+			break
+		}
 	}
+	if !found {
+		t.Fatalf("expected rooted JSON output to include daemon failure, got %#v", decoded.Checks)
+	}
+}
+
+func TestSmoke_S1_DoctorRootReadsScopedStateDir(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".xylem")
+	snapshot := daemonhealth.Snapshot{
+		PID:       99999,
+		StartedAt: time.Now().Add(-24 * time.Hour),
+		UpdatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	require.NoError(t, daemonhealth.Save(stateDir, snapshot))
+
+	scoped, err := doctorDepsForRoot(&appDeps{
+		cfg: &config.Config{
+			StateDir:    ".xylem",
+			Timeout:     "45m",
+			Concurrency: 1,
+			Daemon: config.DaemonConfig{
+				StallMonitor: config.StallMonitorConfig{
+					PhaseStallThreshold: "10m",
+				},
+				AutoUpgrade: true,
+			},
+		},
+	}, root)
+	require.NoError(t, err)
+
+	wt := worktree.New(root, &doctorStubRunner{
+		outputs: map[string][]byte{
+			"git worktree list --porcelain": {},
+		},
+	})
+	out := captureDoctorStdout(t, func() {
+		require.NoError(t, cmdDoctor(scoped.cfg, scoped.q, wt, false, false))
+	})
+
+	assert.Contains(t, out, "Daemon not running")
+	assert.Contains(t, out, "pid=99999")
+	assert.Contains(t, out, "Run with --fix to attempt automatic remediation")
+}
+
+func TestSmoke_S2_DoctorDefaultBehaviorWithoutRootUnchanged(t *testing.T) {
+	defaultRoot := t.TempDir()
+	otherRoot := t.TempDir()
+	defaultStateDir := filepath.Join(defaultRoot, ".xylem")
+
+	require.NoError(t, daemonhealth.Save(defaultStateDir, daemonhealth.Snapshot{
+		PID:       11111,
+		StartedAt: time.Now().Add(-24 * time.Hour),
+		UpdatedAt: time.Now().Add(-1 * time.Hour),
+	}))
+	require.NoError(t, daemonhealth.Save(filepath.Join(otherRoot, ".xylem"), daemonhealth.Snapshot{
+		PID:       22222,
+		StartedAt: time.Now().Add(-24 * time.Hour),
+		UpdatedAt: time.Now().Add(-1 * time.Hour),
+	}))
+
+	base := &appDeps{
+		cfg: &config.Config{
+			StateDir:    defaultStateDir,
+			Timeout:     "45m",
+			Concurrency: 1,
+			Daemon: config.DaemonConfig{
+				StallMonitor: config.StallMonitorConfig{
+					PhaseStallThreshold: "10m",
+				},
+				AutoUpgrade: true,
+			},
+		},
+		q: queue.New(filepath.Join(defaultStateDir, "queue.jsonl")),
+		wt: worktree.New(defaultRoot, &doctorStubRunner{
+			outputs: map[string][]byte{
+				"git worktree list --porcelain": {},
+			},
+		}),
+	}
+
+	scoped, err := doctorDepsForRoot(base, "")
+	require.NoError(t, err)
+	require.Same(t, base, scoped)
+
+	out := captureDoctorStdout(t, func() {
+		require.NoError(t, cmdDoctor(scoped.cfg, scoped.q, scoped.wt, false, false))
+	})
+
+	assert.Contains(t, out, "pid=11111")
+	assert.NotContains(t, out, "pid=22222")
+}
+
+func TestSmoke_S3_DoctorJSONModeHonorsRootFlag(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".xylem")
+	snapshot := daemonhealth.Snapshot{
+		PID:       33333,
+		StartedAt: time.Now().Add(-24 * time.Hour),
+		UpdatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	require.NoError(t, daemonhealth.Save(stateDir, snapshot))
+
+	scoped, err := doctorDepsForRoot(&appDeps{
+		cfg: &config.Config{
+			StateDir:    ".xylem",
+			Timeout:     "45m",
+			Concurrency: 1,
+			Daemon: config.DaemonConfig{
+				StallMonitor: config.StallMonitorConfig{
+					PhaseStallThreshold: "10m",
+				},
+				AutoUpgrade: true,
+			},
+		},
+	}, root)
+	require.NoError(t, err)
+
+	wt := worktree.New(root, &doctorStubRunner{
+		outputs: map[string][]byte{
+			"git worktree list --porcelain": {},
+		},
+	})
+	out := captureDoctorStdout(t, func() {
+		require.NoError(t, cmdDoctor(scoped.cfg, scoped.q, wt, false, true))
+	})
+
+	var decoded doctorReport
+	require.NoError(t, json.Unmarshal([]byte(out), &decoded), "output:\n%s", out)
+
+	var daemonCheck *doctorCheck
+	for i := range decoded.Checks {
+		if decoded.Checks[i].Name == "daemon" {
+			daemonCheck = &decoded.Checks[i]
+			break
+		}
+	}
+	require.NotNil(t, daemonCheck, "expected daemon check in %v", decoded.Checks)
+	assert.Equal(t, "fail", daemonCheck.Status)
+	assert.Contains(t, daemonCheck.Message, "pid=33333")
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -331,6 +331,16 @@ func Load(path string) (*Config, error) {
 	return cfg, nil
 }
 
+// ResolveStateDir rebases a relative state_dir under root.
+func ResolveStateDir(root, stateDir string) string {
+	root = strings.TrimSpace(root)
+	stateDir = strings.TrimSpace(stateDir)
+	if root == "" || stateDir == "" || filepath.IsAbs(stateDir) {
+		return stateDir
+	}
+	return filepath.Join(root, stateDir)
+}
+
 // normalize migrates legacy top-level Repo/Tasks/Exclude into the Sources map.
 func (c *Config) normalize() {
 	if c.Repo != "" && len(c.Sources) == 0 && len(c.Tasks) > 0 {

--- a/cli/internal/config/config_prop_test.go
+++ b/cli/internal/config/config_prop_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -66,6 +67,25 @@ func TestPropObservabilitySampleRateDefaultForOutOfRange(t *testing.T) {
 
 		if got := cfg.ObservabilitySampleRate(); got != 1.0 {
 			t.Fatalf("ObservabilitySampleRate() = %v, want 1.0", got)
+		}
+	})
+}
+
+func TestPropResolveStateDirRebasesRelativePaths(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		root := filepath.Join(
+			rapid.StringMatching(`[A-Za-z0-9._-]{1,8}`).Draw(t, "root-a"),
+			rapid.StringMatching(`[A-Za-z0-9._-]{1,8}`).Draw(t, "root-b"),
+		)
+		stateDir := filepath.Join(
+			rapid.StringMatching(`[A-Za-z0-9._-]{1,8}`).Draw(t, "state-a"),
+			rapid.StringMatching(`[A-Za-z0-9._-]{1,8}`).Draw(t, "state-b"),
+		)
+
+		got := ResolveStateDir(root, stateDir)
+		want := filepath.Join(root, stateDir)
+		if got != want {
+			t.Fatalf("ResolveStateDir(%q, %q) = %q, want %q", root, stateDir, got, want)
 		}
 	})
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -243,6 +243,44 @@ claude:
 	requireErrorContains(t, err, "concurrency.global is required when concurrency is a map")
 }
 
+func TestResolveStateDir(t *testing.T) {
+	t.Run("rebases relative state dir under root", func(t *testing.T) {
+		root := filepath.Join("var", "tmp", "daemon-root")
+		got := ResolveStateDir(root, ".xylem")
+		want := filepath.Join(root, ".xylem")
+		if got != want {
+			t.Fatalf("ResolveStateDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("preserves absolute state dir", func(t *testing.T) {
+		abs := filepath.Join(string(filepath.Separator), "tmp", "xylem-state")
+		if got := ResolveStateDir("daemon-root", abs); got != abs {
+			t.Fatalf("ResolveStateDir() = %q, want %q", got, abs)
+		}
+	})
+
+	t.Run("trims root and state dir before rebasing", func(t *testing.T) {
+		got := ResolveStateDir(" daemon-root ", " .xylem ")
+		want := filepath.Join("daemon-root", ".xylem")
+		if got != want {
+			t.Fatalf("ResolveStateDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns trimmed state dir when root is empty", func(t *testing.T) {
+		if got := ResolveStateDir(" ", " .xylem "); got != ".xylem" {
+			t.Fatalf("ResolveStateDir() = %q, want %q", got, ".xylem")
+		}
+	})
+
+	t.Run("returns empty when state dir is empty", func(t *testing.T) {
+		if got := ResolveStateDir("daemon-root", " "); got != "" {
+			t.Fatalf("ResolveStateDir() = %q, want empty string", got)
+		}
+	})
+}
+
 func validConfig() *Config {
 	cfg := &Config{
 		Repo: "owner/name",


### PR DESCRIPTION
## Summary
+- Implements [issue #304](https://github.com/nicholls-inc/xylem/issues/304) by adding `xylem doctor --root` so doctor can inspect a different checkout or daemon root while preserving existing default behavior.
+- Keeps JSON output aligned with the rooted state directory so automation can target `.daemon-root/.xylem/` without changing the current working directory.
+
+## Smoke scenarios covered
+- `S1` — Doctor root reads scoped state dir
+- `S2` — Doctor default behavior without root unchanged
+- `S3` — Doctor JSON mode honors root flag
+
+## Changes summary
+- Modified `cli/cmd/xylem/doctor.go` to add the `--root` flag, route command execution through `doctorDepsForRoot`, and rebuild scoped queue/worktree dependencies from the selected root.
+- Modified `cli/internal/config/config.go` to add `ResolveStateDir(root, stateDir string) string` for rebasing relative `state_dir` values under an alternate root while preserving absolute paths.
+- Modified `cli/cmd/xylem/doctor_test.go` to add coverage for rooted dependency scoping, rooted JSON output, and smoke scenarios `S1`-`S3`.
+- Modified `cli/internal/config/config_test.go` and `cli/internal/config/config_prop_test.go` to cover `ResolveStateDir` behavior for trimmed input, empty values, absolute paths, and rebased relative paths.
+
+## Test plan
+- `cd cli && goimports -w .`
+- `cd cli && goimports -l .`
+- `cd cli && go vet ./...`
+- `cd cli && golangci-lint run`
+- `cd cli && go build ./cmd/xylem`
+- `cd cli && go test ./...`

Fixes #304