### PR TITLE
fix(cleanup): prune stale worktrees during daemon health ticks

### DIFF
--- a/cli/cmd/xylem/cleanup.go
+++ b/cli/cmd/xylem/cleanup.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
 	"github.com/nicholls-inc/xylem/cli/internal/worktree"
 )
 
@@ -72,25 +73,15 @@ func cleanupWorktrees(wt *worktree.Manager, q *queue.Queue, dryRun bool) error {
 		fmt.Println("No xylem worktrees found.")
 		return nil
 	}
-
-	// Build set of worktree paths for active vessels so we don't kill
-	// running work.
-	activeWorktrees := make(map[string]bool)
-	if vessels, listErr := q.List(); listErr == nil {
-		for _, v := range vessels {
-			if !v.State.IsTerminal() && v.WorktreePath != "" {
-				activeWorktrees[v.WorktreePath] = true
-			}
-		}
+	pruner := runner.New(nil, q, wt, nil)
+	stale, err := pruner.FindStaleWorktrees(ctx)
+	if err != nil {
+		return fmt.Errorf("find stale worktrees: %w", err)
 	}
 
 	removed := 0
-	skipped := 0
-	for _, t := range trees {
-		if activeWorktrees[t.Path] {
-			skipped++
-			continue
-		}
+	skipped := len(trees) - len(stale)
+	for _, t := range stale {
 		if dryRun {
 			fmt.Printf("Would remove: %s\n", t.Path)
 			removed++

--- a/cli/cmd/xylem/cleanup_test.go
+++ b/cli/cmd/xylem/cleanup_test.go
@@ -60,29 +60,18 @@ func testCleanupConfig(t *testing.T) (*config.Config, *queue.Queue) {
 }
 
 func TestCleanupNoWorktrees(t *testing.T) {
-	tests := []struct {
-		name   string
-		dryRun bool
-	}{
-		{"actual", false},
-		{"dry-run", true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
-			cfg := &config.Config{StateDir: filepath.Join(dir, ".xylem")}
-			q := queue.New(filepath.Join(cfg.StateDir, "queue.jsonl"))
-			wt := worktree.New(dir, &emptyWorktreeRunner{})
+	dir := t.TempDir()
+	cfg := &config.Config{StateDir: filepath.Join(dir, ".xylem")}
+	q := queue.New(filepath.Join(cfg.StateDir, "queue.jsonl"))
+	wt := worktree.New(dir, &emptyWorktreeRunner{})
 
-			var err error
-			out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, tt.dryRun) })
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !strings.Contains(out, "No xylem worktrees") {
-				t.Errorf("expected empty message, got: %s", out)
-			}
-		})
+	var err error
+	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false) })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(out); got != "No xylem worktrees found." {
+		t.Fatalf("cleanup output = %q, want %q", got, "No xylem worktrees found.")
 	}
 }
 
@@ -160,6 +149,48 @@ func TestCleanupActualRemoval(t *testing.T) {
 	}
 	if len(r.removeCalls) > 0 && !strings.Contains(r.removeCalls[0], "issue-5-test") {
 		t.Errorf("expected remove call for issue-5-test worktree, got: %s", r.removeCalls[0])
+	}
+}
+
+func TestCleanupSkipsActiveWorktreeWhenQueuePathIsRelative(t *testing.T) {
+	porcelain := strings.Join([]string{
+		"worktree /repo",
+		"HEAD aaa",
+		"branch refs/heads/main",
+		"",
+		"worktree /repo/.claude/worktrees/fix/issue-1-bug",
+		"HEAD bbb",
+		"branch refs/heads/fix/issue-1-bug",
+		"",
+	}, "\n")
+
+	r := &mockCleanupRunner{porcelain: porcelain}
+	wt := worktree.New("/repo", r)
+	cfg, q := testCleanupConfig(t)
+	if _, err := q.Enqueue(queue.Vessel{
+		ID:           "issue-1",
+		Source:       "manual",
+		Workflow:     "fix-bug",
+		State:        queue.StatePending,
+		CreatedAt:    time.Now().UTC(),
+		WorktreePath: filepath.Join(".claude", "worktrees", "fix", "issue-1-bug"),
+	}); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+
+	var err error
+	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, true) })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Skipped 1 active vessel worktree(s)") {
+		t.Fatalf("expected active worktree to be skipped, got: %s", out)
+	}
+	if !strings.Contains(out, "0 worktree(s) would be removed") {
+		t.Fatalf("expected zero removals, got: %s", out)
+	}
+	if len(r.removeCalls) != 0 {
+		t.Fatalf("expected no remove calls, got %d", len(r.removeCalls))
 	}
 }
 

--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -153,6 +153,9 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		stallChecks = daemonChecksFromFindings(findings, daemonNow())
 		drainRunner.CheckWaitingVessels(ctx)
 		drainRunner.CheckHungVessels(ctx)
+		if removed := drainRunner.PruneStaleWorktrees(ctx); removed > 0 {
+			slog.Info("daemon pruned stale worktrees", "removed", removed)
+		}
 		// Cancel pending vessels whose PRs are already merged/closed,
 		// freeing concurrency slots for real work.
 		drainRunner.CancelStalePRVessels(ctx)

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -740,6 +740,71 @@ func TestSmoke_S39_DaemonAutoUpgradeProceedsAfterCancelledVesselDropsInFlight(t 
 	assert.Zero(t, tracker.InFlightCount())
 }
 
+func TestSmoke_S48_DaemonHealthTickPrunesOnlyStaleXylemWorktrees(t *testing.T) {
+	repoRoot := t.TempDir()
+	stateDir := filepath.Join(repoRoot, ".xylem")
+	require.NoError(t, os.MkdirAll(stateDir, 0o755))
+
+	q := queue.New(filepath.Join(stateDir, "queue.jsonl"))
+	_, err := q.Enqueue(queue.Vessel{
+		ID:           "issue-1",
+		Source:       "manual",
+		Workflow:     "fix-bug",
+		State:        queue.StatePending,
+		CreatedAt:    time.Now().UTC(),
+		WorktreePath: filepath.Join(".claude", "worktrees", "fix", "issue-1"),
+	})
+	require.NoError(t, err)
+
+	activePath := filepath.Join(repoRoot, ".claude", "worktrees", "fix", "issue-1")
+	stalePath := filepath.Join(repoRoot, ".claude", "worktrees", "fix", "issue-2")
+	daemonRootPath := filepath.Join(repoRoot, ".daemon-root", "issue-3")
+	porcelain := strings.Join([]string{
+		"worktree " + repoRoot,
+		"HEAD aaa",
+		"branch refs/heads/main",
+		"",
+		"worktree " + activePath,
+		"HEAD bbb",
+		"branch refs/heads/fix/issue-1",
+		"",
+		"worktree " + stalePath,
+		"HEAD ccc",
+		"branch refs/heads/fix/issue-2",
+		"",
+		"worktree " + daemonRootPath,
+		"HEAD ddd",
+		"branch refs/heads/daemon/issue-3",
+		"",
+	}, "\n")
+
+	cmdRunner := &mockCleanupRunner{porcelain: porcelain}
+	pruneRunner := runner.New(nil, q, worktree.New(repoRoot, cmdRunner), nil)
+	var checkCalls atomic.Int32
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = daemonLoop(ctx, q, nil, noopScan, noopDrain, func(ctx context.Context) {
+		checkCalls.Add(1)
+		if pruneRunner.PruneStaleWorktrees(ctx) > 0 {
+			cancel()
+		}
+	}, nil, nil, time.Hour, time.Hour, 0)
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, checkCalls.Load(), int32(1))
+	require.Len(t, cmdRunner.removeCalls, 1)
+	assert.Contains(t, cmdRunner.removeCalls[0], stalePath)
+	assert.NotContains(t, cmdRunner.removeCalls[0], activePath)
+	assert.NotContains(t, cmdRunner.removeCalls[0], daemonRootPath)
+
+	vessel, err := q.FindByID("issue-1")
+	require.NoError(t, err)
+	assert.Equal(t, queue.StatePending, vessel.State)
+	assert.Equal(t, filepath.Join(".claude", "worktrees", "fix", "issue-1"), vessel.WorktreePath)
+}
+
 // TestDaemonLoopUpgradeOverduePausesDrainToCreateIdleWindow verifies the
 // overdue path: when upgrade has been pending for upgradeInterval*3 without
 // firing (because in-flight vessels kept in_flight > 0 continuously), new

--- a/cli/cmd/xylem/doctor.go
+++ b/cli/cmd/xylem/doctor.go
@@ -263,25 +263,11 @@ func checkStaleWorktrees(wt *worktree.Manager, q *queue.Queue, report *doctorRep
 		report.add("worktrees", "ok", "No xylem worktrees")
 		return
 	}
-
-	// Build set of worktree paths for non-terminal vessels
-	vessels, err := q.List()
+	pruner := runner.New(nil, q, wt, nil)
+	stale, err := pruner.FindStaleWorktrees(ctx)
 	if err != nil {
-		report.add("worktrees", "warn", fmt.Sprintf("Failed to list vessels for worktree check: %v", err))
+		report.add("worktrees", "warn", fmt.Sprintf("Failed to identify stale worktrees: %v", err))
 		return
-	}
-	activeWorktrees := make(map[string]bool)
-	for _, v := range vessels {
-		if !v.State.IsTerminal() && v.WorktreePath != "" {
-			activeWorktrees[v.WorktreePath] = true
-		}
-	}
-
-	var stale []worktree.WorktreeInfo
-	for _, t := range trees {
-		if !activeWorktrees[t.Path] {
-			stale = append(stale, t)
-		}
 	}
 
 	if len(stale) == 0 {

--- a/cli/cmd/xylem/doctor_test.go
+++ b/cli/cmd/xylem/doctor_test.go
@@ -56,6 +56,17 @@ func captureDoctorStdout(t *testing.T, fn func()) string {
 	return string(data)
 }
 
+func requireDoctorCheck(t *testing.T, report *doctorReport, name string) doctorCheck {
+	t.Helper()
+	for _, check := range report.Checks {
+		if check.Name == name {
+			return check
+		}
+	}
+	t.Fatalf("expected doctor check %q in %#v", name, report.Checks)
+	return doctorCheck{}
+}
+
 func TestDoctorDetectsZombieVessels(t *testing.T) {
 	dir := t.TempDir()
 	qPath := filepath.Join(dir, "queue.jsonl")
@@ -199,9 +210,66 @@ func TestDoctorQueueHealth(t *testing.T) {
 	report := &doctorReport{}
 	checkQueueHealth(q, report)
 
-	if report.Summary.Fail > 0 {
-		t.Error("expected no failures for healthy queue")
+	if report.Summary != (struct {
+		OK   int `json:"ok"`
+		Warn int `json:"warn"`
+		Fail int `json:"fail"`
+	}{OK: 2}) {
+		t.Fatalf("summary = %#v, want 2 ok / 0 warn / 0 fail", report.Summary)
 	}
+
+	queueCheck := requireDoctorCheck(t, report, "queue")
+	if queueCheck.Status != "ok" {
+		t.Fatalf("queue status = %q, want ok", queueCheck.Status)
+	}
+	if queueCheck.Message != "1 vessel(s) in queue" {
+		t.Fatalf("queue message = %q, want %q", queueCheck.Message, "1 vessel(s) in queue")
+	}
+
+	compactionCheck := requireDoctorCheck(t, report, "queue_compaction")
+	if compactionCheck.Status != "ok" {
+		t.Fatalf("queue_compaction status = %q, want ok", compactionCheck.Status)
+	}
+	if compactionCheck.Message != "Queue is compact" {
+		t.Fatalf("queue_compaction message = %q, want %q", compactionCheck.Message, "Queue is compact")
+	}
+}
+
+func TestDoctorStaleWorktreesTreatsRelativeQueuePathAsActive(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	if _, err := q.Enqueue(queue.Vessel{
+		ID:           "issue-1",
+		Source:       "manual",
+		Workflow:     "fix-bug",
+		State:        queue.StatePending,
+		CreatedAt:    time.Now().UTC(),
+		WorktreePath: filepath.Join(".claude", "worktrees", "fix", "issue-1"),
+	}); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+
+	porcelain := "worktree " + filepath.Join(dir, ".claude", "worktrees", "fix", "issue-1") + "\nHEAD abc123\nbranch refs/heads/fix/issue-1\n\n"
+	runner := &mockCleanupRunner{porcelain: porcelain}
+	wt := worktree.New(dir, runner)
+	report := &doctorReport{}
+
+	checkStaleWorktrees(wt, q, report, false)
+
+	for _, check := range report.Checks {
+		if check.Name != "worktrees" {
+			continue
+		}
+		if check.Status != "ok" {
+			t.Fatalf("worktrees status = %q, want ok", check.Status)
+		}
+		if check.Message != "1 worktree(s), all active" {
+			t.Fatalf("worktrees message = %q, want %q", check.Message, "1 worktree(s), all active")
+		}
+		return
+	}
+
+	t.Fatal("expected worktrees check")
 }
 
 func TestDoctorReportTracksSummaryAndFixedChecks(t *testing.T) {
@@ -224,6 +292,46 @@ func TestDoctorReportTracksSummaryAndFixedChecks(t *testing.T) {
 	}
 	if got := report.Checks[2]; !got.Fixed || got.Status != "ok" || got.Name != "test_fix" {
 		t.Fatalf("fixed check = %#v, want fixed ok check named test_fix", got)
+	}
+}
+
+func TestDoctorJSONOutput(t *testing.T) {
+	report := &doctorReport{}
+	report.add("test_check", "ok", "All good")
+	report.add("test_warn", "warn", "Minor issue")
+	report.addFixed("test_fixed", "Auto-fixed")
+
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded doctorReport
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Summary != (struct {
+		OK   int `json:"ok"`
+		Warn int `json:"warn"`
+		Fail int `json:"fail"`
+	}{OK: 2, Warn: 1}) {
+		t.Fatalf("summary = %#v, want 2 ok / 1 warn / 0 fail", decoded.Summary)
+	}
+
+	okCheck := requireDoctorCheck(t, &decoded, "test_check")
+	if okCheck.Fixed {
+		t.Fatalf("test_check.Fixed = true, want false")
+	}
+
+	fixedCheck := requireDoctorCheck(t, &decoded, "test_fixed")
+	if fixedCheck.Status != "ok" {
+		t.Fatalf("test_fixed status = %q, want ok", fixedCheck.Status)
+	}
+	if !fixedCheck.Fixed {
+		t.Fatalf("test_fixed.Fixed = false, want true")
+	}
+	if fixedCheck.Message != "Auto-fixed" {
+		t.Fatalf("test_fixed message = %q, want %q", fixedCheck.Message, "Auto-fixed")
 	}
 }
 

--- a/cli/internal/runner/worktree_prune.go
+++ b/cli/internal/runner/worktree_prune.go
@@ -1,0 +1,101 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/nicholls-inc/xylem/cli/internal/worktree"
+)
+
+type xylemWorktreeLister interface {
+	ListXylem(ctx context.Context) ([]worktree.WorktreeInfo, error)
+}
+
+type worktreePathNormalizer interface {
+	NormalizePath(worktreePath string) string
+}
+
+// FindStaleWorktrees returns registered xylem worktrees that are not associated
+// with any non-terminal vessel in the queue.
+func (r *Runner) FindStaleWorktrees(ctx context.Context) ([]worktree.WorktreeInfo, error) {
+	lister, ok := r.Worktree.(xylemWorktreeLister)
+	if !ok {
+		return nil, fmt.Errorf("list xylem worktrees: unsupported worktree manager %T", r.Worktree)
+	}
+
+	trees, err := lister.ListXylem(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list xylem worktrees: %w", err)
+	}
+
+	active, err := r.activeWorktreePaths()
+	if err != nil {
+		return nil, fmt.Errorf("list active worktrees: %w", err)
+	}
+
+	stale := make([]worktree.WorktreeInfo, 0, len(trees))
+	for _, tree := range trees {
+		if _, ok := active[r.normalizeWorktreePath(tree.Path)]; ok {
+			continue
+		}
+		stale = append(stale, tree)
+	}
+
+	return stale, nil
+}
+
+// PruneStaleWorktrees removes stale xylem worktrees best-effort and returns the
+// number successfully removed.
+func (r *Runner) PruneStaleWorktrees(ctx context.Context) int {
+	stale, err := r.FindStaleWorktrees(ctx)
+	if err != nil {
+		log.Printf("warn: find stale worktrees: %v", err)
+		return 0
+	}
+
+	removed := 0
+	for _, tree := range stale {
+		if err := r.Worktree.Remove(ctx, tree.Path); err != nil {
+			log.Printf("warn: remove stale worktree %s: %v", tree.Path, err)
+			continue
+		}
+		removed++
+	}
+
+	return removed
+}
+
+func (r *Runner) activeWorktreePaths() (map[string]struct{}, error) {
+	vessels, err := r.Queue.List()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]struct{}{}, nil
+		}
+		return nil, err
+	}
+
+	active := make(map[string]struct{}, len(vessels))
+	for _, vessel := range vessels {
+		if vessel.State.IsTerminal() || vessel.WorktreePath == "" {
+			continue
+		}
+		active[r.normalizeWorktreePath(vessel.WorktreePath)] = struct{}{}
+	}
+
+	return active, nil
+}
+
+func (r *Runner) normalizeWorktreePath(worktreePath string) string {
+	if normalizer, ok := r.Worktree.(worktreePathNormalizer); ok {
+		return normalizer.NormalizePath(worktreePath)
+	}
+
+	if filepath.IsAbs(worktreePath) {
+		return filepath.Clean(worktreePath)
+	}
+
+	return filepath.Clean(worktreePath)
+}

--- a/cli/internal/runner/worktree_prune_test.go
+++ b/cli/internal/runner/worktree_prune_test.go
@@ -1,0 +1,120 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/worktree"
+)
+
+type pruningWorktree struct {
+	list       []worktree.WorktreeInfo
+	removeErrs map[string]error
+	removed    []string
+	repoRoot   string
+}
+
+func (w *pruningWorktree) Create(_ context.Context, branchName string) (string, error) {
+	return filepath.Join(".claude", "worktrees", branchName), nil
+}
+
+func (w *pruningWorktree) Remove(_ context.Context, worktreePath string) error {
+	w.removed = append(w.removed, worktreePath)
+	if err := w.removeErrs[worktreePath]; err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w *pruningWorktree) ListXylem(_ context.Context) ([]worktree.WorktreeInfo, error) {
+	return append([]worktree.WorktreeInfo(nil), w.list...), nil
+}
+
+func (w *pruningWorktree) NormalizePath(worktreePath string) string {
+	normalized := worktreePath
+	if !filepath.IsAbs(normalized) {
+		normalized = filepath.Join(w.repoRoot, normalized)
+	}
+	absPath, err := filepath.Abs(normalized)
+	if err == nil {
+		normalized = absPath
+	}
+	return filepath.Clean(normalized)
+}
+
+func TestFindStaleWorktreesNormalizesRelativeActivePaths(t *testing.T) {
+	repoRoot := t.TempDir()
+	q := queue.New(filepath.Join(repoRoot, "queue.jsonl"))
+	now := time.Now().UTC()
+	if _, err := q.Enqueue(queue.Vessel{
+		ID:           "issue-1",
+		Source:       "manual",
+		Workflow:     "fix-bug",
+		State:        queue.StatePending,
+		CreatedAt:    now,
+		WorktreePath: filepath.Join(".claude", "worktrees", "fix", "issue-1"),
+	}); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+
+	wt := &pruningWorktree{
+		repoRoot: repoRoot,
+		list: []worktree.WorktreeInfo{
+			{Path: filepath.Join(repoRoot, ".claude", "worktrees", "fix", "issue-1"), Branch: "fix/issue-1"},
+			{Path: filepath.Join(repoRoot, ".claude", "worktrees", "fix", "issue-2"), Branch: "fix/issue-2"},
+		},
+	}
+	r := New(nil, q, wt, nil)
+
+	stale, err := r.FindStaleWorktrees(context.Background())
+	if err != nil {
+		t.Fatalf("FindStaleWorktrees() error = %v", err)
+	}
+	if len(stale) != 1 {
+		t.Fatalf("len(stale) = %d, want 1", len(stale))
+	}
+	if got := stale[0].Path; got != filepath.Join(repoRoot, ".claude", "worktrees", "fix", "issue-2") {
+		t.Fatalf("stale[0].Path = %q, want issue-2 worktree", got)
+	}
+}
+
+func TestPruneStaleWorktreesRemovesOnlyDetectedStalePaths(t *testing.T) {
+	repoRoot := t.TempDir()
+	q := queue.New(filepath.Join(repoRoot, "queue.jsonl"))
+	now := time.Now().UTC()
+	if _, err := q.Enqueue(queue.Vessel{
+		ID:           "issue-1",
+		Source:       "manual",
+		Workflow:     "fix-bug",
+		State:        queue.StatePending,
+		CreatedAt:    now,
+		WorktreePath: filepath.Join(".claude", "worktrees", "fix", "issue-1"),
+	}); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+
+	stalePath := filepath.Join(repoRoot, ".claude", "worktrees", "fix", "issue-2")
+	wt := &pruningWorktree{
+		repoRoot: repoRoot,
+		list: []worktree.WorktreeInfo{
+			{Path: filepath.Join(repoRoot, ".claude", "worktrees", "fix", "issue-1"), Branch: "fix/issue-1"},
+			{Path: stalePath, Branch: "fix/issue-2"},
+		},
+		removeErrs: map[string]error{
+			stalePath: errors.New("busy"),
+		},
+	}
+	r := New(nil, q, wt, nil)
+
+	removed := r.PruneStaleWorktrees(context.Background())
+	if removed != 0 {
+		t.Fatalf("PruneStaleWorktrees() removed %d, want 0", removed)
+	}
+	if len(wt.removed) != 1 || wt.removed[0] != stalePath {
+		t.Fatalf("removed paths = %#v, want [%q]", wt.removed, stalePath)
+	}
+}

--- a/cli/internal/worktree/worktree.go
+++ b/cli/internal/worktree/worktree.go
@@ -378,6 +378,26 @@ func (m *Manager) Remove(ctx context.Context, worktreePath string) error {
 	return nil
 }
 
+// NormalizePath resolves a worktree path into a comparable absolute path rooted
+// at the manager's repository root when the input is relative.
+func (m *Manager) NormalizePath(worktreePath string) string {
+	if strings.TrimSpace(worktreePath) == "" {
+		return ""
+	}
+
+	normalized := worktreePath
+	if !filepath.IsAbs(normalized) {
+		normalized = filepath.Join(m.RepoRoot, normalized)
+	}
+
+	absPath, err := filepath.Abs(normalized)
+	if err == nil {
+		normalized = absPath
+	}
+
+	return filepath.Clean(normalized)
+}
+
 // branchForWorktree looks up the branch name for a worktree path by parsing
 // `git worktree list --porcelain`. Returns empty string if not found.
 func (m *Manager) branchForWorktree(ctx context.Context, worktreePath string) string {
@@ -385,21 +405,10 @@ func (m *Manager) branchForWorktree(ctx context.Context, worktreePath string) st
 	if err != nil {
 		return ""
 	}
-	// Normalize the target path for comparison
-	absTarget := worktreePath
-	if !filepath.IsAbs(worktreePath) {
-		absTarget = filepath.Join(m.RepoRoot, worktreePath)
-	}
-	// Resolve to absolute path (handles relative RepoRoot like ".")
-	absTarget, err = filepath.Abs(absTarget)
-	if err != nil {
-		return ""
-	}
-	absTarget = filepath.Clean(absTarget)
+	targetPath := m.NormalizePath(worktreePath)
 
 	for _, wt := range parsePorcelain(string(out)) {
-		candidate := filepath.Clean(wt.Path)
-		if candidate == absTarget {
+		if m.NormalizePath(wt.Path) == targetPath {
 			return wt.Branch
 		}
 	}

--- a/cli/internal/worktree/worktree_prop_test.go
+++ b/cli/internal/worktree/worktree_prop_test.go
@@ -1,0 +1,37 @@
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropNormalizePathMatchesAbsoluteEquivalent(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		repoRoot, err := os.MkdirTemp("", "xylem-worktree-prop-*")
+		if err != nil {
+			rt.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(repoRoot)
+
+		m := &Manager{RepoRoot: repoRoot}
+		segments := []string{
+			".claude",
+			"worktrees",
+			rapid.StringMatching(`[a-z0-9-]{1,8}`).Draw(rt, "seg-1"),
+			rapid.StringMatching(`[a-z0-9-]{1,8}`).Draw(rt, "seg-2"),
+			rapid.StringMatching(`[a-z0-9-]{1,8}`).Draw(rt, "seg-3"),
+		}
+
+		relativePath := filepath.Join(segments...)
+		absolutePath := filepath.Join(append([]string{repoRoot}, segments...)...)
+
+		gotRelative := m.NormalizePath(relativePath)
+		gotAbsolute := m.NormalizePath(absolutePath)
+		if gotRelative != gotAbsolute {
+			rt.Fatalf("NormalizePath(relative) = %q, NormalizePath(absolute) = %q", gotRelative, gotAbsolute)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Implements stale worktree pruning for the daemon health tick in https://github.com/nicholls-inc/xylem/issues/305.
- Reuses the same stale-vs-active worktree detection across daemon, `xylem cleanup`, and `xylem doctor --fix` so all cleanup paths agree on normalized worktree paths.

## Smoke scenarios covered
- `S48` — `DaemonHealthTickPrunesOnlyStaleXylemWorktrees`

## Changes summary
- **Added** `cli/internal/runner/worktree_prune.go` with `Runner.FindStaleWorktrees`, `Runner.PruneStaleWorktrees`, `activeWorktreePaths`, and `normalizeWorktreePath`.
- **Modified** `cli/internal/worktree/worktree.go` to add `Manager.NormalizePath` and normalize worktree-path comparisons in `branchForWorktree`.
- **Modified** `cli/cmd/xylem/daemon.go` so the daemon health tick prunes stale xylem worktrees.
- **Modified** `cli/cmd/xylem/cleanup.go` and `cli/cmd/xylem/doctor.go` to reuse the shared stale-worktree detection instead of duplicating cleanup logic.
- **Modified** `cli/cmd/xylem/cleanup_test.go`, `cli/cmd/xylem/daemon_test.go`, and `cli/cmd/xylem/doctor_test.go`; **added** `cli/internal/runner/worktree_prune_test.go` and `cli/internal/worktree/worktree_prop_test.go` for regression and normalization coverage.

## Test plan
- `go vet ./...`
- `go build ./cmd/xylem`
- `go test ./...`

Fixes #305