### PR TITLE
feat(workflow): add evaluator config block to Phase schema

### DIFF
--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -58,18 +59,33 @@ const (
 
 // Phase represents a single step in a workflow's execution pipeline.
 type Phase struct {
-	Name         string   `yaml:"name"`
-	Type         string   `yaml:"type,omitempty"` // "prompt" (default) or "command"
-	Run          string   `yaml:"run,omitempty"`  // shell command for type=command, supports template variables
-	PromptFile   string   `yaml:"prompt_file"`
-	MaxTurns     int      `yaml:"max_turns"`
-	LLM          *string  `yaml:"llm,omitempty"`
-	Model        *string  `yaml:"model,omitempty"`
-	Tier         *string  `yaml:"tier,omitempty"`
-	NoOp         *NoOp    `yaml:"noop,omitempty"`
-	Gate         *Gate    `yaml:"gate,omitempty"`
-	AllowedTools *string  `yaml:"allowed_tools,omitempty"`
-	DependsOn    []string `yaml:"depends_on,omitempty"`
+	Name         string           `yaml:"name"`
+	Type         string           `yaml:"type,omitempty"` // "prompt" (default) or "command"
+	Run          string           `yaml:"run,omitempty"`  // shell command for type=command, supports template variables
+	PromptFile   string           `yaml:"prompt_file"`
+	MaxTurns     int              `yaml:"max_turns"`
+	LLM          *string          `yaml:"llm,omitempty"`
+	Model        *string          `yaml:"model,omitempty"`
+	Tier         *string          `yaml:"tier,omitempty"`
+	NoOp         *NoOp            `yaml:"noop,omitempty"`
+	Gate         *Gate            `yaml:"gate,omitempty"`
+	Evaluator    *EvaluatorConfig `yaml:"evaluator,omitempty"`
+	AllowedTools *string          `yaml:"allowed_tools,omitempty"`
+	DependsOn    []string         `yaml:"depends_on,omitempty"`
+}
+
+// EvaluatorConfig defines optional evaluator-loop configuration for a phase.
+type EvaluatorConfig struct {
+	Criteria      []EvaluatorCriterion `yaml:"criteria,omitempty"`
+	MaxRetries    int                  `yaml:"max_retries,omitempty"`
+	PassThreshold float64              `yaml:"pass_threshold,omitempty"`
+}
+
+// EvaluatorCriterion defines a single scored evaluator criterion.
+type EvaluatorCriterion struct {
+	Name      string  `yaml:"name"`
+	Weight    float64 `yaml:"weight"`
+	Threshold float64 `yaml:"threshold,omitempty"`
 }
 
 // NoOp defines an early-success completion rule for a phase.
@@ -275,6 +291,12 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 			}
 		}
 
+		if p.Evaluator != nil {
+			if err := validateEvaluator(p.Name, p.Evaluator); err != nil {
+				return err
+			}
+		}
+
 		if p.NoOp != nil {
 			if err := validateNoOp(p.Name, p.NoOp); err != nil {
 				return err
@@ -306,6 +328,45 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 
 	if err := validateDependencyCycles(s.Phases); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+const evaluatorWeightTolerance = 0.01
+
+func validateEvaluator(phaseName string, cfg *EvaluatorConfig) error {
+	if cfg == nil {
+		return nil
+	}
+
+	if cfg.MaxRetries < 0 {
+		return fmt.Errorf("phase %q: evaluator: max_retries must be non-negative, got %d", phaseName, cfg.MaxRetries)
+	}
+	if cfg.PassThreshold < 0 || cfg.PassThreshold > 1 {
+		return fmt.Errorf("phase %q: evaluator: pass_threshold must be in [0, 1], got %f", phaseName, cfg.PassThreshold)
+	}
+
+	seen := make(map[string]bool, len(cfg.Criteria))
+	var weightSum float64
+	for i, criterion := range cfg.Criteria {
+		if strings.TrimSpace(criterion.Name) == "" {
+			return fmt.Errorf("phase %q: evaluator: criteria[%d].name is required", phaseName, i)
+		}
+		if seen[criterion.Name] {
+			return fmt.Errorf("phase %q: evaluator: duplicate criterion name %q", phaseName, criterion.Name)
+		}
+		seen[criterion.Name] = true
+		if criterion.Weight < 0 {
+			return fmt.Errorf("phase %q: evaluator: criterion %q weight must be non-negative, got %f", phaseName, criterion.Name, criterion.Weight)
+		}
+		if criterion.Threshold < 0 || criterion.Threshold > 1 {
+			return fmt.Errorf("phase %q: evaluator: criterion %q threshold must be in [0, 1], got %f", phaseName, criterion.Name, criterion.Threshold)
+		}
+		weightSum += criterion.Weight
+	}
+	if len(cfg.Criteria) > 0 && math.Abs(weightSum-1.0) > evaluatorWeightTolerance {
+		return fmt.Errorf("phase %q: evaluator: criteria weights must sum to 1.0 +/- %.2f, got %f", phaseName, evaluatorWeightTolerance, weightSum)
 	}
 
 	return nil

--- a/cli/internal/workflow/workflow_prop_test.go
+++ b/cli/internal/workflow/workflow_prop_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -44,6 +45,41 @@ func genInvalidWorkflowClass() *rapid.Generator[string] {
 			if err := validateClass(Class(class)); err != nil {
 				return class
 			}
+		}
+	})
+}
+
+func genValidEvaluatorConfig() *rapid.Generator[*EvaluatorConfig] {
+	return rapid.Custom(func(t *rapid.T) *EvaluatorConfig {
+		count := rapid.IntRange(1, 5).Draw(t, "criteria-count")
+		rawWeights := make([]float64, count)
+		var rawTotal float64
+		for i := 0; i < count; i++ {
+			raw := rapid.Float64Range(0.01, 1.0).Draw(t, fmt.Sprintf("raw-weight-%d", i))
+			rawWeights[i] = raw
+			rawTotal += raw
+		}
+
+		criteria := make([]EvaluatorCriterion, count)
+		normalizedSum := 0.0
+		for i := 0; i < count; i++ {
+			weight := rawWeights[i] / rawTotal
+			if i == count-1 {
+				weight = 1.0 - normalizedSum
+			} else {
+				normalizedSum += weight
+			}
+			criteria[i] = EvaluatorCriterion{
+				Name:      fmt.Sprintf("criterion_%d", i),
+				Weight:    weight,
+				Threshold: rapid.Float64Range(0, 1).Draw(t, fmt.Sprintf("threshold-%d", i)),
+			}
+		}
+
+		return &EvaluatorConfig{
+			Criteria:      criteria,
+			MaxRetries:    rapid.IntRange(0, 10).Draw(t, "max-retries"),
+			PassThreshold: rapid.Float64Range(0, 1).Draw(t, "pass-threshold"),
 		}
 	})
 }
@@ -118,6 +154,67 @@ func TestPropValidateClassRejectsUnknownClasses(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), class) {
 			t.Fatalf("validateClass(%q) error = %q, want mention of class", class, err.Error())
+		}
+	})
+}
+
+func TestPropValidateEvaluatorAcceptsNormalizedConfigs(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := genValidEvaluatorConfig().Draw(t, "config")
+		if err := validateEvaluator("analyze", cfg); err != nil {
+			t.Fatalf("validateEvaluator() error = %v for %+v", err, cfg)
+		}
+	})
+}
+
+func TestPropValidateEvaluatorRejectsThresholdsOutsideUnitInterval(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := genValidEvaluatorConfig().Draw(t, "config")
+		idx := rapid.IntRange(0, len(cfg.Criteria)-1).Draw(t, "criterion-index")
+
+		if rapid.Bool().Draw(t, "below-zero") {
+			cfg.Criteria[idx].Threshold = -rapid.Float64Range(0.001, 1.0).Draw(t, "negative-threshold")
+		} else {
+			cfg.Criteria[idx].Threshold = 1 + rapid.Float64Range(0.001, 1.0).Draw(t, "positive-threshold")
+		}
+
+		err := validateEvaluator("analyze", cfg)
+		if err == nil {
+			t.Fatalf("validateEvaluator() error = nil for %+v", cfg)
+		}
+		if !strings.Contains(err.Error(), cfg.Criteria[idx].Name) || !strings.Contains(err.Error(), "threshold must be in [0, 1]") {
+			t.Fatalf("validateEvaluator() error = %q, want criterion %q threshold failure", err.Error(), cfg.Criteria[idx].Name)
+		}
+	})
+}
+
+func TestPropValidateEvaluatorRejectsNegativeWeights(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := genValidEvaluatorConfig().Draw(t, "config")
+		idx := rapid.IntRange(0, len(cfg.Criteria)-1).Draw(t, "criterion-index")
+		cfg.Criteria[idx].Weight = -rapid.Float64Range(0.001, 1.0).Draw(t, "negative-weight")
+
+		err := validateEvaluator("analyze", cfg)
+		if err == nil {
+			t.Fatalf("validateEvaluator() error = nil for %+v", cfg)
+		}
+		if !strings.Contains(err.Error(), cfg.Criteria[idx].Name) || !strings.Contains(err.Error(), "weight must be non-negative") {
+			t.Fatalf("validateEvaluator() error = %q, want criterion %q weight failure", err.Error(), cfg.Criteria[idx].Name)
+		}
+	})
+}
+
+func TestPropValidateEvaluatorRejectsWeightSumsOutsideTolerance(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := genValidEvaluatorConfig().Draw(t, "config")
+		cfg.Criteria[0].Weight += rapid.Float64Range(evaluatorWeightTolerance+0.001, 0.5).Draw(t, "weight-delta")
+
+		err := validateEvaluator("analyze", cfg)
+		if err == nil {
+			t.Fatalf("validateEvaluator() error = nil for %+v", cfg)
+		}
+		if !strings.Contains(err.Error(), "criteria weights must sum to 1.0") {
+			t.Fatalf("validateEvaluator() error = %q, want weight-sum failure", err.Error())
 		}
 	})
 }

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -235,6 +235,225 @@ phases:
 	assert.Equal(t, "", e.TrustBoundary)
 }
 
+func TestSmoke_S15_PhaseEvaluatorConfigParsesAndValidates(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+    evaluator:
+      max_retries: 2
+      pass_threshold: 0.8
+      criteria:
+        - name: coverage
+          weight: 0.6
+          threshold: 0.8
+        - name: correctness
+          weight: 0.4
+          threshold: 0.9
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, got.Phases[0].Evaluator)
+
+	eval := got.Phases[0].Evaluator
+	assert.Equal(t, 2, eval.MaxRetries)
+	assert.Equal(t, 0.8, eval.PassThreshold)
+	require.Len(t, eval.Criteria, 2)
+	assert.Equal(t, "coverage", eval.Criteria[0].Name)
+	assert.Equal(t, 0.6, eval.Criteria[0].Weight)
+	assert.Equal(t, 0.8, eval.Criteria[0].Threshold)
+	assert.Equal(t, "correctness", eval.Criteria[1].Name)
+	assert.Equal(t, 0.4, eval.Criteria[1].Weight)
+	assert.Equal(t, 0.9, eval.Criteria[1].Threshold)
+}
+
+func TestSmoke_S16_PhaseEvaluatorRejectsCriteriaWeightSumsOutsideTolerance(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+    evaluator:
+      criteria:
+        - name: coverage
+          weight: 0.7
+          threshold: 0.8
+        - name: correctness
+          weight: 0.2
+          threshold: 0.9
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `phase "analyze": evaluator: criteria weights must sum to 1.0 +/- 0.01`)
+}
+
+func TestSmoke_S17_PhaseEvaluatorRejectsThresholdsOutsideUnitInterval(t *testing.T) {
+	tests := []struct {
+		name          string
+		evaluatorYAML string
+		wantErr       string
+	}{
+		{
+			name: "criterion threshold out of range",
+			evaluatorYAML: `    evaluator:
+      criteria:
+        - name: coverage
+          weight: 1.0
+          threshold: 1.1
+`,
+			wantErr: `phase "analyze": evaluator: criterion "coverage" threshold must be in [0, 1]`,
+		},
+		{
+			name: "pass threshold out of range",
+			evaluatorYAML: `    evaluator:
+      pass_threshold: 1.1
+      criteria:
+        - name: coverage
+          weight: 1.0
+          threshold: 0.8
+`,
+			wantErr: `phase "analyze": evaluator: pass_threshold must be in [0, 1]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			chdirTemp(t, dir)
+			createPromptFile(t, dir, "prompts/analyze.md")
+
+			path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`+tt.evaluatorYAML)
+
+			_, err := Load(path)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestSmoke_S18_PhaseEvaluatorRejectsNegativeMaxRetries(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+    evaluator:
+      max_retries: -1
+      criteria:
+        - name: coverage
+          weight: 1.0
+          threshold: 0.8
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `phase "analyze": evaluator: max_retries must be non-negative`)
+}
+
+func TestSmoke_S19_WorkflowWithoutEvaluatorStillLoadsWithNilEvaluator(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	require.Len(t, got.Phases, 1)
+	assert.Nil(t, got.Phases[0].Evaluator)
+	assert.Equal(t, "analyze", got.Phases[0].Name)
+	assert.Equal(t, "prompts/analyze.md", got.Phases[0].PromptFile)
+	assert.Equal(t, 10, got.Phases[0].MaxTurns)
+}
+
+func TestLoadWorkflowEvaluatorRejectsInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		evaluatorYAML string
+		wantErr       string
+	}{
+		{
+			name: "negative criterion weight",
+			evaluatorYAML: `    evaluator:
+      criteria:
+        - name: coverage
+          weight: -0.1
+          threshold: 0.8
+        - name: correctness
+          weight: 1.1
+          threshold: 0.9
+`,
+			wantErr: `phase "analyze": evaluator: criterion "coverage" weight must be non-negative`,
+		},
+		{
+			name: "duplicate criterion name",
+			evaluatorYAML: `    evaluator:
+      criteria:
+        - name: coverage
+          weight: 0.5
+          threshold: 0.8
+        - name: coverage
+          weight: 0.5
+          threshold: 0.9
+`,
+			wantErr: `phase "analyze": evaluator: duplicate criterion name "coverage"`,
+		},
+		{
+			name: "blank criterion name",
+			evaluatorYAML: `    evaluator:
+      criteria:
+        - name: ""
+          weight: 1.0
+          threshold: 0.8
+`,
+			wantErr: `phase "analyze": evaluator: criteria[0].name is required`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			chdirTemp(t, dir)
+			createPromptFile(t, dir, "prompts/analyze.md")
+
+			path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`+tt.evaluatorYAML)
+
+			_, err := Load(path)
+			requireErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
 func TestLoadWorkflowAllowAdditiveProtectedWritesDefaultsFalse(t *testing.T) {
 	dir := t.TempDir()
 	chdirTemp(t, dir)


### PR DESCRIPTION
## Summary
- Implements https://github.com/nicholls-inc/xylem/issues/312
- Adds optional phase-level evaluator schema support to workflow loading and validation so workflows can declare evaluator criteria, retry limits, and pass thresholds without changing existing workflow behavior.

## Smoke scenarios covered
- S15 — Phase evaluator config parses and validates
- S16 — Phase evaluator rejects criteria weight sums outside tolerance
- S17 — Phase evaluator rejects thresholds outside unit interval
- S18 — Phase evaluator rejects negative max retries
- S19 — Workflow without evaluator still loads with nil evaluator

## Changes summary
- Modified `cli/internal/workflow/workflow.go`
  - Added `Phase.Evaluator`
  - Added `EvaluatorConfig` and `EvaluatorCriterion`
  - Added `validateEvaluator` and evaluator weight tolerance handling in workflow validation
- Modified `cli/internal/workflow/workflow_test.go`
  - Added smoke-style coverage for valid evaluator parsing, invalid weight sums, invalid thresholds, negative retry counts, duplicate and blank criterion names, and nil evaluator backward compatibility
- Modified `cli/internal/workflow/workflow_prop_test.go`
  - Added property-based generators and validation coverage for normalized evaluator configs, threshold bounds, negative weights, and weight-sum drift

## Test plan
- `cd cli && $(go env GOPATH)/bin/goimports -w .`
- `cd cli && go vet ./...`
- `cd cli && $(go env GOPATH)/bin/golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #312