### PR TITLE
feat(runner): warn on workflow drift when resuming waiting vessels

### DIFF
--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -551,6 +551,7 @@ func (r *Runner) CheckWaitingVessels(ctx context.Context) {
 		}
 		if found {
 			resumeSpan := r.startWaitTransitionSpan(ctx, vessel, "resumed", waitedDuration(vessel.WaitingSince, r.runtimeNow()))
+			r.warnOnWorkflowDrift(vessel)
 			// Advance past the gated phase — CurrentPhase was already incremented
 			// when the vessel entered waiting state. Resume via pending so Drain can
 			// pick the vessel back up through the normal dequeue flow.
@@ -1446,6 +1447,43 @@ func waitedDuration(since *time.Time, now time.Time) time.Duration {
 		return 0
 	}
 	return now.Sub(*since)
+}
+
+func (r *Runner) warnOnWorkflowDrift(vessel queue.Vessel) {
+	storedDigest, currentDigest := workflowDigestsForResume(vessel)
+	if !workflowDigestDrifted(storedDigest, currentDigest) {
+		return
+	}
+	log.Printf(
+		"warn: waiting vessel %s workflow %q drifted while waiting: stored=%s current=%s",
+		vessel.ID,
+		vessel.Workflow,
+		storedDigest,
+		currentDigest,
+	)
+}
+
+func workflowDigestsForResume(vessel queue.Vessel) (string, string) {
+	storedDigest := strings.TrimSpace(vessel.Meta[recovery.MetaWorkflowDigest])
+	currentDigest := currentWorkflowDigest(vessel.Workflow)
+	return storedDigest, currentDigest
+}
+
+func workflowDigestDrifted(storedDigest, currentDigest string) bool {
+	storedDigest = strings.TrimSpace(storedDigest)
+	currentDigest = strings.TrimSpace(currentDigest)
+	if storedDigest == "" || currentDigest == "" {
+		return false
+	}
+	return storedDigest != currentDigest
+}
+
+func currentWorkflowDigest(workflowName string) string {
+	workflowName = strings.TrimSpace(workflowName)
+	if workflowName == "" {
+		return ""
+	}
+	return recovery.DigestFile(filepath.Join(".xylem", "workflows", workflowName+".yaml"), "wf")
 }
 
 func (r *Runner) watchVesselCancellation(parent context.Context, vesselID string) (context.Context, context.CancelCauseFunc) {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/surface"
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
@@ -3191,6 +3192,131 @@ func TestCheckWaitingVesselsAppliesReadyLabelsOnResume(t *testing.T) {
 
 	if !hasRunOutputCallContaining(cmdRunner, "gh issue edit 1 --repo owner/repo", "--add-label ready-for-implementation", "--remove-label blocked") {
 		t.Fatalf("expected ready-label gh issue edit call, got %v", cmdRunner.outputArgs)
+	}
+}
+
+func TestSmoke_S1_WarnsOnWorkflowDriftDuringResume(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{
+			name: "plan", promptContent: "Create plan", maxTurns: 5,
+			gate: "      type: label\n      wait_for: \"plan-approved\"\n      timeout: \"24h\"",
+		},
+		{name: "implement", promptContent: "Implement after approval", maxTurns: 10},
+	})
+	withTestWorkingDir(t, dir)
+
+	currentDigest := recovery.DigestFile(filepath.Join(".xylem", "workflows", "fix-bug.yaml"), "wf")
+	require.NotEmpty(t, currentDigest)
+
+	waitingSince := time.Now().UTC().Add(-time.Hour)
+	vessel := makeVessel(1, "fix-bug")
+	vessel.State = queue.StateWaiting
+	vessel.FailedPhase = "plan"
+	vessel.WaitingFor = "plan-approved"
+	vessel.WaitingSince = &waitingSince
+	vessel.CurrentPhase = 1
+	vessel.Meta[recovery.MetaWorkflowDigest] = "wf-stale"
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	cmdRunner := &mockCmdRunner{outputData: []byte(`{"labels":[{"name":"plan-approved"}]}`)}
+	r := New(cfg, q, &mockWorktree{}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	var logBuf bytes.Buffer
+	oldWriter := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(oldWriter)
+
+	r.CheckWaitingVessels(context.Background())
+
+	resumed, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	require.Equal(t, queue.StatePending, resumed.State)
+	assert.Contains(t, logBuf.String(), `warn: waiting vessel issue-1 workflow "fix-bug" drifted while waiting`)
+	assert.Contains(t, logBuf.String(), "stored=wf-stale")
+	assert.Contains(t, logBuf.String(), "current="+currentDigest)
+}
+
+func TestSmoke_S2_DoesNotWarnWhenWorkflowDigestMatches(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{
+			name: "plan", promptContent: "Create plan", maxTurns: 5,
+			gate: "      type: label\n      wait_for: \"plan-approved\"\n      timeout: \"24h\"",
+		},
+		{name: "implement", promptContent: "Implement after approval", maxTurns: 10},
+	})
+	withTestWorkingDir(t, dir)
+
+	currentDigest := recovery.DigestFile(filepath.Join(".xylem", "workflows", "fix-bug.yaml"), "wf")
+	require.NotEmpty(t, currentDigest)
+
+	waitingSince := time.Now().UTC().Add(-time.Hour)
+	vessel := makeVessel(1, "fix-bug")
+	vessel.State = queue.StateWaiting
+	vessel.FailedPhase = "plan"
+	vessel.WaitingFor = "plan-approved"
+	vessel.WaitingSince = &waitingSince
+	vessel.CurrentPhase = 1
+	vessel.Meta[recovery.MetaWorkflowDigest] = currentDigest
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	cmdRunner := &mockCmdRunner{outputData: []byte(`{"labels":[{"name":"plan-approved"}]}`)}
+	r := New(cfg, q, &mockWorktree{}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	var logBuf bytes.Buffer
+	oldWriter := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(oldWriter)
+
+	r.CheckWaitingVessels(context.Background())
+
+	resumed, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	require.Equal(t, queue.StatePending, resumed.State)
+	assert.NotContains(t, logBuf.String(), "drifted while waiting")
+	assert.NotContains(t, logBuf.String(), "stored="+currentDigest)
+	assert.NotContains(t, logBuf.String(), "current="+currentDigest)
+}
+
+func TestWorkflowDigestDrifted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		stored  string
+		current string
+		want    bool
+	}{
+		{name: "matching digests", stored: "wf-same", current: "wf-same", want: false},
+		{name: "mismatched digests", stored: "wf-old", current: "wf-new", want: true},
+		{name: "missing stored digest", stored: "", current: "wf-new", want: false},
+		{name: "missing current digest", stored: "wf-old", current: "", want: false},
+		{name: "whitespace is ignored", stored: " wf-same ", current: "wf-same", want: false},
+		{name: "whitespace only stored digest is not comparable", stored: " \t\n ", current: "wf-new", want: false},
+		{name: "whitespace only current digest is not comparable", stored: "wf-old", current: " \t\n ", want: false},
+		{name: "different after trimming still drifts", stored: "\twf-old\n", current: " wf-new ", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := workflowDigestDrifted(tt.stored, tt.current); got != tt.want {
+				t.Fatalf("workflowDigestDrifted(%q, %q) = %t, want %t", tt.stored, tt.current, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Detects workflow digest drift when a waiting vessel resumes after its label gate clears and logs a warning-only signal before the vessel returns to `pending`.
- Implements https://github.com/nicholls-inc/xylem/issues/311.

## Smoke scenarios covered
- S1 — Warns on workflow drift during resume.
- S2 — Does not warn when the stored workflow digest matches the current workflow digest.

## Changes summary
- Modified `cli/internal/runner/runner.go` to call `warnOnWorkflowDrift` from `CheckWaitingVessels` and added `warnOnWorkflowDrift`, `workflowDigestsForResume`, `workflowDigestDrifted`, and `currentWorkflowDigest`.
- Modified `cli/internal/runner/runner_test.go` to add `TestSmoke_S1_WarnsOnWorkflowDriftDuringResume`, `TestSmoke_S2_DoesNotWarnWhenWorkflowDigestMatches`, and `TestWorkflowDigestDrifted`.

## Test plan
- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #311