### PR TITLE
feat(queue): snapshot workflow digests onto vessels at launch time

### DIFF
--- a/cli/internal/dtu/events.go
+++ b/cli/internal/dtu/events.go
@@ -189,22 +189,23 @@ type VesselEvent struct {
 
 // VesselSnapshot is a condensed view of queue.Vessel fields relevant to DTU replay.
 type VesselSnapshot struct {
-	State        string `json:"state,omitempty"`
-	Source       string `json:"source,omitempty"`
-	Ref          string `json:"ref,omitempty"`
-	Workflow     string `json:"workflow,omitempty"`
-	Error        string `json:"error,omitempty"`
-	CreatedAt    string `json:"created_at,omitempty"`
-	StartedAt    string `json:"started_at,omitempty"`
-	EndedAt      string `json:"ended_at,omitempty"`
-	CurrentPhase int    `json:"current_phase,omitempty"`
-	GateRetries  int    `json:"gate_retries,omitempty"`
-	WaitingSince string `json:"waiting_since,omitempty"`
-	WaitingFor   string `json:"waiting_for,omitempty"`
-	WorktreePath string `json:"worktree_path,omitempty"`
-	FailedPhase  string `json:"failed_phase,omitempty"`
-	GateOutput   string `json:"gate_output,omitempty"`
-	RetryOf      string `json:"retry_of,omitempty"`
+	State          string `json:"state,omitempty"`
+	Source         string `json:"source,omitempty"`
+	Ref            string `json:"ref,omitempty"`
+	Workflow       string `json:"workflow,omitempty"`
+	WorkflowDigest string `json:"workflow_digest,omitempty"`
+	Error          string `json:"error,omitempty"`
+	CreatedAt      string `json:"created_at,omitempty"`
+	StartedAt      string `json:"started_at,omitempty"`
+	EndedAt        string `json:"ended_at,omitempty"`
+	CurrentPhase   int    `json:"current_phase,omitempty"`
+	GateRetries    int    `json:"gate_retries,omitempty"`
+	WaitingSince   string `json:"waiting_since,omitempty"`
+	WaitingFor     string `json:"waiting_for,omitempty"`
+	WorktreePath   string `json:"worktree_path,omitempty"`
+	FailedPhase    string `json:"failed_phase,omitempty"`
+	GateOutput     string `json:"gate_output,omitempty"`
+	RetryOf        string `json:"retry_of,omitempty"`
 }
 
 // RecordEvent appends a structured DTU event while holding the store lock.

--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -64,19 +64,20 @@ func (s VesselState) IsTerminal() bool {
 }
 
 type Vessel struct {
-	ID            string            `json:"id"`
-	Source        string            `json:"source"`
-	Ref           string            `json:"ref,omitempty"`
-	Workflow      string            `json:"workflow,omitempty"`
-	WorkflowClass string            `json:"workflow_class,omitempty"`
-	Tier          string            `json:"tier,omitempty"`
-	Prompt        string            `json:"prompt,omitempty"`
-	Meta          map[string]string `json:"meta,omitempty"`
-	State         VesselState       `json:"state"`
-	CreatedAt     time.Time         `json:"created_at"`
-	StartedAt     *time.Time        `json:"started_at,omitempty"`
-	EndedAt       *time.Time        `json:"ended_at,omitempty"`
-	Error         string            `json:"error,omitempty"`
+	ID             string            `json:"id"`
+	Source         string            `json:"source"`
+	Ref            string            `json:"ref,omitempty"`
+	Workflow       string            `json:"workflow,omitempty"`
+	WorkflowDigest string            `json:"workflow_digest,omitempty"`
+	WorkflowClass  string            `json:"workflow_class,omitempty"`
+	Tier           string            `json:"tier,omitempty"`
+	Prompt         string            `json:"prompt,omitempty"`
+	Meta           map[string]string `json:"meta,omitempty"`
+	State          VesselState       `json:"state"`
+	CreatedAt      time.Time         `json:"created_at"`
+	StartedAt      *time.Time        `json:"started_at,omitempty"`
+	EndedAt        *time.Time        `json:"ended_at,omitempty"`
+	Error          string            `json:"error,omitempty"`
 
 	// v2 phase-based execution fields
 	CurrentPhase int               `json:"current_phase,omitempty"`
@@ -658,22 +659,23 @@ func buildVesselSnapshot(vessel *Vessel) *dtu.VesselSnapshot {
 		return nil
 	}
 	return &dtu.VesselSnapshot{
-		State:        string(vessel.State),
-		Source:       vessel.Source,
-		Ref:          vessel.Ref,
-		Workflow:     vessel.Workflow,
-		Error:        vessel.Error,
-		CreatedAt:    formatVesselTime(&vessel.CreatedAt),
-		StartedAt:    formatVesselTime(vessel.StartedAt),
-		EndedAt:      formatVesselTime(vessel.EndedAt),
-		CurrentPhase: vessel.CurrentPhase,
-		GateRetries:  vessel.GateRetries,
-		WaitingSince: formatVesselTime(vessel.WaitingSince),
-		WaitingFor:   vessel.WaitingFor,
-		WorktreePath: vessel.WorktreePath,
-		FailedPhase:  vessel.FailedPhase,
-		GateOutput:   vessel.GateOutput,
-		RetryOf:      vessel.RetryOf,
+		State:          string(vessel.State),
+		Source:         vessel.Source,
+		Ref:            vessel.Ref,
+		Workflow:       vessel.Workflow,
+		WorkflowDigest: vessel.WorkflowDigest,
+		Error:          vessel.Error,
+		CreatedAt:      formatVesselTime(&vessel.CreatedAt),
+		StartedAt:      formatVesselTime(vessel.StartedAt),
+		EndedAt:        formatVesselTime(vessel.EndedAt),
+		CurrentPhase:   vessel.CurrentPhase,
+		GateRetries:    vessel.GateRetries,
+		WaitingSince:   formatVesselTime(vessel.WaitingSince),
+		WaitingFor:     vessel.WaitingFor,
+		WorktreePath:   vessel.WorktreePath,
+		FailedPhase:    vessel.FailedPhase,
+		GateOutput:     vessel.GateOutput,
+		RetryOf:        vessel.RetryOf,
 	}
 }
 

--- a/cli/internal/queue/queue_prop_test.go
+++ b/cli/internal/queue/queue_prop_test.go
@@ -49,3 +49,44 @@ func TestPropQueueRoundTripsTier(t *testing.T) {
 		}
 	})
 }
+
+func TestPropQueueRoundTripsWorkflowDigest(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		dir, err := os.MkdirTemp("", "queue-workflow-digest-prop-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(dir)
+
+		q := New(filepath.Join(dir, "queue.jsonl"))
+		digest := rapid.StringMatching(`wf-[0-9a-f]{8,64}`).Draw(t, "workflow_digest")
+		vessel := Vessel{
+			ID:             "issue-1",
+			Source:         "github-issue",
+			Ref:            "https://github.com/example/repo/issues/1",
+			Workflow:       "fix-bug",
+			WorkflowDigest: digest,
+			State:          StatePending,
+			CreatedAt:      time.Now().UTC(),
+		}
+
+		enqueued, err := q.Enqueue(vessel)
+		if err != nil {
+			t.Fatalf("Enqueue() error = %v", err)
+		}
+		if !enqueued {
+			t.Fatal("expected vessel to be enqueued")
+		}
+
+		vessels, err := q.List()
+		if err != nil {
+			t.Fatalf("List() error = %v", err)
+		}
+		if len(vessels) != 1 {
+			t.Fatalf("len(vessels) = %d, want 1", len(vessels))
+		}
+		if vessels[0].WorkflowDigest != digest {
+			t.Fatalf("WorkflowDigest = %q, want %q", vessels[0].WorkflowDigest, digest)
+		}
+	})
+}

--- a/cli/internal/queue/queue_test.go
+++ b/cli/internal/queue/queue_test.go
@@ -127,6 +127,32 @@ func TestSmoke_S3_QueueJsonlRoundTripsTier(t *testing.T) {
 	assert.Equal(t, "high", vessels[0].Tier)
 }
 
+func TestSmoke_S4_LegacyQueueJsonlWithoutWorkflowDigestLoadsEmptyWorkflowDigest(t *testing.T) {
+	q, path := newTestQueue(t)
+	legacy := `{"id":"issue-42","source":"github-issue","ref":"https://github.com/example/repo/issues/42","workflow":"fix-bug","state":"pending","created_at":"2026-04-10T00:00:00Z"}`
+	require.NoError(t, os.WriteFile(path, []byte(legacy+"\n"), 0o644))
+
+	vessels, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Empty(t, vessels[0].WorkflowDigest)
+}
+
+func TestSmoke_S5_QueueJsonlRoundTripsWorkflowDigest(t *testing.T) {
+	q, _ := newTestQueue(t)
+	vessel := testVessel(88)
+	vessel.WorkflowDigest = "wf-1234abcd"
+
+	enqueued, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+	require.True(t, enqueued)
+
+	vessels, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "wf-1234abcd", vessels[0].WorkflowDigest)
+}
+
 // TestWS6S28VesselJSONLNoNewFields verifies that queue JSONL records remain
 // free of harness-specific fields.
 //

--- a/cli/internal/recovery/recovery.go
+++ b/cli/internal/recovery/recovery.go
@@ -594,15 +594,16 @@ func NextRetryVessel(base, parent queue.Vessel, artifact *Artifact, q *queue.Que
 	meta = ApplyRemediationState(meta, RemediationStateFromMeta(meta))
 
 	retry := queue.Vessel{
-		ID:        RetryID(parent.ID, q),
-		Source:    firstNonEmpty(base.Source, parent.Source),
-		Ref:       firstNonEmpty(base.Ref, parent.Ref),
-		Workflow:  firstNonEmpty(base.Workflow, parent.Workflow),
-		Prompt:    firstNonEmpty(base.Prompt, parent.Prompt),
-		Meta:      meta,
-		State:     queue.StatePending,
-		CreatedAt: createdAt.UTC(),
-		RetryOf:   parent.ID,
+		ID:             RetryID(parent.ID, q),
+		Source:         firstNonEmpty(base.Source, parent.Source),
+		Ref:            firstNonEmpty(base.Ref, parent.Ref),
+		Workflow:       firstNonEmpty(base.Workflow, parent.Workflow),
+		WorkflowDigest: "",
+		Prompt:         firstNonEmpty(base.Prompt, parent.Prompt),
+		Meta:           meta,
+		State:          queue.StatePending,
+		CreatedAt:      createdAt.UTC(),
+		RetryOf:        parent.ID,
 	}
 	retry.FailedPhase = parent.FailedPhase
 	retry.GateOutput = parent.GateOutput

--- a/cli/internal/recovery/recovery_test.go
+++ b/cli/internal/recovery/recovery_test.go
@@ -549,14 +549,15 @@ func TestSmoke_S10_NextRetryVesselPreservesRecoveryLineageMetadata(t *testing.T)
 	q := queue.New(filepath.Join(t.TempDir(), "queue.jsonl"))
 	now := time.Date(2026, time.April, 9, 18, 11, 0, 0, time.UTC)
 	parent := queue.Vessel{
-		ID:          "issue-42",
-		Source:      "github-issue",
-		Ref:         "https://github.com/owner/repo/issues/42",
-		Workflow:    "fix-bug",
-		State:       queue.StateFailed,
-		Error:       "temporary failure from upstream 503",
-		FailedPhase: "verify",
-		GateOutput:  "503 Service Unavailable",
+		ID:             "issue-42",
+		Source:         "github-issue",
+		Ref:            "https://github.com/owner/repo/issues/42",
+		Workflow:       "fix-bug",
+		WorkflowDigest: "wf-launch-snapshot",
+		State:          queue.StateFailed,
+		Error:          "temporary failure from upstream 503",
+		FailedPhase:    "verify",
+		GateOutput:     "503 Service Unavailable",
 		Meta: map[string]string{
 			"issue_num":                "42",
 			"source_input_fingerprint": "src-fingerprint",
@@ -577,10 +578,11 @@ func TestSmoke_S10_NextRetryVesselPreservesRecoveryLineageMetadata(t *testing.T)
 	})
 
 	retry := NextRetryVessel(queue.Vessel{
-		ID:       parent.ID,
-		Source:   parent.Source,
-		Ref:      parent.Ref,
-		Workflow: parent.Workflow,
+		ID:             parent.ID,
+		Source:         parent.Source,
+		Ref:            parent.Ref,
+		Workflow:       parent.Workflow,
+		WorkflowDigest: parent.WorkflowDigest,
 		Meta: map[string]string{
 			"issue_num":                "42",
 			"source_input_fingerprint": "src-fingerprint",
@@ -604,6 +606,7 @@ func TestSmoke_S10_NextRetryVesselPreservesRecoveryLineageMetadata(t *testing.T)
 	assert.Equal(t, artifact.FailureFingerprint, retry.Meta[MetaFailureFingerprint])
 	assert.NotEmpty(t, retry.Meta[MetaRemediationFingerprint])
 	assert.Equal(t, "updated title", retry.Meta["issue_title"])
+	assert.Empty(t, retry.WorkflowDigest)
 }
 
 func TestSaveRejectsUnsafeVesselID(t *testing.T) {

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -41,6 +41,8 @@ var errVesselCancelled = errors.New("vessel cancelled")
 
 const vesselCancelPollInterval = 25 * time.Millisecond
 
+const workflowSnapshotDirName = "workflow"
+
 // CommandRunner abstracts subprocess execution for testing.
 type CommandRunner interface {
 	RunOutput(ctx context.Context, name string, args ...string) ([]byte, error)
@@ -491,7 +493,7 @@ func (r *Runner) CheckWaitingVessels(ctx context.Context) {
 		if vessel.WaitingSince != nil {
 			timeoutDur := 24 * time.Hour // default
 			if vessel.Workflow != "" {
-				if s, loadErr := r.loadWorkflow(vessel.Workflow); loadErr == nil {
+				if s, _, loadErr := r.loadWorkflow(vessel.Workflow); loadErr == nil {
 					if int(vessel.CurrentPhase) > 0 && int(vessel.CurrentPhase) <= len(s.Phases) {
 						prevPhase := s.Phases[vessel.CurrentPhase-1]
 						if prevPhase.Gate != nil && prevPhase.Gate.Timeout != "" {
@@ -624,17 +626,17 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 		return r.runBuiltinWorkflow(ctx, vessel, src, vrs, builtin)
 	}
 
-	worktreePath, ok := r.ensureWorktree(ctx, &vessel, src)
-	if !ok {
-		return "failed"
-	}
-
-	sk, err := r.loadWorkflow(vessel.Workflow)
+	sk, _, err := r.loadVesselWorkflow(&vessel)
 	if err != nil {
 		r.failVessel(vessel.ID, fmt.Sprintf("load workflow: %v", err))
 		if err := src.OnFail(ctx, vessel); err != nil {
 			log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
 		}
+		return "failed"
+	}
+
+	worktreePath, ok := r.ensureWorktree(ctx, &vessel, src)
+	if !ok {
 		return "failed"
 	}
 
@@ -1575,17 +1577,18 @@ func (r *Runner) failUpdatedVessel(vessel *queue.Vessel, errMsg string) {
 	vessel.Error = errMsg
 	vessel.EndedAt = &now
 	vessel.Meta = recovery.ApplyToMeta(vessel.Meta, recovery.Build(recovery.Input{
-		VesselID:    vessel.ID,
-		Source:      vessel.Source,
-		Workflow:    vessel.Workflow,
-		Ref:         vessel.Ref,
-		State:       queue.StateFailed,
-		FailedPhase: vessel.FailedPhase,
-		Error:       errMsg,
-		GateOutput:  vessel.GateOutput,
-		RetryOf:     vessel.RetryOf,
-		Meta:        vessel.Meta,
-		CreatedAt:   now,
+		VesselID:       vessel.ID,
+		Source:         vessel.Source,
+		Workflow:       vessel.Workflow,
+		Ref:            vessel.Ref,
+		State:          queue.StateFailed,
+		FailedPhase:    vessel.FailedPhase,
+		Error:          errMsg,
+		GateOutput:     vessel.GateOutput,
+		RetryOf:        vessel.RetryOf,
+		WorkflowDigest: vessel.WorkflowDigest,
+		Meta:           vessel.Meta,
+		CreatedAt:      now,
 	}))
 	if updateErr := r.Queue.UpdateVessel(*vessel); updateErr != nil {
 		if r.cancelledTransition(vessel.ID, updateErr) {
@@ -1605,18 +1608,19 @@ func (r *Runner) annotateRecoveryMetadata(id string, state queue.VesselState, er
 		return
 	}
 	current.Meta = recovery.ApplyToMeta(current.Meta, recovery.Build(recovery.Input{
-		VesselID:    current.ID,
-		Source:      current.Source,
-		Workflow:    current.Workflow,
-		Ref:         current.Ref,
-		State:       state,
-		FailedPhase: current.FailedPhase,
-		Error:       errMsg,
-		GateOutput:  current.GateOutput,
-		RetryOf:     current.RetryOf,
-		Meta:        current.Meta,
-		Trace:       trace,
-		CreatedAt:   r.runtimeNow(),
+		VesselID:       current.ID,
+		Source:         current.Source,
+		Workflow:       current.Workflow,
+		Ref:            current.Ref,
+		State:          state,
+		FailedPhase:    current.FailedPhase,
+		Error:          errMsg,
+		GateOutput:     current.GateOutput,
+		RetryOf:        current.RetryOf,
+		WorkflowDigest: current.WorkflowDigest,
+		Meta:           current.Meta,
+		Trace:          trace,
+		CreatedAt:      r.runtimeNow(),
 	}))
 	if updateErr := r.Queue.UpdateVessel(*current); updateErr != nil {
 		log.Printf("warn: annotate recovery metadata for vessel %s: %v", id, updateErr)
@@ -1716,18 +1720,19 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 
 	if state == string(queue.StateFailed) || state == string(queue.StateTimedOut) {
 		seedArtifact := recovery.Build(recovery.Input{
-			VesselID:    artifactVessel.ID,
-			Source:      artifactVessel.Source,
-			Workflow:    artifactVessel.Workflow,
-			Ref:         artifactVessel.Ref,
-			State:       artifactVessel.State,
-			FailedPhase: artifactVessel.FailedPhase,
-			Error:       artifactVessel.Error,
-			GateOutput:  artifactVessel.GateOutput,
-			RetryOf:     artifactVessel.RetryOf,
-			Meta:        artifactVessel.Meta,
-			Trace:       traceContextPointer(vrs.trace),
-			CreatedAt:   now,
+			VesselID:       artifactVessel.ID,
+			Source:         artifactVessel.Source,
+			Workflow:       artifactVessel.Workflow,
+			Ref:            artifactVessel.Ref,
+			State:          artifactVessel.State,
+			FailedPhase:    artifactVessel.FailedPhase,
+			Error:          artifactVessel.Error,
+			GateOutput:     artifactVessel.GateOutput,
+			RetryOf:        artifactVessel.RetryOf,
+			WorkflowDigest: artifactVessel.WorkflowDigest,
+			Meta:           artifactVessel.Meta,
+			Trace:          traceContextPointer(vrs.trace),
+			CreatedAt:      now,
 		})
 		reviewArtifact := recovery.Build(recovery.Input{
 			VesselID:             artifactVessel.ID,
@@ -1739,6 +1744,7 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 			Error:                artifactVessel.Error,
 			GateOutput:           artifactVessel.GateOutput,
 			RetryOf:              artifactVessel.RetryOf,
+			WorkflowDigest:       artifactVessel.WorkflowDigest,
 			Meta:                 artifactVessel.Meta,
 			Trace:                traceContextPointer(vrs.trace),
 			CreatedAt:            now,
@@ -3148,7 +3154,7 @@ func (r *Runner) workflowProtectedWritePolicy(vessel queue.Vessel, violations []
 		return protectedSurfaceWorkflowPolicy{}, nil
 	}
 
-	sk, err := r.loadWorkflow(vessel.Workflow)
+	sk, _, err := r.loadWorkflow(vessel.Workflow)
 	if err != nil {
 		return protectedSurfaceWorkflowPolicy{}, fmt.Errorf("load workflow %q: %w", vessel.Workflow, err)
 	}
@@ -3583,9 +3589,97 @@ func (r *Runner) sourceConfigNameFromMeta(v queue.Vessel) string {
 	return v.Meta["config_source"]
 }
 
-func (r *Runner) loadWorkflow(name string) (*workflow.Workflow, error) {
+func (r *Runner) snapshotWorkflowDigest(vessel *queue.Vessel, digest string) error {
+	if vessel == nil {
+		return nil
+	}
+	vessel.WorkflowDigest = strings.TrimSpace(digest)
+	state := recovery.RemediationStateFromMeta(vessel.Meta)
+	state.WorkflowDigest = vessel.WorkflowDigest
+	vessel.Meta = recovery.ApplyRemediationState(vessel.Meta, state)
+	if r.Queue == nil {
+		return nil
+	}
+	if err := r.Queue.UpdateVessel(*vessel); err != nil {
+		return fmt.Errorf("persist workflow digest snapshot: %w", err)
+	}
+	return nil
+}
+
+func (r *Runner) loadVesselWorkflow(vessel *queue.Vessel) (*workflow.Workflow, string, error) {
+	if vessel == nil {
+		return nil, "", fmt.Errorf("vessel must not be nil")
+	}
+
+	storedDigest := strings.TrimSpace(vessel.WorkflowDigest)
+	snapshotPath := r.workflowSnapshotPath(vessel.ID, vessel.Workflow)
+	if storedDigest != "" && snapshotPath != "" {
+		snapshot, snapshotDigest, err := r.loadWorkflowFromSnapshot(snapshotPath)
+		if err == nil {
+			if snapshotDigest != storedDigest {
+				return nil, "", fmt.Errorf("workflow snapshot digest mismatch for vessel %s: stored=%s snapshot=%s", vessel.ID, storedDigest, snapshotDigest)
+			}
+			return snapshot, snapshotDigest, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, "", err
+		}
+	}
+
+	livePath := filepath.Join(".xylem", "workflows", vessel.Workflow+".yaml")
+	sk, liveDigest, err := workflow.LoadWithDigest(livePath)
+	if err != nil {
+		return nil, "", err
+	}
+	if storedDigest != "" && vessel.CurrentPhase > 0 && storedDigest != liveDigest {
+		return nil, "", fmt.Errorf("workflow snapshot missing for vessel %s: stored digest %s no longer matches live workflow %s", vessel.ID, storedDigest, liveDigest)
+	}
+	if snapshotPath != "" {
+		if err := r.writeWorkflowSnapshot(livePath, snapshotPath); err != nil {
+			return nil, "", err
+		}
+	}
+	if err := r.snapshotWorkflowDigest(vessel, liveDigest); err != nil {
+		return nil, "", fmt.Errorf("persist workflow snapshot: %w", err)
+	}
+	return sk, liveDigest, nil
+}
+
+func (r *Runner) loadWorkflowFromSnapshot(path string) (*workflow.Workflow, string, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, "", err
+	}
+	sk, digest, err := workflow.LoadWithDigest(path)
+	if err != nil {
+		return nil, "", fmt.Errorf("load workflow snapshot %q: %w", path, err)
+	}
+	return sk, digest, nil
+}
+
+func (r *Runner) writeWorkflowSnapshot(srcPath, snapshotPath string) error {
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return fmt.Errorf("read workflow source %q: %w", srcPath, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
+		return fmt.Errorf("create workflow snapshot dir %q: %w", filepath.Dir(snapshotPath), err)
+	}
+	if err := os.WriteFile(snapshotPath, data, 0o644); err != nil {
+		return fmt.Errorf("write workflow snapshot %q: %w", snapshotPath, err)
+	}
+	return nil
+}
+
+func (r *Runner) loadWorkflow(name string) (*workflow.Workflow, string, error) {
 	path := filepath.Join(".xylem", "workflows", name+".yaml")
-	return workflow.Load(path)
+	return workflow.LoadWithDigest(path)
+}
+
+func (r *Runner) workflowSnapshotPath(vesselID, workflowName string) string {
+	if r == nil || r.Config == nil || r.Config.StateDir == "" || strings.TrimSpace(vesselID) == "" || strings.TrimSpace(workflowName) == "" {
+		return ""
+	}
+	return filepath.Join(r.Config.StateDir, "phases", vesselID, workflowSnapshotDirName, workflowName+".yaml")
 }
 
 func (r *Runner) readHarness() string {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -2535,6 +2535,133 @@ func TestRunVessel_BuiltinWorkflowCompletesWithoutLoadingWorkflowFile(t *testing
 	assert.Equal(t, "completed", summary.Phases[0].Status)
 }
 
+func TestSmoke_S6_WorkflowDigestSnapshotPopulatedAtLaunch(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{{
+		name:          "analyze",
+		promptContent: "do the thing",
+		maxTurns:      1,
+	}})
+	withTestWorkingDir(t, dir)
+
+	workflowPath := filepath.Join(dir, ".xylem", "workflows", "fix-bug.yaml")
+	_, expectedDigest, err := workflow.LoadWithDigest(workflowPath)
+	require.NoError(t, err)
+
+	originalWorkflow, err := os.ReadFile(workflowPath)
+	require.NoError(t, err)
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	v := makeVessel(1, "fix-bug")
+	v.WorkflowDigest = "wf-stale-scan-digest"
+	_, err = q.Enqueue(v)
+	require.NoError(t, err)
+
+	dequeued, err := q.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, dequeued)
+
+	cmdRunner := &mockCmdRunner{
+		runPhaseHook: func(dirPath, prompt, name string, args ...string) ([]byte, error, bool) {
+			mutated := append([]byte("description: mutated during run\n"), originalWorkflow...)
+			require.NoError(t, os.WriteFile(workflowPath, mutated, 0o644))
+			return nil, errors.New("phase boom"), true
+		},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+
+	outcome := r.runVessel(context.Background(), *dequeued)
+	assert.Equal(t, "failed", outcome)
+
+	final := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, final.State)
+	assert.Equal(t, expectedDigest, final.WorkflowDigest)
+	assert.Equal(t, expectedDigest, final.Meta[recovery.MetaWorkflowDigest])
+	assert.NotEqual(t, "wf-stale-scan-digest", final.WorkflowDigest)
+	assert.NotEqual(t, recovery.DigestFile(workflowPath, "wf"), final.WorkflowDigest)
+
+	snapshotPath := filepath.Join(cfg.StateDir, "phases", final.ID, workflowSnapshotDirName, final.Workflow+".yaml")
+	snapshotBytes, err := os.ReadFile(snapshotPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalWorkflow, snapshotBytes)
+
+	artifact, err := recovery.Load(filepath.Join(cfg.StateDir, "phases", final.ID, "failure-review.json"))
+	require.NoError(t, err)
+	assert.Equal(t, expectedDigest, artifact.WorkflowDigest)
+}
+
+func TestSmoke_S7_WaitingVesselResumesAgainstFrozenWorkflowSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fix-bug"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{
+			name: "plan", promptContent: "Create plan", maxTurns: 5,
+			gate: "      type: label\n      wait_for: \"plan-approved\"\n      timeout: \"24h\"",
+		},
+		{name: "implement", promptContent: "Implement after approval", maxTurns: 10},
+	})
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldWd)
+
+	workflowPath := filepath.Join(dir, ".xylem", "workflows", "fix-bug.yaml")
+	_, expectedDigest, err := workflow.LoadWithDigest(workflowPath)
+	require.NoError(t, err)
+
+	labelViewJSON := `{"labels":[{"name":"plan-approved"}]}`
+	cmdRunner := &mockCmdRunner{
+		outputData: []byte(labelViewJSON),
+	}
+	wt := &mockWorktree{}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	first, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, first.Waiting)
+
+	waiting, err := q.FindByID("issue-1")
+	require.NoError(t, err)
+	require.Equal(t, queue.StateWaiting, waiting.State)
+	require.Equal(t, expectedDigest, waiting.WorkflowDigest)
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{
+			name: "plan", promptContent: "Create mutated plan", maxTurns: 5,
+			gate: "      type: label\n      wait_for: \"plan-approved\"\n      timeout: \"24h\"",
+		},
+		{name: "mutated", promptContent: "Mutated after approval", maxTurns: 10},
+	})
+
+	r.CheckWaitingVessels(context.Background())
+
+	second, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, second.Completed)
+
+	done, err := q.FindByID("issue-1")
+	require.NoError(t, err)
+	require.Equal(t, queue.StateCompleted, done.State)
+	require.Equal(t, expectedDigest, done.WorkflowDigest)
+	require.Len(t, cmdRunner.phaseCalls, 2)
+	assert.Contains(t, cmdRunner.phaseCalls[1].prompt, "Implement after approval")
+	assert.NotContains(t, cmdRunner.phaseCalls[1].prompt, "Mutated after approval")
+
+	snapshotPath := filepath.Join(cfg.StateDir, "phases", done.ID, workflowSnapshotDirName, done.Workflow+".yaml")
+	_, snapshotDigest, err := workflow.LoadWithDigest(snapshotPath)
+	require.NoError(t, err)
+	assert.Equal(t, expectedDigest, snapshotDigest)
+}
+
 func TestSmoke_WS6_S15_PromptOnlyVesselNoPolicy(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -171,26 +172,39 @@ type LiveCommandAssertGate struct {
 
 // Load reads and validates a workflow definition YAML file at path.
 func Load(path string) (*Workflow, error) {
+	s, _, err := LoadWithDigest(path)
+	return s, err
+}
+
+// LoadWithDigest reads and validates a workflow definition YAML file at path
+// and returns the workflow digest for the exact bytes that were loaded.
+func LoadWithDigest(path string) (*Workflow, string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read workflow file %q: %w", path, err)
+		return nil, "", fmt.Errorf("read workflow file %q: %w", path, err)
 	}
+	digest := digestWorkflowData(data)
 
 	var raw workflowYAML
 	if err := yaml.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("parse workflow yaml %q: %w", path, err)
+		return nil, "", fmt.Errorf("parse workflow yaml %q: %w", path, err)
 	}
 
 	s, err := workflowFromYAML(raw)
 	if err != nil {
-		return nil, fmt.Errorf("parse workflow yaml %q: %w", path, err)
+		return nil, "", fmt.Errorf("parse workflow yaml %q: %w", path, err)
 	}
 
 	if err := s.Validate(path); err != nil {
-		return nil, fmt.Errorf("validate workflow %q: %w", path, err)
+		return nil, "", fmt.Errorf("validate workflow %q: %w", path, err)
 	}
 
-	return s, nil
+	return s, digest, nil
+}
+
+func digestWorkflowData(data []byte) string {
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("wf-%x", sum)
 }
 
 // Validate checks that the workflow definition is well-formed. workflowFilePath is

--- a/cli/internal/workflow/workflow_digest_test.go
+++ b/cli/internal/workflow/workflow_digest_test.go
@@ -1,0 +1,36 @@
+package workflow
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadWithDigestReturnsLoadedWorkflowDigest(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompts", "fix-bug", "analyze.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
+	require.NoError(t, os.WriteFile(promptPath, []byte("analyze"), 0o644))
+
+	workflowPath := filepath.Join(dir, "fix-bug.yaml")
+	workflowYAML := "name: fix-bug\nphases:\n  - name: analyze\n    prompt_file: " + promptPath + "\n    max_turns: 1\n"
+	require.NoError(t, os.WriteFile(workflowPath, []byte(workflowYAML), 0o644))
+	wantDigest := fmt.Sprintf("wf-%x", sha256.Sum256([]byte(workflowYAML)))
+
+	wf, digest, err := LoadWithDigest(workflowPath)
+	require.NoError(t, err)
+	require.NotNil(t, wf)
+	assert.Equal(t, "fix-bug", wf.Name)
+	assert.Equal(t, wantDigest, digest)
+}
+
+func TestLoadWithDigestReturnsReadError(t *testing.T) {
+	_, _, err := LoadWithDigest(filepath.Join(t.TempDir(), "missing.yaml"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read workflow file")
+}


### PR DESCRIPTION
## Summary
- Implements [issue #310](https://github.com/nicholls-inc/xylem/issues/310) by adding `WorkflowDigest` to `queue.Vessel`, snapshotting the exact workflow YAML bytes loaded at launch, persisting that digest into queue and recovery state, and resuming waiting/recovery paths from the frozen workflow snapshot instead of the live workflow file.

## Smoke scenarios covered
- `S4` — Legacy queue JSONL without `WorkflowDigest` loads empty `WorkflowDigest`
- `S5` — Queue JSONL round-trips `WorkflowDigest`
- `S6` — WorkflowDigest snapshot populated at launch
- `S7` — Waiting vessel resumes against frozen workflow snapshot

## Changes summary
- **Modified:** `cli/internal/queue/queue.go`, `cli/internal/dtu/events.go`, `cli/internal/recovery/recovery.go`, `cli/internal/runner/runner.go`, `cli/internal/workflow/workflow.go`, `cli/internal/queue/queue_test.go`, `cli/internal/queue/queue_prop_test.go`, `cli/internal/recovery/recovery_test.go`, `cli/internal/runner/runner_test.go`
- **Added:** `cli/internal/workflow/workflow_digest_test.go`
- **Key types/functions:** `queue.Vessel.WorkflowDigest`, `workflow.LoadWithDigest`, `runner.snapshotWorkflowDigest`, `runner.loadVesselWorkflow`, `recovery.Input.WorkflowDigest`, `dtu.VesselSnapshot.WorkflowDigest`

## Test plan
- `cd cli && goimports -w .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #310