### PR TITLE
fix(scanner): add cooldown retry fallback for failed vessels

### DIFF
--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/review"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/stretchr/testify/assert"
@@ -606,6 +607,59 @@ func TestScanReenqueuesChangedFailedIssue(t *testing.T) {
 	if vessels[1].Meta["source_input_fingerprint"] == oldFingerprint {
 		t.Fatal("expected updated fingerprint for changed issue input")
 	}
+}
+
+func TestScanRetriesUnchangedFailedIssueAfterCooldownWithoutRecoveryArtifact(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{
+		{Number: 1, Title: "same title", Body: "same body", URL: "https://github.com/owner/repo/issues/1", Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}}},
+	}
+	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	for _, prefix := range []string{"fix", "feat"} {
+		r.set([]byte(""), "git", "ls-remote", "--heads", "origin", fmt.Sprintf("%s/issue-%d-*", prefix, 1))
+		r.set([]byte("[]"), "gh", "pr", "list", "--repo", "owner/repo", "--search", fmt.Sprintf("head:%s/issue-%d-", prefix, 1), "--state", "open", "--json", "number,headRefName", "--limit", "5")
+	}
+
+	fingerprint := scanFingerprint("same title", "same body", []string{"bug"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "issue-1",
+		Source:   "github-issue",
+		Ref:      "https://github.com/owner/repo/issues/1",
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "1",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("issue-1", queue.StateFailed, "boom"))
+
+	failed, err := q.FindByID("issue-1")
+	require.NoError(t, err)
+	endedAt := time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown)
+	failed.EndedAt = &endedAt
+	require.NoError(t, q.UpdateVessel(*failed))
+
+	s := New(cfg, q, r)
+	result, err := s.Scan(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Added)
+
+	vessels, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, vessels, 2)
+	assert.Equal(t, "issue-1", vessels[1].RetryOf)
+	assert.Equal(t, "cooldown", vessels[1].Meta[recovery.MetaUnlockedBy])
 }
 
 func TestScanPRFalsePositiveIgnored(t *testing.T) {

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -346,10 +346,8 @@ func (g *GitHub) retryCandidate(base queue.Vessel) (*queue.Vessel, bool, error) 
 			return nil, false, loadErr
 		}
 		if !found {
-			if latest.Meta["source_input_fingerprint"] != base.Meta["source_input_fingerprint"] {
-				return nil, false, nil
-			}
-			return nil, true, nil
+			retry, blocked := retryCandidateWithoutArtifact(base, *latest, g.Queue, sourceNow())
+			return retry, blocked, nil
 		}
 		base.Meta = applyCurrentRemediationMeta(base.Meta, artifact, g.currentHarnessDigest(), g.currentWorkflowDigest(base.Workflow))
 		decision := retryDecision(artifact, latest.Meta, base.Meta, sourceNow())

--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -380,10 +380,8 @@ func (g *GitHubPR) retryCandidate(base queue.Vessel, prURL, fingerprint, workflo
 			return nil, false, loadErr
 		}
 		if !found {
-			if latest.Meta["source_input_fingerprint"] != fingerprint {
-				return nil, false, nil
-			}
-			return nil, true, nil
+			retry, blocked := retryCandidateWithoutArtifact(base, *latest, g.Queue, sourceNow())
+			return retry, blocked, nil
 		}
 		base.Meta = applyCurrentRemediationMeta(base.Meta, artifact, g.currentHarnessDigest(), g.currentWorkflowDigest(base.Workflow))
 		decision := retryDecision(artifact, latest.Meta, base.Meta, sourceNow())

--- a/cli/internal/source/github_pr_test.go
+++ b/cli/internal/source/github_pr_test.go
@@ -551,7 +551,7 @@ func TestSmoke_S6_GitHubPRScanBlocksNonTransientRecoveryClasses(t *testing.T) {
 	assert.Empty(t, vessels)
 }
 
-func TestSmoke_S7_GitHubPRScanKeepsLegacyBlockingWhenRecoveryArtifactMissing(t *testing.T) {
+func TestSmoke_S7_GitHubPRScanRetriesAfterCooldownWhenRecoveryArtifactMissing(t *testing.T) {
 	dir := t.TempDir()
 	q := queue.New(dir + "/queue.jsonl")
 	r := newMock()
@@ -583,6 +583,12 @@ func TestSmoke_S7_GitHubPRScanKeepsLegacyBlockingWhenRecoveryArtifactMissing(t *
 	require.NoError(t, err)
 	require.NoError(t, q.Update("pr-10-review-pr", queue.StateFailed, "temporary network outage"))
 
+	failed, err := q.FindByID("pr-10-review-pr")
+	require.NoError(t, err)
+	endedAt := time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown)
+	failed.EndedAt = &endedAt
+	require.NoError(t, q.UpdateVessel(*failed))
+
 	src := &GitHubPR{
 		Repo:      "owner/repo",
 		Tasks:     map[string]GitHubTask{"review": {Labels: []string{"review-me"}, Workflow: "review-pr"}},
@@ -593,7 +599,10 @@ func TestSmoke_S7_GitHubPRScanKeepsLegacyBlockingWhenRecoveryArtifactMissing(t *
 
 	vessels, err := src.Scan(context.Background())
 	require.NoError(t, err)
-	assert.Empty(t, vessels)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "pr-10-review-pr-retry-1", vessels[0].ID)
+	assert.Equal(t, "pr-10-review-pr", vessels[0].RetryOf)
+	assert.Equal(t, "cooldown", vessels[0].Meta[recovery.MetaUnlockedBy])
 }
 
 func TestGitHubPRScanRetriesWhenOnlyWorkflowDigestChanges(t *testing.T) {

--- a/cli/internal/source/github_test.go
+++ b/cli/internal/source/github_test.go
@@ -509,7 +509,7 @@ func TestSmoke_S3_GitHubScanBlocksNonTransientRecoveryClasses(t *testing.T) {
 	assert.Empty(t, vessels)
 }
 
-func TestSmoke_S4_GitHubScanKeepsLegacyBlockingWhenRecoveryArtifactMissing(t *testing.T) {
+func TestSmoke_S4_GitHubScanRetriesAfterCooldownWhenRecoveryArtifactMissing(t *testing.T) {
 	dir := t.TempDir()
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
 	r := newMock()
@@ -549,6 +549,12 @@ func TestSmoke_S4_GitHubScanKeepsLegacyBlockingWhenRecoveryArtifactMissing(t *te
 	require.NoError(t, err)
 	require.NoError(t, q.Update("issue-42", queue.StateFailed, "temporary failure from upstream 503"))
 
+	failed, err := q.FindByID("issue-42")
+	require.NoError(t, err)
+	endedAt := time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown)
+	failed.EndedAt = &endedAt
+	require.NoError(t, q.UpdateVessel(*failed))
+
 	g := &GitHub{
 		Repo:      "owner/repo",
 		Tasks:     map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
@@ -559,7 +565,72 @@ func TestSmoke_S4_GitHubScanKeepsLegacyBlockingWhenRecoveryArtifactMissing(t *te
 
 	vessels, err := g.Scan(context.Background())
 	require.NoError(t, err)
-	assert.Empty(t, vessels)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "issue-42-retry-1", vessels[0].ID)
+	assert.Equal(t, "issue-42", vessels[0].RetryOf)
+	assert.Equal(t, "cooldown", vessels[0].Meta[recovery.MetaUnlockedBy])
+}
+
+func TestGitHubScanRetriesAfterCooldownWithoutArtifactFallsBackToStartedAt(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{{
+		Number: 42,
+		Title:  "flaky dependency",
+		Body:   "same body",
+		URL:    "https://github.com/owner/repo/issues/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}},
+	}}
+	issueBytes, _ := json.Marshal(issues)
+	r.set(issueBytes, "gh", "search", "issues",
+		"--repo", "owner/repo",
+		"--state", "open",
+		"--json", "number,title,body,url,labels",
+		"--limit", "20",
+		"--label", "bug")
+
+	fingerprint := githubSourceFingerprint("flaky dependency", "same body", []string{"bug"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      issues[0].URL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("issue-42", queue.StateFailed, "temporary failure from upstream 503"))
+
+	failed, err := q.FindByID("issue-42")
+	require.NoError(t, err)
+	startedAt := time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown)
+	failed.StartedAt = &startedAt
+	failed.EndedAt = nil
+	require.NoError(t, q.UpdateVessel(*failed))
+
+	g := &GitHub{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "issue-42-retry-1", vessels[0].ID)
+	assert.Equal(t, "cooldown", vessels[0].Meta[recovery.MetaUnlockedBy])
 }
 
 func TestGitHubScanRetriesWhenOnlySourceFingerprintChanges(t *testing.T) {

--- a/cli/internal/source/remediation.go
+++ b/cli/internal/source/remediation.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 )
 
@@ -62,4 +63,36 @@ func retryDecision(artifact *recovery.Artifact, previousMeta, currentMeta map[st
 	comparison.RemediationEpoch = stored.RemediationEpoch
 	comparison.RemediationFP = stored.RemediationFP
 	return recovery.RetryReadyWithRemediation(&comparison, recovery.RemediationStateFromMeta(currentMeta), now)
+}
+
+func retryCandidateWithoutArtifact(base, latest queue.Vessel, q *queue.Queue, now time.Time) (*queue.Vessel, bool) {
+	if strings.TrimSpace(latest.Meta["source_input_fingerprint"]) != strings.TrimSpace(base.Meta["source_input_fingerprint"]) {
+		return nil, false
+	}
+	if !legacyRetryCooldownElapsed(latest, now) {
+		return nil, true
+	}
+	retry := recovery.NextRetryVessel(base, latest, nil, q, now, "cooldown")
+	return &retry, false
+}
+
+func legacyRetryCooldownElapsed(vessel queue.Vessel, now time.Time) bool {
+	anchor := legacyRetryCooldownAnchor(vessel)
+	if anchor.IsZero() {
+		return true
+	}
+	return !now.UTC().Before(anchor.Add(recovery.DefaultRetryCooldown))
+}
+
+func legacyRetryCooldownAnchor(vessel queue.Vessel) time.Time {
+	if vessel.EndedAt != nil && !vessel.EndedAt.IsZero() {
+		return vessel.EndedAt.UTC()
+	}
+	if vessel.StartedAt != nil && !vessel.StartedAt.IsZero() {
+		return vessel.StartedAt.UTC()
+	}
+	if !vessel.CreatedAt.IsZero() {
+		return vessel.CreatedAt.UTC()
+	}
+	return time.Time{}
 }


### PR DESCRIPTION
## Summary
- retry failed or timed-out GitHub issue/PR vessels without recovery artifacts once the default cooldown has elapsed
- anchor the legacy cooldown fallback on EndedAt first, with StartedAt/CreatedAt fallback for older queue records
- add regression coverage for scanner, GitHub issue, and GitHub PR retry behavior

Fixes https://github.com/nicholls-inc/xylem/issues/334