### PR TITLE
fix: apply daemon auto-merge to all ready-to-merge vessel PRs

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -187,7 +187,7 @@ daemon:
   auto_upgrade: true
   auto_merge: true
   auto_merge_repo: nicholls-inc/xylem
-  auto_merge_labels: [ready-to-merge, harness-impl]
+  auto_merge_labels: [ready-to-merge]
   auto_merge_branch_pattern: "^(feat|fix|chore)/issue-\\d+"
   auto_merge_reviewer: "copilot-pull-request-reviewer"
 

--- a/.xylem/HARNESS.md
+++ b/.xylem/HARNESS.md
@@ -80,12 +80,16 @@ CI runs, in order: `goimports -l .`, `go vet`, `golangci-lint`, `go build`, `go 
 - **claude** — Claude Code CLI, for session execution
 - **gh** — GitHub CLI, authenticated. Required only for `github` source scanning.
 
-# Harness PR auto-admin-merge contract
+# PR auto-admin-merge contract
 
-For self-hosted `harness-impl` pull requests, the daemon and the checked-in
-`merge-pr` workflow share the same contract:
+The daemon auto-merge loop applies to vessel-produced pull requests on
+xylem-managed issue branches that carry the required merge labels:
 
-- Only PRs on xylem-managed issue branches with the required merge labels are eligible.
+- `ready-to-merge` is the daemon's merge-readiness signal for vessel PRs.
 - The `no-auto-admin-merge` label is an immediate opt-out and leaves the PR for manual handling.
-- Auto-admin-merge only fires when the PR is `MERGEABLE`, CI is fully green, there is no active `CHANGES_REQUESTED` review state, and all review threads are resolved.
-- Non-`harness-impl` or otherwise human-authored PRs remain outside this path and still require normal manual merge decisions.
+- Auto-admin-merge only fires when the PR is `MERGEABLE`, CI is fully green, and there is no active `CHANGES_REQUESTED` review state.
+- Human-authored PRs that do not match the xylem issue-branch + merge-label contract remain outside this path and still require normal manual merge decisions.
+
+Separately, the checked-in self-hosting `merge-pr` workflow remains scoped to
+`harness-impl` pull requests, so self-hosted harness PRs carry both
+`harness-impl` and `ready-to-merge`.

--- a/.xylem/prompts/fix-bug/pr.md
+++ b/.xylem/prompts/fix-bug/pr.md
@@ -10,4 +10,4 @@ URL: {{.Issue.URL}}
 {{.PreviousOutputs.plan}}
 
 Commit all changes with a clear commit message, push the branch, and create a PR using:
-gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>"
+gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>" --label "ready-to-merge"

--- a/.xylem/prompts/implement-feature/pr.md
+++ b/.xylem/prompts/implement-feature/pr.md
@@ -10,4 +10,4 @@ URL: {{.Issue.URL}}
 {{.PreviousOutputs.plan}}
 
 Commit all changes with a clear commit message, push the branch, and create a PR using:
-gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>"
+gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>" --label "ready-to-merge"

--- a/cli/cmd/xylem/automerge.go
+++ b/cli/cmd/xylem/automerge.go
@@ -229,7 +229,7 @@ func allChecksGreen(pr prSummary) bool {
 // The existing `respond-to-pr-review`, `fix-pr-checks`, and
 // `resolve-conflicts` workflows handle the intermediate steps via the
 // `github-pr-events` source, so auto-merge only needs to (1) kick off the
-// review cycle and (2) admin-merge trusted harness PRs once deterministic
+// review cycle and (2) admin-merge trusted vessel PRs once deterministic
 // merge safety checks pass.
 //
 // The repo slug comes from daemon.auto_merge_repo. If empty, gh uses the

--- a/cli/cmd/xylem/automerge_prop_test.go
+++ b/cli/cmd/xylem/automerge_prop_test.go
@@ -45,7 +45,7 @@ func TestPropDecideAutoMergeActionMatchesMergeReadiness(t *testing.T) {
 		}
 
 		want := actionSkip
-		if isXylemBranch && hasReadyLabel && hasHarnessLabel {
+		if isXylemBranch && hasReadyLabel {
 			want = actionRequestReview
 		}
 
@@ -104,18 +104,62 @@ func TestPropDecideAutoMergeActionAdminMergesWithReviewerEvidence(t *testing.T) 
 func TestPropDecideAutoMergeActionOptOutLabelAlwaysBlocks(t *testing.T) {
 	settings := xylemAutoMergeSettings(t)
 	rapid.Check(t, func(t *rapid.T) {
+		hasHarnessLabel := rapid.Bool().Draw(t, "hasHarnessLabel")
+		hasConflictRoutingLabel := rapid.Bool().Draw(t, "hasConflictRoutingLabel")
+		mergeable := rapid.SampledFrom([]string{"MERGEABLE", "CONFLICTING", "UNKNOWN"}).Draw(t, "mergeable")
+		reviewDecision := rapid.SampledFrom([]string{"", "REVIEW_REQUIRED", "APPROVED", "CHANGES_REQUESTED"}).Draw(t, "reviewDecision")
+		checkOutcome := rapid.SampledFrom([]struct {
+			conclusion string
+			status     string
+		}{
+			{conclusion: "SUCCESS", status: "COMPLETED"},
+			{conclusion: "FAILURE", status: "COMPLETED"},
+			{conclusion: "", status: "IN_PROGRESS"},
+		}).Draw(t, "checkOutcome")
+		reviewerEvidence := rapid.SampledFrom([]string{"none", "request", "latest-review"}).Draw(t, "reviewerEvidence")
+
+		labels := []struct {
+			Name string `json:"name"`
+		}{{Name: "ready-to-merge"}, {Name: settings.optOutLabel}}
+		if hasHarnessLabel {
+			labels = append(labels, struct {
+				Name string `json:"name"`
+			}{Name: "harness-impl"})
+		}
+		if hasConflictRoutingLabel {
+			labels = append(labels, struct {
+				Name string `json:"name"`
+			}{Name: "needs-conflict-resolution"})
+		}
+
 		pr := prSummary{
 			HeadRefName:    "feat/issue-42-42",
 			State:          "OPEN",
-			Mergeable:      "MERGEABLE",
-			ReviewDecision: "APPROVED",
-			Labels: []struct {
-				Name string `json:"name"`
-			}{{Name: "ready-to-merge"}, {Name: "harness-impl"}, {Name: settings.optOutLabel}},
+			Mergeable:      mergeable,
+			ReviewDecision: reviewDecision,
+			Labels:         labels,
 			StatusCheckRollup: []struct {
 				Conclusion string `json:"conclusion"`
 				Status     string `json:"status"`
-			}{{Conclusion: "SUCCESS", Status: "COMPLETED"}},
+			}{{Conclusion: checkOutcome.conclusion, Status: checkOutcome.status}},
+		}
+		switch reviewerEvidence {
+		case "request":
+			pr.ReviewRequests = []struct {
+				Login string `json:"login"`
+			}{{Login: settings.reviewer}}
+		case "latest-review":
+			pr.LatestReviews = append(pr.LatestReviews, struct {
+				Author struct {
+					Login string `json:"login"`
+				} `json:"author"`
+				State string `json:"state"`
+			}{
+				Author: struct {
+					Login string `json:"login"`
+				}{Login: settings.reviewer},
+				State: "COMMENTED",
+			})
 		}
 
 		if got := decideAutoMergeAction(pr, settings); got != actionBlockedOptOut {

--- a/cli/cmd/xylem/automerge_test.go
+++ b/cli/cmd/xylem/automerge_test.go
@@ -15,7 +15,7 @@ func xylemAutoMergeSettings(t *testing.T) autoMergeSettings {
 
 	settings, err := newAutoMergeSettings(config.DaemonConfig{
 		AutoMergeRepo:          "nicholls-inc/xylem",
-		AutoMergeLabels:        []string{"ready-to-merge", "harness-impl"},
+		AutoMergeLabels:        []string{"ready-to-merge"},
 		AutoMergeBranchPattern: `^(feat|fix|chore)/issue-\d+`,
 		AutoMergeReviewer:      "copilot-pull-request-reviewer",
 	})
@@ -208,7 +208,7 @@ func TestDecideAutoMergeAction(t *testing.T) {
 	}{{Conclusion: "SUCCESS", Status: "COMPLETED"}}
 	mergeReadyLabels := []struct {
 		Name string `json:"name"`
-	}{{Name: "ready-to-merge"}, {Name: "harness-impl"}}
+	}{{Name: "ready-to-merge"}}
 	copilotReviewed := []struct {
 		Author struct {
 			Login string `json:"login"`
@@ -244,12 +244,24 @@ func TestDecideAutoMergeAction(t *testing.T) {
 			want: actionSkip,
 		},
 		{
+			name: "xylem PR with harness label but no ready label is skipped",
+			pr: prSummary{
+				HeadRefName: "feat/issue-1-1",
+				State:       "OPEN",
+				Mergeable:   "MERGEABLE",
+				Labels: []struct {
+					Name string `json:"name"`
+				}{{Name: "harness-impl"}},
+			},
+			want: actionSkip,
+		},
+		{
 			name: "xylem PR with opt-out label stays blocked",
 			pr: prSummary{
 				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "MERGEABLE",
 				Labels: []struct {
 					Name string `json:"name"`
-				}{{Name: "ready-to-merge"}, {Name: "harness-impl"}, {Name: settings.optOutLabel}},
+				}{{Name: "ready-to-merge"}, {Name: settings.optOutLabel}},
 				StatusCheckRollup: greenChecks,
 			},
 			want: actionBlockedOptOut,
@@ -270,7 +282,7 @@ func TestDecideAutoMergeAction(t *testing.T) {
 				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "CONFLICTING",
 				Labels: []struct {
 					Name string `json:"name"`
-				}{{Name: "needs-conflict-resolution"}, {Name: "ready-to-merge"}, {Name: "harness-impl"}},
+				}{{Name: "needs-conflict-resolution"}, {Name: "ready-to-merge"}},
 			},
 			want: actionWaitForMergeable,
 		},
@@ -350,6 +362,102 @@ func TestDecideAutoMergeAction(t *testing.T) {
 	}
 }
 
+func TestSmoke_S7_AutoMergeAppliesToReadyToMergeVesselPRWithoutHarnessImpl(t *testing.T) {
+	settings := xylemAutoMergeSettings(t)
+	origListOpenPRsFn := listOpenPRsFn
+	origGetPRSummaryFn := getPRSummaryFn
+	origRequestCopilotReviewFn := requestCopilotReviewFn
+	origAddPRLabelsFn := addPRLabelsFn
+	origAdminMergePRFn := adminMergePRFn
+	t.Cleanup(func() {
+		listOpenPRsFn = origListOpenPRsFn
+		getPRSummaryFn = origGetPRSummaryFn
+		requestCopilotReviewFn = origRequestCopilotReviewFn
+		addPRLabelsFn = origAddPRLabelsFn
+		adminMergePRFn = origAdminMergePRFn
+	})
+
+	mergeReadyPR := prSummary{
+		Number:         335,
+		HeadRefName:    "fix/issue-334-334",
+		Mergeable:      "MERGEABLE",
+		State:          "OPEN",
+		ReviewDecision: "APPROVED",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "ready-to-merge"}},
+		StatusCheckRollup: []struct {
+			Conclusion string `json:"conclusion"`
+			Status     string `json:"status"`
+		}{{Conclusion: "SUCCESS", Status: "COMPLETED"}},
+		LatestReviews: []struct {
+			Author struct {
+				Login string `json:"login"`
+			} `json:"author"`
+			State string `json:"state"`
+		}{{
+			Author: struct {
+				Login string `json:"login"`
+			}{Login: settings.reviewer},
+			State: "APPROVED",
+		}},
+	}
+	require.Equal(t, actionAdminMerge, decideAutoMergeAction(mergeReadyPR, settings))
+
+	listCalls := 0
+	listOpenPRsFn = func(_ context.Context, repo string) ([]prSummary, error) {
+		listCalls++
+		assert.Equal(t, settings.repo, repo)
+		return []prSummary{{
+			Number:      mergeReadyPR.Number,
+			HeadRefName: mergeReadyPR.HeadRefName,
+			State:       mergeReadyPR.State,
+			Labels:      mergeReadyPR.Labels,
+		}}, nil
+	}
+
+	summaryCalls := 0
+	getPRSummaryFn = func(_ context.Context, repo string, number int) (prSummary, error) {
+		summaryCalls++
+		assert.Equal(t, settings.repo, repo)
+		assert.Equal(t, mergeReadyPR.Number, number)
+		return mergeReadyPR, nil
+	}
+
+	reviewCalls := 0
+	requestCopilotReviewFn = func(context.Context, string, int, string) error {
+		reviewCalls++
+		return nil
+	}
+
+	labelCalls := 0
+	addPRLabelsFn = func(context.Context, string, int, []string) error {
+		labelCalls++
+		return nil
+	}
+
+	adminMergeCalls := 0
+	adminMergePRFn = func(_ context.Context, repo string, number int) error {
+		adminMergeCalls++
+		assert.Equal(t, settings.repo, repo)
+		assert.Equal(t, mergeReadyPR.Number, number)
+		return nil
+	}
+
+	autoMergeXylemPRs(context.Background(), config.DaemonConfig{
+		AutoMergeRepo:          settings.repo,
+		AutoMergeLabels:        append([]string(nil), settings.labels...),
+		AutoMergeBranchPattern: settings.branchPatternRaw,
+		AutoMergeReviewer:      settings.reviewer,
+	})
+
+	assert.Equal(t, 1, listCalls)
+	assert.Equal(t, 1, summaryCalls)
+	assert.Equal(t, 0, reviewCalls)
+	assert.Equal(t, 0, labelCalls)
+	assert.Equal(t, 1, adminMergeCalls)
+}
+
 func TestSmoke_S8_AutoMergeContinuesWhenConfiguredReviewerIsNotCollaborator(t *testing.T) {
 	settings := xylemAutoMergeSettings(t)
 	origListOpenPRsFn := listOpenPRsFn
@@ -373,7 +481,7 @@ func TestSmoke_S8_AutoMergeContinuesWhenConfiguredReviewerIsNotCollaborator(t *t
 		ReviewDecision: "REVIEW_REQUIRED",
 		Labels: []struct {
 			Name string `json:"name"`
-		}{{Name: "ready-to-merge"}, {Name: "harness-impl"}},
+		}{{Name: "ready-to-merge"}},
 		StatusCheckRollup: []struct {
 			Conclusion string `json:"conclusion"`
 			Status     string `json:"status"`
@@ -458,7 +566,7 @@ func TestSmoke_S9_AutoAdminMergeWithinOneDaemonTick(t *testing.T) {
 		ReviewDecision: "APPROVED",
 		Labels: []struct {
 			Name string `json:"name"`
-		}{{Name: "ready-to-merge"}, {Name: "harness-impl"}},
+		}{{Name: "ready-to-merge"}},
 		StatusCheckRollup: []struct {
 			Conclusion string `json:"conclusion"`
 			Status     string `json:"status"`

--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -160,7 +160,7 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		// freeing concurrency slots for real work.
 		drainRunner.CancelStalePRVessels(ctx)
 		// Auto-merge: best-effort request copilot review on merge-ready
-		// harness PRs, then admin-merge once deterministic safety checks
+		// vessel PRs, then admin-merge once deterministic safety checks
 		// are green.
 		if cfg.Daemon.AutoMerge {
 			autoMergeXylemPRs(ctx, cfg.Daemon)

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -196,7 +196,7 @@ type DaemonConfig struct {
 	// AutoUpgrade is true. Defaults to 5m. Accepts any Go duration string.
 	UpgradeInterval string `yaml:"upgrade_interval,omitempty"`
 	// AutoMerge enables the daemon's automatic reviewer-request +
-	// admin-merge loop for merge-ready harness PRs. Only PRs matching the
+	// admin-merge loop for merge-ready vessel PRs. Only PRs matching the
 	// configured labels and branch pattern are eligible, and the
 	// no-auto-admin-merge label always opts a PR out.
 	AutoMerge bool `yaml:"auto_merge,omitempty"`

--- a/cli/internal/profiles/core/prompts/adapt-repo/pr.md
+++ b/cli/internal/profiles/core/prompts/adapt-repo/pr.md
@@ -12,3 +12,10 @@ The PR body must:
 - Explain that the changes are restricted to harness/control-plane files and remain PR-gated.
 
 Do not broaden scope beyond the validated adaptation plan.
+
+Create the PR with the merge-ready label so the daemon auto-merge path can pick
+up this vessel-produced PR once checks are green:
+
+```
+gh pr create --title "[xylem] adapt harness to this repository" --body "<body>" --label "ready-to-merge"
+```

--- a/cli/internal/profiles/core/prompts/fix-bug/pr.md
+++ b/cli/internal/profiles/core/prompts/fix-bug/pr.md
@@ -10,4 +10,4 @@ URL: {{.Issue.URL}}
 {{.PreviousOutputs.plan}}
 
 Commit all changes with a clear commit message, push the branch, and create a PR using:
-gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>"
+gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>" --label "ready-to-merge"

--- a/cli/internal/profiles/core/prompts/implement-feature/pr.md
+++ b/cli/internal/profiles/core/prompts/implement-feature/pr.md
@@ -10,4 +10,4 @@ URL: {{.Issue.URL}}
 {{.PreviousOutputs.plan}}
 
 Commit all changes with a clear commit message, push the branch, and create a PR using:
-gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>"
+gh pr create --title "<descriptive title>" --body "<summary of changes, linking to {{.Issue.URL}}>" --label "ready-to-merge"

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -75,6 +75,7 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 		"workflow-health-report",
 	}, sortedKeys(composed.Workflows))
 	assert.Contains(t, sortedKeys(composed.Prompts), "adapt-repo/plan")
+	assert.Contains(t, sortedKeys(composed.Prompts), "adapt-repo/pr")
 	assert.Contains(t, sortedKeys(composed.Prompts), "security-compliance/synthesize")
 	assert.Contains(t, sortedKeys(composed.Prompts), "workflow-health-report/report")
 	assert.Contains(t, sortedKeys(composed.Sources), "pr-lifecycle")
@@ -83,7 +84,10 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 
 	assert.Contains(t, string(composed.Workflows["fix-bug"]), "name: fix-bug")
 	assert.Contains(t, string(composed.Workflows["implement-feature"]), "name: implement-feature")
+	assert.Contains(t, string(composed.Prompts["adapt-repo/pr"]), `--label "ready-to-merge"`)
 	assert.Contains(t, string(composed.Prompts["fix-bug/pr"]), "Create a pull request")
+	assert.Contains(t, string(composed.Prompts["fix-bug/pr"]), `--label "ready-to-merge"`)
+	assert.Contains(t, string(composed.Prompts["implement-feature/pr"]), `--label "ready-to-merge"`)
 	assert.Contains(t, string(composed.ConfigOverlays[0]), `repo: "{{ .Repo }}"`)
 }
 


### PR DESCRIPTION
## Summary
+- Implements https://github.com/nicholls-inc/xylem/issues/336.
+- Removes the daemon's `harness-impl` label requirement so auto-merge applies to any vessel-produced PR on a xylem-managed issue branch once it carries `ready-to-merge`.
+- Updates seeded PR prompts and harness docs so vessel-created PRs consistently request the merge-ready label while keeping the self-hosted `merge-pr` workflow scoped to `harness-impl` PRs.

## Smoke scenarios covered
+- `S7` — `AutoMergeAppliesToReadyToMergeVesselPRWithoutHarnessImpl`
+- `S8` — `AutoMergeContinuesWhenConfiguredReviewerIsNotCollaborator`
+- `S9` — `AutoAdminMergeWithinOneDaemonTick`

## Changes summary
+- **Modified** `.xylem.yml` to change `daemon.auto_merge_labels` from `[ready-to-merge, harness-impl]` to `[ready-to-merge]`.
+- **Modified** `cli/cmd/xylem/automerge.go` and `cli/cmd/xylem/daemon.go` to document and enforce vessel-wide auto-merge behavior through `autoMergeXylemPRs` and `decideAutoMergeAction`.
+- **Modified** `cli/internal/config/config.go` so `config.DaemonConfig` documents the daemon contract in terms of merge-ready vessel PRs.
+- **Modified** `cli/cmd/xylem/automerge_test.go` and `cli/cmd/xylem/automerge_prop_test.go` to cover ready-to-merge PRs without `harness-impl`, opt-out behavior, reviewer edge cases, and same-tick admin merge.
+- **Modified** `.xylem/HARNESS.md`, `.xylem/prompts/*/pr.md`, `cli/internal/profiles/core/prompts/*/pr.md`, and `cli/internal/profiles/profiles_test.go` so generated PR instructions add `--label "ready-to-merge"` and the checked-in contract docs match the new daemon behavior.

## Test plan
+- `cd cli && ../.bin/goimports -w .`
+- `cd cli && ../.bin/goimports -l .`
+- `cd cli && golangci-lint run`
+- `cd cli && go vet ./...`
+- `cd cli && go build ./cmd/xylem`
+- `cd cli && go test ./...`
+- `git fetch origin main && git rebase origin/main`
+- `cd cli && go vet ./... && go build ./cmd/xylem && go test ./...`

Fixes #336