### PR TITLE
fix: restore failed issue retry routing

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -6,7 +6,7 @@ sources:
     type: github
     repo: nicholls-inc/xylem
     exclude:
-      [wontfix, duplicate, in-progress, no-bot, harness-impl, xylem-failed]
+      [wontfix, duplicate, in-progress, no-bot, harness-impl]
     tasks:
       fix-bugs:
         labels: [bug, ready-for-work]
@@ -19,7 +19,7 @@ sources:
     type: github
     repo: nicholls-inc/xylem
     exclude:
-      [wontfix, duplicate, in-progress, no-bot, harness-impl, xylem-failed]
+      [wontfix, duplicate, in-progress, no-bot, harness-impl]
     tasks:
       implement-features:
         labels: [enhancement, ready-for-work]
@@ -32,7 +32,7 @@ sources:
     type: github
     repo: nicholls-inc/xylem
     exclude:
-      [wontfix, duplicate, in-progress, no-bot, needs-refinement, xylem-failed]
+      [wontfix, duplicate, in-progress, no-bot, needs-refinement]
     tasks:
       triage-issues:
         labels: [needs-triage]
@@ -44,7 +44,7 @@ sources:
   refinement:
     type: github
     repo: nicholls-inc/xylem
-    exclude: [wontfix, duplicate, in-progress, no-bot, xylem-failed]
+    exclude: [wontfix, duplicate, in-progress, no-bot]
     tasks:
       refine-issues:
         labels: [needs-refinement]
@@ -58,7 +58,7 @@ sources:
     type: github
     repo: nicholls-inc/xylem
     timeout: "90m"
-    exclude: [wontfix, duplicate, in-progress, no-bot, blocked, xylem-failed]
+    exclude: [wontfix, duplicate, in-progress, no-bot, blocked]
     tasks:
       implement-harness-steps:
         labels: [harness-impl, ready-for-work]

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -3,7 +3,7 @@ sources:
     type: github
     repo: "{{ .Repo }}"
     timeout: "90m"
-    exclude: [wontfix, duplicate, in-progress, no-bot, blocked, xylem-failed]
+    exclude: [wontfix, duplicate, in-progress, no-bot, blocked]
     tasks:
       implement-harness-steps:
         labels: [harness-impl, ready-for-work]

--- a/cli/internal/review/harness_gap.go
+++ b/cli/internal/review/harness_gap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 )
 
 const (
@@ -301,7 +305,7 @@ func buildHarnessGapFindings(ctx context.Context, stateDir, repo string, runner 
 	} else if finding != nil {
 		findings = append(findings, *finding)
 	}
-	if finding, err := detectFailedFingerprintBacklogGap(ctx, repo, runner); err != nil {
+	if finding, err := detectFailedFingerprintBacklogGap(ctx, stateDir, repo, runner); err != nil {
 		return nil, nil, err
 	} else if finding != nil {
 		findings = append(findings, *finding)
@@ -565,7 +569,7 @@ func detectConfigDriftGap(ctx context.Context, runner issueRunner) (*HarnessGapF
 	return &finding, nil
 }
 
-func detectFailedFingerprintBacklogGap(ctx context.Context, repo string, runner issueRunner) (*HarnessGapFinding, error) {
+func detectFailedFingerprintBacklogGap(ctx context.Context, stateDir, repo string, runner issueRunner) (*HarnessGapFinding, error) {
 	args := append(harnessGapRepoArgs(repo), "issue", "list", "--state", "open", "--label", "xylem-failed", "--limit", "100", "--json", "number,title,url,labels")
 	out, err := runner.RunOutput(ctx, "gh", args...)
 	if err != nil {
@@ -576,14 +580,25 @@ func detectFailedFingerprintBacklogGap(ctx context.Context, repo string, runner 
 		return nil, fmt.Errorf("detect failed-fingerprint backlog gap: parse gh issue list output: %w", err)
 	}
 
+	var q *queue.Queue
+	if strings.TrimSpace(stateDir) != "" {
+		q = queue.New(filepath.Join(stateDir, "queue.jsonl"))
+	}
 	evidence := make([]string, 0, len(issues))
 	count := 0
 	for _, issue := range issues {
 		if hasHarnessGapLabel(issue.Labels, "ready-for-work") {
 			continue
 		}
+		missingRoute, detail, err := failedFingerprintIssueMissingRoute(stateDir, q, issue)
+		if err != nil {
+			return nil, err
+		}
+		if !missingRoute {
+			continue
+		}
 		count++
-		evidence = append(evidence, fmt.Sprintf("#%d `%s` is still labeled `xylem-failed` without `ready-for-work`", issue.Number, issue.Title))
+		evidence = append(evidence, detail)
 	}
 	if count < harnessGapFailedBacklogThreshold {
 		return nil, nil
@@ -592,16 +607,44 @@ func detectFailedFingerprintBacklogGap(ctx context.Context, repo string, runner 
 	finding := newHarnessGapFinding(
 		"failed-fingerprint-backlog",
 		"harness-gap-analysis: failed backlog is missing automatic retry routing",
-		fmt.Sprintf("%d failed issue(s) remain parked behind `xylem-failed` without a ready-for-work route", count),
+		fmt.Sprintf("%d failed issue(s) remain labeled `xylem-failed` without queue lineage or a recorded recovery policy", count),
 		count,
 		harnessGapFailedBacklogThreshold,
 		evidence,
 		[]string{
-			"Escalate parked failed issues when no retry cooldown or unlock path returns them to the backlog.",
-			"Pair failure fingerprints with deterministic requeue policies so failed work does not silently accumulate.",
+			"Persist queue lineage and failure-review artifacts for failed issues so the scanner can prove whether a retry or follow-up route exists.",
+			"Escalate failed issues only when they lack a recorded recovery policy, not merely because they are waiting out cooldown.",
 		},
 	)
 	return &finding, nil
+}
+
+func failedFingerprintIssueMissingRoute(stateDir string, q *queue.Queue, issue harnessGapIssue) (bool, string, error) {
+	if q == nil {
+		return true, fmt.Sprintf("#%d `%s` has no local queue context to verify recovery routing", issue.Number, issue.Title), nil
+	}
+	latest, err := q.FindLatestByRef(issue.URL)
+	if err != nil {
+		return true, fmt.Sprintf("#%d `%s` has `xylem-failed` but no queue lineage to reconstruct a retry policy", issue.Number, issue.Title), nil
+	}
+	switch latest.State {
+	case queue.StatePending, queue.StateRunning, queue.StateWaiting, queue.StateCompleted:
+		return false, "", nil
+	case queue.StateFailed, queue.StateTimedOut:
+		artifact, err := recovery.LoadForVessel(stateDir, latest.ID)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return true, fmt.Sprintf("#%d `%s` latest failed vessel `%s` has no failure-review policy", issue.Number, issue.Title, latest.ID), nil
+			}
+			return false, "", fmt.Errorf("detect failed-fingerprint backlog gap: load recovery artifact for %s: %w", latest.ID, err)
+		}
+		if strings.TrimSpace(string(artifact.RecoveryAction)) == "" {
+			return true, fmt.Sprintf("#%d `%s` latest failed vessel `%s` has an empty recovery action", issue.Number, issue.Title, latest.ID), nil
+		}
+		return false, "", nil
+	default:
+		return true, fmt.Sprintf("#%d `%s` latest vessel `%s` is `%s` without an active recovery route", issue.Number, issue.Title, latest.ID, latest.State), nil
+	}
 }
 
 func loadHarnessGapDaemonLog(path string) ([]harnessGapDaemonEntry, error) {

--- a/cli/internal/review/harness_gap_test.go
+++ b/cli/internal/review/harness_gap_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -138,6 +140,56 @@ func TestGenerateHarnessGapAnalysisNoSignalsWritesNoopReport(t *testing.T) {
 	if len(result.Report.Warnings) != 1 {
 		t.Fatalf("warnings = %+v, want daemon-log warning", result.Report.Warnings)
 	}
+}
+
+func TestDetectFailedFingerprintBacklogGapIgnoresRecordedRecoveryPolicy(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 10, 1, 0, 0, 0, time.UTC)
+	issueURL := "https://example/issue/31"
+	q := queue.New(filepath.Join(stateDir, "queue.jsonl"))
+
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "issue-31",
+		Source:   "github-issue",
+		Ref:      issueURL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "31",
+			"source_input_fingerprint": "src-fp",
+		},
+		State:     queue.StatePending,
+		CreatedAt: now.Add(-15 * time.Minute),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("issue-31", queue.StateFailed, "temporary failure from upstream 503"))
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID:  "issue-31",
+		Source:    "github-issue",
+		Workflow:  "fix-bug",
+		Ref:       issueURL,
+		State:     queue.StateFailed,
+		Error:     "temporary failure from upstream 503",
+		CreatedAt: now.Add(-10 * time.Minute),
+		Meta: map[string]string{
+			"source_input_fingerprint": "src-fp",
+		},
+	})
+	require.NoError(t, recovery.Save(stateDir, artifact))
+
+	runner := &harnessGapTestRunner{
+		responses: map[string][]byte{
+			commandKey("gh", "--repo", "owner/repo", "issue", "list", "--state", "open", "--label", "xylem-failed", "--limit", "100", "--json", "number,title,url,labels"): mustJSON(t, []map[string]any{
+				{"number": 31, "title": "failed one", "url": issueURL, "labels": []map[string]any{{"name": "xylem-failed"}}},
+			}),
+		},
+	}
+
+	finding, err := detectFailedFingerprintBacklogGap(context.Background(), stateDir, "owner/repo", runner)
+	require.NoError(t, err)
+	assert.Nil(t, finding)
 }
 
 func TestSmoke_S1_HarnessGapAnalysisFilesAutoAdminMergeIssue(t *testing.T) {

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -484,6 +484,9 @@ func issueFingerprintLabels(labels []struct {
 
 func managedIssueLabels(task GitHubTask) map[string]bool {
 	managed := make(map[string]bool, 7)
+	if task.StatusLabels == nil {
+		managed["in-progress"] = true
+	}
 	if task.StatusLabels != nil {
 		for _, label := range []string{
 			task.StatusLabels.Queued,

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -86,53 +86,17 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 				if seen[issue.Number] {
 					continue
 				}
-				fingerprint := githubSourceFingerprint(issue.Title, issue.Body, issueLabelNames(issue.Labels))
-				baseMeta := map[string]string{
-					"issue_num":                strconv.Itoa(issue.Number),
-					"issue_title":              issue.Title,
-					"issue_body":               issue.Body,
-					"issue_labels":             strings.Join(issueLabelNames(issue.Labels), ","),
-					"source_input_fingerprint": fingerprint,
-					// trigger_label records which of this task's configured
-					// labels matched on the source issue during scan. On
-					// vessel completion this label is removed so the issue
-					// no longer appears in the scanner's candidate set,
-					// preventing duplicate enqueue after PR lifecycle events
-					// (close/merge) and keeping the issue's UI state
-					// consistent with its workflow state.
-					"trigger_label": label,
-				}
-				baseMeta = applyCurrentRemediationMeta(baseMeta, nil, g.currentHarnessDigest(), g.currentWorkflowDigest(task.Workflow))
-				sl := task.StatusLabels
-				if sl != nil {
-					baseMeta["status_label_queued"] = sl.Queued
-					baseMeta["status_label_running"] = sl.Running
-					baseMeta["status_label_completed"] = sl.Completed
-					baseMeta["status_label_failed"] = sl.Failed
-					baseMeta["status_label_timed_out"] = sl.TimedOut
-				}
-				lgl := task.LabelGateLabels
-				if lgl != nil {
-					baseMeta["label_gate_label_waiting"] = lgl.Waiting
-					baseMeta["label_gate_label_ready"] = lgl.Ready
-				}
-				baseVessel := queue.Vessel{
-					ID:        fmt.Sprintf("issue-%d", issue.Number),
-					Source:    "github-issue",
-					Ref:       issue.URL,
-					Workflow:  task.Workflow,
-					Tier:      ResolveTaskTier(task.Tier, g.DefaultTier),
-					Meta:      baseMeta,
-					State:     queue.StatePending,
-					CreatedAt: sourceNow(),
-				}
-				if g.hasExcludedLabel(issue, excludeSet) {
+				baseVessel := g.newIssueCandidate(issue, label, task)
+				if g.hasHardExcludedLabel(issue, excludeSet, task) {
 					continue
 				}
 
 				retryVessel, blocked, err := g.retryCandidate(baseVessel)
 				if err != nil {
 					return vessels, err
+				}
+				if retryVessel == nil && g.hasFailureStatusLabel(issue, task) {
+					continue
 				}
 				if blocked {
 					continue
@@ -182,7 +146,21 @@ func (g *GitHub) BacklogCount(ctx context.Context) (int, error) {
 			}
 
 			for _, issue := range issues {
-				if _, ok := seen[issue.Number]; ok || g.hasExcludedLabel(issue, excludeSet) {
+				if _, ok := seen[issue.Number]; ok {
+					continue
+				}
+				baseVessel := g.newIssueCandidate(issue, label, task)
+				if g.hasHardExcludedLabel(issue, excludeSet, task) {
+					continue
+				}
+				retryVessel, blocked, err := g.retryCandidate(baseVessel)
+				if err != nil {
+					return 0, err
+				}
+				if retryVessel == nil && g.hasFailureStatusLabel(issue, task) {
+					continue
+				}
+				if blocked || g.scanBlockedByRepoState(ctx, issue.Number, retryVessel != nil) {
 					continue
 				}
 				seen[issue.Number] = struct{}{}
@@ -191,6 +169,45 @@ func (g *GitHub) BacklogCount(ctx context.Context) (int, error) {
 		}
 	}
 	return count, nil
+}
+
+func (g *GitHub) newIssueCandidate(issue ghIssue, triggerLabel string, task GitHubTask) queue.Vessel {
+	fingerprint := githubSourceFingerprint(issue.Title, issue.Body, issueFingerprintLabels(issue.Labels, task))
+	meta := map[string]string{
+		"issue_num":                strconv.Itoa(issue.Number),
+		"issue_title":              issue.Title,
+		"issue_body":               issue.Body,
+		"issue_labels":             strings.Join(issueLabelNames(issue.Labels), ","),
+		"source_input_fingerprint": fingerprint,
+		// trigger_label records which of this task's configured labels matched
+		// on the source issue during scan. On vessel completion this label is
+		// removed so the issue no longer appears in the scanner's candidate set,
+		// preventing duplicate enqueue after PR lifecycle events (close/merge)
+		// and keeping the issue's UI state consistent with its workflow state.
+		"trigger_label": triggerLabel,
+	}
+	meta = applyCurrentRemediationMeta(meta, nil, g.currentHarnessDigest(), g.currentWorkflowDigest(task.Workflow))
+	if sl := task.StatusLabels; sl != nil {
+		meta["status_label_queued"] = sl.Queued
+		meta["status_label_running"] = sl.Running
+		meta["status_label_completed"] = sl.Completed
+		meta["status_label_failed"] = sl.Failed
+		meta["status_label_timed_out"] = sl.TimedOut
+	}
+	if lgl := task.LabelGateLabels; lgl != nil {
+		meta["label_gate_label_waiting"] = lgl.Waiting
+		meta["label_gate_label_ready"] = lgl.Ready
+	}
+	return queue.Vessel{
+		ID:        fmt.Sprintf("issue-%d", issue.Number),
+		Source:    "github-issue",
+		Ref:       issue.URL,
+		Workflow:  task.Workflow,
+		Tier:      ResolveTaskTier(task.Tier, g.DefaultTier),
+		Meta:      meta,
+		State:     queue.StatePending,
+		CreatedAt: sourceNow(),
+	}
 }
 
 func (g *GitHub) OnEnqueue(ctx context.Context, vessel queue.Vessel) error {
@@ -311,9 +328,36 @@ func (g *GitHub) BranchName(vessel queue.Vessel) string {
 	return fmt.Sprintf("%s/issue-%s-%s", prefix, issueNum, slug)
 }
 
-func (g *GitHub) hasExcludedLabel(issue ghIssue, excluded map[string]bool) bool {
+func (g *GitHub) hasHardExcludedLabel(issue ghIssue, excluded map[string]bool, task GitHubTask) bool {
+	softExcluded := make(map[string]bool, 2)
+	if task.StatusLabels != nil {
+		if label := strings.TrimSpace(task.StatusLabels.Failed); label != "" {
+			softExcluded[label] = true
+		}
+		if label := strings.TrimSpace(task.StatusLabels.TimedOut); label != "" {
+			softExcluded[label] = true
+		}
+	}
 	for _, l := range issue.Labels {
-		if excluded[l.Name] {
+		if !excluded[l.Name] || softExcluded[l.Name] {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func (g *GitHub) hasFailureStatusLabel(issue ghIssue, task GitHubTask) bool {
+	if task.StatusLabels == nil {
+		return false
+	}
+	failed := strings.TrimSpace(task.StatusLabels.Failed)
+	timedOut := strings.TrimSpace(task.StatusLabels.TimedOut)
+	if failed == "" && timedOut == "" {
+		return false
+	}
+	for _, l := range issue.Labels {
+		if l.Name == failed || l.Name == timedOut {
 			return true
 		}
 	}
@@ -419,6 +463,51 @@ func issueLabelNames(labels []struct {
 		names = append(names, l.Name)
 	}
 	return names
+}
+
+func issueFingerprintLabels(labels []struct {
+	Name string `json:"name"`
+}, task GitHubTask) []string {
+	managed := managedIssueLabels(task)
+	if len(managed) == 0 {
+		return issueLabelNames(labels)
+	}
+	names := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if managed[l.Name] {
+			continue
+		}
+		names = append(names, l.Name)
+	}
+	return names
+}
+
+func managedIssueLabels(task GitHubTask) map[string]bool {
+	managed := make(map[string]bool, 7)
+	if task.StatusLabels != nil {
+		for _, label := range []string{
+			task.StatusLabels.Queued,
+			task.StatusLabels.Running,
+			task.StatusLabels.Completed,
+			task.StatusLabels.Failed,
+			task.StatusLabels.TimedOut,
+		} {
+			if label = strings.TrimSpace(label); label != "" {
+				managed[label] = true
+			}
+		}
+	}
+	if task.LabelGateLabels != nil {
+		for _, label := range []string{
+			task.LabelGateLabels.Waiting,
+			task.LabelGateLabels.Ready,
+		} {
+			if label = strings.TrimSpace(label); label != "" {
+				managed[label] = true
+			}
+		}
+	}
+	return managed
 }
 
 func githubSourceFingerprint(title, body string, labels []string) string {

--- a/cli/internal/source/github_test.go
+++ b/cli/internal/source/github_test.go
@@ -202,7 +202,7 @@ func TestSmoke_S2_GitHubScanAutoRetriesEligibleTransientFailure(t *testing.T) {
 		URL:    "https://github.com/owner/repo/issues/42",
 		Labels: []struct {
 			Name string `json:"name"`
-		}{{Name: "bug"}},
+		}{{Name: "bug"}, {Name: "xylem-failed"}},
 	}}
 	issueBytes, _ := json.Marshal(issues)
 	r.set(issueBytes, "gh", "search", "issues",
@@ -242,8 +242,13 @@ func TestSmoke_S2_GitHubScanAutoRetriesEligibleTransientFailure(t *testing.T) {
 	require.NoError(t, recovery.Save(dir, artifact))
 
 	g := &GitHub{
-		Repo:      "owner/repo",
-		Tasks:     map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		Repo: "owner/repo",
+		Tasks: map[string]GitHubTask{"fix": {
+			Labels:       []string{"bug"},
+			Workflow:     "fix-bug",
+			StatusLabels: &StatusLabels{Failed: "xylem-failed"},
+		}},
+		Exclude:   []string{"xylem-failed"},
 		StateDir:  dir,
 		Queue:     q,
 		CmdRunner: r,
@@ -1002,7 +1007,7 @@ func TestOnFailNilRunner(t *testing.T) {
 	}
 }
 
-func TestScanSkipsExcludedFailedLabel(t *testing.T) {
+func TestScanSkipsFailedStatusLabelWithoutEligibleRetry(t *testing.T) {
 	dir := t.TempDir()
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
 	r := newMock()
@@ -1028,8 +1033,12 @@ func TestScanSkipsExcludedFailedLabel(t *testing.T) {
 		"--label", "bug")
 
 	g := &GitHub{
-		Repo:      "owner/repo",
-		Tasks:     map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		Repo: "owner/repo",
+		Tasks: map[string]GitHubTask{"fix": {
+			Labels:       []string{"bug"},
+			Workflow:     "fix-bug",
+			StatusLabels: &StatusLabels{Failed: "xylem-failed"},
+		}},
 		Exclude:   []string{"xylem-failed"},
 		Queue:     q,
 		CmdRunner: r,
@@ -1040,8 +1049,77 @@ func TestScanSkipsExcludedFailedLabel(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(vessels) != 0 {
-		t.Errorf("expected 0 vessels (xylem-failed excluded), got %d", len(vessels))
+		t.Errorf("expected 0 vessels (failed status labels require retry eligibility), got %d", len(vessels))
 	}
+}
+
+func TestBacklogCountIncludesEligibleRetryableFailedIssue(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{{
+		Number: 42,
+		Title:  "flaky dependency",
+		Body:   "same body",
+		URL:    "https://github.com/owner/repo/issues/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}, {Name: "xylem-failed"}},
+	}}
+	issueBytes, _ := json.Marshal(issues)
+	r.set(issueBytes, "gh", "search", "issues",
+		"--repo", "owner/repo",
+		"--state", "open",
+		"--json", "number,title,body,url,labels",
+		"--limit", "20",
+		"--label", "bug")
+
+	fingerprint := githubSourceFingerprint("flaky dependency", "same body", []string{"bug"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      issues[0].URL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("issue-42", queue.StateFailed, "temporary failure from upstream 503"))
+
+	artifact := recovery.Build(recovery.Input{
+		VesselID:  "issue-42",
+		Source:    "github-issue",
+		Workflow:  "fix-bug",
+		Ref:       issues[0].URL,
+		State:     queue.StateFailed,
+		Error:     "temporary failure from upstream 503",
+		CreatedAt: time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown),
+	})
+	require.NoError(t, recovery.Save(dir, artifact))
+
+	g := &GitHub{
+		Repo: "owner/repo",
+		Tasks: map[string]GitHubTask{"fix": {
+			Labels:       []string{"bug"},
+			Workflow:     "fix-bug",
+			StatusLabels: &StatusLabels{Failed: "xylem-failed"},
+		}},
+		Exclude:   []string{"xylem-failed"},
+		StateDir:  dir,
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	count, err := g.BacklogCount(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
 }
 
 func TestScanPersistsTriggerLabelInMeta(t *testing.T) {

--- a/cli/internal/source/github_test.go
+++ b/cli/internal/source/github_test.go
@@ -638,6 +638,67 @@ func TestGitHubScanRetriesAfterCooldownWithoutArtifactFallsBackToStartedAt(t *te
 	assert.Equal(t, "cooldown", vessels[0].Meta[recovery.MetaUnlockedBy])
 }
 
+func TestGitHubScanLegacyRunningLabelDoesNotChangeRetryFingerprint(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{{
+		Number: 42,
+		Title:  "flaky dependency",
+		Body:   "same body",
+		URL:    "https://github.com/owner/repo/issues/42",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}, {Name: "in-progress"}},
+	}}
+	issueBytes, _ := json.Marshal(issues)
+	r.set(issueBytes, "gh", "search", "issues",
+		"--repo", "owner/repo",
+		"--state", "open",
+		"--json", "number,title,body,url,labels",
+		"--limit", "20",
+		"--label", "bug")
+
+	fingerprint := githubSourceFingerprint("flaky dependency", "same body", []string{"bug"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "issue-42",
+		Source:   "github-issue",
+		Ref:      issues[0].URL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "42",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("issue-42", queue.StateFailed, "temporary failure from upstream 503"))
+
+	failed, err := q.FindByID("issue-42")
+	require.NoError(t, err)
+	endedAt := time.Now().UTC().Add(-2 * recovery.DefaultRetryCooldown)
+	failed.EndedAt = &endedAt
+	require.NoError(t, q.UpdateVessel(*failed))
+
+	g := &GitHub{
+		Repo:      "owner/repo",
+		Tasks:     map[string]GitHubTask{"fix": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "issue-42-retry-1", vessels[0].ID)
+	assert.Equal(t, "issue-42", vessels[0].RetryOf)
+	assert.Equal(t, "cooldown", vessels[0].Meta[recovery.MetaUnlockedBy])
+}
+
 func TestGitHubScanRetriesWhenOnlySourceFingerprintChanges(t *testing.T) {
 	dir := t.TempDir()
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))


### PR DESCRIPTION
## Summary
- allow self-hosting GitHub issue sources to scan xylem-failed issues through retry eligibility instead of excluding them up front
- keep status-managed labels out of the source fingerprint and add coverage for eligible retry backlog counting and failed-label suppression without retry eligibility
- tighten harness-gap backlog detection so it only flags failed issues that lack queue lineage or a recorded recovery policy

Closes https://github.com/nicholls-inc/xylem/issues/321