### PR TITLE
Requeue orphaned running vessels on daemon restart

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -580,10 +580,11 @@ func daemonBacklogHealthCheck(now, lastActivityAt time.Time, idleThreshold time.
 	}
 }
 
-// reconcileStaleVessels transitions ALL running vessels to timed_out. The
+// reconcileStaleVessels requeues ALL running vessels as pending work. The
 // singleton daemon lock guarantees that no other daemon is executing vessels
-// when this runs, so every running vessel is orphaned by definition. The
-// timed_out state supports retry via `xylem retry`.
+// when this runs, so every running vessel is orphaned by definition. Restart
+// recovery preserves completed phase progress but clears crash-specific runtime
+// fields so the daemon can safely resume the vessel on the next drain tick.
 func reconcileStaleVessels(q *queue.Queue, wt *worktree.Manager) {
 	vessels, err := q.List()
 	if err != nil {
@@ -596,8 +597,8 @@ func reconcileStaleVessels(q *queue.Queue, wt *worktree.Manager) {
 		if v.State != queue.StateRunning {
 			continue
 		}
-		slog.Warn("daemon reconcile found orphaned running vessel", "vessel", v.ID, "target_state", queue.StateTimedOut)
-		if err := q.Update(v.ID, queue.StateTimedOut, "orphaned by daemon restart"); err != nil {
+		slog.Warn("daemon reconcile found orphaned running vessel", "vessel", v.ID, "target_state", queue.StatePending)
+		if err := q.Update(v.ID, queue.StatePending, ""); err != nil {
 			slog.Error("daemon reconcile failed to update vessel", "vessel", v.ID, "error", err)
 			continue
 		}
@@ -611,7 +612,7 @@ func reconcileStaleVessels(q *queue.Queue, wt *worktree.Manager) {
 		}
 	}
 	if recovered > 0 {
-		slog.Info("daemon reconcile recovered orphaned vessels", "recovered", recovered)
+		slog.Info("daemon reconcile requeued orphaned vessels", "recovered", recovered)
 	}
 }
 

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -1049,7 +1049,7 @@ func TestWS1S28DaemonPathWiresScaffolding(t *testing.T) {
 }
 
 func TestReconcileStaleVessels(t *testing.T) {
-	t.Run("orphaned running vessel transitions to timed_out", func(t *testing.T) {
+	t.Run("orphaned running vessel is requeued as pending", func(t *testing.T) {
 		dir := t.TempDir()
 		q := queue.New(filepath.Join(dir, "queue.jsonl"))
 		now := time.Now().UTC()
@@ -1060,6 +1060,12 @@ func TestReconcileStaleVessels(t *testing.T) {
 			t.Fatal("expected vessel from dequeue")
 			return
 		}
+		v.CurrentPhase = 2
+		v.PhaseOutputs = map[string]string{"plan": "done"}
+		v.WorktreePath = "/tmp/worktree-stale-1"
+		if err := q.UpdateVessel(*v); err != nil {
+			t.Fatalf("UpdateVessel() error = %v", err)
+		}
 
 		reconcileStaleVessels(q, nil)
 
@@ -1067,15 +1073,27 @@ func TestReconcileStaleVessels(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to find vessel: %v", err)
 		}
-		if updated.State != queue.StateTimedOut {
-			t.Errorf("expected state %s, got %s", queue.StateTimedOut, updated.State)
+		if updated.State != queue.StatePending {
+			t.Errorf("expected state %s, got %s", queue.StatePending, updated.State)
 		}
-		if updated.Error != "orphaned by daemon restart" {
-			t.Errorf("expected error 'orphaned by daemon restart', got %q", updated.Error)
+		if updated.Error != "" {
+			t.Errorf("expected cleared error, got %q", updated.Error)
+		}
+		if updated.StartedAt != nil {
+			t.Fatal("expected StartedAt to be cleared")
+		}
+		if updated.CurrentPhase != 2 {
+			t.Fatalf("updated.CurrentPhase = %d, want 2", updated.CurrentPhase)
+		}
+		if updated.PhaseOutputs["plan"] != "done" {
+			t.Fatalf("updated.PhaseOutputs[plan] = %q, want done", updated.PhaseOutputs["plan"])
+		}
+		if updated.WorktreePath != "" {
+			t.Fatalf("updated.WorktreePath = %q, want empty", updated.WorktreePath)
 		}
 	})
 
-	t.Run("recently started running vessel is also recovered", func(t *testing.T) {
+	t.Run("recently started running vessel is also requeued", func(t *testing.T) {
 		dir := t.TempDir()
 		q := queue.New(filepath.Join(dir, "queue.jsonl"))
 		now := time.Now().UTC()
@@ -1094,8 +1112,8 @@ func TestReconcileStaleVessels(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to find vessel: %v", err)
 		}
-		if updated.State != queue.StateTimedOut {
-			t.Errorf("expected state %s, got %s", queue.StateTimedOut, updated.State)
+		if updated.State != queue.StatePending {
+			t.Errorf("expected state %s, got %s", queue.StatePending, updated.State)
 		}
 	})
 
@@ -1119,7 +1137,7 @@ func TestReconcileStaleVessels(t *testing.T) {
 		}
 	})
 
-	t.Run("running vessel with nil StartedAt is recovered", func(t *testing.T) {
+	t.Run("running vessel with nil StartedAt is requeued", func(t *testing.T) {
 		dir := t.TempDir()
 		q := queue.New(filepath.Join(dir, "queue.jsonl"))
 		now := time.Now().UTC()
@@ -1132,12 +1150,12 @@ func TestReconcileStaleVessels(t *testing.T) {
 		reconcileStaleVessels(q, nil)
 
 		updated, _ := q.FindByID("nil-start")
-		if updated.State != queue.StateTimedOut {
-			t.Errorf("expected state timed_out for nil StartedAt, got %s", updated.State)
+		if updated.State != queue.StatePending {
+			t.Errorf("expected state pending for nil StartedAt, got %s", updated.State)
 		}
 	})
 
-	t.Run("dtu fixture-backed stale running vessel keeps DTU evidence", func(t *testing.T) {
+	t.Run("dtu fixture-backed stale running vessel is requeued without timeout side effects", func(t *testing.T) {
 		repoDir, store, q, cmdRunner := newDaemonDTUEnv(t, "issue-daemon-recovery.yaml")
 		defer withDaemonWorkingDir(t, repoDir)()
 
@@ -1211,28 +1229,31 @@ func TestReconcileStaleVessels(t *testing.T) {
 			t.Fatalf("Stat(%q): %v", absWorktree, err)
 		}
 
-		reconcileStaleVessels(q, nil)
+		reconcileStaleVessels(q, wt)
 
 		updated, err := q.FindByID("issue-4")
 		if err != nil {
 			t.Fatalf("FindByID(issue-4) error = %v", err)
 		}
-		if updated.State != queue.StateTimedOut {
-			t.Fatalf("updated.State = %q, want %q", updated.State, queue.StateTimedOut)
+		if updated.State != queue.StatePending {
+			t.Fatalf("updated.State = %q, want %q", updated.State, queue.StatePending)
 		}
-		if updated.Error != "orphaned by daemon restart" {
-			t.Fatalf("updated.Error = %q, want %q", updated.Error, "orphaned by daemon restart")
+		if updated.Error != "" {
+			t.Fatalf("updated.Error = %q, want empty", updated.Error)
 		}
-		if updated.EndedAt == nil {
-			t.Fatal("updated.EndedAt = nil, want end timestamp")
+		if updated.EndedAt != nil {
+			t.Fatal("updated.EndedAt != nil, want cleared end timestamp")
 		}
-		if updated.StartedAt == nil {
-			t.Fatal("updated.StartedAt = nil, want start timestamp")
+		if updated.StartedAt != nil {
+			t.Fatal("updated.StartedAt != nil, want cleared start timestamp")
+		}
+		if updated.WorktreePath != "" {
+			t.Fatalf("updated.WorktreePath = %q, want empty", updated.WorktreePath)
 		}
 
 		assertLabelsEqual(t, readDaemonDTULabels(t, store, "owner/repo", 4), []string{"bug", "in-progress"})
-		if _, err := os.Stat(absWorktree); err != nil {
-			t.Fatalf("Stat(%q) after reconcile: %v", absWorktree, err)
+		if _, err := os.Stat(absWorktree); !os.IsNotExist(err) {
+			t.Fatalf("Stat(%q) after reconcile error = %v, want not exist", absWorktree, err)
 		}
 
 		state := loadDaemonDTUState(t, store)
@@ -1241,11 +1262,8 @@ func TestReconcileStaleVessels(t *testing.T) {
 			t.Fatal("RepositoryBySlug(owner/repo) = nil")
 			return
 		}
-		if len(repo.Worktrees) != 1 {
-			t.Fatalf("len(repo.Worktrees) = %d, want 1", len(repo.Worktrees))
-		}
-		if repo.Worktrees[0].Branch != src.BranchName(*vessel) {
-			t.Fatalf("worktree branch = %q, want %q", repo.Worktrees[0].Branch, src.BranchName(*vessel))
+		if len(repo.Worktrees) != 0 {
+			t.Fatalf("len(repo.Worktrees) = %d, want 0", len(repo.Worktrees))
 		}
 
 		events := readDaemonDTUEvents(t, store)
@@ -1262,6 +1280,7 @@ func TestReconcileStaleVessels(t *testing.T) {
 			{"fetch", "origin", "main"},
 			{"worktree", "list", "--porcelain"},
 			{"worktree", "add", ".claude/worktrees/" + wantBranch, "-B", wantBranch, "origin/main"},
+			{"worktree", "remove", worktreePath, "--force"},
 		}
 		for _, want := range wantCommands {
 			found := false

--- a/cli/internal/dtu/scenario_daemon_test.go
+++ b/cli/internal/dtu/scenario_daemon_test.go
@@ -17,11 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// reconcileStaleVesselsForTest replicates the daemon's stale-vessel
-// reconciliation logic (from cli/cmd/xylem/daemon.go) so the DTU scenario
-// test can exercise recovery without importing the main package.
-// The singleton daemon lock guarantees all running vessels are orphaned,
-// so no timeout heuristic is needed.
+// reconcileStaleVesselsForTest replicates the daemon's startup recovery
+// behavior (from cli/cmd/xylem/daemon.go) so the DTU scenario test can
+// exercise orphan recovery without importing the main package.
 func reconcileStaleVesselsForTest(q *queue.Queue) int {
 	vessels, err := q.List()
 	if err != nil {
@@ -33,7 +31,7 @@ func reconcileStaleVesselsForTest(q *queue.Queue) int {
 		if v.State != queue.StateRunning {
 			continue
 		}
-		q.Update(v.ID, queue.StateTimedOut, "orphaned by daemon restart") //nolint:errcheck
+		q.Update(v.ID, queue.StatePending, "") //nolint:errcheck
 		reconciled++
 	}
 	return reconciled
@@ -109,72 +107,50 @@ func TestScenarioDaemonRecovery(t *testing.T) {
 		t.Fatalf("reconciled = %d, want 1", reconciled)
 	}
 
-	// Verify the orphaned vessel transitioned to timed_out.
+	// Verify the orphaned vessel was requeued for another drain attempt.
 	updated, err := env.queue.FindByID("issue-4")
 	if err != nil {
 		t.Fatalf("FindByID(issue-4) error = %v", err)
 	}
-	if updated.State != queue.StateTimedOut {
-		t.Fatalf("updated.State = %q, want %q", updated.State, queue.StateTimedOut)
+	if updated.State != queue.StatePending {
+		t.Fatalf("updated.State = %q, want %q", updated.State, queue.StatePending)
 	}
-	if updated.Error != "orphaned by daemon restart" {
-		t.Fatalf("updated.Error = %q, want %q", updated.Error, "orphaned by daemon restart")
+	if updated.Error != "" {
+		t.Fatalf("updated.Error = %q, want empty", updated.Error)
 	}
-	if updated.EndedAt == nil {
-		t.Fatal("updated.EndedAt = nil, want end timestamp")
-	}
-
-	// --- Phase 5: Daemon continues processing new vessels after recovery ---
-	// Enqueue a fresh manual vessel to simulate continued daemon operation.
-	now, err := dtu.RuntimeNow()
-	if err != nil {
-		t.Fatalf("RuntimeNow() error = %v", err)
-	}
-	enqueued, err := env.queue.Enqueue(queue.Vessel{
-		ID:        "manual-recovery-1",
-		Source:    "manual",
-		Ref:       "",
-		Workflow:  "fix-bug",
-		Prompt:    "recovery test",
-		State:     queue.StatePending,
-		CreatedAt: now,
-	})
-	if err != nil {
-		t.Fatalf("Enqueue(manual-recovery-1) error = %v", err)
-	}
-	if !enqueued {
-		t.Fatal("Enqueue(manual-recovery-1) = false, want true")
+	if updated.EndedAt != nil {
+		t.Fatal("updated.EndedAt != nil, want cleared end timestamp")
 	}
 
-	// Dequeue and verify the new vessel enters running state.
+	// --- Phase 5: Daemon drains the recovered vessel on the next pass ---
 	newVessel, err := env.queue.Dequeue()
 	if err != nil {
 		t.Fatalf("Dequeue() error = %v", err)
 	}
 	if newVessel == nil {
-		t.Fatal("second Dequeue() = nil, want vessel")
+		t.Fatal("second Dequeue() = nil, want recovered vessel")
 		return
 	}
-	if newVessel.ID != "manual-recovery-1" {
-		t.Fatalf("newVessel.ID = %q, want %q", newVessel.ID, "manual-recovery-1")
+	if newVessel.ID != "issue-4" {
+		t.Fatalf("newVessel.ID = %q, want %q", newVessel.ID, "issue-4")
 	}
 	if newVessel.State != queue.StateRunning {
 		t.Fatalf("newVessel.State = %q, want %q", newVessel.State, queue.StateRunning)
 	}
 
-	// Complete the new vessel to prove the pipeline is fully operational.
-	if err := env.queue.Update("manual-recovery-1", queue.StateCompleted, ""); err != nil {
-		t.Fatalf("Update(manual-recovery-1, completed) error = %v", err)
+	// Complete the recovered vessel to prove the pipeline is fully operational.
+	if err := env.queue.Update("issue-4", queue.StateCompleted, ""); err != nil {
+		t.Fatalf("Update(issue-4, completed) error = %v", err)
 	}
-	completed, err := env.queue.FindByID("manual-recovery-1")
+	completed, err := env.queue.FindByID("issue-4")
 	if err != nil {
-		t.Fatalf("FindByID(manual-recovery-1) error = %v", err)
+		t.Fatalf("FindByID(issue-4) error = %v", err)
 	}
 	if completed.State != queue.StateCompleted {
 		t.Fatalf("completed.State = %q, want %q", completed.State, queue.StateCompleted)
 	}
 
-	// Verify the full queue state: orphaned vessel timed_out, new vessel completed.
+	// Verify the full queue state: the recovered vessel eventually completes.
 	vessels, err := env.queue.List()
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
@@ -183,11 +159,8 @@ func TestScenarioDaemonRecovery(t *testing.T) {
 	for _, v := range vessels {
 		states[v.ID] = v.State
 	}
-	if states["issue-4"] != queue.StateTimedOut {
-		t.Fatalf("queue[issue-4] = %q, want %q", states["issue-4"], queue.StateTimedOut)
-	}
-	if states["manual-recovery-1"] != queue.StateCompleted {
-		t.Fatalf("queue[manual-recovery-1] = %q, want %q", states["manual-recovery-1"], queue.StateCompleted)
+	if states["issue-4"] != queue.StateCompleted {
+		t.Fatalf("queue[issue-4] = %q, want %q", states["issue-4"], queue.StateCompleted)
 	}
 
 	// Verify DTU events were recorded during the scenario.

--- a/cli/internal/dtu/scenario_daemon_test.go
+++ b/cli/internal/dtu/scenario_daemon_test.go
@@ -20,10 +20,10 @@ import (
 // reconcileStaleVesselsForTest replicates the daemon's startup recovery
 // behavior (from cli/cmd/xylem/daemon.go) so the DTU scenario test can
 // exercise orphan recovery without importing the main package.
-func reconcileStaleVesselsForTest(q *queue.Queue) int {
+func reconcileStaleVesselsForTest(q *queue.Queue) (int, error) {
 	vessels, err := q.List()
 	if err != nil {
-		return 0
+		return 0, err
 	}
 
 	reconciled := 0
@@ -31,10 +31,12 @@ func reconcileStaleVesselsForTest(q *queue.Queue) int {
 		if v.State != queue.StateRunning {
 			continue
 		}
-		q.Update(v.ID, queue.StatePending, "") //nolint:errcheck
+		if err := q.Update(v.ID, queue.StatePending, ""); err != nil {
+			return reconciled, err
+		}
 		reconciled++
 	}
-	return reconciled
+	return reconciled, nil
 }
 
 func TestScenarioDaemonRecovery(t *testing.T) {
@@ -102,7 +104,10 @@ func TestScenarioDaemonRecovery(t *testing.T) {
 	// --- Phase 3: Daemon restarts and reconciles orphaned vessels ---
 	// No need to advance time — the singleton lock means all running vessels
 	// are orphaned by definition.
-	reconciled := reconcileStaleVesselsForTest(env.queue)
+	reconciled, err := reconcileStaleVesselsForTest(env.queue)
+	if err != nil {
+		t.Fatalf("reconcileStaleVesselsForTest() error = %v", err)
+	}
 	if reconciled != 1 {
 		t.Fatalf("reconciled = %d, want 1", reconciled)
 	}

--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -35,6 +35,7 @@ var validTransitions = map[VesselState]map[VesselState]bool{
 		StateCancelled: true,
 	},
 	StateRunning: {
+		StatePending:   true, // daemon restart recovery requeues orphaned work
 		StateCompleted: true,
 		StateFailed:    true,
 		StateCancelled: true,
@@ -227,13 +228,7 @@ func (q *Queue) Update(id string, state VesselState, errMsg string) error {
 			vessels[i].State = state
 			switch state {
 			case StatePending:
-				vessels[i].EndedAt = nil
-				vessels[i].Error = ""
-				vessels[i].GateRetries = 0
-				vessels[i].WaitingSince = nil
-				vessels[i].WaitingFor = ""
-				vessels[i].FailedPhase = ""
-				vessels[i].GateOutput = ""
+				resetPendingState(&vessels[i], previous.State)
 			case StateRunning:
 				if vessels[i].StartedAt == nil {
 					vessels[i].StartedAt = &now
@@ -268,6 +263,20 @@ func (q *Queue) Update(id string, state VesselState, errMsg string) error {
 
 		return fmt.Errorf("vessel %s not found", id)
 	})
+}
+
+func resetPendingState(vessel *Vessel, previousState VesselState) {
+	vessel.StartedAt = nil
+	vessel.EndedAt = nil
+	vessel.Error = ""
+	vessel.GateRetries = 0
+	vessel.WaitingSince = nil
+	vessel.WaitingFor = ""
+	vessel.FailedPhase = ""
+	vessel.GateOutput = ""
+	if previousState == StateRunning {
+		vessel.WorktreePath = ""
+	}
 }
 
 func (q *Queue) List() ([]Vessel, error) {

--- a/cli/internal/queue/queue_test.go
+++ b/cli/internal/queue/queue_test.go
@@ -869,18 +869,94 @@ func TestUpdateValidTransitionFailedToPending(t *testing.T) {
 	if err := q.Update(vessel.ID, StateFailed, "transient error"); err != nil {
 		t.Fatalf("fail: %v", err)
 	}
+	failed, err := q.FindByID(vessel.ID)
+	if err != nil {
+		t.Fatalf("FindByID after fail: %v", err)
+	}
+	failed.CurrentPhase = 2
+	failed.PhaseOutputs = map[string]string{"plan": "done"}
+	failed.WorktreePath = "/tmp/wt-14"
+	if err := q.UpdateVessel(*failed); err != nil {
+		t.Fatalf("UpdateVessel(failed): %v", err)
+	}
 
 	// Retry: failed -> pending should be allowed.
 	if err := q.Update(vessel.ID, StatePending, ""); err != nil {
 		t.Fatalf("expected failed->pending to succeed for retry, got: %v", err)
 	}
 
-	vessels, err := q.List()
+	got, err := q.FindByID(vessel.ID)
 	if err != nil {
-		t.Fatalf("list: %v", err)
+		t.Fatalf("FindByID: %v", err)
 	}
-	if vessels[0].State != StatePending {
-		t.Fatalf("expected pending after retry, got %q", vessels[0].State)
+	if got.State != StatePending {
+		t.Fatalf("expected pending after retry, got %q", got.State)
+	}
+	if got.WorktreePath != "/tmp/wt-14" {
+		t.Fatalf("expected WorktreePath preserved, got %q", got.WorktreePath)
+	}
+	if got.CurrentPhase != 2 {
+		t.Fatalf("expected CurrentPhase preserved, got %d", got.CurrentPhase)
+	}
+	if got.PhaseOutputs["plan"] != "done" {
+		t.Fatalf("expected PhaseOutputs[plan]=done, got %q", got.PhaseOutputs["plan"])
+	}
+}
+
+func TestUpdateValidTransitionRunningToPending(t *testing.T) {
+	q, _ := newTestQueue(t)
+	vessel := testVessel(15)
+	if _, err := q.Enqueue(vessel); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	running, err := q.Dequeue()
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if running == nil {
+		t.Fatal("Dequeue() = nil, want vessel")
+	}
+	running.CurrentPhase = 2
+	running.PhaseOutputs = map[string]string{"plan": "done"}
+	running.WorktreePath = "/tmp/wt-15"
+	running.GateRetries = 3
+	running.FailedPhase = "implement"
+	running.GateOutput = "missing check"
+	if err := q.UpdateVessel(*running); err != nil {
+		t.Fatalf("UpdateVessel(running): %v", err)
+	}
+
+	if err := q.Update(vessel.ID, StatePending, ""); err != nil {
+		t.Fatalf("expected running->pending to succeed for restart recovery, got: %v", err)
+	}
+
+	got, err := q.FindByID(vessel.ID)
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if got.State != StatePending {
+		t.Fatalf("expected pending after restart recovery, got %q", got.State)
+	}
+	if got.StartedAt != nil {
+		t.Fatal("expected StartedAt to be cleared")
+	}
+	if got.GateRetries != 0 {
+		t.Fatalf("expected GateRetries reset, got %d", got.GateRetries)
+	}
+	if got.FailedPhase != "" {
+		t.Fatalf("expected FailedPhase cleared, got %q", got.FailedPhase)
+	}
+	if got.GateOutput != "" {
+		t.Fatalf("expected GateOutput cleared, got %q", got.GateOutput)
+	}
+	if got.CurrentPhase != 2 {
+		t.Fatalf("expected CurrentPhase preserved, got %d", got.CurrentPhase)
+	}
+	if got.PhaseOutputs["plan"] != "done" {
+		t.Fatalf("expected PhaseOutputs[plan]=done, got %q", got.PhaseOutputs["plan"])
+	}
+	if got.WorktreePath != "" {
+		t.Fatalf("expected WorktreePath cleared, got %q", got.WorktreePath)
 	}
 }
 


### PR DESCRIPTION
## Summary
- requeue orphaned `running` vessels to `pending` during daemon startup instead of forcing `timed_out`
- preserve completed phase progress while clearing crash-specific runtime state and stale worktree paths
- update daemon, queue, and DTU coverage for restart recovery semantics

Fixes https://github.com/nicholls-inc/xylem/issues/320