### PR TITLE
feat(daemon): add supervised auto-restart and clean daemon stop flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ See the [Workflows Guide](docs/workflows.md) for template variables, custom work
 | `xylem drain` | Dequeue pending vessels and launch sessions |
 | `xylem review` | Roll up failures, evals, and pruning signals into a harness review |
 | `xylem daemon` | Continuous scan-drain loop |
+| `xylem daemon-supervisor` | Restart the daemon after unexpected exits |
+| `xylem daemon stop` | Stop the daemon and suppress supervisor restarts |
 | `xylem enqueue` | Manually enqueue a task |
 | `xylem retry` | Retry a failed vessel with failure context, or restart from scratch |
 | `xylem status` | Show queue state and vessel summary |
@@ -180,6 +182,8 @@ See the [Workflows Guide](docs/workflows.md) for template variables, custom work
 # Common patterns
 xylem scan && xylem drain           # One-shot scan and process
 xylem daemon                        # Continuous operation
+xylem daemon-supervisor             # Auto-restart wrapper around xylem daemon
+xylem daemon stop                   # Stop the daemon without triggering a restart
 xylem enqueue --workflow fix-bug \
   --ref "https://github.com/owner/repo/issues/99"  # Ad-hoc task
 xylem status --json | jq '.[] | select(.state == "failed")'  # Query failures
@@ -197,8 +201,9 @@ See the [CLI Reference](docs/cli-reference.md) for all flags, examples, and exit
 **Daemon mode** (recommended):
 
 ```bash
-xylem daemon
-# Or as a background service with systemd, launchd, etc.
+xylem daemon-supervisor
+# Loads .daemon-root/.env on each restart, waits 10s after unexpected exits,
+# and hands off clean shutdowns to `xylem daemon stop`.
 ```
 
 **Cron**:

--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -37,7 +38,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "bootstrap", "continuous-improvement", "continuous-simplicity", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "retry", "visualize", "version"}
+	expected := []string{"init", "bootstrap", "continuous-improvement", "continuous-simplicity", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)
@@ -67,5 +68,41 @@ func TestCobraStatusJsonFlag(t *testing.T) {
 	trimmed := strings.TrimSpace(out)
 	if trimmed != "[]" {
 		t.Errorf("expected '[]' for --json empty status, got: %q", trimmed)
+	}
+}
+
+func TestCobraDaemonStopBypassesToolingChecks(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	dir := t.TempDir()
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd(): %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir(%q): %v", dir, err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(origWD); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+
+	configPath := filepath.Join(dir, ".xylem.yml")
+	if err := cmdInit(configPath, false); err != nil {
+		t.Fatalf("cmdInit(%q): %v", configPath, err)
+	}
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"--config", configPath, "daemon", "stop"})
+
+	out := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.TrimSpace(out) != "Daemon not running." {
+		t.Fatalf("output = %q, want %q", out, "Daemon not running.\n")
 	}
 }

--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -37,6 +37,7 @@ func newDaemonCmd() *cobra.Command {
 			return cmdDaemon(deps.cfg, deps.q, deps.wt)
 		},
 	}
+	cmd.AddCommand(newDaemonStopCmd())
 	return cmd
 }
 
@@ -53,8 +54,7 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	scanInterval, drainInterval := parseDaemonIntervals(cfg.Daemon)
 
 	// P0-3: Acquire singleton lock to prevent multiple daemons.
-	pidPath := filepath.Join(cfg.StateDir, "daemon.pid")
-	unlock, err := acquireDaemonLock(pidPath)
+	unlock, err := acquireDaemonLock(daemonPIDPath(cfg))
 	if err != nil {
 		return err
 	}
@@ -640,38 +640,46 @@ func daemonAfter(ctx context.Context, delay time.Duration) <-chan time.Time {
 // function. On failure (another daemon holds the lock) it returns an error
 // that includes the PID of the existing daemon.
 func acquireDaemonLock(pidPath string) (unlock func(), err error) {
+	return acquireProcessLock(pidPath, "daemon")
+}
+
+func acquireDaemonSupervisorLock(pidPath string) (unlock func(), err error) {
+	return acquireProcessLock(pidPath, "daemon supervisor")
+}
+
+func acquireProcessLock(pidPath, processName string) (unlock func(), err error) {
 	// Ensure the parent directory exists.
 	if mkErr := os.MkdirAll(filepath.Dir(pidPath), 0o755); mkErr != nil {
-		return nil, fmt.Errorf("daemon lock: create state dir: %w", mkErr)
+		return nil, fmt.Errorf("%s lock: create state dir: %w", processName, mkErr)
 	}
 
 	fl := flock.New(pidPath)
 	locked, err := fl.TryLock()
 	if err != nil {
-		return nil, fmt.Errorf("daemon lock: %w", err)
+		return nil, fmt.Errorf("%s lock: %w", processName, err)
 	}
 	if !locked {
 		// Try to read existing PID for a helpful error message.
 		if data, readErr := os.ReadFile(pidPath); readErr == nil {
 			if pid, parseErr := strconv.Atoi(string(data)); parseErr == nil {
-				return nil, fmt.Errorf("daemon already running (PID %d)", pid)
+				return nil, fmt.Errorf("%s already running (PID %d)", processName, pid)
 			}
 		}
-		return nil, fmt.Errorf("daemon already running (could not read PID)")
+		return nil, fmt.Errorf("%s already running (could not read PID)", processName)
 	}
 
 	// Write our PID to the file.
 	pid := os.Getpid()
 	if writeErr := os.WriteFile(pidPath, []byte(strconv.Itoa(pid)), 0o644); writeErr != nil {
 		fl.Unlock() //nolint:errcheck
-		return nil, fmt.Errorf("daemon lock: write PID: %w", writeErr)
+		return nil, fmt.Errorf("%s lock: write PID: %w", processName, writeErr)
 	}
 
-	slog.Info("daemon acquired lock", "path", pidPath, "pid", pid)
+	slog.Info(processName+" acquired lock", "path", pidPath, "pid", pid)
 
 	return func() {
 		if unlockErr := fl.Unlock(); unlockErr != nil {
-			slog.Error("daemon failed to release lock", "path", pidPath, "error", unlockErr)
+			slog.Error(processName+" failed to release lock", "path", pidPath, "error", unlockErr)
 		}
 		os.Remove(pidPath) //nolint:errcheck
 	}, nil

--- a/cli/cmd/xylem/daemon_supervisor.go
+++ b/cli/cmd/xylem/daemon_supervisor.go
@@ -1,0 +1,511 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+)
+
+const daemonRestartDelay = 10 * time.Second
+
+var daemonEnvKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+type daemonSupervisorProcess interface {
+	PID() int
+	Signal(os.Signal) error
+	Wait() error
+}
+
+type daemonSupervisorLaunch struct {
+	ExecutablePath string
+	Args           []string
+	Env            []string
+	WorkingDir     string
+}
+
+type daemonSupervisorStarter func(daemonSupervisorLaunch) (daemonSupervisorProcess, error)
+type daemonSupervisorSleep func(context.Context, time.Duration) error
+
+type daemonSupervisorOptions struct {
+	Cfg            *config.Config
+	ConfigPath     string
+	ExecutablePath string
+	WorkingDir     string
+	Start          daemonSupervisorStarter
+	Sleep          daemonSupervisorSleep
+}
+
+type execDaemonSupervisorProcess struct {
+	cmd *exec.Cmd
+}
+
+func (p *execDaemonSupervisorProcess) PID() int {
+	if p == nil || p.cmd == nil || p.cmd.Process == nil {
+		return 0
+	}
+	return p.cmd.Process.Pid
+}
+
+func (p *execDaemonSupervisorProcess) Signal(sig os.Signal) error {
+	if p == nil || p.cmd == nil || p.cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	return p.cmd.Process.Signal(sig)
+}
+
+func (p *execDaemonSupervisorProcess) Wait() error {
+	if p == nil || p.cmd == nil {
+		return fmt.Errorf("wait daemon process: nil command")
+	}
+	return p.cmd.Wait()
+}
+
+func newDaemonSupervisorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "daemon-supervisor",
+		Short: "Restart the daemon after unexpected exits",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmdDaemonSupervisor(deps.cfg)
+		},
+	}
+}
+
+func newDaemonStopCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the daemon and disable supervisor restarts",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmdDaemonStop(deps.cfg)
+		},
+	}
+}
+
+func cmdDaemonSupervisor(cfg *config.Config) error {
+	executablePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve xylem executable: %w", err)
+	}
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	return runDaemonSupervisor(ctx, daemonSupervisorOptions{
+		Cfg:            cfg,
+		ConfigPath:     viper.GetString("config"),
+		ExecutablePath: executablePath,
+		WorkingDir:     workingDir,
+		Start:          startDaemonSupervisorProcess,
+		Sleep:          daemonSupervisorSleepWithContext,
+	})
+}
+
+func runDaemonSupervisor(ctx context.Context, opts daemonSupervisorOptions) error {
+	if opts.Cfg == nil {
+		return fmt.Errorf("run daemon supervisor: nil config")
+	}
+	if opts.ExecutablePath == "" {
+		return fmt.Errorf("run daemon supervisor: executable path is required")
+	}
+	if opts.WorkingDir == "" {
+		return fmt.Errorf("run daemon supervisor: working directory is required")
+	}
+	if opts.Start == nil {
+		return fmt.Errorf("run daemon supervisor: start function is required")
+	}
+	if opts.Sleep == nil {
+		opts.Sleep = daemonSupervisorSleepWithContext
+	}
+	if err := os.MkdirAll(opts.Cfg.StateDir, 0o755); err != nil {
+		return fmt.Errorf("run daemon supervisor: create state dir: %w", err)
+	}
+	if err := clearDaemonSupervisorStopRequest(opts.Cfg); err != nil {
+		return err
+	}
+
+	unlock, err := acquireDaemonSupervisorLock(daemonSupervisorPIDPath(opts.Cfg))
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	restartCount := 0
+	for {
+		if daemonSupervisorStopRequested(opts.Cfg) {
+			return clearDaemonSupervisorStopRequest(opts.Cfg)
+		}
+
+		env, err := daemonSupervisorProcessEnv(opts.WorkingDir)
+		if err != nil {
+			return err
+		}
+		launch := daemonSupervisorLaunch{
+			ExecutablePath: opts.ExecutablePath,
+			Args:           daemonSupervisorCommandArgs(opts.ConfigPath),
+			Env:            env,
+			WorkingDir:     opts.WorkingDir,
+		}
+		proc, err := opts.Start(launch)
+		if err != nil {
+			if daemonSupervisorStopRequested(opts.Cfg) || ctx.Err() != nil {
+				if clearErr := clearDaemonSupervisorStopRequest(opts.Cfg); clearErr != nil {
+					return clearErr
+				}
+				return nil
+			}
+			restartCount++
+			slog.Warn("daemon supervisor failed to start daemon; retrying",
+				"restart_count", restartCount,
+				"retry_in", daemonRestartDelay,
+				"error", err)
+			if err := opts.Sleep(ctx, daemonRestartDelay); err != nil {
+				if daemonSupervisorStopRequested(opts.Cfg) || ctx.Err() != nil {
+					if clearErr := clearDaemonSupervisorStopRequest(opts.Cfg); clearErr != nil {
+						return clearErr
+					}
+					return nil
+				}
+				return err
+			}
+			continue
+		}
+
+		slog.Info("daemon supervisor started daemon",
+			"pid", proc.PID(),
+			"restart_count", restartCount)
+
+		waitErr := waitForDaemonSupervisorProcess(ctx, proc)
+		if daemonSupervisorStopRequested(opts.Cfg) || ctx.Err() != nil {
+			if clearErr := clearDaemonSupervisorStopRequest(opts.Cfg); clearErr != nil {
+				return clearErr
+			}
+			return nil
+		}
+
+		restartCount++
+		slog.Warn("daemon supervisor restarting daemon after exit",
+			"restart_count", restartCount,
+			"retry_in", daemonRestartDelay,
+			"error", waitErr)
+		if err := opts.Sleep(ctx, daemonRestartDelay); err != nil {
+			if daemonSupervisorStopRequested(opts.Cfg) || ctx.Err() != nil {
+				if clearErr := clearDaemonSupervisorStopRequest(opts.Cfg); clearErr != nil {
+					return clearErr
+				}
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func cmdDaemonStop(cfg *config.Config) error {
+	result, err := stopDaemonProcesses(cfg, signalProcessFromPIDFile)
+	if err != nil {
+		return err
+	}
+	switch {
+	case result.supervisorStopped && result.daemonStopped:
+		fmt.Printf("Stopping daemon pid %d and supervisor pid %d.\n", result.daemonPID, result.supervisorPID)
+	case result.supervisorStopped:
+		fmt.Printf("Stopping supervisor pid %d.\n", result.supervisorPID)
+	case result.daemonStopped:
+		fmt.Printf("Stopping daemon pid %d.\n", result.daemonPID)
+	default:
+		fmt.Println("Daemon not running.")
+	}
+	return nil
+}
+
+type daemonStopResult struct {
+	daemonPID         int
+	supervisorPID     int
+	daemonStopped     bool
+	supervisorStopped bool
+}
+
+type daemonProcessSignaler func(pidPath string, sig syscall.Signal) (int, bool, error)
+
+func stopDaemonProcesses(cfg *config.Config, signaler daemonProcessSignaler) (daemonStopResult, error) {
+	if cfg == nil {
+		return daemonStopResult{}, fmt.Errorf("stop daemon: nil config")
+	}
+	if signaler == nil {
+		return daemonStopResult{}, fmt.Errorf("stop daemon: nil process signaler")
+	}
+
+	supervisorPID, supervisorStopped, err := signaler(daemonSupervisorPIDPath(cfg), syscall.Signal(0))
+	if err != nil {
+		return daemonStopResult{}, err
+	}
+	if supervisorStopped {
+		if err := requestDaemonSupervisorStop(cfg); err != nil {
+			return daemonStopResult{}, err
+		}
+	}
+
+	daemonPID, daemonStopped, err := signaler(daemonPIDPath(cfg), syscall.SIGTERM)
+	if err != nil {
+		return daemonStopResult{}, err
+	}
+	if supervisorStopped {
+		supervisorPID, supervisorStopped, err = signaler(daemonSupervisorPIDPath(cfg), syscall.SIGTERM)
+		if err != nil {
+			return daemonStopResult{}, err
+		}
+	} else if err := clearDaemonSupervisorStopRequest(cfg); err != nil {
+		return daemonStopResult{}, err
+	}
+
+	return daemonStopResult{
+		daemonPID:         daemonPID,
+		supervisorPID:     supervisorPID,
+		daemonStopped:     daemonStopped,
+		supervisorStopped: supervisorStopped,
+	}, nil
+}
+
+func waitForDaemonSupervisorProcess(ctx context.Context, proc daemonSupervisorProcess) error {
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- proc.Wait()
+	}()
+
+	select {
+	case err := <-waitCh:
+		return err
+	case <-ctx.Done():
+		if err := proc.Signal(syscall.SIGTERM); err != nil && !isMissingProcessError(err) {
+			return fmt.Errorf("stop daemon process %d: %w", proc.PID(), err)
+		}
+		select {
+		case err := <-waitCh:
+			return err
+		case <-time.After(drainShutdownTimeout):
+			return ctx.Err()
+		}
+	}
+}
+
+func startDaemonSupervisorProcess(launch daemonSupervisorLaunch) (daemonSupervisorProcess, error) {
+	cmd := exec.Command(launch.ExecutablePath, launch.Args...)
+	cmd.Dir = launch.WorkingDir
+	cmd.Env = launch.Env
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start daemon process: %w", err)
+	}
+	return &execDaemonSupervisorProcess{cmd: cmd}, nil
+}
+
+func daemonSupervisorProcessEnv(workingDir string) ([]string, error) {
+	envFile, err := loadDaemonSupervisorEnvFile(daemonSupervisorEnvFilePath(workingDir))
+	if err != nil {
+		return nil, err
+	}
+	return append(os.Environ(), envFile...), nil
+}
+
+func daemonSupervisorCommandArgs(configPath string) []string {
+	args := make([]string, 0, 3)
+	if strings.TrimSpace(configPath) != "" {
+		args = append(args, "--config", configPath)
+	}
+	args = append(args, "daemon")
+	return args
+}
+
+func daemonSupervisorEnvFilePath(workingDir string) string {
+	return filepath.Join(workingDir, ".daemon-root", ".env")
+}
+
+func loadDaemonSupervisorEnvFile(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("load daemon env file %q: %w", path, err)
+	}
+	defer file.Close()
+
+	env := make([]string, 0)
+	scanner := bufio.NewScanner(file)
+	for lineNum := 1; scanner.Scan(); lineNum++ {
+		key, value, ok, err := parseDaemonEnvLine(scanner.Text())
+		if err != nil {
+			return nil, fmt.Errorf("load daemon env file %q line %d: %w", path, lineNum, err)
+		}
+		if !ok {
+			continue
+		}
+		env = append(env, key+"="+value)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("load daemon env file %q: scan: %w", path, err)
+	}
+	return env, nil
+}
+
+func parseDaemonEnvLine(line string) (key, value string, ok bool, err error) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		return "", "", false, nil
+	}
+	if strings.HasPrefix(trimmed, "export ") {
+		trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "export "))
+	}
+	eq := strings.IndexByte(trimmed, '=')
+	if eq < 0 {
+		return "", "", false, fmt.Errorf("expected KEY=VALUE assignment")
+	}
+	key = strings.TrimSpace(trimmed[:eq])
+	if !daemonEnvKeyPattern.MatchString(key) {
+		return "", "", false, fmt.Errorf("invalid env key %q", key)
+	}
+	value, err = parseDaemonEnvValue(strings.TrimSpace(trimmed[eq+1:]))
+	if err != nil {
+		return "", "", false, err
+	}
+	return key, value, true, nil
+}
+
+func parseDaemonEnvValue(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	switch raw[0] {
+	case '"':
+		unquoted, err := strconv.Unquote(raw)
+		if err != nil {
+			return "", fmt.Errorf("invalid double-quoted env value: %w", err)
+		}
+		return unquoted, nil
+	case '\'':
+		if len(raw) < 2 || raw[len(raw)-1] != '\'' {
+			return "", fmt.Errorf("unterminated single-quoted env value")
+		}
+		return raw[1 : len(raw)-1], nil
+	default:
+		return stripDaemonEnvInlineComment(raw), nil
+	}
+}
+
+func stripDaemonEnvInlineComment(raw string) string {
+	for i := 0; i < len(raw); i++ {
+		if raw[i] != '#' {
+			continue
+		}
+		if i == 0 || raw[i-1] == ' ' || raw[i-1] == '\t' {
+			return strings.TrimSpace(raw[:i])
+		}
+	}
+	return strings.TrimSpace(raw)
+}
+
+func daemonSupervisorSleepWithContext(ctx context.Context, delay time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(delay):
+		return nil
+	}
+}
+
+func daemonPIDPath(cfg *config.Config) string {
+	return filepath.Join(cfg.StateDir, "daemon.pid")
+}
+
+func daemonSupervisorPIDPath(cfg *config.Config) string {
+	return filepath.Join(cfg.StateDir, "daemon-supervisor.pid")
+}
+
+func daemonSupervisorStopPath(cfg *config.Config) string {
+	return filepath.Join(cfg.StateDir, "daemon-supervisor.stop")
+}
+
+func daemonSupervisorStopRequested(cfg *config.Config) bool {
+	_, err := os.Stat(daemonSupervisorStopPath(cfg))
+	return err == nil
+}
+
+func requestDaemonSupervisorStop(cfg *config.Config) error {
+	if cfg == nil {
+		return fmt.Errorf("request daemon supervisor stop: nil config")
+	}
+	if err := os.MkdirAll(cfg.StateDir, 0o755); err != nil {
+		return fmt.Errorf("request daemon supervisor stop: create state dir: %w", err)
+	}
+	if err := os.WriteFile(daemonSupervisorStopPath(cfg), []byte(time.Now().UTC().Format(time.RFC3339Nano)), 0o644); err != nil {
+		return fmt.Errorf("request daemon supervisor stop: write stop marker: %w", err)
+	}
+	return nil
+}
+
+func clearDaemonSupervisorStopRequest(cfg *config.Config) error {
+	if cfg == nil {
+		return fmt.Errorf("clear daemon supervisor stop: nil config")
+	}
+	if err := os.Remove(daemonSupervisorStopPath(cfg)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("clear daemon supervisor stop: %w", err)
+	}
+	return nil
+}
+
+func signalProcessFromPIDFile(pidPath string, sig syscall.Signal) (int, bool, error) {
+	pid, err := readPIDFile(pidPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return pid, false, fmt.Errorf("signal process from %q: find pid %d: %w", pidPath, pid, err)
+	}
+	if err := proc.Signal(sig); err != nil {
+		if isMissingProcessError(err) {
+			if removeErr := os.Remove(pidPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+				return pid, false, fmt.Errorf("signal process from %q: remove stale pid file: %w", pidPath, removeErr)
+			}
+			return pid, false, nil
+		}
+		return pid, false, fmt.Errorf("signal process from %q: signal pid %d: %w", pidPath, pid, err)
+	}
+	return pid, true, nil
+}
+
+func readPIDFile(pidPath string) (int, error) {
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("read pid file %q: parse pid: %w", pidPath, err)
+	}
+	return pid, nil
+}
+
+func isMissingProcessError(err error) bool {
+	return errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH)
+}

--- a/cli/cmd/xylem/daemon_supervisor_prop_test.go
+++ b/cli/cmd/xylem/daemon_supervisor_prop_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropParseDaemonEnvLineRoundTripsBareAssignments(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		key := rapid.StringMatching(`[A-Za-z_][A-Za-z0-9_]{0,15}`).Draw(rt, "key")
+		value := rapid.StringMatching(`[A-Za-z0-9_./:-]{0,24}`).Draw(rt, "value")
+
+		gotKey, gotValue, ok, err := parseDaemonEnvLine("  " + key + " = " + value + "  ")
+		if err != nil {
+			rt.Fatalf("parseDaemonEnvLine() error = %v", err)
+		}
+		if !ok {
+			rt.Fatal("parseDaemonEnvLine() reported ok=false for bare assignment")
+		}
+		if gotKey != key {
+			rt.Fatalf("got key %q, want %q", gotKey, key)
+		}
+		if gotValue != value {
+			rt.Fatalf("got value %q, want %q", gotValue, value)
+		}
+	})
+}

--- a/cli/cmd/xylem/daemon_supervisor_test.go
+++ b/cli/cmd/xylem/daemon_supervisor_test.go
@@ -1,0 +1,464 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDaemonSupervisorProcess struct {
+	pid      int
+	signalFn func(os.Signal) error
+	waitFn   func() error
+}
+
+func (p *fakeDaemonSupervisorProcess) PID() int {
+	return p.pid
+}
+
+func (p *fakeDaemonSupervisorProcess) Signal(sig os.Signal) error {
+	if p.signalFn != nil {
+		return p.signalFn(sig)
+	}
+	return nil
+}
+
+func (p *fakeDaemonSupervisorProcess) Wait() error {
+	if p.waitFn != nil {
+		return p.waitFn()
+	}
+	return nil
+}
+
+func TestRunDaemonSupervisorRestartsAfterUnexpectedExitAndReloadsEnv(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{StateDir: filepath.Join(repoDir, ".xylem")}
+	envPath := daemonSupervisorEnvFilePath(repoDir)
+	if err := os.MkdirAll(filepath.Dir(envPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(envPath), err)
+	}
+	if err := os.WriteFile(envPath, []byte("API_TOKEN=first\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", envPath, err)
+	}
+
+	logBuf := withBufferedDefaultLogger(t)
+	var launches []daemonSupervisorLaunch
+	var sleepCalls []time.Duration
+
+	err := runDaemonSupervisor(context.Background(), daemonSupervisorOptions{
+		Cfg:            cfg,
+		ConfigPath:     ".xylem.yml",
+		ExecutablePath: "/tmp/xylem",
+		WorkingDir:     repoDir,
+		Start: func(launch daemonSupervisorLaunch) (daemonSupervisorProcess, error) {
+			launches = append(launches, launch)
+			switch len(launches) {
+			case 1:
+				return &fakeDaemonSupervisorProcess{
+					pid: 101,
+					waitFn: func() error {
+						if err := os.WriteFile(envPath, []byte("API_TOKEN=second\n"), 0o644); err != nil {
+							t.Fatalf("WriteFile(%q): %v", envPath, err)
+						}
+						return nil
+					},
+				}, nil
+			case 2:
+				return &fakeDaemonSupervisorProcess{
+					pid: 102,
+					waitFn: func() error {
+						if err := requestDaemonSupervisorStop(cfg); err != nil {
+							t.Fatalf("requestDaemonSupervisorStop() error = %v", err)
+						}
+						return nil
+					},
+				}, nil
+			default:
+				t.Fatalf("unexpected extra launch %d", len(launches))
+				return nil, nil
+			}
+		},
+		Sleep: func(_ context.Context, delay time.Duration) error {
+			sleepCalls = append(sleepCalls, delay)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runDaemonSupervisor() error = %v", err)
+	}
+
+	if len(launches) != 2 {
+		t.Fatalf("len(launches) = %d, want 2", len(launches))
+	}
+	if len(sleepCalls) != 1 || sleepCalls[0] != daemonRestartDelay {
+		t.Fatalf("sleepCalls = %v, want [%s]", sleepCalls, daemonRestartDelay)
+	}
+	if got := daemonEnvValue(launches[0].Env, "API_TOKEN"); got != "first" {
+		t.Fatalf("first launch API_TOKEN = %q, want %q", got, "first")
+	}
+	if got := daemonEnvValue(launches[1].Env, "API_TOKEN"); got != "second" {
+		t.Fatalf("second launch API_TOKEN = %q, want %q", got, "second")
+	}
+	if want := []string{"--config", ".xylem.yml", "daemon"}; strings.Join(launches[0].Args, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("launch args = %v, want %v", launches[0].Args, want)
+	}
+	if daemonSupervisorStopRequested(cfg) {
+		t.Fatal("stop marker still present after clean supervisor shutdown")
+	}
+	if !strings.Contains(logBuf.String(), "restart_count=1") {
+		t.Fatalf("log output %q does not include restart_count=1", logBuf.String())
+	}
+}
+
+func TestRunDaemonSupervisorStopRequestedDoesNotRestart(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{StateDir: filepath.Join(repoDir, ".xylem")}
+	var launches int
+
+	err := runDaemonSupervisor(context.Background(), daemonSupervisorOptions{
+		Cfg:            cfg,
+		ExecutablePath: "/tmp/xylem",
+		WorkingDir:     repoDir,
+		Start: func(launch daemonSupervisorLaunch) (daemonSupervisorProcess, error) {
+			launches++
+			return &fakeDaemonSupervisorProcess{
+				pid: 201,
+				waitFn: func() error {
+					return requestDaemonSupervisorStop(cfg)
+				},
+			}, nil
+		},
+		Sleep: func(_ context.Context, delay time.Duration) error {
+			t.Fatalf("unexpected sleep call with %s", delay)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runDaemonSupervisor() error = %v", err)
+	}
+	if launches != 1 {
+		t.Fatalf("launches = %d, want 1", launches)
+	}
+	if daemonSupervisorStopRequested(cfg) {
+		t.Fatal("stop marker still present after supervisor exit")
+	}
+}
+
+func TestStopDaemonProcessesSignalsSupervisorAndDaemon(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{StateDir: filepath.Join(repoDir, ".xylem")}
+
+	type signalCall struct {
+		path string
+		sig  syscall.Signal
+	}
+	var calls []signalCall
+	result, err := stopDaemonProcesses(cfg, func(pidPath string, sig syscall.Signal) (int, bool, error) {
+		calls = append(calls, signalCall{path: filepath.Base(pidPath), sig: sig})
+		switch filepath.Base(pidPath) {
+		case "daemon-supervisor.pid":
+			return 22, true, nil
+		case "daemon.pid":
+			return 11, true, nil
+		default:
+			return 0, false, nil
+		}
+	})
+	if err != nil {
+		t.Fatalf("stopDaemonProcesses() error = %v", err)
+	}
+	if !result.supervisorStopped || !result.daemonStopped {
+		t.Fatalf("result = %+v, want both daemon and supervisor stopped", result)
+	}
+	if result.supervisorPID != 22 || result.daemonPID != 11 {
+		t.Fatalf("result PIDs = %+v, want supervisor=22 daemon=11", result)
+	}
+	wantCalls := []signalCall{
+		{path: "daemon-supervisor.pid", sig: syscall.Signal(0)},
+		{path: "daemon.pid", sig: syscall.SIGTERM},
+		{path: "daemon-supervisor.pid", sig: syscall.SIGTERM},
+	}
+	if len(calls) != len(wantCalls) {
+		t.Fatalf("len(calls) = %d, want %d (%v)", len(calls), len(wantCalls), calls)
+	}
+	for i, want := range wantCalls {
+		if calls[i] != want {
+			t.Fatalf("calls[%d] = %+v, want %+v", i, calls[i], want)
+		}
+	}
+	if !daemonSupervisorStopRequested(cfg) {
+		t.Fatal("expected stop marker to be written when supervisor is running")
+	}
+}
+
+func TestStopDaemonProcessesWithoutSupervisorClearsStopMarker(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{StateDir: filepath.Join(repoDir, ".xylem")}
+	if err := requestDaemonSupervisorStop(cfg); err != nil {
+		t.Fatalf("requestDaemonSupervisorStop() error = %v", err)
+	}
+
+	result, err := stopDaemonProcesses(cfg, func(pidPath string, sig syscall.Signal) (int, bool, error) {
+		switch filepath.Base(pidPath) {
+		case "daemon-supervisor.pid":
+			return 0, false, nil
+		case "daemon.pid":
+			return 11, true, nil
+		default:
+			return 0, false, nil
+		}
+	})
+	if err != nil {
+		t.Fatalf("stopDaemonProcesses() error = %v", err)
+	}
+	if result.supervisorStopped {
+		t.Fatalf("result.supervisorStopped = true, want false")
+	}
+	if !result.daemonStopped {
+		t.Fatalf("result.daemonStopped = false, want true")
+	}
+	if daemonSupervisorStopRequested(cfg) {
+		t.Fatal("expected stale stop marker to be removed when supervisor is absent")
+	}
+}
+
+func TestLoadDaemonSupervisorEnvFile(t *testing.T) {
+	t.Run("parses exports quotes and inline comments", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".env")
+		content := strings.Join([]string{
+			"# comment",
+			"export API_TOKEN=abc123",
+			`NAME="xylem daemon"`,
+			`SINGLE='quoted value'`,
+			`INLINE=value # ignored`,
+		}, "\n")
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile(%q): %v", path, err)
+		}
+
+		env, err := loadDaemonSupervisorEnvFile(path)
+		if err != nil {
+			t.Fatalf("loadDaemonSupervisorEnvFile(%q) error = %v", path, err)
+		}
+		if got := daemonEnvValue(env, "API_TOKEN"); got != "abc123" {
+			t.Fatalf("API_TOKEN = %q, want %q", got, "abc123")
+		}
+		if got := daemonEnvValue(env, "NAME"); got != "xylem daemon" {
+			t.Fatalf("NAME = %q, want %q", got, "xylem daemon")
+		}
+		if got := daemonEnvValue(env, "SINGLE"); got != "quoted value" {
+			t.Fatalf("SINGLE = %q, want %q", got, "quoted value")
+		}
+		if got := daemonEnvValue(env, "INLINE"); got != "value" {
+			t.Fatalf("INLINE = %q, want %q", got, "value")
+		}
+	})
+
+	t.Run("missing file returns empty env", func(t *testing.T) {
+		env, err := loadDaemonSupervisorEnvFile(filepath.Join(t.TempDir(), ".env"))
+		if err != nil {
+			t.Fatalf("loadDaemonSupervisorEnvFile(missing) error = %v", err)
+		}
+		if len(env) != 0 {
+			t.Fatalf("len(env) = %d, want 0", len(env))
+		}
+	})
+
+	t.Run("invalid assignment returns error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".env")
+		if err := os.WriteFile(path, []byte("not-an-assignment\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%q): %v", path, err)
+		}
+		if _, err := loadDaemonSupervisorEnvFile(path); err == nil {
+			t.Fatal("loadDaemonSupervisorEnvFile() error = nil, want error")
+		}
+	})
+}
+
+type daemonSupervisorSmokeResult struct {
+	cfg        *config.Config
+	logOutput  string
+	launches   []daemonSupervisorLaunch
+	sleepCalls []time.Duration
+}
+
+func TestSmoke_S1_DaemonSupervisorRestartsWithinThirtySecondsAfterUnexpectedExit(t *testing.T) {
+	result := runDaemonSupervisorUnexpectedExitSmoke(t)
+
+	require.Len(t, result.launches, 2)
+	require.Len(t, result.sleepCalls, 1)
+	assert.Equal(t, daemonRestartDelay, result.sleepCalls[0])
+	assert.LessOrEqual(t, result.sleepCalls[0], 30*time.Second)
+	assert.Equal(t, []string{"--config", ".xylem.yml", "daemon"}, result.launches[0].Args)
+}
+
+func TestSmoke_S2_DaemonSupervisorReloadsEnvOnEachRestart(t *testing.T) {
+	result := runDaemonSupervisorUnexpectedExitSmoke(t)
+
+	require.Len(t, result.launches, 2)
+	assert.Equal(t, "first", daemonEnvValue(result.launches[0].Env, "API_TOKEN"))
+	assert.Equal(t, "second", daemonEnvValue(result.launches[1].Env, "API_TOKEN"))
+	assert.False(t, daemonSupervisorStopRequested(result.cfg))
+}
+
+func TestSmoke_S3_DaemonSupervisorLogsRestartCount(t *testing.T) {
+	result := runDaemonSupervisorUnexpectedExitSmoke(t)
+
+	assert.Contains(t, result.logOutput, "daemon supervisor restarting daemon after exit")
+	assert.Contains(t, result.logOutput, "restart_count=1")
+}
+
+func TestSmoke_S4_ManualDaemonStopDoesNotTriggerRestart(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{StateDir: filepath.Join(repoDir, ".xylem")}
+	started := make(chan struct{}, 1)
+	stopProcess := make(chan struct{})
+	supervisorDone := make(chan error, 1)
+	var launches []daemonSupervisorLaunch
+	var sleepCalls []time.Duration
+
+	go func() {
+		supervisorDone <- runDaemonSupervisor(context.Background(), daemonSupervisorOptions{
+			Cfg:            cfg,
+			ConfigPath:     ".xylem.yml",
+			ExecutablePath: "/tmp/xylem",
+			WorkingDir:     repoDir,
+			Start: func(launch daemonSupervisorLaunch) (daemonSupervisorProcess, error) {
+				launches = append(launches, launch)
+				started <- struct{}{}
+				return &fakeDaemonSupervisorProcess{
+					pid: 501,
+					waitFn: func() error {
+						<-stopProcess
+						return nil
+					},
+				}, nil
+			},
+			Sleep: func(_ context.Context, delay time.Duration) error {
+				sleepCalls = append(sleepCalls, delay)
+				return nil
+			},
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon supervisor did not start")
+	}
+
+	var signals []string
+	result, err := stopDaemonProcesses(cfg, func(pidPath string, sig syscall.Signal) (int, bool, error) {
+		signals = append(signals, filepath.Base(pidPath)+":"+sig.String())
+		switch filepath.Base(pidPath) {
+		case "daemon-supervisor.pid":
+			if sig == syscall.Signal(0) {
+				return 22, true, nil
+			}
+			close(stopProcess)
+			return 22, true, nil
+		case "daemon.pid":
+			return 11, true, nil
+		default:
+			return 0, false, nil
+		}
+	})
+	require.NoError(t, err)
+	assert.True(t, result.supervisorStopped)
+	assert.True(t, result.daemonStopped)
+	assert.Equal(t, 22, result.supervisorPID)
+	assert.Equal(t, 11, result.daemonPID)
+
+	select {
+	case err := <-supervisorDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon supervisor did not exit after stop request")
+	}
+
+	assert.Equal(t, []string{
+		"daemon-supervisor.pid:signal 0",
+		"daemon.pid:terminated",
+		"daemon-supervisor.pid:terminated",
+	}, signals)
+	assert.Len(t, launches, 1)
+	assert.Empty(t, sleepCalls)
+	assert.False(t, daemonSupervisorStopRequested(cfg))
+}
+
+func daemonEnvValue(env []string, key string) string {
+	prefix := key + "="
+	value := ""
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			value = strings.TrimPrefix(entry, prefix)
+		}
+	}
+	return value
+}
+
+func runDaemonSupervisorUnexpectedExitSmoke(t *testing.T) daemonSupervisorSmokeResult {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	cfg := &config.Config{StateDir: filepath.Join(repoDir, ".xylem")}
+	envPath := daemonSupervisorEnvFilePath(repoDir)
+	require.NoError(t, os.MkdirAll(filepath.Dir(envPath), 0o755))
+	require.NoError(t, os.WriteFile(envPath, []byte("API_TOKEN=first\n"), 0o644))
+
+	logBuf := withBufferedDefaultLogger(t)
+	var launches []daemonSupervisorLaunch
+	var sleepCalls []time.Duration
+
+	err := runDaemonSupervisor(context.Background(), daemonSupervisorOptions{
+		Cfg:            cfg,
+		ConfigPath:     ".xylem.yml",
+		ExecutablePath: "/tmp/xylem",
+		WorkingDir:     repoDir,
+		Start: func(launch daemonSupervisorLaunch) (daemonSupervisorProcess, error) {
+			launches = append(launches, launch)
+			switch len(launches) {
+			case 1:
+				return &fakeDaemonSupervisorProcess{
+					pid: 101,
+					waitFn: func() error {
+						require.NoError(t, os.WriteFile(envPath, []byte("API_TOKEN=second\n"), 0o644))
+						return errors.New("exit status 1")
+					},
+				}, nil
+			case 2:
+				return &fakeDaemonSupervisorProcess{
+					pid: 102,
+					waitFn: func() error {
+						require.NoError(t, requestDaemonSupervisorStop(cfg))
+						return nil
+					},
+				}, nil
+			default:
+				t.Fatalf("unexpected extra launch %d", len(launches))
+				return nil, nil
+			}
+		},
+		Sleep: func(_ context.Context, delay time.Duration) error {
+			sleepCalls = append(sleepCalls, delay)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	return daemonSupervisorSmokeResult{
+		cfg:        cfg,
+		logOutput:  logBuf.String(),
+		launches:   launches,
+		sleepCalls: sleepCalls,
+	}
+}

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -36,14 +36,16 @@ func newRootCmd() *cobra.Command {
 				return nil
 			}
 
-			// visualize (and its subcommands) and review are read-only commands
-			// that only parse config, workflow YAML, and local state; they
-			// don't shell out to git or gh. continuous-improvement select is
-			// another local-only helper used by a command phase.
+			// visualize (and its subcommands), review, and daemon stop are
+			// local-only commands that only parse config, workflow YAML, and
+			// local state; they don't shell out to git or gh.
+			// continuous-improvement select is another local-only helper used
+			// by a command phase.
 			skipTooling := cmd.Name() == "visualize" ||
 				strings.HasPrefix(commandPath, "xylem visualize") ||
 				cmd.Name() == "review" ||
-				commandPath == "xylem continuous-improvement select"
+				commandPath == "xylem continuous-improvement select" ||
+				commandPath == "xylem daemon stop"
 
 			if !skipTooling {
 				if _, err := exec.LookPath("git"); err != nil {
@@ -104,6 +106,7 @@ func newRootCmd() *cobra.Command {
 		newCleanupCmd(),
 		newDoctorCmd(),
 		newDaemonCmd(),
+		newDaemonSupervisorCmd(),
 		newRetryCmd(),
 		newVisualizeCmd(),
 		newVersionCmd(),

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -483,8 +483,41 @@ xylem daemon
 # Run as a background process
 xylem daemon &
 
+# Stop a foreground or supervised daemon cleanly
+xylem daemon stop
+
 # With systemd, launchd, or similar process managers
 # See "Common Patterns" below for a systemd unit example
+```
+
+---
+
+## xylem daemon-supervisor
+
+Restart `xylem daemon` after unexpected exits.
+
+### Usage
+
+```
+xylem daemon-supervisor
+```
+
+### Behavior
+
+1. Acquires a singleton supervisor PID lock at `<state_dir>/daemon-supervisor.pid`.
+2. Loads environment overrides from `.daemon-root/.env` before each daemon start.
+3. Starts `xylem daemon` with the active `--config` path.
+4. If the daemon exits without a matching `xylem daemon stop` request, logs the restart count, waits 10 seconds, and starts it again.
+5. `xylem daemon stop` writes `<state_dir>/daemon-supervisor.stop`, signals the daemon, and prevents the next restart.
+
+### Examples
+
+```bash
+# Keep the daemon alive and reload .daemon-root/.env on every restart
+xylem daemon-supervisor
+
+# Stop a supervised daemon without triggering the restart loop
+xylem daemon stop
 ```
 
 ---
@@ -904,7 +937,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/path/to/repo
-ExecStart=/usr/local/bin/xylem daemon
+ExecStart=/usr/local/bin/xylem daemon-supervisor
 Restart=on-failure
 RestartSec=10
 
@@ -925,7 +958,7 @@ WantedBy=multi-user.target
   <key>ProgramArguments</key>
   <array>
     <string>/usr/local/bin/xylem</string>
-    <string>daemon</string>
+    <string>daemon-supervisor</string>
   </array>
   <key>WorkingDirectory</key>
   <string>/path/to/repo</string>
@@ -938,6 +971,8 @@ WantedBy=multi-user.target
 </dict>
 </plist>
 ```
+
+Place API keys in `/path/to/repo/.daemon-root/.env` so the supervisor reloads them before every daemon restart. Use `xylem daemon stop` for a clean shutdown that does not bounce back via KeepAlive.
 
 ## Vessel States
 


### PR DESCRIPTION
## Summary
Implements [feat(daemon): auto-restart via launchd plist or wrapper script](https://github.com/nicholls-inc/xylem/issues/330) by adding a built-in `xylem daemon-supervisor` wrapper, a matching `xylem daemon stop` path that suppresses restart bounce, and updated launchd/systemd documentation for running the daemon under a process manager.

## Smoke scenarios covered
- `S1` — Daemon supervisor restarts within thirty seconds after unexpected exit.
- `S2` — Daemon supervisor reloads `.daemon-root/.env` on each restart.
- `S3` — Daemon supervisor logs the restart count after an unexpected exit.
- `S4` — Manual daemon stop does not trigger a restart.

## Changes summary
- **Added** `cli/cmd/xylem/daemon_supervisor.go` with `daemonSupervisorOptions`, `daemonSupervisorLaunch`, `runDaemonSupervisor`, `cmdDaemonSupervisor`, `cmdDaemonStop`, `stopDaemonProcesses`, env-file parsing helpers, and PID/stop-marker helpers.
- **Modified** `cli/cmd/xylem/daemon.go` to wire in `daemon stop`, reuse the shared PID helpers, and keep daemon locking compatible with the supervisor flow.
- **Modified** `cli/cmd/xylem/root.go` so `xylem daemon stop` is treated as a local-only command that can run without git/gh availability while still loading config and local state.
- **Added** `cli/cmd/xylem/daemon_supervisor_test.go` and `cli/cmd/xylem/daemon_supervisor_prop_test.go` to cover restart behavior, env reloads, clean-stop suppression, and env-line parsing.
- **Modified** `cli/cmd/xylem/cobra_test.go` to verify command registration and the tooling-bypass behavior for `xylem daemon stop`.
- **Modified** `README.md` and `docs/cli-reference.md` to document `xylem daemon-supervisor`, `xylem daemon stop`, `.daemon-root/.env` reload behavior, and launchd/systemd supervisor examples.

## Test plan
- `cd cli && goimports -w .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #330