### PR TITLE
feat(workflow): add continuous-refactoring workflow

### DIFF
--- a/.xylem/workflows/continuous-refactoring.yaml
+++ b/.xylem/workflows/continuous-refactoring.yaml
@@ -1,0 +1,23 @@
+name: continuous-refactoring
+class: harness-maintenance
+description: "Recurring semantic refactor and large-file simplification issue finder"
+phases:
+  - name: inspect
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem --config ../.xylem.yml continuous-refactoring inspect \
+        --repo-root .. \
+        --source {{.Source.Name}} \
+        --output ../.xylem/state/continuous-refactoring/{{.Source.Name}}-manifest.json
+  - name: open_issues
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem --config ../.xylem.yml continuous-refactoring open-issues \
+        --source {{.Source.Name}} \
+        --mode {{if eq .Source.Name "continuous-refactoring-file-diet"}}file-diet{{else}}semantic{{end}} \
+        --manifest ../.xylem/state/continuous-refactoring/{{.Source.Name}}-manifest.json \
+        --output ../.xylem/state/continuous-refactoring/{{.Source.Name}}-issues.json

--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -38,7 +38,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "bootstrap", "continuous-improvement", "continuous-simplicity", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version"}
+	expected := []string{"init", "bootstrap", "continuous-refactoring", "continuous-improvement", "continuous-simplicity", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/continuous_refactoring.go
+++ b/cli/cmd/xylem/continuous_refactoring.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholls-inc/xylem/cli/internal/continuousrefactoring"
+)
+
+var continuousRefactoringNow = func() time.Time {
+	return time.Now().UTC()
+}
+
+var newContinuousRefactoringRunner = func() continuousrefactoring.CommandRunner {
+	return &realCmdRunner{}
+}
+
+func newContinuousRefactoringCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "continuous-refactoring",
+		Short: "Deterministic helpers for the continuous-refactoring workflow",
+	}
+	cmd.AddCommand(
+		newContinuousRefactoringInspectCmd(),
+		newContinuousRefactoringOpenIssuesCmd(),
+	)
+	return cmd
+}
+
+func newContinuousRefactoringInspectCmd() *cobra.Command {
+	var repoRoot, sourceName, outputPath string
+	var nowRaw string
+	cmd := &cobra.Command{
+		Use:   "inspect",
+		Short: "Scan configured source directories for refactor and file-diet candidates",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if deps == nil || deps.cfg == nil {
+				return fmt.Errorf("continuous-refactoring inspect requires loaded config")
+			}
+			now, err := parseContinuousRefactoringNow(nowRaw)
+			if err != nil {
+				return err
+			}
+			manifest, err := continuousrefactoring.Inspect(deps.cfg, repoRoot, sourceName, now)
+			if err != nil {
+				return err
+			}
+			if err := continuousrefactoring.WriteJSON(outputPath, manifest); err != nil {
+				return err
+			}
+			fmt.Printf("Wrote %s\n", outputPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repoRoot, "repo-root", ".", "Repository root to inspect")
+	cmd.Flags().StringVar(&sourceName, "source", "", "Config source name to inspect")
+	cmd.Flags().StringVar(&outputPath, "output", "", "Path to write the inspection manifest JSON")
+	cmd.Flags().StringVar(&nowRaw, "now", "", "Optional RFC3339 timestamp override for deterministic runs")
+	cmd.MarkFlagRequired("source") //nolint:errcheck
+	cmd.MarkFlagRequired("output") //nolint:errcheck
+	return cmd
+}
+
+func newContinuousRefactoringOpenIssuesCmd() *cobra.Command {
+	var manifestPath, outputPath, sourceName, modeRaw string
+	var nowRaw string
+	cmd := &cobra.Command{
+		Use:   "open-issues",
+		Short: "Create deduplicated refactor issues from a continuous-refactoring manifest",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			now, err := parseContinuousRefactoringNow(nowRaw)
+			if err != nil {
+				return err
+			}
+			mode, err := parseContinuousRefactoringMode(modeRaw)
+			if err != nil {
+				return err
+			}
+			manifest, err := continuousrefactoring.LoadManifest(manifestPath)
+			if err != nil {
+				return err
+			}
+			if sourceName != "" {
+				manifest.SourceName = sourceName
+			}
+			result, err := continuousrefactoring.OpenIssues(context.Background(), newContinuousRefactoringRunner(), manifest, mode, now)
+			if err != nil {
+				return err
+			}
+			if err := continuousrefactoring.WriteJSON(outputPath, result); err != nil {
+				return err
+			}
+			fmt.Printf("Wrote %s\n", outputPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&manifestPath, "manifest", "", "Path to the continuous-refactoring manifest JSON")
+	cmd.Flags().StringVar(&outputPath, "output", "", "Path to write the issue creation result JSON")
+	cmd.Flags().StringVar(&sourceName, "source", "", "Optional source name override for result metadata")
+	cmd.Flags().StringVar(&modeRaw, "mode", string(continuousrefactoring.ModeSemantic), "Issue mode to open: semantic or file-diet")
+	cmd.Flags().StringVar(&nowRaw, "now", "", "Optional RFC3339 timestamp override for deterministic runs")
+	cmd.MarkFlagRequired("manifest") //nolint:errcheck
+	cmd.MarkFlagRequired("output")   //nolint:errcheck
+	return cmd
+}
+
+func parseContinuousRefactoringNow(raw string) (time.Time, error) {
+	if strings.TrimSpace(raw) == "" {
+		return continuousRefactoringNow(), nil
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse --now: %w", err)
+	}
+	return parsed.UTC(), nil
+}
+
+func parseContinuousRefactoringMode(raw string) (continuousrefactoring.Mode, error) {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case string(continuousrefactoring.ModeSemantic):
+		return continuousrefactoring.ModeSemantic, nil
+	case string(continuousrefactoring.ModeFileDiet):
+		return continuousrefactoring.ModeFileDiet, nil
+	default:
+		return "", fmt.Errorf("parse --mode: unsupported mode %q", raw)
+	}
+}

--- a/cli/cmd/xylem/continuous_refactoring_test.go
+++ b/cli/cmd/xylem/continuous_refactoring_test.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/continuousrefactoring"
+)
+
+type continuousRefactoringRunnerStub struct {
+	outputs map[string][]byte
+	calls   [][]string
+}
+
+func (r *continuousRefactoringRunnerStub) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	r.calls = append(r.calls, call)
+	key := strings.Join(call, "\x00")
+	out, ok := r.outputs[key]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return out, nil
+}
+
+func TestContinuousRefactoringInspectCommandWritesManifest(t *testing.T) {
+	setupTestDeps(t)
+
+	repoRoot := t.TempDir()
+	writeContinuousRefactoringTestFile(t, repoRoot, "cli/internal/example.go", `package example
+
+func Small() {}
+
+func BigFunction() {
+	a := 1
+	b := 2
+	c := a + b
+	if c > 0 {
+		a++
+	}
+	if a > 1 {
+		b++
+	}
+	if b > 2 {
+		c++
+	}
+	if c > 3 {
+		a += b
+	}
+	if a > 3 {
+		c += a
+	}
+	println(a, b, c)
+}
+`)
+	writeContinuousRefactoringTestFile(t, repoRoot, "cli/internal/example_test.go", `package example
+
+func TestIgnored(t *testing.T) {}
+`)
+
+	deps.cfg = &config.Config{
+		Repo: "owner/repo",
+		Sources: map[string]config.SourceConfig{
+			"continuous-refactoring-semantic": {
+				Type:            "schedule",
+				Repo:            "owner/repo",
+				Workflow:        "continuous-refactoring",
+				SourceDirs:      []string{"cli/internal"},
+				FileExtensions:  []string{".go"},
+				LOCThreshold:    10,
+				MaxIssuesPerRun: 2,
+				ExcludePatterns: []string{"**/*_test.go"},
+			},
+		},
+	}
+
+	now := time.Date(2026, 4, 10, 8, 0, 0, 0, time.UTC)
+	oldNow := continuousRefactoringNow
+	continuousRefactoringNow = func() time.Time { return now }
+	t.Cleanup(func() { continuousRefactoringNow = oldNow })
+
+	outputPath := filepath.Join(t.TempDir(), "manifest.json")
+	cmd := newContinuousRefactoringCmd()
+	cmd.SetArgs([]string{
+		"inspect",
+		"--repo-root", repoRoot,
+		"--source", "continuous-refactoring-semantic",
+		"--output", outputPath,
+	})
+
+	output := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+	if strings.TrimSpace(output) != "Wrote "+outputPath {
+		t.Fatalf("stdout = %q, want %q", output, "Wrote "+outputPath)
+	}
+
+	manifest, err := continuousrefactoring.LoadManifest(outputPath)
+	if err != nil {
+		t.Fatalf("LoadManifest() error = %v", err)
+	}
+	if manifest.SourceName != "continuous-refactoring-semantic" {
+		t.Fatalf("SourceName = %q, want continuous-refactoring-semantic", manifest.SourceName)
+	}
+	if manifest.Repo != "owner/repo" {
+		t.Fatalf("Repo = %q, want owner/repo", manifest.Repo)
+	}
+	if manifest.LOCThreshold != 10 {
+		t.Fatalf("LOCThreshold = %d, want 10", manifest.LOCThreshold)
+	}
+	if len(manifest.SemanticFindings) != 1 {
+		t.Fatalf("len(SemanticFindings) = %d, want 1", len(manifest.SemanticFindings))
+	}
+	if got := manifest.SemanticFindings[0].Function; got != "BigFunction" {
+		t.Fatalf("Function = %q, want BigFunction", got)
+	}
+	if len(manifest.FileFindings) != 1 || manifest.FileFindings[0].Path != "cli/internal/example.go" {
+		t.Fatalf("FileFindings = %#v, want example.go only", manifest.FileFindings)
+	}
+}
+
+func TestContinuousRefactoringOpenIssuesCommandWritesResult(t *testing.T) {
+	setupTestDeps(t)
+
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.json")
+	outputPath := filepath.Join(dir, "issues.json")
+	now := time.Date(2026, 4, 10, 8, 15, 0, 0, time.UTC)
+	requireManifest := continuousrefactoring.Manifest{
+		Version:         1,
+		GeneratedAt:     now.Format(time.RFC3339),
+		Repo:            "owner/repo",
+		RepoRoot:        dir,
+		SourceName:      "continuous-refactoring-semantic",
+		LOCThreshold:    80,
+		MaxIssuesPerRun: 2,
+		SemanticFindings: []continuousrefactoring.SemanticCandidate{
+			{
+				ID:             "semantic-runner-drain",
+				Path:           "cli/internal/runner/runner.go",
+				Function:       "Drain",
+				StartLine:      10,
+				EndLine:        140,
+				LOC:            131,
+				StatementCount: 24,
+			},
+			{
+				ID:             "semantic-runner-build-template-data",
+				Path:           "cli/internal/runner/runner.go",
+				Function:       "buildTemplateData",
+				StartLine:      200,
+				EndLine:        320,
+				LOC:            121,
+				StatementCount: 16,
+			},
+		},
+	}
+	writeJSONFixture(t, manifestPath, requireManifest)
+
+	runner := &continuousRefactoringRunnerStub{
+		outputs: map[string][]byte{
+			strings.Join([]string{"gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body", "--limit", "100"}, "\x00"):   []byte(`[]`),
+			strings.Join([]string{"gh", "issue", "list", "--repo", "owner/repo", "--state", "closed", "--json", "number,title,body", "--limit", "100"}, "\x00"): []byte(`[{"number":41,"title":"[refactor] split old thing","body":"<!-- xylem:continuous-refactoring id:other -->"}]`),
+			strings.Join([]string{"gh", "issue", "create", "--repo", "owner/repo", "--title", "[refactor] split Drain in cli/internal/runner/runner.go", "--body", strings.TrimSpace(`
+<!-- xylem:continuous-refactoring id:semantic-runner-drain -->
+## Why this function is a refactor target
+- Path: cli/internal/runner/runner.go
+- Function: Drain
+- Lines: 10-140 (131 LOC)
+- Statements: 24
+- Scope: continuous-refactoring-semantic
+
+## Suggested outcome
+- Extract smaller helpers so the function falls below the configured 80 LOC threshold.
+- Preserve current behavior and public APIs.
+- Add or update focused tests if the refactor exposes missing coverage seams.
+`)}, "\x00"): []byte("https://github.com/owner/repo/issues/42\n"),
+			strings.Join([]string{"gh", "issue", "create", "--repo", "owner/repo", "--title", "[refactor] split buildTemplateData in cli/internal/runner/runner.go", "--body", strings.TrimSpace(`
+<!-- xylem:continuous-refactoring id:semantic-runner-build-template-data -->
+## Why this function is a refactor target
+- Path: cli/internal/runner/runner.go
+- Function: buildTemplateData
+- Lines: 200-320 (121 LOC)
+- Statements: 16
+- Scope: continuous-refactoring-semantic
+
+## Suggested outcome
+- Extract smaller helpers so the function falls below the configured 80 LOC threshold.
+- Preserve current behavior and public APIs.
+- Add or update focused tests if the refactor exposes missing coverage seams.
+`)}, "\x00"): []byte("https://github.com/owner/repo/issues/43\n"),
+		},
+	}
+
+	oldNow := continuousRefactoringNow
+	oldRunner := newContinuousRefactoringRunner
+	continuousRefactoringNow = func() time.Time { return now }
+	newContinuousRefactoringRunner = func() continuousrefactoring.CommandRunner { return runner }
+	t.Cleanup(func() {
+		continuousRefactoringNow = oldNow
+		newContinuousRefactoringRunner = oldRunner
+	})
+
+	cmd := newContinuousRefactoringCmd()
+	cmd.SetArgs([]string{
+		"open-issues",
+		"--manifest", manifestPath,
+		"--output", outputPath,
+		"--mode", "semantic",
+	})
+
+	output := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+	if strings.TrimSpace(output) != "Wrote "+outputPath {
+		t.Fatalf("stdout = %q, want %q", output, "Wrote "+outputPath)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", outputPath, err)
+	}
+	var result continuousrefactoring.OpenResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if len(result.Created) != 2 {
+		t.Fatalf("len(Created) = %d, want 2", len(result.Created))
+	}
+	if result.Created[0].URL != "https://github.com/owner/repo/issues/42" {
+		t.Fatalf("Created[0].URL = %q, want issue URL", result.Created[0].URL)
+	}
+}
+
+func writeContinuousRefactoringTestFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -38,6 +38,7 @@ var expectedCoreWorkflows = []string{
 
 var expectedSelfHostingWorkflows = []string{
 	"audit",
+	"continuous-refactoring",
 	"continuous-improvement",
 	"continuous-simplicity",
 	"diagnose-failures",

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -89,6 +89,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		newInitCmd(),
 		newBootstrapCmd(),
+		newContinuousRefactoringCmd(),
 		newContinuousImprovementCmd(),
 		newContinuousSimplicityCmd(),
 		newDtuCmd(),

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -103,16 +104,21 @@ type TierRouting struct {
 }
 
 type SourceConfig struct {
-	Type     string          `yaml:"type"`
-	Repo     string          `yaml:"repo,omitempty"`
-	Schedule string          `yaml:"schedule,omitempty"`
-	Cadence  string          `yaml:"cadence,omitempty"`
-	Workflow string          `yaml:"workflow,omitempty"`
-	LLM      string          `yaml:"llm,omitempty"`
-	Model    string          `yaml:"model,omitempty"`
-	Timeout  string          `yaml:"timeout,omitempty"`
-	Exclude  []string        `yaml:"exclude,omitempty"`
-	Tasks    map[string]Task `yaml:"tasks,omitempty"`
+	Type            string          `yaml:"type"`
+	Repo            string          `yaml:"repo,omitempty"`
+	Schedule        string          `yaml:"schedule,omitempty"`
+	Cadence         string          `yaml:"cadence,omitempty"`
+	Workflow        string          `yaml:"workflow,omitempty"`
+	LLM             string          `yaml:"llm,omitempty"`
+	Model           string          `yaml:"model,omitempty"`
+	Timeout         string          `yaml:"timeout,omitempty"`
+	Exclude         []string        `yaml:"exclude,omitempty"`
+	Tasks           map[string]Task `yaml:"tasks,omitempty"`
+	SourceDirs      []string        `yaml:"source_dirs,omitempty"`
+	FileExtensions  []string        `yaml:"file_extensions,omitempty"`
+	LOCThreshold    int             `yaml:"loc_threshold,omitempty"`
+	MaxIssuesPerRun int             `yaml:"max_issues_per_run,omitempty"`
+	ExcludePatterns []string        `yaml:"exclude_patterns,omitempty"`
 }
 
 type StatusLabels struct {
@@ -465,6 +471,10 @@ func (c *Config) Validate() error {
 			if dur < minTimeout {
 				return fmt.Errorf("source %q: timeout must be at least %s", name, minTimeout)
 			}
+		}
+
+		if err := validateContinuousRefactoringFields(name, src); err != nil {
+			return err
 		}
 
 		switch src.Type {
@@ -1225,6 +1235,12 @@ func parseScheduleValue(value string) (time.Duration, error) {
 	return interval, nil
 }
 func validateScheduleSource(name string, src SourceConfig) error {
+	if repo := strings.TrimSpace(src.Repo); repo != "" {
+		parts := strings.Split(repo, "/")
+		if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+			return fmt.Errorf("source %q (schedule): repo must be in owner/name format", name)
+		}
+	}
 	if strings.TrimSpace(src.Workflow) == "" {
 		return fmt.Errorf("source %q (schedule): workflow is required", name)
 	}
@@ -1235,4 +1251,55 @@ func validateScheduleSource(name string, src SourceConfig) error {
 		return fmt.Errorf("source %q (schedule): cadence is invalid: %w", name, err)
 	}
 	return nil
+}
+
+func validateContinuousRefactoringFields(name string, src SourceConfig) error {
+	for i, dir := range src.SourceDirs {
+		trimmed := strings.TrimSpace(dir)
+		if trimmed == "" {
+			return fmt.Errorf("source %q: source_dirs[%d] must be non-empty", name, i)
+		}
+		if filepath.IsAbs(trimmed) {
+			return fmt.Errorf("source %q: source_dirs[%d] must be relative", name, i)
+		}
+		if !isPathWithinRoot(trimmed) {
+			return fmt.Errorf("source %q: source_dirs[%d] must stay within repo root", name, i)
+		}
+	}
+	for i, ext := range src.FileExtensions {
+		trimmed := strings.TrimSpace(ext)
+		if trimmed == "" {
+			return fmt.Errorf("source %q: file_extensions[%d] must be non-empty", name, i)
+		}
+		if !strings.HasPrefix(trimmed, ".") {
+			return fmt.Errorf("source %q: file_extensions[%d] must start with \".\"", name, i)
+		}
+	}
+	if src.LOCThreshold < 0 {
+		return fmt.Errorf("source %q: loc_threshold must be greater than or equal to 0", name)
+	}
+	if src.MaxIssuesPerRun < 0 {
+		return fmt.Errorf("source %q: max_issues_per_run must be greater than or equal to 0", name)
+	}
+	for i, pattern := range src.ExcludePatterns {
+		if strings.TrimSpace(pattern) == "" {
+			return fmt.Errorf("source %q: exclude_patterns[%d] must be non-empty", name, i)
+		}
+		if err := validateDoublestarPattern(pattern); err != nil {
+			return fmt.Errorf("source %q: exclude_patterns[%d] invalid glob %q: %w", name, i, pattern, err)
+		}
+	}
+	return nil
+}
+
+func validateDoublestarPattern(pattern string) error {
+	normalized := strings.ReplaceAll(filepath.ToSlash(strings.TrimSpace(pattern)), "**", "*")
+	_, err := path.Match(normalized, "test")
+	return err
+}
+
+func isPathWithinRoot(value string) bool {
+	cleaned := filepath.Clean(value)
+	parentPrefix := ".." + string(filepath.Separator)
+	return cleaned != ".." && !strings.HasPrefix(cleaned, parentPrefix)
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -2209,6 +2209,92 @@ func TestSmoke_S38_ScheduledSourceRejectsInvalidSchedule(t *testing.T) {
 	assert.Contains(t, err.Error(), "schedule is invalid")
 }
 
+func TestScheduleSourceAllowsContinuousRefactoringFields(t *testing.T) {
+	cfg := validConfig()
+	cfg.Sources = map[string]SourceConfig{
+		"continuous-refactoring-semantic": {
+			Type:            "schedule",
+			Repo:            "owner/repo",
+			Cadence:         "0 9 * * 1",
+			Workflow:        "continuous-refactoring",
+			SourceDirs:      []string{"cli/internal", "cli/cmd/xylem"},
+			FileExtensions:  []string{".go"},
+			LOCThreshold:    80,
+			MaxIssuesPerRun: 2,
+			ExcludePatterns: []string{"**/*_test.go", ".xylem/**"},
+		},
+	}
+
+	err := cfg.Validate()
+	require.NoError(t, err)
+
+	sourceCfg := cfg.Sources["continuous-refactoring-semantic"]
+	assert.Equal(t, "owner/repo", sourceCfg.Repo)
+	assert.Equal(t, []string{"cli/internal", "cli/cmd/xylem"}, sourceCfg.SourceDirs)
+	assert.Equal(t, []string{".go"}, sourceCfg.FileExtensions)
+	assert.Equal(t, 80, sourceCfg.LOCThreshold)
+	assert.Equal(t, 2, sourceCfg.MaxIssuesPerRun)
+	assert.Equal(t, []string{"**/*_test.go", ".xylem/**"}, sourceCfg.ExcludePatterns)
+}
+
+func TestContinuousRefactoringFieldsRejectInvalidValues(t *testing.T) {
+	cfg := validConfig()
+	cfg.Sources = map[string]SourceConfig{
+		"continuous-refactoring-semantic": {
+			Type:            "schedule",
+			Repo:            "owner/repo",
+			Cadence:         "0 9 * * 1",
+			Workflow:        "continuous-refactoring",
+			FileExtensions:  []string{"go"},
+			MaxIssuesPerRun: -1,
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file_extensions[0] must start with")
+}
+
+func TestContinuousRefactoringFieldsRejectSourceDirsOutsideRepoRoot(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+		want string
+	}{
+		{
+			name: "parent escape",
+			dir:  "../outside",
+			want: "source_dirs[0] must stay within repo root",
+		},
+		{
+			name: "absolute path",
+			dir:  filepath.Join(string(filepath.Separator), "tmp", "outside"),
+			want: "source_dirs[0] must be relative",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.Sources = map[string]SourceConfig{
+				"continuous-refactoring-semantic": {
+					Type:            "schedule",
+					Repo:            "owner/repo",
+					Cadence:         "0 9 * * 1",
+					Workflow:        "continuous-refactoring",
+					SourceDirs:      []string{tt.dir},
+					FileExtensions:  []string{".go"},
+					MaxIssuesPerRun: 1,
+				},
+			}
+
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
 func TestSmoke_S39_LegacyProvidersNormalizeWithPreferredProviderFirst(t *testing.T) {
 	path := writeConfigFile(t, `sources:
   github:

--- a/cli/internal/continuousrefactoring/refactoring.go
+++ b/cli/internal/continuousrefactoring/refactoring.go
@@ -1,0 +1,695 @@
+package continuousrefactoring
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+)
+
+const (
+	DefaultLOCThreshold    = 120
+	DefaultMaxIssuesPerRun = 2
+)
+
+var DefaultSourceDirs = []string{
+	"cli/cmd/xylem",
+	"cli/internal",
+}
+
+var DefaultFileExtensions = []string{
+	".go",
+}
+
+var DefaultExcludePatterns = []string{
+	"**/*_test.go",
+	"**/testdata/**",
+	".xylem/**",
+}
+
+type CommandRunner interface {
+	RunOutput(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type Mode string
+
+const (
+	ModeSemantic Mode = "semantic"
+	ModeFileDiet Mode = "file-diet"
+)
+
+type Manifest struct {
+	Version          int                 `json:"version"`
+	GeneratedAt      string              `json:"generated_at"`
+	Repo             string              `json:"repo"`
+	RepoRoot         string              `json:"repo_root"`
+	SourceName       string              `json:"source_name"`
+	SourceDirs       []string            `json:"source_dirs"`
+	FileExtensions   []string            `json:"file_extensions"`
+	LOCThreshold     int                 `json:"loc_threshold"`
+	MaxIssuesPerRun  int                 `json:"max_issues_per_run"`
+	ExcludePatterns  []string            `json:"exclude_patterns"`
+	SemanticFindings []SemanticCandidate `json:"semantic_findings"`
+	FileFindings     []FileCandidate     `json:"file_findings"`
+}
+
+type SemanticCandidate struct {
+	ID             string `json:"id"`
+	Path           string `json:"path"`
+	Function       string `json:"function"`
+	Receiver       string `json:"receiver,omitempty"`
+	StartLine      int    `json:"start_line"`
+	EndLine        int    `json:"end_line"`
+	LOC            int    `json:"loc"`
+	StatementCount int    `json:"statement_count"`
+}
+
+type FileCandidate struct {
+	ID   string `json:"id"`
+	Path string `json:"path"`
+	LOC  int    `json:"loc"`
+}
+
+type OpenResult struct {
+	Version     int                 `json:"version"`
+	GeneratedAt string              `json:"generated_at"`
+	Repo        string              `json:"repo"`
+	SourceName  string              `json:"source_name"`
+	Mode        Mode                `json:"mode"`
+	Created     []OpenedIssueResult `json:"created"`
+	Skipped     []OpenedIssueResult `json:"skipped"`
+}
+
+type OpenedIssueResult struct {
+	ID     string `json:"id"`
+	Title  string `json:"title"`
+	Number int    `json:"number,omitempty"`
+	URL    string `json:"url,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type existingIssue struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	Body   string `json:"body"`
+}
+
+type issueCandidate struct {
+	ID    string
+	Title string
+	Body  string
+}
+
+func Inspect(cfg *config.Config, repoRoot, sourceName string, now time.Time) (*Manifest, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	srcCfg, ok := cfg.Sources[sourceName]
+	if !ok {
+		return nil, fmt.Errorf("source %q not found in config", sourceName)
+	}
+	resolvedRoot, err := canonicalizeRoot(strings.TrimSpace(repoRoot))
+	if err != nil {
+		return nil, fmt.Errorf("resolve repo root: %w", err)
+	}
+	settings := normalizeSettings(srcCfg)
+	files, err := collectCandidateFiles(resolvedRoot, settings)
+	if err != nil {
+		return nil, err
+	}
+
+	manifest := &Manifest{
+		Version:          1,
+		GeneratedAt:      now.UTC().Format(time.RFC3339),
+		Repo:             resolveRepo(cfg, srcCfg),
+		RepoRoot:         resolvedRoot,
+		SourceName:       sourceName,
+		SourceDirs:       append([]string(nil), settings.SourceDirs...),
+		FileExtensions:   append([]string(nil), settings.OrderedExts...),
+		LOCThreshold:     settings.LOCThreshold,
+		MaxIssuesPerRun:  settings.MaxIssuesPerRun,
+		ExcludePatterns:  append([]string(nil), settings.ExcludePatterns...),
+		SemanticFindings: collectSemanticCandidates(resolvedRoot, settings.LOCThreshold, files),
+		FileFindings:     collectFileCandidates(settings.LOCThreshold, files),
+	}
+	return manifest, nil
+}
+
+func OpenIssues(ctx context.Context, runner CommandRunner, manifest *Manifest, mode Mode, now time.Time) (*OpenResult, error) {
+	if runner == nil {
+		return nil, fmt.Errorf("runner is required")
+	}
+	if manifest == nil {
+		return nil, fmt.Errorf("manifest is required")
+	}
+	if strings.TrimSpace(manifest.Repo) == "" {
+		return nil, fmt.Errorf("manifest repo is required")
+	}
+	if mode != ModeSemantic && mode != ModeFileDiet {
+		return nil, fmt.Errorf("unsupported mode %q", mode)
+	}
+
+	candidates := issueCandidatesForMode(manifest, mode)
+	existing, err := loadExistingIssues(ctx, runner, manifest.Repo)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &OpenResult{
+		Version:     1,
+		GeneratedAt: now.UTC().Format(time.RFC3339),
+		Repo:        manifest.Repo,
+		SourceName:  manifest.SourceName,
+		Mode:        mode,
+	}
+	for _, candidate := range candidates {
+		if match, ok := findExistingIssue(existing, candidate); ok {
+			result.Skipped = append(result.Skipped, OpenedIssueResult{
+				ID:     candidate.ID,
+				Title:  candidate.Title,
+				Number: match.Number,
+				Reason: "already tracked",
+			})
+			continue
+		}
+		out, err := runner.RunOutput(ctx, "gh", "issue", "create",
+			"--repo", manifest.Repo,
+			"--title", candidate.Title,
+			"--body", candidate.Body,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create issue %q: %w", candidate.ID, err)
+		}
+		url := strings.TrimSpace(string(out))
+		result.Created = append(result.Created, OpenedIssueResult{
+			ID:    candidate.ID,
+			Title: candidate.Title,
+			URL:   url,
+		})
+	}
+	return result, nil
+}
+
+func LoadManifest(path string) (*Manifest, error) {
+	var manifest Manifest
+	if err := loadJSON(path, &manifest); err != nil {
+		return nil, err
+	}
+	return &manifest, nil
+}
+
+func WriteJSON(path string, value any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create directory for %s: %w", path, err)
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func loadJSON(path string, target any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	if err := json.Unmarshal(data, target); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	return nil
+}
+
+type normalizedSettings struct {
+	SourceDirs      []string
+	FileExtensions  map[string]struct{}
+	OrderedExts     []string
+	LOCThreshold    int
+	MaxIssuesPerRun int
+	ExcludePatterns []string
+}
+
+func normalizeSettings(src config.SourceConfig) normalizedSettings {
+	sourceDirs := append([]string(nil), src.SourceDirs...)
+	if len(sourceDirs) == 0 {
+		sourceDirs = append([]string(nil), DefaultSourceDirs...)
+	}
+	fileExtensions := append([]string(nil), src.FileExtensions...)
+	if len(fileExtensions) == 0 {
+		fileExtensions = append([]string(nil), DefaultFileExtensions...)
+	}
+	extSet := make(map[string]struct{}, len(fileExtensions))
+	orderedExts := make([]string, 0, len(fileExtensions))
+	for _, ext := range fileExtensions {
+		trimmed := strings.TrimSpace(ext)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := extSet[trimmed]; ok {
+			continue
+		}
+		extSet[trimmed] = struct{}{}
+		orderedExts = append(orderedExts, trimmed)
+	}
+	locThreshold := src.LOCThreshold
+	if locThreshold <= 0 {
+		locThreshold = DefaultLOCThreshold
+	}
+	maxIssues := src.MaxIssuesPerRun
+	if maxIssues <= 0 {
+		maxIssues = DefaultMaxIssuesPerRun
+	}
+	excludePatterns := append([]string(nil), src.ExcludePatterns...)
+	if len(excludePatterns) == 0 {
+		excludePatterns = append([]string(nil), DefaultExcludePatterns...)
+	}
+	return normalizedSettings{
+		SourceDirs:      sourceDirs,
+		FileExtensions:  extSet,
+		OrderedExts:     orderedExts,
+		LOCThreshold:    locThreshold,
+		MaxIssuesPerRun: maxIssues,
+		ExcludePatterns: excludePatterns,
+	}
+}
+
+type scannedFile struct {
+	RelativePath string
+	AbsolutePath string
+	Content      []byte
+	LOC          int
+}
+
+func collectCandidateFiles(repoRoot string, settings normalizedSettings) ([]scannedFile, error) {
+	seen := make(map[string]struct{})
+	files := make([]scannedFile, 0)
+	for _, sourceDir := range settings.SourceDirs {
+		root, err := resolveSourceDir(repoRoot, sourceDir)
+		if err != nil {
+			return nil, err
+		}
+		if err := filepath.WalkDir(root, func(filePath string, d os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				if os.IsNotExist(walkErr) {
+					return nil
+				}
+				return fmt.Errorf("walk %s: %w", sourceDir, walkErr)
+			}
+			if d.IsDir() {
+				return nil
+			}
+			ext := filepath.Ext(filePath)
+			if _, ok := settings.FileExtensions[ext]; !ok {
+				return nil
+			}
+			relPath, err := filepath.Rel(repoRoot, filePath)
+			if err != nil {
+				return fmt.Errorf("relative path for %s: %w", filePath, err)
+			}
+			normalized := normalizePath(relPath)
+			if matchesAnyPattern(normalized, settings.ExcludePatterns) {
+				return nil
+			}
+			if _, ok := seen[normalized]; ok {
+				return nil
+			}
+			seen[normalized] = struct{}{}
+			content, err := os.ReadFile(filePath)
+			if err != nil {
+				return fmt.Errorf("read %s: %w", normalized, err)
+			}
+			files = append(files, scannedFile{
+				RelativePath: normalized,
+				AbsolutePath: filePath,
+				Content:      content,
+				LOC:          countLOC(content),
+			})
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].RelativePath < files[j].RelativePath
+	})
+	return files, nil
+}
+
+func resolveSourceDir(repoRoot, sourceDir string) (string, error) {
+	canonicalRepoRoot, err := canonicalizeRoot(repoRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve repo root for source dir %q: %w", sourceDir, err)
+	}
+
+	root := filepath.Join(canonicalRepoRoot, sourceDir)
+	resolvedRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve source dir %q: %w", sourceDir, err)
+	}
+	if evalRoot, evalErr := filepath.EvalSymlinks(resolvedRoot); evalErr == nil {
+		resolvedRoot = evalRoot
+	} else if !os.IsNotExist(evalErr) {
+		return "", fmt.Errorf("evaluate source dir %q: %w", sourceDir, evalErr)
+	}
+	rel, err := filepath.Rel(canonicalRepoRoot, resolvedRoot)
+	if err != nil {
+		return "", fmt.Errorf("relativize source dir %q: %w", sourceDir, err)
+	}
+	parentPrefix := ".." + string(filepath.Separator)
+	if rel == ".." || strings.HasPrefix(rel, parentPrefix) {
+		return "", fmt.Errorf("source dir %q escapes repo root", sourceDir)
+	}
+	return resolvedRoot, nil
+}
+
+func canonicalizeRoot(root string) (string, error) {
+	resolvedRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+	if evalRoot, evalErr := filepath.EvalSymlinks(resolvedRoot); evalErr == nil {
+		resolvedRoot = evalRoot
+	} else if !os.IsNotExist(evalErr) {
+		return "", evalErr
+	}
+	return resolvedRoot, nil
+}
+
+func collectSemanticCandidates(repoRoot string, locThreshold int, files []scannedFile) []SemanticCandidate {
+	candidates := make([]SemanticCandidate, 0)
+	for _, file := range files {
+		if filepath.Ext(file.AbsolutePath) != ".go" {
+			continue
+		}
+		fset := token.NewFileSet()
+		parsed, err := parser.ParseFile(fset, file.AbsolutePath, file.Content, parser.SkipObjectResolution)
+		if err != nil {
+			continue
+		}
+		for _, decl := range parsed.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			start := fset.Position(fn.Pos()).Line
+			end := fset.Position(fn.End()).Line
+			loc := end - start + 1
+			if loc < locThreshold {
+				continue
+			}
+			receiver := receiverName(fn)
+			candidates = append(candidates, SemanticCandidate{
+				ID:             semanticID(file.RelativePath, receiver, fn.Name.Name),
+				Path:           file.RelativePath,
+				Function:       fn.Name.Name,
+				Receiver:       receiver,
+				StartLine:      start,
+				EndLine:        end,
+				LOC:            loc,
+				StatementCount: countStatements(fn.Body),
+			})
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		leftScore := candidates[i].LOC*10 + candidates[i].StatementCount
+		rightScore := candidates[j].LOC*10 + candidates[j].StatementCount
+		if leftScore != rightScore {
+			return leftScore > rightScore
+		}
+		if candidates[i].Path != candidates[j].Path {
+			return candidates[i].Path < candidates[j].Path
+		}
+		if candidates[i].Receiver != candidates[j].Receiver {
+			return candidates[i].Receiver < candidates[j].Receiver
+		}
+		return candidates[i].Function < candidates[j].Function
+	})
+	return candidates
+}
+
+func collectFileCandidates(locThreshold int, files []scannedFile) []FileCandidate {
+	candidates := make([]FileCandidate, 0, len(files))
+	for _, file := range files {
+		if file.LOC < locThreshold {
+			continue
+		}
+		candidates = append(candidates, FileCandidate{
+			ID:   fileID(file.RelativePath),
+			Path: file.RelativePath,
+			LOC:  file.LOC,
+		})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].LOC != candidates[j].LOC {
+			return candidates[i].LOC > candidates[j].LOC
+		}
+		return candidates[i].Path < candidates[j].Path
+	})
+	return candidates
+}
+
+func issueCandidatesForMode(manifest *Manifest, mode Mode) []issueCandidate {
+	limit := manifest.MaxIssuesPerRun
+	if limit <= 0 {
+		limit = DefaultMaxIssuesPerRun
+	}
+
+	switch mode {
+	case ModeSemantic:
+		candidates := make([]issueCandidate, 0, min(limit, len(manifest.SemanticFindings)))
+		for _, finding := range manifest.SemanticFindings {
+			candidates = append(candidates, issueCandidate{
+				ID:    finding.ID,
+				Title: fmt.Sprintf("[refactor] split %s in %s", qualifiedFunctionName(finding), finding.Path),
+				Body: strings.TrimSpace(fmt.Sprintf(`
+<!-- xylem:continuous-refactoring id:%s -->
+## Why this function is a refactor target
+- Path: %s
+- Function: %s
+- Lines: %d-%d (%d LOC)
+- Statements: %d
+- Scope: %s
+
+## Suggested outcome
+- Extract smaller helpers so the function falls below the configured %d LOC threshold.
+- Preserve current behavior and public APIs.
+- Add or update focused tests if the refactor exposes missing coverage seams.
+`, finding.ID, finding.Path, qualifiedFunctionName(finding), finding.StartLine, finding.EndLine, finding.LOC, finding.StatementCount, manifest.SourceName, manifest.LOCThreshold)),
+			})
+			if len(candidates) == limit {
+				break
+			}
+		}
+		return candidates
+	case ModeFileDiet:
+		candidates := make([]issueCandidate, 0, min(limit, len(manifest.FileFindings)))
+		for _, finding := range manifest.FileFindings {
+			candidates = append(candidates, issueCandidate{
+				ID:    finding.ID,
+				Title: fmt.Sprintf("[file-diet] simplify %s", finding.Path),
+				Body: strings.TrimSpace(fmt.Sprintf(`
+<!-- xylem:continuous-refactoring id:%s -->
+## Why this file needs a diet pass
+- Path: %s
+- Current size: %d LOC
+- Configured threshold: %d LOC
+- Scope: %s
+
+## Suggested outcome
+- Split the file into smaller focused units or helpers.
+- Remove low-value indirection and keep behavior unchanged.
+- Leave the resulting structure easier to navigate than the current monolith.
+`, finding.ID, finding.Path, finding.LOC, manifest.LOCThreshold, manifest.SourceName)),
+			})
+			if len(candidates) == limit {
+				break
+			}
+		}
+		return candidates
+	default:
+		return nil
+	}
+}
+
+func loadExistingIssues(ctx context.Context, runner CommandRunner, repo string) ([]existingIssue, error) {
+	openIssues, err := readIssues(ctx, runner, repo, "open")
+	if err != nil {
+		return nil, err
+	}
+	closedIssues, err := readIssues(ctx, runner, repo, "closed")
+	if err != nil {
+		return nil, err
+	}
+	return append(openIssues, closedIssues...), nil
+}
+
+func readIssues(ctx context.Context, runner CommandRunner, repo, state string) ([]existingIssue, error) {
+	out, err := runner.RunOutput(ctx, "gh", "issue", "list",
+		"--repo", repo,
+		"--state", state,
+		"--json", "number,title,body",
+		"--limit", "100",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list %s issues: %w", state, err)
+	}
+	var issues []existingIssue
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return nil, fmt.Errorf("parse %s issues: %w", state, err)
+	}
+	return issues, nil
+}
+
+func findExistingIssue(issues []existingIssue, candidate issueCandidate) (existingIssue, bool) {
+	marker := issueMarker(candidate.ID)
+	for _, issue := range issues {
+		if strings.Contains(issue.Body, marker) || strings.TrimSpace(issue.Title) == strings.TrimSpace(candidate.Title) {
+			return issue, true
+		}
+	}
+	return existingIssue{}, false
+}
+
+func issueMarker(id string) string {
+	return fmt.Sprintf("xylem:continuous-refactoring id:%s", id)
+}
+
+func resolveRepo(cfg *config.Config, src config.SourceConfig) string {
+	if repo := strings.TrimSpace(src.Repo); repo != "" {
+		return repo
+	}
+	if cfg != nil {
+		return strings.TrimSpace(cfg.Repo)
+	}
+	return ""
+}
+
+func countStatements(body *ast.BlockStmt) int {
+	count := 0
+	ast.Inspect(body, func(node ast.Node) bool {
+		if _, ok := node.(ast.Stmt); ok {
+			count++
+		}
+		return true
+	})
+	return count
+}
+
+func receiverName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+	switch expr := fn.Recv.List[0].Type.(type) {
+	case *ast.Ident:
+		return expr.Name
+	case *ast.StarExpr:
+		if ident, ok := expr.X.(*ast.Ident); ok {
+			return ident.Name
+		}
+	}
+	return ""
+}
+
+func qualifiedFunctionName(candidate SemanticCandidate) string {
+	if candidate.Receiver == "" {
+		return candidate.Function
+	}
+	return candidate.Receiver + "." + candidate.Function
+}
+
+func semanticID(relPath, receiver, functionName string) string {
+	base := strings.TrimSuffix(filepath.Base(relPath), filepath.Ext(relPath))
+	parts := []string{"semantic", normalizeToken(base)}
+	if receiver != "" {
+		parts = append(parts, normalizeToken(receiver))
+	}
+	parts = append(parts, normalizeToken(functionName))
+	return strings.Join(parts, "-")
+}
+
+func fileID(relPath string) string {
+	return "file-diet-" + normalizeToken(strings.TrimSuffix(relPath, filepath.Ext(relPath)))
+}
+
+func normalizeToken(value string) string {
+	replacer := strings.NewReplacer("/", "-", "\\", "-", "_", "-", ".", "-", "*", "-", " ", "-")
+	cleaned := replacer.Replace(strings.ToLower(value))
+	cleaned = strings.Trim(cleaned, "-")
+	if cleaned == "" {
+		return "item"
+	}
+	return cleaned
+}
+
+func countLOC(content []byte) int {
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+	count := 0
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+func matchesAnyPattern(target string, patterns []string) bool {
+	for _, pattern := range patterns {
+		matched, err := doublestarMatch(pattern, target)
+		if err == nil && matched {
+			return true
+		}
+	}
+	return false
+}
+
+func doublestarMatch(pattern, target string) (bool, error) {
+	pattern = normalizePath(pattern)
+	target = normalizePath(target)
+	if !strings.Contains(pattern, "**") {
+		return path.Match(pattern, target)
+	}
+	if strings.HasPrefix(pattern, "**/") {
+		suffix := strings.TrimPrefix(pattern, "**/")
+		for candidate := target; ; {
+			matched, err := path.Match(suffix, candidate)
+			if matched || err != nil {
+				return matched, err
+			}
+			slash := strings.IndexByte(candidate, '/')
+			if slash < 0 {
+				return false, nil
+			}
+			candidate = candidate[slash+1:]
+		}
+	}
+	if strings.HasSuffix(pattern, "/**") {
+		prefix := strings.TrimSuffix(pattern, "/**")
+		return target == prefix || strings.HasPrefix(target, prefix+"/"), nil
+	}
+	return path.Match(strings.ReplaceAll(pattern, "**", "*"), target)
+}
+
+func normalizePath(value string) string {
+	return filepath.ToSlash(filepath.Clean(value))
+}
+
+func min(left, right int) int {
+	if left < right {
+		return left
+	}
+	return right
+}

--- a/cli/internal/continuousrefactoring/refactoring_test.go
+++ b/cli/internal/continuousrefactoring/refactoring_test.go
@@ -1,0 +1,51 @@
+package continuousrefactoring
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+)
+
+func TestInspectRejectsSourceDirOutsideRepoRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Sources: map[string]config.SourceConfig{
+			"continuous-refactoring-semantic": {
+				Type:           "schedule",
+				Repo:           "owner/repo",
+				Workflow:       "continuous-refactoring",
+				SourceDirs:     []string{"../outside"},
+				FileExtensions: []string{".go"},
+			},
+		},
+	}
+
+	_, err := Inspect(cfg, repoRoot, "continuous-refactoring-semantic", time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC))
+	if err == nil {
+		t.Fatal("Inspect() error = nil, want source dir rejection")
+	}
+	if !strings.Contains(err.Error(), `source dir "../outside" escapes repo root`) {
+		t.Fatalf("Inspect() error = %q, want source dir escape error", err)
+	}
+}
+
+func TestResolveSourceDirAcceptsNestedRepoPath(t *testing.T) {
+	repoRoot := t.TempDir()
+
+	got, err := resolveSourceDir(repoRoot, filepath.Join("cli", "internal"))
+	if err != nil {
+		t.Fatalf("resolveSourceDir() error = %v", err)
+	}
+
+	want := filepath.Join(repoRoot, "cli", "internal")
+	if evalWant, evalErr := filepath.EvalSymlinks(repoRoot); evalErr == nil {
+		want = filepath.Join(evalWant, "cli", "internal")
+	}
+	if got != want {
+		t.Fatalf("resolveSourceDir() = %q, want %q", got, want)
+	}
+}

--- a/cli/internal/phase/phase.go
+++ b/cli/internal/phase/phase.go
@@ -58,8 +58,17 @@ type RepoData struct {
 
 // SourceData describes the configured source that produced the vessel.
 type SourceData struct {
-	Name string
-	Repo string
+	Name            string
+	Repo            string
+	Type            string
+	Workflow        string
+	Schedule        string
+	Cadence         string
+	SourceDirs      []string
+	FileExtensions  []string
+	LOCThreshold    int
+	MaxIssuesPerRun int
+	ExcludePatterns []string
 }
 
 // ValidationData describes optional repo-specific validation commands.

--- a/cli/internal/phase/phase_test.go
+++ b/cli/internal/phase/phase_test.go
@@ -183,6 +183,24 @@ func TestRenderPrompt(t *testing.T) {
 			},
 			want: "Issue #7: Add caching layer\nURL: https://github.com/org/repo/issues/7\nPhase: implement (2)\nVessel: issue-7\nPrevious: Step 1: Add Redis. Step 2: Wire it up.\nGate: tests pass",
 		},
+		{
+			name:     "renders extended source config fields",
+			template: "{{.Source.Name}}|{{.Source.Type}}|{{.Source.Workflow}}|{{.Source.Cadence}}|{{.Source.LOCThreshold}}|{{.Source.MaxIssuesPerRun}}|{{index .Source.SourceDirs 0}}|{{index .Source.FileExtensions 0}}|{{index .Source.ExcludePatterns 0}}",
+			data: TemplateData{
+				Source: SourceData{
+					Name:            "continuous-refactoring-semantic",
+					Type:            "schedule",
+					Workflow:        "continuous-refactoring",
+					Cadence:         "0 9 * * 1",
+					SourceDirs:      []string{"cli/internal"},
+					FileExtensions:  []string{".go"},
+					LOCThreshold:    80,
+					MaxIssuesPerRun: 2,
+					ExcludePatterns: []string{"**/*_test.go"},
+				},
+			},
+			want: "continuous-refactoring-semantic|schedule|continuous-refactoring|0 9 * * 1|80|2|cli/internal|.go|**/*_test.go",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -125,6 +125,7 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, sortedKeys(composed.Workflows), "implement-harness")
+	assert.Contains(t, sortedKeys(composed.Workflows), "continuous-refactoring")
 	assert.Contains(t, sortedKeys(composed.Workflows), "continuous-improvement")
 	assert.Contains(t, sortedKeys(composed.Workflows), "continuous-simplicity")
 	assert.Contains(t, sortedKeys(composed.Workflows), "sota-gap-analysis")
@@ -134,6 +135,8 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/verify")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-impl")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-pr-lifecycle")
+	assert.Contains(t, sortedKeys(composed.Sources), "continuous-refactoring-semantic")
+	assert.Contains(t, sortedKeys(composed.Sources), "continuous-refactoring-file-diet")
 	assert.Contains(t, sortedKeys(composed.Sources), "continuous-improvement")
 	assert.Contains(t, sortedKeys(composed.Sources), "continuous-simplicity")
 	assert.Contains(t, sortedKeys(composed.Sources), "sota-gap")
@@ -143,6 +146,10 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	assert.Contains(t, implementHarnessWorkflow, `--repo nicholls-inc/xylem`)
 	assert.Contains(t, implementHarnessWorkflow, `--label "harness-impl"`)
 	assert.Contains(t, implementHarnessWorkflow, `--label "ready-to-merge"`)
+
+	continuousRefactoringWorkflow := string(composed.Workflows["continuous-refactoring"])
+	assert.Contains(t, continuousRefactoringWorkflow, "continuous-refactoring inspect")
+	assert.Contains(t, continuousRefactoringWorkflow, "continuous-refactoring open-issues")
 }
 
 func TestSmoke_S3_SelfHostingProfileScaffoldsContinuousImprovementScheduledWorkflow(t *testing.T) {
@@ -180,6 +187,41 @@ func TestSmoke_S3_SelfHostingProfileScaffoldsContinuousImprovementScheduledWorkf
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/plan")
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/implement")
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/verify")
+}
+
+func TestSelfHostingProfileScaffoldsContinuousRefactoringSchedules(t *testing.T) {
+	t.Parallel()
+
+	composed, err := Compose("core", "self-hosting-xylem")
+	require.NoError(t, err)
+
+	var semanticSource config.SourceConfig
+	require.NoError(t, yaml.Unmarshal(composed.Sources["continuous-refactoring-semantic"], &semanticSource))
+	assert.Equal(t, "schedule", semanticSource.Type)
+	assert.Equal(t, "{{ .Repo }}", semanticSource.Repo)
+	assert.Equal(t, "0 9 * * 1", semanticSource.Cadence)
+	assert.Equal(t, "continuous-refactoring", semanticSource.Workflow)
+	assert.Equal(t, []string{"cli/cmd/xylem", "cli/internal"}, semanticSource.SourceDirs)
+	assert.Equal(t, []string{".go"}, semanticSource.FileExtensions)
+	assert.Equal(t, 80, semanticSource.LOCThreshold)
+	assert.Equal(t, 2, semanticSource.MaxIssuesPerRun)
+
+	var fileDietSource config.SourceConfig
+	require.NoError(t, yaml.Unmarshal(composed.Sources["continuous-refactoring-file-diet"], &fileDietSource))
+	assert.Equal(t, "0 9 * * 1-5", fileDietSource.Cadence)
+	assert.Equal(t, 250, fileDietSource.LOCThreshold)
+	assert.Equal(t, 1, fileDietSource.MaxIssuesPerRun)
+
+	var wf workflowpkg.Workflow
+	require.NoError(t, yaml.Unmarshal(composed.Workflows["continuous-refactoring"], &wf))
+	assert.Equal(t, "continuous-refactoring", wf.Name)
+	assert.Equal(t, workflowpkg.ClassHarnessMaintenance, wf.Class)
+	require.Len(t, wf.Phases, 2)
+	assert.Equal(t, "inspect", wf.Phases[0].Name)
+	assert.Equal(t, "command", wf.Phases[0].Type)
+	assert.Contains(t, wf.Phases[0].Run, "continuous-refactoring inspect")
+	assert.Equal(t, "open_issues", wf.Phases[1].Name)
+	assert.Contains(t, wf.Phases[1].Run, "--mode {{if eq .Source.Name \"continuous-refactoring-file-diet\"}}file-diet{{else}}semantic{{end}}")
 }
 
 func TestAdaptRepoWorkflowAssetParsesCleanly(t *testing.T) {

--- a/cli/internal/profiles/self-hosting-xylem/workflows/continuous-refactoring.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/continuous-refactoring.yaml
@@ -1,0 +1,23 @@
+name: continuous-refactoring
+class: harness-maintenance
+description: "Recurring semantic refactor and large-file simplification issue finder"
+phases:
+  - name: inspect
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem --config ../.xylem.yml continuous-refactoring inspect \
+        --repo-root .. \
+        --source {{.Source.Name}} \
+        --output ../.xylem/state/continuous-refactoring/{{.Source.Name}}-manifest.json
+  - name: open_issues
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem --config ../.xylem.yml continuous-refactoring open-issues \
+        --source {{.Source.Name}} \
+        --mode {{if eq .Source.Name "continuous-refactoring-file-diet"}}file-diet{{else}}semantic{{end}} \
+        --manifest ../.xylem/state/continuous-refactoring/{{.Source.Name}}-manifest.json \
+        --output ../.xylem/state/continuous-refactoring/{{.Source.Name}}-issues.json

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -77,6 +77,40 @@ sources:
       daily-rotation:
         workflow: continuous-improvement
         ref: continuous-improvement
+  continuous-refactoring-semantic:
+    type: schedule
+    repo: "{{ .Repo }}"
+    cadence: "0 9 * * 1"
+    workflow: continuous-refactoring
+    timeout: "90m"
+    source_dirs:
+      - cli/cmd/xylem
+      - cli/internal
+    file_extensions:
+      - .go
+    loc_threshold: 80
+    max_issues_per_run: 2
+    exclude_patterns:
+      - "**/*_test.go"
+      - "**/testdata/**"
+      - ".xylem/**"
+  continuous-refactoring-file-diet:
+    type: schedule
+    repo: "{{ .Repo }}"
+    cadence: "0 9 * * 1-5"
+    workflow: continuous-refactoring
+    timeout: "90m"
+    source_dirs:
+      - cli/cmd/xylem
+      - cli/internal
+    file_extensions:
+      - .go
+    loc_threshold: 250
+    max_issues_per_run: 1
+    exclude_patterns:
+      - "**/*_test.go"
+      - "**/testdata/**"
+      - ".xylem/**"
   metrics-collector:
     type: scheduled
     repo: "{{ .Repo }}"

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -4018,6 +4018,8 @@ func (r *Runner) resolveDefaultBranch() string {
 
 func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueData, phaseName string, phaseIndex int, previousOutputs map[string]string, gateResult string) phase.TemplateData {
 	sourceName := vessel.Source
+	sourceData := phase.SourceData{}
+	sourceCfg := r.sourceConfigFromMeta(vessel)
 	if configSource := r.sourceConfigNameFromMeta(vessel); configSource != "" {
 		sourceName = configSource
 	}
@@ -4031,6 +4033,28 @@ func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueDat
 			Test:   strings.TrimSpace(r.Config.Validation.Test),
 		}
 	}
+	if sourceCfg != nil {
+		sourceData = phase.SourceData{
+			Name:            sourceName,
+			Repo:            strings.TrimSpace(sourceCfg.Repo),
+			Type:            strings.TrimSpace(sourceCfg.Type),
+			Workflow:        strings.TrimSpace(sourceCfg.Workflow),
+			Schedule:        strings.TrimSpace(sourceCfg.Schedule),
+			Cadence:         strings.TrimSpace(sourceCfg.Cadence),
+			SourceDirs:      append([]string(nil), sourceCfg.SourceDirs...),
+			FileExtensions:  append([]string(nil), sourceCfg.FileExtensions...),
+			LOCThreshold:    sourceCfg.LOCThreshold,
+			MaxIssuesPerRun: sourceCfg.MaxIssuesPerRun,
+			ExcludePatterns: append([]string(nil), sourceCfg.ExcludePatterns...),
+		}
+	}
+	if strings.TrimSpace(sourceData.Name) == "" {
+		sourceData.Name = sourceName
+	}
+	if strings.TrimSpace(sourceData.Repo) == "" {
+		sourceData.Repo = repoSlug
+	}
+
 	return phase.TemplateData{
 		Issue: issueData,
 		Phase: phase.PhaseData{
@@ -4049,10 +4073,7 @@ func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueDat
 			Slug:          repoSlug,
 			DefaultBranch: r.resolveDefaultBranch(),
 		},
-		Source: phase.SourceData{
-			Name: sourceName,
-			Repo: repoSlug,
-		},
+		Source:     sourceData,
 		Validation: validation,
 	}
 }

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -5319,6 +5319,38 @@ func TestResolveSourcePrefersConfigSource(t *testing.T) {
 	}
 }
 
+func TestBuildTemplateDataIncludesExtendedSourceConfigFields(t *testing.T) {
+	cfg := makeTestConfig(t.TempDir(), 1)
+	cfg.Sources["continuous-refactoring-semantic"] = config.SourceConfig{
+		Type:            "schedule",
+		Repo:            "owner/config-repo",
+		Cadence:         "0 9 * * 1",
+		Workflow:        "continuous-refactoring",
+		SourceDirs:      []string{"cli/internal"},
+		FileExtensions:  []string{".go"},
+		LOCThreshold:    80,
+		MaxIssuesPerRun: 2,
+		ExcludePatterns: []string{"**/*_test.go"},
+	}
+	r := &Runner{Config: cfg}
+
+	td := r.buildTemplateData(queue.Vessel{
+		Source: "schedule",
+		Meta:   map[string]string{"config_source": "continuous-refactoring-semantic"},
+	}, phase.IssueData{}, "inspect", 0, nil, "")
+
+	assert.Equal(t, "continuous-refactoring-semantic", td.Source.Name)
+	assert.Equal(t, "owner/config-repo", td.Source.Repo)
+	assert.Equal(t, "schedule", td.Source.Type)
+	assert.Equal(t, "continuous-refactoring", td.Source.Workflow)
+	assert.Equal(t, "0 9 * * 1", td.Source.Cadence)
+	assert.Equal(t, []string{"cli/internal"}, td.Source.SourceDirs)
+	assert.Equal(t, []string{".go"}, td.Source.FileExtensions)
+	assert.Equal(t, 80, td.Source.LOCThreshold)
+	assert.Equal(t, 2, td.Source.MaxIssuesPerRun)
+	assert.Equal(t, []string{"**/*_test.go"}, td.Source.ExcludePatterns)
+}
+
 // --- Orchestrated (parallel) execution tests ---
 
 func TestDrainOrchestratedDiamondWorkflow(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a continuous-refactoring workflow with deterministic inspect/open-issues helpers for semantic refactors and large-file file-diet sweeps
- thread source scheduling/config fields through validation, runner template data, and self-hosting profile scaffolding
- cover the new workflow, CLI commands, config validation, profile composition, and runner template plumbing with tests

Closes https://github.com/nicholls-inc/xylem/issues/271