### PR TITLE
feat(workflow): add continuous-style analysis workflow

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -151,6 +151,16 @@ sources:
         workflow: continuous-improvement
         ref: continuous-improvement
 
+  continuous-style:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "@daily"
+    timeout: "60m"
+    tasks:
+      daily-continuous-style:
+        workflow: continuous-style
+        ref: continuous-style
+
   harness-gap-analysis:
     type: scheduled
     repo: nicholls-inc/xylem

--- a/.xylem/prompts/continuous-style/ingest.md
+++ b/.xylem/prompts/continuous-style/ingest.md
@@ -1,0 +1,21 @@
+Prepare the scheduled continuous-style run for xylem.
+
+Target the CLI's user-facing terminal output surfaces:
+
+1. `cli/cmd/xylem/`
+2. `cli/internal/reporter/`
+3. `cli/internal/review/`
+4. `cli/internal/lessons/`
+5. Any directly related helpers those packages rely on for user-facing output
+
+Your goal in this phase is to produce a factual inventory that the next phase can convert into a stable findings file.
+
+The inventory must identify:
+
+1. the concrete files and commands that emit user-facing stdout or stderr
+2. which surfaces are primarily tabular, status-oriented, markdown/report-oriented, or warning/error-oriented
+3. where the current output already looks consistent and operator-friendly
+4. where the output feels inconsistent, noisy, poorly routed, or hard to scan
+5. the exact file paths and line ranges that support each observation
+
+Stay grounded in this repository's conventions. Do not assume xylem wants a full terminal UI framework; just inventory the current output patterns and the most meaningful rough edges.

--- a/.xylem/prompts/continuous-style/report.md
+++ b/.xylem/prompts/continuous-style/report.md
@@ -1,0 +1,21 @@
+Turn the continuous-style findings into a human-readable markdown report.
+
+Read:
+
+1. `.xylem/state/continuous-style/findings.json`
+
+Write:
+
+`.xylem/state/continuous-style/report.md`
+
+The report must contain:
+
+1. a short executive summary of the current terminal-output health
+2. a section on what already looks consistent or operator-friendly
+3. a ranked section of the findings to address next
+4. file-path-level evidence and concrete follow-up directions for each finding
+5. a clear note when the run found no worthwhile issues
+
+Keep the report concrete and grounded in xylem's current CLI surfaces. Avoid generic terminal-UI advice that is not tied to this repository.
+
+After writing the report, print a brief confirmation with the top findings or `no findings`.

--- a/.xylem/prompts/continuous-style/survey.md
+++ b/.xylem/prompts/continuous-style/survey.md
@@ -1,0 +1,51 @@
+Convert the continuous-style inventory into the committed findings format.
+
+Inputs to use:
+
+1. `{{.PreviousOutputs.ingest}}`
+2. the live source under `cli/cmd/xylem/`, `cli/internal/reporter/`, `cli/internal/review/`, and `cli/internal/lessons/`
+
+Write exactly one JSON file at:
+
+`.xylem/state/continuous-style/findings.json`
+
+The JSON must have this shape:
+
+```json
+{
+  "version": 1,
+  "repo": "nicholls-inc/xylem",
+  "generated_at": "2026-04-10T00:00:00Z",
+  "target_surface": "cli terminal output",
+  "findings": [
+    {
+      "id": "stable-kebab-case-id",
+      "title": "Human-readable issue title",
+      "category": "consistency|stderr-routing|scannability|accessibility|output-contracts",
+      "summary": "What is wrong today and why it matters.",
+      "recommendation": "Specific direction for the follow-up issue.",
+      "priority": 8,
+      "paths": ["cli/cmd/xylem/status.go"],
+      "evidence": [
+        {
+          "path": "cli/cmd/xylem/status.go",
+          "line_start": 123,
+          "line_end": 140,
+          "summary": "Precise evidence for the finding."
+        }
+      ]
+    }
+  ]
+}
+```
+
+Requirements:
+
+1. Keep `findings` focused and high-signal. Prefer `0-5` findings total.
+2. Only include findings that are worth a dedicated GitHub issue.
+3. Use stable IDs and precise evidence line numbers.
+4. Favor consistency, stderr/stdout routing, scan-friendly tables/status output, and clear output contracts over purely cosmetic nitpicks.
+5. Do not recommend new third-party terminal UI dependencies unless the repository already uses them on the exact surface under discussion and the recommendation is clearly justified.
+6. If the current CLI output is already in good shape for this run, emit an empty `findings` array rather than inventing weak work.
+
+After writing the file, print a short summary with the finding count and the highest-priority IDs.

--- a/.xylem/workflows/continuous-style.yaml
+++ b/.xylem/workflows/continuous-style.yaml
@@ -1,0 +1,36 @@
+name: continuous-style
+class: harness-maintenance
+description: "Recurring terminal-output style analysis for xylem's CLI surfaces"
+phases:
+  - name: ingest
+    prompt_file: .xylem/prompts/continuous-style/ingest.md
+    max_turns: 30
+  - name: survey
+    prompt_file: .xylem/prompts/continuous-style/survey.md
+    max_turns: 45
+  - name: report
+    prompt_file: .xylem/prompts/continuous-style/report.md
+    max_turns: 30
+  - name: file_issues
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem continuous-style file-issues \
+        --repo nicholls-inc/xylem \
+        --report ../.xylem/state/continuous-style/findings.json \
+        --output ../.xylem/state/continuous-style/filed-issues.json \
+        --prefix "[continuous-style]" \
+        --labels enhancement \
+        --labels ready-for-work
+  - name: summary
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem continuous-style post-summary \
+        --repo nicholls-inc/xylem \
+        --report ../.xylem/state/continuous-style/findings.json \
+        --filed ../.xylem/state/continuous-style/filed-issues.json \
+        --summary ../.xylem/state/continuous-style/report.md \
+        --tracking-title "[continuous-style] Tracking"

--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -38,7 +38,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "bootstrap", "continuous-improvement", "continuous-simplicity", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version"}
+	expected := []string{"init", "bootstrap", "continuous-style", "continuous-improvement", "continuous-simplicity", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/continuous_style.go
+++ b/cli/cmd/xylem/continuous_style.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholls-inc/xylem/cli/internal/continuousstyle"
+)
+
+var newContinuousStyleRunner = func() continuousstyle.CommandRunner {
+	return &realCmdRunner{}
+}
+
+func newContinuousStyleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "continuous-style",
+		Short: "Deterministic helpers for scheduled terminal-style analysis runs",
+	}
+	cmd.AddCommand(
+		newContinuousStyleFileIssuesCmd(),
+		newContinuousStylePostSummaryCmd(),
+	)
+	return cmd
+}
+
+func newContinuousStyleFileIssuesCmd() *cobra.Command {
+	var reportPath, outputPath, repo, prefix string
+	var limit int
+	var labels []string
+	cmd := &cobra.Command{
+		Use:   "file-issues",
+		Short: "Create top-ranked continuous-style issues with deduping",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := continuousstyle.LoadReport(reportPath)
+			if err != nil {
+				return err
+			}
+			result, err := continuousstyle.FileIssues(context.Background(), newContinuousStyleRunner(), repo, report, limit, prefix, labels)
+			if err != nil {
+				return err
+			}
+			if err := continuousstyle.WriteJSON(outputPath, result); err != nil {
+				return err
+			}
+			fmt.Printf("Wrote %s\n", outputPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&reportPath, "report", "", "Path to continuous-style findings JSON")
+	cmd.Flags().StringVar(&outputPath, "output", "", "Path to write filed-issues JSON")
+	cmd.Flags().StringVar(&repo, "repo", "", "GitHub repository slug (owner/name)")
+	cmd.Flags().StringVar(&prefix, "prefix", "[continuous-style]", "Issue title prefix")
+	cmd.Flags().IntVar(&limit, "limit", 3, "Maximum number of issues to create")
+	cmd.Flags().StringSliceVar(&labels, "labels", []string{"enhancement", "ready-for-work"}, "Labels to apply to new issues")
+	cmd.MarkFlagRequired("report") //nolint:errcheck
+	cmd.MarkFlagRequired("output") //nolint:errcheck
+	cmd.MarkFlagRequired("repo")   //nolint:errcheck
+	return cmd
+}
+
+func newContinuousStylePostSummaryCmd() *cobra.Command {
+	var reportPath, filedPath, summaryPath, repo, trackingTitle string
+	cmd := &cobra.Command{
+		Use:   "post-summary",
+		Short: "Ensure a tracking issue exists and post a continuous-style summary comment",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := continuousstyle.LoadReport(reportPath)
+			if err != nil {
+				return err
+			}
+			filed, err := loadContinuousStyleFileResult(filedPath)
+			if err != nil {
+				return err
+			}
+			summaryBytes, err := os.ReadFile(summaryPath)
+			if err != nil {
+				return fmt.Errorf("read summary %q: %w", summaryPath, err)
+			}
+			tracking, err := continuousstyle.EnsureTrackingIssue(context.Background(), newContinuousStyleRunner(), repo, trackingTitle)
+			if err != nil {
+				return err
+			}
+			if err := continuousstyle.PostSummary(context.Background(), newContinuousStyleRunner(), repo, tracking.Number, report, filed, string(summaryBytes)); err != nil {
+				return err
+			}
+			fmt.Printf("Posted summary to issue #%d\n", tracking.Number)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&reportPath, "report", "", "Path to continuous-style findings JSON")
+	cmd.Flags().StringVar(&filedPath, "filed", "", "Path to filed-issues JSON")
+	cmd.Flags().StringVar(&summaryPath, "summary", "", "Path to markdown summary")
+	cmd.Flags().StringVar(&repo, "repo", "", "GitHub repository slug (owner/name)")
+	cmd.Flags().StringVar(&trackingTitle, "tracking-title", continuousstyle.DefaultTrackingIssueTitle, "Tracking issue title")
+	cmd.MarkFlagRequired("report")  //nolint:errcheck
+	cmd.MarkFlagRequired("filed")   //nolint:errcheck
+	cmd.MarkFlagRequired("summary") //nolint:errcheck
+	cmd.MarkFlagRequired("repo")    //nolint:errcheck
+	return cmd
+}
+
+func loadContinuousStyleFileResult(path string) (*continuousstyle.FileResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read filed issues %q: %w", path, err)
+	}
+	var filed continuousstyle.FileResult
+	if err := json.Unmarshal(data, &filed); err != nil {
+		return nil, fmt.Errorf("parse filed issues %q: %w", path, err)
+	}
+	return &filed, nil
+}

--- a/cli/cmd/xylem/continuous_style_test.go
+++ b/cli/cmd/xylem/continuous_style_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/continuousstyle"
+)
+
+type continuousStyleRunnerStub struct {
+	outputs map[string][]byte
+	calls   [][]string
+}
+
+func (r *continuousStyleRunnerStub) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	r.calls = append(r.calls, call)
+	key := strings.Join(call, "\x00")
+	out, ok := r.outputs[key]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return out, nil
+}
+
+func TestContinuousStyleFileIssuesCommandWritesResult(t *testing.T) {
+	dir := t.TempDir()
+	reportPath := filepath.Join(dir, "report.json")
+	outputPath := filepath.Join(dir, "filed.json")
+	writeContinuousStyleReport(t, reportPath, continuousstyle.Report{
+		Version:       continuousstyle.ReportVersion,
+		Repo:          "owner/repo",
+		GeneratedAt:   "2026-04-10T00:00:00Z",
+		TargetSurface: "cli terminal output",
+		Findings: []continuousstyle.Finding{{
+			ID:             "route-stderr",
+			Title:          "Route stderr consistently",
+			Category:       "stderr-routing",
+			Summary:        "summary",
+			Recommendation: "recommendation",
+			Priority:       9,
+			Paths:          []string{"cli/cmd/xylem/main.go"},
+			Evidence: []continuousstyle.Evidence{{
+				Path:      "cli/cmd/xylem/main.go",
+				LineStart: 30,
+				Summary:   "evidence",
+			}},
+		}},
+	})
+	runner := &continuousStyleRunnerStub{
+		outputs: map[string][]byte{
+			strings.Join([]string{"gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url", "--limit", "100", "--search", "[continuous-style]"}, "\x00"): []byte("[]"),
+			strings.Join([]string{"gh", "issue", "create", "--repo", "owner/repo", "--title", "[continuous-style] Route stderr consistently", "--body", "summary\n\nCategory: `stderr-routing`\nPriority: `9`\nTarget surface: `cli terminal output`\n\n## Affected paths\n- `cli/cmd/xylem/main.go`\n\n## Current code evidence\n- `cli/cmd/xylem/main.go:30` — evidence\n\n## Suggested direction\nrecommendation", "--label", "enhancement", "--label", "ready-for-work"}, "\x00"): []byte("https://github.com/owner/repo/issues/9\n"),
+		},
+	}
+
+	original := newContinuousStyleRunner
+	newContinuousStyleRunner = func() continuousstyle.CommandRunner { return runner }
+	t.Cleanup(func() { newContinuousStyleRunner = original })
+
+	cmd := newContinuousStyleCmd()
+	cmd.SetArgs([]string{"file-issues", "--report", reportPath, "--output", outputPath, "--repo", "owner/repo"})
+
+	output := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+	if strings.TrimSpace(output) != "Wrote "+outputPath {
+		t.Fatalf("stdout = %q, want %q", output, "Wrote "+outputPath)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", outputPath, err)
+	}
+	var result continuousstyle.FileResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if len(result.Created) != 1 || result.Created[0].Number != 9 {
+		t.Fatalf("Created = %#v, want one created issue #9", result.Created)
+	}
+}
+
+func TestContinuousStylePostSummaryCommandPostsTrackingComment(t *testing.T) {
+	dir := t.TempDir()
+	reportPath := filepath.Join(dir, "report.json")
+	filedPath := filepath.Join(dir, "filed.json")
+	summaryPath := filepath.Join(dir, "summary.md")
+	writeContinuousStyleReport(t, reportPath, continuousstyle.Report{
+		Version:       continuousstyle.ReportVersion,
+		Repo:          "owner/repo",
+		GeneratedAt:   "2026-04-10T00:00:00Z",
+		TargetSurface: "cli terminal output",
+		Findings: []continuousstyle.Finding{{
+			ID:             "route-stderr",
+			Title:          "Route stderr consistently",
+			Category:       "stderr-routing",
+			Summary:        "summary",
+			Recommendation: "recommendation",
+			Priority:       9,
+			Paths:          []string{"cli/cmd/xylem/main.go"},
+			Evidence: []continuousstyle.Evidence{{
+				Path:      "cli/cmd/xylem/main.go",
+				LineStart: 30,
+				Summary:   "evidence",
+			}},
+		}},
+	})
+	writeContinuousStyleFileResult(t, filedPath, continuousstyle.FileResult{
+		Created: []continuousstyle.FiledIssue{{
+			ID:      "route-stderr",
+			Title:   "[continuous-style] Route stderr consistently",
+			Number:  9,
+			URL:     "https://github.com/owner/repo/issues/9",
+			Created: true,
+		}},
+	})
+	if err := os.WriteFile(summaryPath, []byte("# Continuous style report\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", summaryPath, err)
+	}
+	runner := &continuousStyleRunnerStub{
+		outputs: map[string][]byte{
+			strings.Join([]string{"gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url", "--limit", "100", "--search", continuousstyle.DefaultTrackingIssueTitle}, "\x00"):                                                                                                                                                                                                                                                                 []byte(`[]`),
+			strings.Join([]string{"gh", "issue", "create", "--repo", "owner/repo", "--title", continuousstyle.DefaultTrackingIssueTitle, "--body", "Scheduled continuous-style summaries land here so operators can track terminal-output polish opportunities across xylem's CLI surfaces."}, "\x00"):                                                                                                                                                                                 []byte("https://github.com/owner/repo/issues/11\n"),
+			strings.Join([]string{"gh", "issue", "comment", "11", "--repo", "owner/repo", "--body", "**xylem — continuous style analysis**\n\n- Target surface: cli terminal output\n- Findings this run: 1\n- Highest-priority findings:\n  - Route stderr consistently (`stderr-routing`, priority=9)\n- Filed issues:\n  - [continuous-style] Route stderr consistently (#9)\n\n<details>\n<summary>Analysis report</summary>\n\n# Continuous style report\n\n</details>"}, "\x00"): []byte(""),
+		},
+	}
+
+	original := newContinuousStyleRunner
+	newContinuousStyleRunner = func() continuousstyle.CommandRunner { return runner }
+	t.Cleanup(func() { newContinuousStyleRunner = original })
+
+	cmd := newContinuousStyleCmd()
+	cmd.SetArgs([]string{"post-summary", "--report", reportPath, "--filed", filedPath, "--summary", summaryPath, "--repo", "owner/repo"})
+
+	output := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+	if strings.TrimSpace(output) != "Posted summary to issue #11" {
+		t.Fatalf("stdout = %q, want tracking issue confirmation", output)
+	}
+
+	wantCalls := [][]string{
+		{"gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url", "--limit", "100", "--search", continuousstyle.DefaultTrackingIssueTitle},
+		{"gh", "issue", "create", "--repo", "owner/repo", "--title", continuousstyle.DefaultTrackingIssueTitle, "--body", "Scheduled continuous-style summaries land here so operators can track terminal-output polish opportunities across xylem's CLI surfaces."},
+		{"gh", "issue", "comment", "11", "--repo", "owner/repo", "--body", "**xylem — continuous style analysis**\n\n- Target surface: cli terminal output\n- Findings this run: 1\n- Highest-priority findings:\n  - Route stderr consistently (`stderr-routing`, priority=9)\n- Filed issues:\n  - [continuous-style] Route stderr consistently (#9)\n\n<details>\n<summary>Analysis report</summary>\n\n# Continuous style report\n\n</details>"},
+	}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("runner calls = %#v, want %#v", runner.calls, wantCalls)
+	}
+}
+
+func writeContinuousStyleReport(t *testing.T, path string, report continuousstyle.Report) {
+	t.Helper()
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("json.Marshal(report) error = %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}
+
+func writeContinuousStyleFileResult(t *testing.T, path string, result continuousstyle.FileResult) {
+	t.Helper()
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json.Marshal(result) error = %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -41,6 +41,7 @@ var expectedSelfHostingWorkflows = []string{
 	"audit",
 	"continuous-improvement",
 	"continuous-simplicity",
+	"continuous-style",
 	"diagnose-failures",
 	"implement-harness",
 	"metrics-collector",
@@ -682,6 +683,7 @@ func TestSmoke_S5_CorePlusSelfHostingOverlayScaffoldsOverlayWorkflows(t *testing
 	sort.Strings(expectedWorkflows)
 	assert.Equal(t, expectedWorkflows, scaffoldedWorkflowNames(t, dir))
 	assert.Contains(t, output, "Created .xylem/workflows/continuous-simplicity.yaml")
+	assert.Contains(t, output, "Created .xylem/workflows/continuous-style.yaml")
 	assert.Contains(t, output, "Created .xylem/workflows/implement-harness.yaml")
 	assert.Contains(t, output, "Created .xylem/workflows/unblock-wave.yaml")
 

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -32,7 +32,7 @@ func newRootCmd() *cobra.Command {
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			commandPath := cmd.CommandPath()
-			if cmd.Name() == "init" || cmd.Name() == "shim-dispatch" || cmd.Name() == "version" || commandPath == "xylem dtu" || strings.HasPrefix(commandPath, "xylem dtu ") || commandPath == "xylem bootstrap" || strings.HasPrefix(commandPath, "xylem bootstrap ") || strings.HasPrefix(commandPath, "xylem continuous-simplicity") {
+			if cmd.Name() == "init" || cmd.Name() == "shim-dispatch" || cmd.Name() == "version" || commandPath == "xylem dtu" || strings.HasPrefix(commandPath, "xylem dtu ") || commandPath == "xylem bootstrap" || strings.HasPrefix(commandPath, "xylem bootstrap ") || strings.HasPrefix(commandPath, "xylem continuous-simplicity") || strings.HasPrefix(commandPath, "xylem continuous-style") {
 				return nil
 			}
 
@@ -89,6 +89,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		newInitCmd(),
 		newBootstrapCmd(),
+		newContinuousStyleCmd(),
 		newContinuousImprovementCmd(),
 		newContinuousSimplicityCmd(),
 		newDtuCmd(),

--- a/cli/internal/continuousstyle/github.go
+++ b/cli/internal/continuousstyle/github.go
@@ -1,0 +1,234 @@
+package continuousstyle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+)
+
+const DefaultTrackingIssueTitle = "[continuous-style] Tracking"
+
+type CommandRunner interface {
+	RunOutput(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type FiledIssue struct {
+	ID      string `json:"id"`
+	Title   string `json:"title"`
+	Number  int    `json:"number,omitempty"`
+	URL     string `json:"url,omitempty"`
+	Created bool   `json:"created"`
+}
+
+type FileResult struct {
+	Created  []FiledIssue `json:"created"`
+	Existing []FiledIssue `json:"existing"`
+}
+
+func FileIssues(ctx context.Context, runner CommandRunner, repo string, report *Report, limit int, prefix string, labels []string) (*FileResult, error) {
+	if runner == nil {
+		return nil, fmt.Errorf("runner is required")
+	}
+	if report == nil {
+		return nil, fmt.Errorf("report is required")
+	}
+	if limit <= 0 {
+		limit = 3
+	}
+	openIssues, err := loadOpenIssues(ctx, runner, repo, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &FileResult{}
+	for _, finding := range SortedFindings(report) {
+		if len(result.Created) >= limit {
+			break
+		}
+		title := issueTitle(prefix, finding)
+		if existing, ok := openIssues[title]; ok {
+			result.Existing = append(result.Existing, FiledIssue{
+				ID:      finding.ID,
+				Title:   title,
+				Number:  existing.Number,
+				URL:     existing.URL,
+				Created: false,
+			})
+			continue
+		}
+		body := issueBody(report.TargetSurface, finding)
+		args := []string{"issue", "create", "--repo", repo, "--title", title, "--body", body}
+		for _, label := range labels {
+			args = append(args, "--label", label)
+		}
+		out, err := runner.RunOutput(ctx, "gh", args...)
+		if err != nil {
+			return nil, fmt.Errorf("create issue %q: %w", title, err)
+		}
+		urlValue := strings.TrimSpace(string(out))
+		number, parseErr := issueNumberFromURL(urlValue)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse created issue url %q: %w", urlValue, parseErr)
+		}
+		result.Created = append(result.Created, FiledIssue{
+			ID:      finding.ID,
+			Title:   title,
+			Number:  number,
+			URL:     urlValue,
+			Created: true,
+		})
+		openIssues[title] = issueSummary{Number: number, URL: urlValue}
+	}
+	return result, nil
+}
+
+func EnsureTrackingIssue(ctx context.Context, runner CommandRunner, repo string, title string) (FiledIssue, error) {
+	if runner == nil {
+		return FiledIssue{}, fmt.Errorf("runner is required")
+	}
+	if strings.TrimSpace(title) == "" {
+		title = DefaultTrackingIssueTitle
+	}
+	openIssues, err := loadOpenIssues(ctx, runner, repo, title)
+	if err != nil {
+		return FiledIssue{}, err
+	}
+	if existing, ok := openIssues[title]; ok {
+		return FiledIssue{Title: title, Number: existing.Number, URL: existing.URL, Created: false}, nil
+	}
+	body := "Scheduled continuous-style summaries land here so operators can track terminal-output polish opportunities across xylem's CLI surfaces."
+	out, err := runner.RunOutput(ctx, "gh", "issue", "create", "--repo", repo, "--title", title, "--body", body)
+	if err != nil {
+		return FiledIssue{}, fmt.Errorf("create tracking issue %q: %w", title, err)
+	}
+	urlValue := strings.TrimSpace(string(out))
+	number, err := issueNumberFromURL(urlValue)
+	if err != nil {
+		return FiledIssue{}, fmt.Errorf("parse tracking issue url %q: %w", urlValue, err)
+	}
+	return FiledIssue{Title: title, Number: number, URL: urlValue, Created: true}, nil
+}
+
+func PostSummary(ctx context.Context, runner CommandRunner, repo string, trackingIssue int, report *Report, filed *FileResult, summary string) error {
+	if runner == nil {
+		return fmt.Errorf("runner is required")
+	}
+	if report == nil {
+		return fmt.Errorf("report is required")
+	}
+	lines := []string{
+		"**xylem — continuous style analysis**",
+		"",
+		fmt.Sprintf("- Target surface: %s", report.TargetSurface),
+		fmt.Sprintf("- Findings this run: %d", len(report.Findings)),
+	}
+	top := SortedFindings(report)
+	if len(top) > 0 {
+		lines = append(lines, "- Highest-priority findings:")
+		for _, finding := range top[:min(3, len(top))] {
+			lines = append(lines, fmt.Sprintf("  - %s (`%s`, priority=%d)", finding.Title, finding.Category, finding.Priority))
+		}
+	}
+	if filed != nil && len(filed.Created) > 0 {
+		lines = append(lines, "- Filed issues:")
+		for _, item := range filed.Created {
+			lines = append(lines, fmt.Sprintf("  - %s (#%d)", item.Title, item.Number))
+		}
+	}
+	if filed != nil && len(filed.Existing) > 0 {
+		lines = append(lines, "- Existing open style issues already covering these findings:")
+		for _, item := range filed.Existing {
+			lines = append(lines, fmt.Sprintf("  - %s (#%d)", item.Title, item.Number))
+		}
+	}
+	if trimmed := strings.TrimSpace(summary); trimmed != "" {
+		lines = append(lines, "", "<details>", "<summary>Analysis report</summary>", "", trimmed, "", "</details>")
+	}
+	body := strings.Join(lines, "\n")
+	if _, err := runner.RunOutput(ctx, "gh", "issue", "comment", strconv.Itoa(trackingIssue), "--repo", repo, "--body", body); err != nil {
+		return fmt.Errorf("post tracking summary comment: %w", err)
+	}
+	return nil
+}
+
+type issueSummary struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	URL    string `json:"url"`
+}
+
+func loadOpenIssues(ctx context.Context, runner CommandRunner, repo string, search string) (map[string]issueSummary, error) {
+	args := []string{"search", "issues", "--repo", repo, "--state", "open", "--json", "number,title,url", "--limit", "100"}
+	if strings.TrimSpace(search) != "" {
+		args = append(args, "--search", search)
+	}
+	out, err := runner.RunOutput(ctx, "gh", args...)
+	if err != nil {
+		return nil, fmt.Errorf("search open issues in %s: %w", repo, err)
+	}
+	var issues []issueSummary
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return nil, fmt.Errorf("parse issue search output: %w", err)
+	}
+	index := make(map[string]issueSummary, len(issues))
+	for _, item := range issues {
+		index[item.Title] = item
+	}
+	return index, nil
+}
+
+func issueTitle(prefix string, finding Finding) string {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		prefix = "[continuous-style]"
+	}
+	return fmt.Sprintf("%s %s", prefix, finding.Title)
+}
+
+func issueBody(targetSurface string, finding Finding) string {
+	lines := []string{
+		finding.Summary,
+		"",
+		fmt.Sprintf("Category: `%s`", finding.Category),
+		fmt.Sprintf("Priority: `%d`", finding.Priority),
+		fmt.Sprintf("Target surface: `%s`", targetSurface),
+		"",
+		"## Affected paths",
+	}
+	for _, path := range finding.Paths {
+		lines = append(lines, fmt.Sprintf("- `%s`", path))
+	}
+	lines = append(lines, "", "## Current code evidence")
+	for _, evidence := range finding.Evidence {
+		location := fmt.Sprintf("`%s:%d`", evidence.Path, evidence.LineStart)
+		if evidence.LineEnd > 0 && evidence.LineEnd != evidence.LineStart {
+			location = fmt.Sprintf("`%s:%d-%d`", evidence.Path, evidence.LineStart, evidence.LineEnd)
+		}
+		lines = append(lines, fmt.Sprintf("- %s — %s", location, evidence.Summary))
+	}
+	lines = append(lines, "", "## Suggested direction", finding.Recommendation)
+	return strings.Join(lines, "\n")
+}
+
+func issueNumberFromURL(raw string) (int, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, err
+	}
+	number, err := strconv.Atoi(path.Base(parsed.Path))
+	if err != nil {
+		return 0, err
+	}
+	return number, nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cli/internal/continuousstyle/github_test.go
+++ b/cli/internal/continuousstyle/github_test.go
@@ -1,0 +1,192 @@
+package continuousstyle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type mockRunner struct {
+	calls   [][]string
+	outputs map[string][]byte
+}
+
+func (m *mockRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	m.calls = append(m.calls, call)
+	if m.outputs == nil {
+		return nil, nil
+	}
+	return m.outputs[strings.Join(call, " ")], nil
+}
+
+func TestFileIssuesCreatesAndDedupes(t *testing.T) {
+	searchOut, err := json.Marshal([]issueSummary{{
+		Number: 7,
+		Title:  "[continuous-style] Existing finding",
+		URL:    "https://github.com/owner/repo/issues/7",
+	}})
+	if err != nil {
+		t.Fatalf("Marshal issueSummary: %v", err)
+	}
+	runner := &mockRunner{
+		outputs: map[string][]byte{
+			"gh search issues --repo owner/repo --state open --json number,title,url --limit 100 --search [continuous-style]": searchOut,
+			"gh issue create --repo owner/repo --title [continuous-style] Route stderr consistently --body summary\n\nCategory: `stderr-routing`\nPriority: `9`\nTarget surface: `cli terminal output`\n\n## Affected paths\n- `cli/cmd/xylem/main.go`\n\n## Current code evidence\n- `cli/cmd/xylem/main.go:30` — evidence\n\n## Suggested direction\nrecommendation --label enhancement --label ready-for-work": []byte("https://github.com/owner/repo/issues/9\n"),
+		},
+	}
+	report := &Report{
+		Version:       ReportVersion,
+		Repo:          "owner/repo",
+		GeneratedAt:   "2026-04-10T00:00:00Z",
+		TargetSurface: "cli terminal output",
+		Findings: []Finding{
+			{
+				ID:             "route-stderr",
+				Title:          "Route stderr consistently",
+				Category:       "stderr-routing",
+				Summary:        "summary",
+				Recommendation: "recommendation",
+				Priority:       9,
+				Paths:          []string{"cli/cmd/xylem/main.go"},
+				Evidence: []Evidence{{
+					Path:      "cli/cmd/xylem/main.go",
+					LineStart: 30,
+					Summary:   "evidence",
+				}},
+			},
+			{
+				ID:             "existing-finding",
+				Title:          "Existing finding",
+				Category:       "consistency",
+				Summary:        "summary",
+				Recommendation: "recommendation",
+				Priority:       6,
+				Paths:          []string{"cli/cmd/xylem/status.go"},
+				Evidence: []Evidence{{
+					Path:      "cli/cmd/xylem/status.go",
+					LineStart: 10,
+					Summary:   "evidence",
+				}},
+			},
+		},
+	}
+
+	result, err := FileIssues(context.Background(), runner, "owner/repo", report, 3, "[continuous-style]", []string{"enhancement", "ready-for-work"})
+	if err != nil {
+		t.Fatalf("FileIssues() error = %v", err)
+	}
+	if len(result.Created) != 1 || result.Created[0].Number != 9 {
+		t.Fatalf("Created = %#v, want one created issue #9", result.Created)
+	}
+	if len(result.Existing) != 1 || result.Existing[0].Number != 7 {
+		t.Fatalf("Existing = %#v, want one deduped issue #7", result.Existing)
+	}
+}
+
+func TestEnsureTrackingIssueCreatesWhenMissing(t *testing.T) {
+	searchOut, err := json.Marshal([]issueSummary{})
+	if err != nil {
+		t.Fatalf("Marshal empty issueSummary: %v", err)
+	}
+	runner := &mockRunner{
+		outputs: map[string][]byte{
+			fmt.Sprintf("gh search issues --repo owner/repo --state open --json number,title,url --limit 100 --search %s", DefaultTrackingIssueTitle):                                                                                             []byte(string(searchOut)),
+			fmt.Sprintf("gh issue create --repo owner/repo --title %s --body Scheduled continuous-style summaries land here so operators can track terminal-output polish opportunities across xylem's CLI surfaces.", DefaultTrackingIssueTitle): []byte("https://github.com/owner/repo/issues/11\n"),
+		},
+	}
+	item, err := EnsureTrackingIssue(context.Background(), runner, "owner/repo", DefaultTrackingIssueTitle)
+	if err != nil {
+		t.Fatalf("EnsureTrackingIssue() error = %v", err)
+	}
+	if !item.Created || item.Number != 11 {
+		t.Fatalf("EnsureTrackingIssue() = %#v, want created issue #11", item)
+	}
+}
+
+func TestFileIssuesDoesNotCountExistingAgainstCreateLimit(t *testing.T) {
+	searchOut, err := json.Marshal([]issueSummary{
+		{
+			Number: 7,
+			Title:  "[continuous-style] Existing highest priority",
+			URL:    "https://github.com/owner/repo/issues/7",
+		},
+		{
+			Number: 8,
+			Title:  "[continuous-style] Existing second priority",
+			URL:    "https://github.com/owner/repo/issues/8",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal issueSummary: %v", err)
+	}
+	runner := &mockRunner{
+		outputs: map[string][]byte{
+			"gh search issues --repo owner/repo --state open --json number,title,url --limit 100 --search [continuous-style]": searchOut,
+			"gh issue create --repo owner/repo --title [continuous-style] New third priority --body summary\n\nCategory: `consistency`\nPriority: `7`\nTarget surface: `cli terminal output`\n\n## Affected paths\n- `cli/cmd/xylem/status.go`\n\n## Current code evidence\n- `cli/cmd/xylem/status.go:10` — evidence\n\n## Suggested direction\nrecommendation": []byte("https://github.com/owner/repo/issues/9\n"),
+		},
+	}
+	report := &Report{
+		Version:       ReportVersion,
+		Repo:          "owner/repo",
+		GeneratedAt:   "2026-04-10T00:00:00Z",
+		TargetSurface: "cli terminal output",
+		Findings: []Finding{
+			{
+				ID:             "existing-highest-priority",
+				Title:          "Existing highest priority",
+				Category:       "consistency",
+				Summary:        "summary",
+				Recommendation: "recommendation",
+				Priority:       9,
+				Paths:          []string{"cli/cmd/xylem/status.go"},
+				Evidence: []Evidence{{
+					Path:      "cli/cmd/xylem/status.go",
+					LineStart: 10,
+					Summary:   "evidence",
+				}},
+			},
+			{
+				ID:             "existing-second-priority",
+				Title:          "Existing second priority",
+				Category:       "consistency",
+				Summary:        "summary",
+				Recommendation: "recommendation",
+				Priority:       8,
+				Paths:          []string{"cli/cmd/xylem/status.go"},
+				Evidence: []Evidence{{
+					Path:      "cli/cmd/xylem/status.go",
+					LineStart: 10,
+					Summary:   "evidence",
+				}},
+			},
+			{
+				ID:             "new-third-priority",
+				Title:          "New third priority",
+				Category:       "consistency",
+				Summary:        "summary",
+				Recommendation: "recommendation",
+				Priority:       7,
+				Paths:          []string{"cli/cmd/xylem/status.go"},
+				Evidence: []Evidence{{
+					Path:      "cli/cmd/xylem/status.go",
+					LineStart: 10,
+					Summary:   "evidence",
+				}},
+			},
+		},
+	}
+
+	result, err := FileIssues(context.Background(), runner, "owner/repo", report, 1, "[continuous-style]", nil)
+	if err != nil {
+		t.Fatalf("FileIssues() error = %v", err)
+	}
+	if len(result.Existing) != 2 {
+		t.Fatalf("len(Existing) = %d, want 2", len(result.Existing))
+	}
+	if len(result.Created) != 1 || result.Created[0].Number != 9 {
+		t.Fatalf("Created = %#v, want one created issue #9", result.Created)
+	}
+}

--- a/cli/internal/continuousstyle/report.go
+++ b/cli/internal/continuousstyle/report.go
@@ -1,0 +1,174 @@
+package continuousstyle
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	ReportVersion = 1
+)
+
+type Report struct {
+	Version       int       `json:"version"`
+	Repo          string    `json:"repo"`
+	GeneratedAt   string    `json:"generated_at"`
+	TargetSurface string    `json:"target_surface"`
+	Findings      []Finding `json:"findings"`
+}
+
+type Finding struct {
+	ID             string     `json:"id"`
+	Title          string     `json:"title"`
+	Category       string     `json:"category"`
+	Summary        string     `json:"summary"`
+	Recommendation string     `json:"recommendation"`
+	Priority       int        `json:"priority"`
+	Paths          []string   `json:"paths"`
+	Evidence       []Evidence `json:"evidence"`
+}
+
+type Evidence struct {
+	Path      string `json:"path"`
+	LineStart int    `json:"line_start"`
+	LineEnd   int    `json:"line_end,omitempty"`
+	Summary   string `json:"summary"`
+}
+
+func LoadReport(path string) (*Report, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read report %q: %w", path, err)
+	}
+	var report Report
+	if err := json.Unmarshal(data, &report); err != nil {
+		return nil, fmt.Errorf("parse report %q: %w", path, err)
+	}
+	if err := report.Validate(); err != nil {
+		return nil, fmt.Errorf("validate report %q: %w", path, err)
+	}
+	return &report, nil
+}
+
+func (r *Report) Validate() error {
+	if r == nil {
+		return fmt.Errorf("report must not be nil")
+	}
+	if r.Version <= 0 {
+		return fmt.Errorf("version must be greater than 0")
+	}
+	if strings.TrimSpace(r.Repo) == "" {
+		return fmt.Errorf("repo is required")
+	}
+	if strings.TrimSpace(r.GeneratedAt) == "" {
+		return fmt.Errorf("generated_at is required")
+	}
+	if _, err := time.Parse(time.RFC3339, r.GeneratedAt); err != nil {
+		return fmt.Errorf("generated_at must be RFC3339: %w", err)
+	}
+	if strings.TrimSpace(r.TargetSurface) == "" {
+		return fmt.Errorf("target_surface is required")
+	}
+	seen := make(map[string]struct{}, len(r.Findings))
+	for i := range r.Findings {
+		if err := r.Findings[i].Validate(); err != nil {
+			return fmt.Errorf("findings[%d]: %w", i, err)
+		}
+		if _, ok := seen[r.Findings[i].ID]; ok {
+			return fmt.Errorf("duplicate finding id %q", r.Findings[i].ID)
+		}
+		seen[r.Findings[i].ID] = struct{}{}
+	}
+	return nil
+}
+
+func (f *Finding) Validate() error {
+	if strings.TrimSpace(f.ID) == "" {
+		return fmt.Errorf("id is required")
+	}
+	if strings.TrimSpace(f.Title) == "" {
+		return fmt.Errorf("title is required")
+	}
+	if strings.TrimSpace(f.Category) == "" {
+		return fmt.Errorf("category is required")
+	}
+	if strings.TrimSpace(f.Summary) == "" {
+		return fmt.Errorf("summary is required")
+	}
+	if strings.TrimSpace(f.Recommendation) == "" {
+		return fmt.Errorf("recommendation is required")
+	}
+	if f.Priority < 0 {
+		return fmt.Errorf("priority must be non-negative")
+	}
+	if len(f.Paths) == 0 {
+		return fmt.Errorf("paths must not be empty")
+	}
+	for i, path := range f.Paths {
+		if strings.TrimSpace(path) == "" {
+			return fmt.Errorf("paths[%d] is required", i)
+		}
+	}
+	if len(f.Evidence) == 0 {
+		return fmt.Errorf("evidence must not be empty")
+	}
+	for i := range f.Evidence {
+		if err := f.Evidence[i].Validate(); err != nil {
+			return fmt.Errorf("evidence[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func (e *Evidence) Validate() error {
+	if strings.TrimSpace(e.Path) == "" {
+		return fmt.Errorf("path is required")
+	}
+	if e.LineStart <= 0 {
+		return fmt.Errorf("line_start must be greater than 0")
+	}
+	if e.LineEnd < 0 {
+		return fmt.Errorf("line_end must be non-negative")
+	}
+	if e.LineEnd > 0 && e.LineEnd < e.LineStart {
+		return fmt.Errorf("line_end must be greater than or equal to line_start")
+	}
+	if strings.TrimSpace(e.Summary) == "" {
+		return fmt.Errorf("summary is required")
+	}
+	return nil
+}
+
+func WriteJSON(path string, value any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create parent dir for %q: %w", path, err)
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal json for %q: %w", path, err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write json %q: %w", path, err)
+	}
+	return nil
+}
+
+func SortedFindings(report *Report) []Finding {
+	if report == nil {
+		return nil
+	}
+	items := append([]Finding(nil), report.Findings...)
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Priority != items[j].Priority {
+			return items[i].Priority > items[j].Priority
+		}
+		return items[i].ID < items[j].ID
+	})
+	return items
+}

--- a/cli/internal/continuousstyle/report_test.go
+++ b/cli/internal/continuousstyle/report_test.go
@@ -1,0 +1,56 @@
+package continuousstyle
+
+import "testing"
+
+func TestReportValidateRejectsDuplicateFindingIDs(t *testing.T) {
+	report := &Report{
+		Version:       ReportVersion,
+		Repo:          "owner/repo",
+		GeneratedAt:   "2026-04-10T00:00:00Z",
+		TargetSurface: "cli/cmd/xylem and cli/internal/reporter",
+		Findings: []Finding{
+			testFinding("stderr-routing", "Route errors consistently"),
+			testFinding("stderr-routing", "Duplicate"),
+		},
+	}
+
+	if err := report.Validate(); err == nil {
+		t.Fatal("Validate() error = nil, want duplicate finding id error")
+	}
+}
+
+func TestSortedFindingsOrdersByPriorityThenID(t *testing.T) {
+	report := &Report{
+		Findings: []Finding{
+			testFinding("beta", "B"),
+			testFinding("alpha", "A"),
+		},
+	}
+	report.Findings[0].Priority = 5
+	report.Findings[1].Priority = 5
+
+	sorted := SortedFindings(report)
+	if len(sorted) != 2 {
+		t.Fatalf("len(SortedFindings()) = %d, want 2", len(sorted))
+	}
+	if sorted[0].ID != "alpha" || sorted[1].ID != "beta" {
+		t.Fatalf("SortedFindings() = %#v, want alpha before beta", sorted)
+	}
+}
+
+func testFinding(id, title string) Finding {
+	return Finding{
+		ID:             id,
+		Title:          title,
+		Category:       "consistency",
+		Summary:        "summary",
+		Recommendation: "recommendation",
+		Priority:       7,
+		Paths:          []string{"cli/cmd/xylem/status.go"},
+		Evidence: []Evidence{{
+			Path:      "cli/cmd/xylem/status.go",
+			LineStart: 10,
+			Summary:   "evidence",
+		}},
+	}
+}

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -266,8 +266,10 @@ func TestSmoke_S3_SelfHostingProfileScaffoldsContinuousStyleScheduledWorkflow(t 
 	assert.Equal(t, ".xylem/prompts/continuous-style/report.md", wf.Phases[2].PromptFile)
 	assert.Equal(t, "command", wf.Phases[3].Type)
 	assert.Contains(t, wf.Phases[3].Run, "continuous-style file-issues")
+	assert.Contains(t, wf.Phases[3].Run, "--repo {{ .Repo.Slug }}")
 	assert.Equal(t, "command", wf.Phases[4].Type)
 	assert.Contains(t, wf.Phases[4].Run, "continuous-style post-summary")
+	assert.Contains(t, wf.Phases[4].Run, "--repo {{ .Repo.Slug }}")
 
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-style/ingest")
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-style/survey")

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -175,15 +175,18 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 
 	assert.Contains(t, sortedKeys(composed.Workflows), "implement-harness")
 	assert.Contains(t, sortedKeys(composed.Workflows), "continuous-improvement")
+	assert.Contains(t, sortedKeys(composed.Workflows), "continuous-style")
 	assert.Contains(t, sortedKeys(composed.Workflows), "continuous-simplicity")
 	assert.Contains(t, sortedKeys(composed.Workflows), "sota-gap-analysis")
 	assert.Contains(t, sortedKeys(composed.Workflows), "unblock-wave")
 	assert.Contains(t, sortedKeys(composed.Workflows), "diagnose-failures")
 	assert.Contains(t, sortedKeys(composed.Prompts), "implement-harness/pr_draft")
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/verify")
+	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-style/report")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-impl")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-pr-lifecycle")
 	assert.Contains(t, sortedKeys(composed.Sources), "continuous-improvement")
+	assert.Contains(t, sortedKeys(composed.Sources), "continuous-style")
 	assert.Contains(t, sortedKeys(composed.Sources), "continuous-simplicity")
 	assert.Contains(t, sortedKeys(composed.Sources), "sota-gap")
 	require.Len(t, composed.ConfigOverlays, 2)
@@ -229,6 +232,39 @@ func TestSmoke_S3_SelfHostingProfileScaffoldsContinuousImprovementScheduledWorkf
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/plan")
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/implement")
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/verify")
+}
+
+func TestSmoke_S3_SelfHostingProfileScaffoldsContinuousStyleScheduledWorkflow(t *testing.T) {
+	t.Parallel()
+
+	composed, err := Compose("core", "self-hosting-xylem")
+	require.NoError(t, err)
+
+	var source config.SourceConfig
+	require.NoError(t, yaml.Unmarshal(composed.Sources["continuous-style"], &source))
+	assert.Equal(t, "scheduled", source.Type)
+	assert.Equal(t, "{{ .Repo }}", source.Repo)
+	assert.Equal(t, "@daily", source.Schedule)
+	require.Contains(t, source.Tasks, "daily-continuous-style")
+	assert.Equal(t, "continuous-style", source.Tasks["daily-continuous-style"].Workflow)
+	assert.Equal(t, "continuous-style", source.Tasks["daily-continuous-style"].Ref)
+
+	var wf workflowpkg.Workflow
+	require.NoError(t, yaml.Unmarshal(composed.Workflows["continuous-style"], &wf))
+	assert.Equal(t, "continuous-style", wf.Name)
+	assert.Equal(t, workflowpkg.ClassHarnessMaintenance, wf.Class)
+	require.Len(t, wf.Phases, 5)
+	assert.Equal(t, "ingest", wf.Phases[0].Name)
+	assert.Equal(t, ".xylem/prompts/continuous-style/ingest.md", wf.Phases[0].PromptFile)
+	assert.Equal(t, ".xylem/prompts/continuous-style/report.md", wf.Phases[2].PromptFile)
+	assert.Equal(t, "command", wf.Phases[3].Type)
+	assert.Contains(t, wf.Phases[3].Run, "continuous-style file-issues")
+	assert.Equal(t, "command", wf.Phases[4].Type)
+	assert.Contains(t, wf.Phases[4].Run, "continuous-style post-summary")
+
+	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-style/ingest")
+	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-style/survey")
+	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-style/report")
 }
 
 func TestAdaptRepoWorkflowAssetParsesCleanly(t *testing.T) {

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-style/ingest.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-style/ingest.md
@@ -1,0 +1,21 @@
+Prepare the scheduled continuous-style run for xylem.
+
+Target the CLI's user-facing terminal output surfaces:
+
+1. `cli/cmd/xylem/`
+2. `cli/internal/reporter/`
+3. `cli/internal/review/`
+4. `cli/internal/lessons/`
+5. Any directly related helpers those packages rely on for user-facing output
+
+Your goal in this phase is to produce a factual inventory that the next phase can convert into a stable findings file.
+
+The inventory must identify:
+
+1. the concrete files and commands that emit user-facing stdout or stderr
+2. which surfaces are primarily tabular, status-oriented, markdown/report-oriented, or warning/error-oriented
+3. where the current output already looks consistent and operator-friendly
+4. where the output feels inconsistent, noisy, poorly routed, or hard to scan
+5. the exact file paths and line ranges that support each observation
+
+Stay grounded in this repository's conventions. Do not assume xylem wants a full terminal UI framework; just inventory the current output patterns and the most meaningful rough edges.

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-style/report.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-style/report.md
@@ -1,0 +1,21 @@
+Turn the continuous-style findings into a human-readable markdown report.
+
+Read:
+
+1. `.xylem/state/continuous-style/findings.json`
+
+Write:
+
+`.xylem/state/continuous-style/report.md`
+
+The report must contain:
+
+1. a short executive summary of the current terminal-output health
+2. a section on what already looks consistent or operator-friendly
+3. a ranked section of the findings to address next
+4. file-path-level evidence and concrete follow-up directions for each finding
+5. a clear note when the run found no worthwhile issues
+
+Keep the report concrete and grounded in xylem's current CLI surfaces. Avoid generic terminal-UI advice that is not tied to this repository.
+
+After writing the report, print a brief confirmation with the top findings or `no findings`.

--- a/cli/internal/profiles/self-hosting-xylem/prompts/continuous-style/survey.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/continuous-style/survey.md
@@ -1,0 +1,51 @@
+Convert the continuous-style inventory into the committed findings format.
+
+Inputs to use:
+
+1. `{{.PreviousOutputs.ingest}}`
+2. the live source under `cli/cmd/xylem/`, `cli/internal/reporter/`, `cli/internal/review/`, and `cli/internal/lessons/`
+
+Write exactly one JSON file at:
+
+`.xylem/state/continuous-style/findings.json`
+
+The JSON must have this shape:
+
+```json
+{
+  "version": 1,
+  "repo": "nicholls-inc/xylem",
+  "generated_at": "2026-04-10T00:00:00Z",
+  "target_surface": "cli terminal output",
+  "findings": [
+    {
+      "id": "stable-kebab-case-id",
+      "title": "Human-readable issue title",
+      "category": "consistency|stderr-routing|scannability|accessibility|output-contracts",
+      "summary": "What is wrong today and why it matters.",
+      "recommendation": "Specific direction for the follow-up issue.",
+      "priority": 8,
+      "paths": ["cli/cmd/xylem/status.go"],
+      "evidence": [
+        {
+          "path": "cli/cmd/xylem/status.go",
+          "line_start": 123,
+          "line_end": 140,
+          "summary": "Precise evidence for the finding."
+        }
+      ]
+    }
+  ]
+}
+```
+
+Requirements:
+
+1. Keep `findings` focused and high-signal. Prefer `0-5` findings total.
+2. Only include findings that are worth a dedicated GitHub issue.
+3. Use stable IDs and precise evidence line numbers.
+4. Favor consistency, stderr/stdout routing, scan-friendly tables/status output, and clear output contracts over purely cosmetic nitpicks.
+5. Do not recommend new third-party terminal UI dependencies unless the repository already uses them on the exact surface under discussion and the recommendation is clearly justified.
+6. If the current CLI output is already in good shape for this run, emit an empty `findings` array rather than inventing weak work.
+
+After writing the file, print a short summary with the finding count and the highest-priority IDs.

--- a/cli/internal/profiles/self-hosting-xylem/workflows/continuous-style.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/continuous-style.yaml
@@ -17,7 +17,7 @@ phases:
       set -euo pipefail
       cd cli
       go run ./cmd/xylem continuous-style file-issues \
-        --repo {{ .Repo }} \
+        --repo {{ .Repo.Slug }} \
         --report ../.xylem/state/continuous-style/findings.json \
         --output ../.xylem/state/continuous-style/filed-issues.json \
         --prefix "[continuous-style]" \
@@ -29,7 +29,7 @@ phases:
       set -euo pipefail
       cd cli
       go run ./cmd/xylem continuous-style post-summary \
-        --repo {{ .Repo }} \
+        --repo {{ .Repo.Slug }} \
         --report ../.xylem/state/continuous-style/findings.json \
         --filed ../.xylem/state/continuous-style/filed-issues.json \
         --summary ../.xylem/state/continuous-style/report.md \

--- a/cli/internal/profiles/self-hosting-xylem/workflows/continuous-style.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/continuous-style.yaml
@@ -1,0 +1,36 @@
+name: continuous-style
+class: harness-maintenance
+description: "Recurring terminal-output style analysis for xylem's CLI surfaces"
+phases:
+  - name: ingest
+    prompt_file: .xylem/prompts/continuous-style/ingest.md
+    max_turns: 30
+  - name: survey
+    prompt_file: .xylem/prompts/continuous-style/survey.md
+    max_turns: 45
+  - name: report
+    prompt_file: .xylem/prompts/continuous-style/report.md
+    max_turns: 30
+  - name: file_issues
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem continuous-style file-issues \
+        --repo {{ .Repo }} \
+        --report ../.xylem/state/continuous-style/findings.json \
+        --output ../.xylem/state/continuous-style/filed-issues.json \
+        --prefix "[continuous-style]" \
+        --labels enhancement \
+        --labels ready-for-work
+  - name: summary
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem continuous-style post-summary \
+        --repo {{ .Repo }} \
+        --report ../.xylem/state/continuous-style/findings.json \
+        --filed ../.xylem/state/continuous-style/filed-issues.json \
+        --summary ../.xylem/state/continuous-style/report.md \
+        --tracking-title "[continuous-style] Tracking"

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -77,6 +77,15 @@ sources:
       daily-rotation:
         workflow: continuous-improvement
         ref: continuous-improvement
+  continuous-style:
+    type: scheduled
+    repo: "{{ .Repo }}"
+    schedule: "@daily"
+    timeout: "60m"
+    tasks:
+      daily-continuous-style:
+        workflow: continuous-style
+        ref: continuous-style
   metrics-collector:
     type: scheduled
     repo: "{{ .Repo }}"

--- a/cli/internal/source/scheduled_test.go
+++ b/cli/internal/source/scheduled_test.go
@@ -159,3 +159,82 @@ func TestSmoke_S1_ContinuousSimplicityScheduledVesselEnqueuesOncePerWindow(t *te
 	require.NoError(t, err)
 	assert.Empty(t, suppressed)
 }
+
+func TestSmoke_S1_ContinuousStyleScheduledVesselEnqueuesOncePerWindow(t *testing.T) {
+	ctx := context.Background()
+	stateDir := t.TempDir()
+	queuePath := filepath.Join(t.TempDir(), "queue.jsonl")
+	q := queue.New(queuePath)
+	interval, err := parseSchedule("@daily")
+	require.NoError(t, err)
+
+	src := &Scheduled{
+		Repo:       "nicholls-inc/xylem",
+		StateDir:   stateDir,
+		ConfigName: "continuous-style",
+		Schedule:   "@daily",
+		Queue:      q,
+		Tasks: map[string]ScheduledTask{
+			"daily-continuous-style": {
+				Workflow: "continuous-style",
+				Ref:      "continuous-style",
+			},
+		},
+	}
+
+	first, err := src.Scan(ctx)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+
+	vessel := first[0]
+	slotStart, slotEnd := scheduleWindow(vessel.CreatedAt, interval)
+	bucket := slotStart.UnixNano() / interval.Nanoseconds()
+
+	assert.Equal(t, "scheduled", vessel.Source)
+	assert.Equal(t, queue.StatePending, vessel.State)
+	assert.Equal(t, "continuous-style", vessel.Workflow)
+	assert.Equal(t, "continuous-style", vessel.Meta["schedule_ref"])
+	assert.Equal(t, "daily-continuous-style", vessel.Meta["schedule_task"])
+	assert.Equal(t, "@daily", vessel.Meta["schedule_spec"])
+	assert.Equal(t, "continuous-style", vessel.Meta["scheduled_config_name"])
+	assert.Equal(t, "nicholls-inc/xylem", vessel.Meta["scheduled_repo"])
+	assert.Equal(t, fmt.Sprintf("%d", bucket), vessel.Meta["scheduled_bucket"])
+	assert.Equal(t, slotStart.Format(time.RFC3339), vessel.Meta["schedule_slot_start"])
+	assert.Equal(t, slotEnd.Format(time.RFC3339), vessel.Meta["schedule_slot_end"])
+	assert.Equal(t,
+		"scheduled://continuous-style/daily-continuous-style@"+vessel.Meta["scheduled_bucket"],
+		vessel.Ref,
+	)
+	assert.Equal(t, "scheduled-continuous-style-daily-continuous-style-"+vessel.Meta["scheduled_bucket"], vessel.ID)
+	assert.Equal(t,
+		scheduledFingerprint("continuous-style", "daily-continuous-style", "continuous-style", "continuous-style"),
+		vessel.Meta["scheduled_fingerprint"],
+	)
+
+	_, err = q.Enqueue(vessel)
+	require.NoError(t, err)
+	require.NoError(t, src.OnEnqueue(ctx, vessel))
+
+	stateBytes, err := os.ReadFile(filepath.Join(stateDir, "schedules", "continuous-style.json"))
+	require.NoError(t, err)
+	var persisted scheduleState
+	require.NoError(t, json.Unmarshal(stateBytes, &persisted))
+	assert.Equal(t, map[string]int64{"daily-continuous-style": bucket}, persisted.LastEnqueuedBuckets)
+
+	restarted := &Scheduled{
+		Repo:       "nicholls-inc/xylem",
+		StateDir:   stateDir,
+		ConfigName: "continuous-style",
+		Schedule:   "@daily",
+		Queue:      queue.New(filepath.Join(t.TempDir(), "queue-restart.jsonl")),
+		Tasks: map[string]ScheduledTask{
+			"daily-continuous-style": {
+				Workflow: "continuous-style",
+				Ref:      "continuous-style",
+			},
+		},
+	}
+	suppressed, err := restarted.Scan(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, suppressed)
+}


### PR DESCRIPTION
## Summary
- add a scheduled self-hosting `continuous-style` workflow with new prompt assets and profile scaffolding
- add deterministic `xylem continuous-style` helpers to validate findings, file deduped issues, and post tracking summaries
- cover the new workflow wiring with CLI, profile, and scheduled-source tests

Closes https://github.com/nicholls-inc/xylem/issues/269