### PR TITLE
feat(workflow): add evaluator config block to Phase schema

### DIFF
--- a/cli/internal/evaluator/evaluator.go
+++ b/cli/internal/evaluator/evaluator.go
@@ -82,17 +82,17 @@ type EvalResult struct {
 
 // Criterion defines one dimension of quality evaluation.
 type Criterion struct {
-	Name        string  `json:"name"`
-	Description string  `json:"description"`
-	Weight      float64 `json:"weight"`
-	Threshold   float64 `json:"threshold"`
+	Name        string  `json:"name" yaml:"name"`
+	Description string  `json:"description" yaml:"description"`
+	Weight      float64 `json:"weight" yaml:"weight"`
+	Threshold   float64 `json:"threshold" yaml:"threshold"`
 }
 
 // EvalConfig controls the gen-eval loop behavior.
 type EvalConfig struct {
-	Criteria      []Criterion `json:"criteria"`
-	MaxIterations int         `json:"max_iterations"`
-	PassThreshold float64     `json:"pass_threshold"`
+	Criteria      []Criterion `json:"criteria" yaml:"criteria"`
+	MaxIterations int         `json:"max_iterations" yaml:"max_iterations"`
+	PassThreshold float64     `json:"pass_threshold" yaml:"pass_threshold"`
 }
 
 // DefaultMaxIterations is used when MaxIterations is zero.

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"gopkg.in/yaml.v3"
@@ -59,18 +60,19 @@ const (
 
 // Phase represents a single step in a workflow's execution pipeline.
 type Phase struct {
-	Name         string   `yaml:"name"`
-	Type         string   `yaml:"type,omitempty"` // "prompt" (default) or "command"
-	Run          string   `yaml:"run,omitempty"`  // shell command for type=command, supports template variables
-	PromptFile   string   `yaml:"prompt_file"`
-	MaxTurns     int      `yaml:"max_turns"`
-	LLM          *string  `yaml:"llm,omitempty"`
-	Model        *string  `yaml:"model,omitempty"`
-	Tier         *string  `yaml:"tier,omitempty"`
-	NoOp         *NoOp    `yaml:"noop,omitempty"`
-	Gate         *Gate    `yaml:"gate,omitempty"`
-	AllowedTools *string  `yaml:"allowed_tools,omitempty"`
-	DependsOn    []string `yaml:"depends_on,omitempty"`
+	Name         string                `yaml:"name"`
+	Type         string                `yaml:"type,omitempty"` // "prompt" (default) or "command"
+	Run          string                `yaml:"run,omitempty"`  // shell command for type=command, supports template variables
+	PromptFile   string                `yaml:"prompt_file"`
+	MaxTurns     int                   `yaml:"max_turns"`
+	LLM          *string               `yaml:"llm,omitempty"`
+	Model        *string               `yaml:"model,omitempty"`
+	Tier         *string               `yaml:"tier,omitempty"`
+	NoOp         *NoOp                 `yaml:"noop,omitempty"`
+	Gate         *Gate                 `yaml:"gate,omitempty"`
+	Evaluator    *evaluator.EvalConfig `yaml:"evaluator,omitempty"`
+	AllowedTools *string               `yaml:"allowed_tools,omitempty"`
+	DependsOn    []string              `yaml:"depends_on,omitempty"`
 }
 
 // NoOp defines an early-success completion rule for a phase.
@@ -295,6 +297,10 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 			}
 		}
 
+		if err := validatePhaseEvaluator(p); err != nil {
+			return err
+		}
+
 		if p.AllowedTools != nil && *p.AllowedTools == "" {
 			return fmt.Errorf("phase %q: allowed_tools must not be empty when specified", p.Name)
 		}
@@ -458,6 +464,19 @@ func validateDependencyCycles(phases []Phase) error {
 func validateNoOp(phaseName string, n *NoOp) error {
 	if strings.TrimSpace(n.Match) == "" {
 		return fmt.Errorf("phase %q: noop: match is required", phaseName)
+	}
+	return nil
+}
+
+func validatePhaseEvaluator(p Phase) error {
+	if p.Evaluator == nil {
+		return nil
+	}
+	if p.Type == "command" {
+		return fmt.Errorf("phase %q: evaluator is only supported for prompt phases", p.Name)
+	}
+	if err := evaluator.ValidateConfig(*p.Evaluator); err != nil {
+		return fmt.Errorf("phase %q: evaluator: %w", p.Name, err)
 	}
 	return nil
 }

--- a/cli/internal/workflow/workflow_prop_test.go
+++ b/cli/internal/workflow/workflow_prop_test.go
@@ -1,9 +1,11 @@
 package workflow
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"gopkg.in/yaml.v3"
 	"pgregory.net/rapid"
@@ -45,6 +47,48 @@ func genInvalidWorkflowClass() *rapid.Generator[string] {
 				return class
 			}
 		}
+	})
+}
+
+func genValidEvaluatorConfig() *rapid.Generator[evaluator.EvalConfig] {
+	return rapid.Custom(func(t *rapid.T) evaluator.EvalConfig {
+		thresholdA := rapid.Float64Range(0, 1).Draw(t, "threshold-a")
+		thresholdB := rapid.Float64Range(0, 1).Draw(t, "threshold-b")
+		weightA := rapid.Float64Range(0.05, 0.95).Draw(t, "weight-a")
+		weightB := 1 - weightA
+		return evaluator.EvalConfig{
+			MaxIterations: rapid.IntRange(0, 8).Draw(t, "max-iterations"),
+			PassThreshold: rapid.Float64Range(0, 1).Draw(t, "pass-threshold"),
+			Criteria: []evaluator.Criterion{
+				{
+					Name:        "criterion_a",
+					Description: rapid.StringMatching(`[A-Za-z][A-Za-z ]{0,31}`).Draw(t, "desc-a"),
+					Weight:      weightA,
+					Threshold:   thresholdA,
+				},
+				{
+					Name:        "criterion_b",
+					Description: rapid.StringMatching(`[A-Za-z][A-Za-z ]{0,31}`).Draw(t, "desc-b"),
+					Weight:      weightB,
+					Threshold:   thresholdB,
+				},
+			},
+		}
+	})
+}
+
+func genInvalidEvaluatorConfig() *rapid.Generator[evaluator.EvalConfig] {
+	return rapid.Custom(func(t *rapid.T) evaluator.EvalConfig {
+		cfg := genValidEvaluatorConfig().Draw(t, "base-config")
+		switch rapid.SampledFrom([]string{"negative-iterations", "bad-pass-threshold", "duplicate-criteria"}).Draw(t, "invalid-kind") {
+		case "negative-iterations":
+			cfg.MaxIterations = -rapid.IntRange(1, 8).Draw(t, "negative-max-iterations")
+		case "bad-pass-threshold":
+			cfg.PassThreshold = rapid.SampledFrom([]float64{-0.1, 1.1, 2.0}).Draw(t, "bad-pass-threshold")
+		default:
+			cfg.Criteria[1].Name = cfg.Criteria[0].Name
+		}
+		return cfg
 	})
 }
 
@@ -167,5 +211,61 @@ func TestPropWorkflowTierYAMLRoundTripPreservesPointerSemantics(t *testing.T) {
 
 		assertOptional("workflow tier", wf.Tier, roundTripped.Tier)
 		assertOptional("phase tier", wf.Phases[0].Tier, roundTripped.Phases[0].Tier)
+	})
+}
+
+func TestPropValidateAcceptsValidPromptPhaseEvaluatorConfig(t *testing.T) {
+	promptPath, err := filepath.Abs("workflow.go")
+	if err != nil {
+		t.Fatalf("filepath.Abs(workflow.go): %v", err)
+	}
+
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := genValidEvaluatorConfig().Draw(t, "cfg")
+		wf := Workflow{
+			Name: "test",
+			Phases: []Phase{
+				{
+					Name:       "plan",
+					PromptFile: promptPath,
+					MaxTurns:   1,
+					Evaluator:  &cfg,
+				},
+			},
+		}
+
+		if err := wf.Validate("test.yaml"); err != nil {
+			t.Fatalf("Validate() error = %v for config %#v", err, cfg)
+		}
+	})
+}
+
+func TestPropValidateRejectsInvalidPromptPhaseEvaluatorConfig(t *testing.T) {
+	promptPath, err := filepath.Abs("workflow.go")
+	if err != nil {
+		t.Fatalf("filepath.Abs(workflow.go): %v", err)
+	}
+
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := genInvalidEvaluatorConfig().Draw(t, "cfg")
+		wf := Workflow{
+			Name: "test",
+			Phases: []Phase{
+				{
+					Name:       "plan",
+					PromptFile: promptPath,
+					MaxTurns:   1,
+					Evaluator:  &cfg,
+				},
+			},
+		}
+
+		err := wf.Validate("test.yaml")
+		if err == nil {
+			t.Fatalf("Validate() error = nil for invalid config %#v", cfg)
+		}
+		if !strings.Contains(err.Error(), `phase "plan": evaluator:`) {
+			t.Fatalf("Validate() error = %q, want evaluator context", err.Error())
+		}
 	})
 }

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
 	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1251,6 +1252,140 @@ phases:
 	requireErrorContains(t, err, `phase "analyze": noop: match is required`)
 }
 
+func TestSmoke_S8_PromptPhaseEvaluatorConfigParsesFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+    evaluator:
+      max_iterations: 4
+      pass_threshold: 0.8
+      criteria:
+        - name: correctness
+          description: Output is correct
+          weight: 0.6
+          threshold: 0.8
+        - name: completeness
+          description: Output is complete
+          weight: 0.4
+          threshold: 0.7
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	require.Len(t, got.Phases, 1)
+	require.NotNil(t, got.Phases[0].Evaluator)
+	assert.Equal(t, "analyze", got.Phases[0].Name)
+	assert.Equal(t, &evaluator.EvalConfig{
+		MaxIterations: 4,
+		PassThreshold: 0.8,
+		Criteria: []evaluator.Criterion{
+			{Name: "correctness", Description: "Output is correct", Weight: 0.6, Threshold: 0.8},
+			{Name: "completeness", Description: "Output is complete", Weight: 0.4, Threshold: 0.7},
+		},
+	}, got.Phases[0].Evaluator)
+}
+
+func TestSmoke_S9_InvalidEvaluatorConfigIsRejectedWithClearError(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+    evaluator:
+      pass_threshold: 1.5
+`)
+
+	got, err := Load(path)
+	require.Error(t, err)
+	require.Nil(t, got)
+	assert.Contains(t, err.Error(), `phase "analyze": evaluator:`)
+	assert.Contains(t, err.Error(), `pass_threshold must be in [0, 1]`)
+}
+
+func TestSmoke_S10_WorkflowWithoutEvaluatorBlockLoadsWithoutError(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	require.Len(t, got.Phases, 1)
+	assert.Equal(t, "analyze", got.Phases[0].Name)
+	assert.Equal(t, 10, got.Phases[0].MaxTurns)
+	assert.Nil(t, got.Phases[0].Evaluator)
+}
+
+func TestLoadWorkflowPhaseEvaluatorAllowsEmptyConfigDefaults(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+    evaluator: {}
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, got.Phases[0].Evaluator)
+	assert.Equal(t, &evaluator.EvalConfig{}, got.Phases[0].Evaluator)
+}
+
+func TestLoadWorkflowPhaseEvaluatorRejectsInvalidConfig(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/analyze.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: analyze
+    prompt_file: prompts/analyze.md
+    max_turns: 10
+    evaluator:
+      pass_threshold: 1.5
+`)
+
+	_, err := Load(path)
+	requireErrorContains(t, err, `phase "analyze": evaluator: validate config: pass_threshold must be in [0, 1]`)
+}
+
+func TestLoadWorkflowPhaseEvaluatorRejectsCommandPhase(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: apply
+    type: command
+    run: echo ok
+    evaluator:
+      max_iterations: 2
+`)
+
+	_, err := Load(path)
+	requireErrorContains(t, err, `phase "apply": evaluator is only supported for prompt phases`)
+}
+
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -1689,6 +1824,79 @@ func TestValidate(t *testing.T) {
 					{Name: "build", Type: "command", Run: "make build", Gate: &Gate{Type: "command", Run: "make test"}},
 				},
 			},
+		},
+		{
+			name:             "prompt phase with valid evaluator config",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{
+						Name:       "plan",
+						PromptFile: "prompt.md",
+						MaxTurns:   5,
+						Evaluator: &evaluator.EvalConfig{
+							MaxIterations: 2,
+							PassThreshold: 0.75,
+							Criteria: []evaluator.Criterion{
+								{Name: "quality", Description: "Checks quality", Weight: 1, Threshold: 0.7},
+							},
+						},
+					},
+				},
+			},
+			prompts: []string{"prompt.md"},
+		},
+		{
+			name:             "prompt phase with empty evaluator config uses defaults",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{
+						Name:       "plan",
+						PromptFile: "prompt.md",
+						MaxTurns:   5,
+						Evaluator:  &evaluator.EvalConfig{},
+					},
+				},
+			},
+			prompts: []string{"prompt.md"},
+		},
+		{
+			name:             "prompt phase with invalid evaluator config",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{
+						Name:       "plan",
+						PromptFile: "prompt.md",
+						MaxTurns:   5,
+						Evaluator: &evaluator.EvalConfig{
+							MaxIterations: -1,
+						},
+					},
+				},
+			},
+			prompts: []string{"prompt.md"},
+			wantErr: `phase "plan": evaluator: validate config: max_iterations must be non-negative, got -1`,
+		},
+		{
+			name:             "command phase rejects evaluator config",
+			workflowFileName: "test",
+			wf: Workflow{
+				Name: "test",
+				Phases: []Phase{
+					{
+						Name:      "build",
+						Type:      "command",
+						Run:       "echo hello",
+						Evaluator: &evaluator.EvalConfig{MaxIterations: 1},
+					},
+				},
+			},
+			wantErr: `phase "build": evaluator is only supported for prompt phases`,
 		},
 		{
 			name:             "prompt phase default",


### PR DESCRIPTION
## Summary
- Implements [issue #312](https://github.com/nicholls-inc/xylem/issues/312) by adding an `evaluator` config block to workflow prompt phases and validating it against the evaluator package rules.
- Preserves existing workflow behavior when `evaluator` is omitted and rejects unsupported command-phase usage with phase-scoped errors.

## Smoke scenarios covered
- **S8** — Prompt phase evaluator config parses from YAML.
- **S9** — Invalid evaluator config is rejected with a clear evaluator validation error.
- **S10** — Workflow without an evaluator block still loads without error.

## Changes summary
- **Modified `cli/internal/workflow/workflow.go`**: added `Phase.Evaluator *evaluator.EvalConfig`, imported the evaluator package, and added `validatePhaseEvaluator` to enforce prompt-phase-only usage and evaluator config validation.
- **Modified `cli/internal/evaluator/evaluator.go`**: added YAML tags to `Criterion` and `EvalConfig` fields so workflow YAML can decode directly into evaluator config types.
- **Modified `cli/internal/workflow/workflow_test.go`**: added smoke coverage for YAML parsing, invalid evaluator configs, missing evaluator configs, empty evaluator defaults, and command-phase rejection; extended table-driven validation coverage.
- **Modified `cli/internal/workflow/workflow_prop_test.go`**: added generators and property tests covering valid and invalid evaluator configs flowing through workflow validation.

## Test plan
- `go vet ./...`
- `go build ./cmd/xylem`
- `go test ./...`

Fixes #312