### PR TITLE
feat(daemon): scaffold missing profile workflows on auto-upgrade

### DIFF
--- a/cli/cmd/xylem/upgrade.go
+++ b/cli/cmd/xylem/upgrade.go
@@ -8,14 +8,21 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/profiles"
 )
 
 var (
-	daemonGitPull  = gitPull
-	daemonGoBuild  = goBuild
-	daemonHashFile = hashFile
-	daemonExec     = func(path string, args []string, env []string) error {
+	daemonGitPull          = gitPull
+	daemonGoBuild          = goBuild
+	daemonHashFile         = hashFile
+	daemonLoadConfig       = config.Load
+	daemonComposeProfiles  = profiles.Compose
+	daemonSyncProfileFiles = syncProfileAssets
+	daemonExec             = func(path string, args []string, env []string) error {
 		return syscall.Exec(path, args, env)
 	}
 )
@@ -97,10 +104,52 @@ func selfUpgrade(repoDir, executablePath string) {
 		return
 	}
 
+	if err := syncDaemonProfileAssets(repoDir); err != nil {
+		slog.Warn("daemon auto-upgrade profile asset sync failed", "error", err)
+	}
+
 	slog.Info("daemon auto-upgrade execing rebuilt binary", "old_hash", oldHash[:12], "new_hash", newHash[:12])
 	execErr := daemonExec(executablePath, os.Args, os.Environ())
 	// If we reach here, exec() failed.
 	slog.Warn("daemon auto-upgrade exec failed", "error", execErr)
+}
+
+func syncDaemonProfileAssets(repoDir string) error {
+	cfg, err := daemonLoadConfig(filepath.Join(repoDir, ".xylem.yml"))
+	if err != nil {
+		return fmt.Errorf("load daemon config: %w", err)
+	}
+
+	composed, err := daemonComposeProfiles(daemonProfileNames(cfg)...)
+	if err != nil {
+		return fmt.Errorf("compose daemon profiles: %w", err)
+	}
+
+	stateDir := config.ResolveStateDir(repoDir, cfg.StateDir)
+	if err := daemonSyncProfileFiles(stateDir, composed, false); err != nil {
+		return fmt.Errorf("sync daemon profile assets: %w", err)
+	}
+
+	return nil
+}
+
+func daemonProfileNames(cfg *config.Config) []string {
+	if cfg == nil {
+		return []string{"core"}
+	}
+
+	names := make([]string, 0, len(cfg.Profiles))
+	for _, name := range cfg.Profiles {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			continue
+		}
+		names = append(names, trimmed)
+	}
+	if len(names) == 0 {
+		return []string{"core"}
+	}
+	return names
 }
 
 func gitPull(repoDir string) error {

--- a/cli/cmd/xylem/upgrade_prop_test.go
+++ b/cli/cmd/xylem/upgrade_prop_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"pgregory.net/rapid"
 )
 
@@ -85,6 +87,61 @@ func TestPropDaemonUpgradeTargetAlwaysUsesWorkingDirectory(t *testing.T) {
 		}
 		if targetB.repoDir == filepath.Dir(filepath.Dir(executablePathB)) {
 			rt.Fatalf("repoDir unexpectedly matched second binary repo: repoDir=%q executablePath=%q", targetB.repoDir, executablePathB)
+		}
+	})
+}
+
+func TestDaemonProfileNamesDefaultsToCoreWhenConfigIsNil(t *testing.T) {
+	t.Parallel()
+
+	got := daemonProfileNames(nil)
+	if len(got) != 1 || got[0] != "core" {
+		t.Fatalf("daemonProfileNames(nil) = %v, want [core]", got)
+	}
+}
+
+func TestPropDaemonProfileNamesNormalizesConfiguredProfiles(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		rawNames := rapid.SliceOf(rapid.SampledFrom([]string{
+			"",
+			" ",
+			"core",
+			" core ",
+			"self-hosting-xylem",
+			" self-hosting-xylem ",
+		})).Draw(t, "profiles")
+
+		got := daemonProfileNames(&config.Config{Profiles: rawNames})
+
+		expectedIndex := 0
+		for _, raw := range rawNames {
+			trimmed := strings.TrimSpace(raw)
+			if trimmed == "" {
+				continue
+			}
+			if expectedIndex >= len(got) {
+				t.Fatalf("daemonProfileNames(%v) returned too few names: got %v", rawNames, got)
+			}
+			if got[expectedIndex] != trimmed {
+				t.Fatalf("daemonProfileNames(%v)[%d] = %q, want %q", rawNames, expectedIndex, got[expectedIndex], trimmed)
+			}
+			if got[expectedIndex] == "" || got[expectedIndex] != strings.TrimSpace(got[expectedIndex]) {
+				t.Fatalf("daemonProfileNames(%v) returned untrimmed name %q", rawNames, got[expectedIndex])
+			}
+			expectedIndex++
+		}
+
+		if expectedIndex == 0 {
+			if len(got) != 1 || got[0] != "core" {
+				t.Fatalf("daemonProfileNames(%v) = %v, want [core]", rawNames, got)
+			}
+			return
+		}
+
+		if len(got) != expectedIndex {
+			t.Fatalf("daemonProfileNames(%v) returned extra names: got %v", rawNames, got)
 		}
 	})
 }

--- a/cli/cmd/xylem/upgrade_test.go
+++ b/cli/cmd/xylem/upgrade_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/profiles"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,6 +30,27 @@ func stubDaemonUpgradeDependencies(
 		daemonGitPull = prevGitPull
 		daemonGoBuild = prevGoBuild
 		daemonExec = prevExec
+	})
+}
+
+func stubUpgradeProfileDependencies(
+	t *testing.T,
+	loadConfig func(string) (*config.Config, error),
+	composeProfiles func(...string) (*profiles.ComposedProfile, error),
+	syncProfileFiles func(string, *profiles.ComposedProfile, bool) error,
+) {
+	t.Helper()
+
+	prevLoadConfig := daemonLoadConfig
+	prevComposeProfiles := daemonComposeProfiles
+	prevSyncProfileFiles := daemonSyncProfileFiles
+	daemonLoadConfig = loadConfig
+	daemonComposeProfiles = composeProfiles
+	daemonSyncProfileFiles = syncProfileFiles
+	t.Cleanup(func() {
+		daemonLoadConfig = prevLoadConfig
+		daemonComposeProfiles = prevComposeProfiles
+		daemonSyncProfileFiles = prevSyncProfileFiles
 	})
 }
 
@@ -100,17 +123,13 @@ func TestSmoke_S37_DaemonAutoUpgradeSyncsDaemonWorktreeControlPlaneFiles(t *test
 	require.NoError(t, os.MkdirAll(filepath.Dir(executablePath), 0o755))
 	require.NoError(t, os.WriteFile(executablePath, []byte("old-binary"), 0o755))
 
-	binaryWorkflowPath := filepath.Join(binaryRepo, ".xylem", "workflows", "merge-pr.yaml")
+	upgradedWorkflowData := []byte(`run: "gh pr merge 181 --auto"`)
+	upgradedPromptData := []byte("use the upgraded merge workflow")
 	daemonWorkflowPath := filepath.Join(daemonRepo, ".xylem", "workflows", "merge-pr.yaml")
-	binaryPromptPath := filepath.Join(binaryRepo, ".xylem", "prompts", "merge-pr", "check.md")
 	daemonPromptPath := filepath.Join(daemonRepo, ".xylem", "prompts", "merge-pr", "check.md")
-	require.NoError(t, os.MkdirAll(filepath.Dir(binaryWorkflowPath), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Dir(daemonWorkflowPath), 0o755))
-	require.NoError(t, os.MkdirAll(filepath.Dir(binaryPromptPath), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Dir(daemonPromptPath), 0o755))
-	require.NoError(t, os.WriteFile(binaryWorkflowPath, []byte(`run: "gh pr merge 181 --auto"`), 0o644))
 	require.NoError(t, os.WriteFile(daemonWorkflowPath, []byte(`run: "gh pr merge 181 --admin"`), 0o644))
-	require.NoError(t, os.WriteFile(binaryPromptPath, []byte("use the upgraded merge workflow"), 0o644))
 	require.NoError(t, os.WriteFile(daemonPromptPath, []byte("stale prompt from old worktree"), 0o644))
 
 	var pulledRepo string
@@ -120,18 +139,18 @@ func TestSmoke_S37_DaemonAutoUpgradeSyncsDaemonWorktreeControlPlaneFiles(t *test
 		t,
 		func(repoDir string) error {
 			pulledRepo = repoDir
-			updated, err := os.ReadFile(binaryWorkflowPath)
-			if err != nil {
+			targetWorkflowPath := filepath.Join(repoDir, ".xylem", "workflows", "merge-pr.yaml")
+			targetPromptPath := filepath.Join(repoDir, ".xylem", "prompts", "merge-pr", "check.md")
+			if err := os.MkdirAll(filepath.Dir(targetWorkflowPath), 0o755); err != nil {
 				return err
 			}
-			if err := os.WriteFile(daemonWorkflowPath, updated, 0o644); err != nil {
+			if err := os.MkdirAll(filepath.Dir(targetPromptPath), 0o755); err != nil {
 				return err
 			}
-			updatedPrompt, err := os.ReadFile(binaryPromptPath)
-			if err != nil {
+			if err := os.WriteFile(targetWorkflowPath, upgradedWorkflowData, 0o644); err != nil {
 				return err
 			}
-			return os.WriteFile(daemonPromptPath, updatedPrompt, 0o644)
+			return os.WriteFile(targetPromptPath, upgradedPromptData, 0o644)
 		},
 		func(cliDir, outPath string) error {
 			builtCLI = cliDir
@@ -157,10 +176,149 @@ func TestSmoke_S37_DaemonAutoUpgradeSyncsDaemonWorktreeControlPlaneFiles(t *test
 
 	got, err := os.ReadFile(filepath.Join(target.repoDir, ".xylem", "workflows", "merge-pr.yaml"))
 	require.NoError(t, err)
-	assert.Contains(t, string(got), "--auto")
-	assert.NotContains(t, string(got), "--admin")
+	assert.Equal(t, upgradedWorkflowData, got)
 
 	prompt, err := os.ReadFile(filepath.Join(target.repoDir, ".xylem", "prompts", "merge-pr", "check.md"))
 	require.NoError(t, err)
-	assert.Equal(t, "use the upgraded merge workflow", string(prompt))
+	assert.Equal(t, upgradedPromptData, prompt)
+
+	binaryWorkflowPath := filepath.Join(binaryRepo, ".xylem", "workflows", "merge-pr.yaml")
+	assert.NoFileExists(t, binaryWorkflowPath)
+}
+
+func TestSyncDaemonProfileAssetsUsesConfiguredProfilesAndStateDir(t *testing.T) {
+	repoDir := t.TempDir()
+	composed := &profiles.ComposedProfile{}
+
+	var loadedConfigPath string
+	var composedProfiles []string
+	var syncedStateDir string
+	var syncedForce bool
+	var syncedProfile *profiles.ComposedProfile
+	stubUpgradeProfileDependencies(
+		t,
+		func(path string) (*config.Config, error) {
+			loadedConfigPath = path
+			return &config.Config{
+				Profiles: []string{"core", "self-hosting-xylem"},
+				StateDir: ".state/xylem",
+			}, nil
+		},
+		func(names ...string) (*profiles.ComposedProfile, error) {
+			composedProfiles = append([]string(nil), names...)
+			return composed, nil
+		},
+		func(stateDir string, got *profiles.ComposedProfile, force bool) error {
+			syncedStateDir = stateDir
+			syncedProfile = got
+			syncedForce = force
+			return nil
+		},
+	)
+
+	require.NoError(t, syncDaemonProfileAssets(repoDir))
+	assert.Equal(t, filepath.Join(repoDir, ".xylem.yml"), loadedConfigPath)
+	assert.Equal(t, []string{"core", "self-hosting-xylem"}, composedProfiles)
+	assert.Equal(t, filepath.Join(repoDir, ".state/xylem"), syncedStateDir)
+	assert.Same(t, composed, syncedProfile)
+	assert.False(t, syncedForce)
+}
+
+func TestSelfUpgradeContinuesToExecWhenProfileSyncFails(t *testing.T) {
+	repoDir := t.TempDir()
+	executablePath := filepath.Join(repoDir, "cli", "xylem")
+	require.NoError(t, os.MkdirAll(filepath.Dir(executablePath), 0o755))
+	require.NoError(t, os.WriteFile(executablePath, []byte("old-binary"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".xylem.yml"), []byte("profiles:\n  - core\n"), 0o644))
+
+	var execPath string
+	var loadedConfigPath string
+	var composedProfiles []string
+	syncAttempts := 0
+	stubDaemonUpgradeDependencies(
+		t,
+		func(string) error { return nil },
+		func(string, string) error {
+			return os.WriteFile(executablePath+".upgrade", []byte("new-binary"), 0o755)
+		},
+		func(path string, _ []string, _ []string) error {
+			execPath = path
+			return errors.New("exec blocked in test")
+		},
+	)
+	stubUpgradeProfileDependencies(
+		t,
+		func(path string) (*config.Config, error) {
+			loadedConfigPath = path
+			return &config.Config{Profiles: []string{"core"}, StateDir: ".xylem"}, nil
+		},
+		func(names ...string) (*profiles.ComposedProfile, error) {
+			composedProfiles = append([]string(nil), names...)
+			return &profiles.ComposedProfile{}, nil
+		},
+		func(string, *profiles.ComposedProfile, bool) error {
+			syncAttempts++
+			return errors.New("sync failed")
+		},
+	)
+
+	selfUpgrade(repoDir, executablePath)
+
+	assert.Equal(t, executablePath, execPath)
+	assert.Equal(t, filepath.Join(repoDir, ".xylem.yml"), loadedConfigPath)
+	assert.Equal(t, []string{"core"}, composedProfiles)
+	assert.Equal(t, 1, syncAttempts)
+}
+
+func TestSmoke_S38_DaemonAutoUpgradeScaffoldsMissingProfileWorkflowAssets(t *testing.T) {
+	repoDir := t.TempDir()
+	executablePath := filepath.Join(repoDir, "cli", "xylem")
+	require.NoError(t, os.MkdirAll(filepath.Dir(executablePath), 0o755))
+	require.NoError(t, os.WriteFile(executablePath, []byte("old-binary"), 0o755))
+
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "remote", "add", "origin", "git@github.com:nicholls-inc/xylem.git")
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(repoDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(oldWd))
+	})
+	require.NoError(t, cmdInitWithProfile(filepath.Join(repoDir, ".xylem.yml"), false, "core,self-hosting-xylem"))
+
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".xylem", "workflows", "fix-bug.yaml"), []byte("existing workflow\n"), 0o644))
+	require.NoError(t, os.Remove(filepath.Join(repoDir, ".xylem", "workflows", "implement-harness.yaml")))
+	require.NoError(t, os.Remove(filepath.Join(repoDir, ".xylem", "prompts", "implement-harness", "plan.md")))
+
+	var execPath string
+	stubDaemonUpgradeDependencies(
+		t,
+		func(string) error { return nil },
+		func(string, string) error {
+			return os.WriteFile(executablePath+".upgrade", []byte("new-binary"), 0o755)
+		},
+		func(path string, _ []string, _ []string) error {
+			execPath = path
+			return errors.New("exec blocked in test")
+		},
+	)
+
+	selfUpgrade(repoDir, executablePath)
+
+	assert.Equal(t, executablePath, execPath)
+
+	composed, err := profiles.Compose("core", "self-hosting-xylem")
+	require.NoError(t, err)
+
+	workflowData, err := os.ReadFile(filepath.Join(repoDir, ".xylem", "workflows", "implement-harness.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, composed.Workflows["implement-harness"], workflowData)
+
+	promptData, err := os.ReadFile(filepath.Join(repoDir, ".xylem", "prompts", "implement-harness", "plan.md"))
+	require.NoError(t, err)
+	assert.Equal(t, composed.Prompts["implement-harness/plan"], promptData)
+
+	existingWorkflowData, err := os.ReadFile(filepath.Join(repoDir, ".xylem", "workflows", "fix-bug.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "existing workflow\n", string(existingWorkflowData))
 }


### PR DESCRIPTION
## Summary
- Implements [issue #309](https://github.com/nicholls-inc/xylem/issues/309).
- Reloads the daemon worktree profile configuration during auto-upgrade, composes the active profiles, and syncs missing workflow/prompt assets into the daemon state directory before `exec()`.
- Treats profile asset sync as warning-only so a rebuilt daemon still restarts even when scaffold sync fails.

## Smoke scenarios covered
- `S37` — `Daemon auto-upgrade syncs daemon worktree control plane files`
- `S38` — `Daemon auto-upgrade scaffolds missing profile workflow assets`

## Changes summary
- **Modified:** `cli/cmd/xylem/upgrade.go`
  - Added `daemonLoadConfig`, `daemonComposeProfiles`, and `daemonSyncProfileFiles` seams for upgrade/profile wiring.
  - Added `syncDaemonProfileAssets(repoDir string) error` to load `.xylem.yml`, resolve profile names, compose profiles, and sync assets into the resolved state dir.
  - Added `daemonProfileNames(cfg *config.Config) []string` and invoked profile asset sync from `selfUpgrade` before `exec()`.
- **Modified:** `cli/cmd/xylem/upgrade_test.go`
  - Added `stubUpgradeProfileDependencies` and coverage for configured profile/state-dir sync, warning-and-continue behavior, and missing workflow/prompt scaffolding.
- **Modified:** `cli/cmd/xylem/upgrade_prop_test.go`
  - Added property coverage for profile-name normalization and core fallback behavior.

## Test plan
- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #309