### PR TITLE
Add scheduled hardening audit workflow and CLI

### DIFF
--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -38,7 +38,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "bootstrap", "continuous-improvement", "continuous-simplicity", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report"}
+	expected := []string{"init", "bootstrap", "continuous-improvement", "continuous-simplicity", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/harden.go
+++ b/cli/cmd/xylem/harden.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholls-inc/xylem/cli/internal/hardening"
+)
+
+func newHardenCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "harden",
+		Aliases: []string{"hardening-report"},
+		Short:   "Deterministic helpers for recurring hardening audits",
+	}
+	cmd.AddCommand(
+		newHardenInventoryCmd(),
+		newHardenScoreCmd(),
+		newHardenFileIssuesCmd(),
+		newHardenTrackCmd(),
+	)
+	return cmd
+}
+
+func newHardenInventoryCmd() *cobra.Command {
+	var repoRoot, workflowDir, outputPath, nowRaw string
+	cmd := &cobra.Command{
+		Use:   "inventory",
+		Short: "Inventory workflow phases and classify their hardening shape",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(outputPath) == "" {
+				outputPath = filepath.Join(defaultStateDirPath(), "state", "hardening-audit", "inventory.json")
+			}
+			now, err := parseOptionalNow(nowRaw)
+			if err != nil {
+				return err
+			}
+			inventory, err := cmdHardenInventory(repoRoot, workflowDir, outputPath, now)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Wrote %s (%d workflows, %d phases)\n", outputPath, len(inventory.Workflows), countInventoryPhases(inventory))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repoRoot, "repo-root", ".", "Repository root containing .xylem/")
+	cmd.Flags().StringVar(&workflowDir, "workflow-dir", ".xylem/workflows", "Directory containing workflow YAML files")
+	cmd.Flags().StringVar(&outputPath, "output", "", "Path to write the inventory JSON")
+	cmd.Flags().StringVar(&nowRaw, "now", "", "Optional RFC3339 timestamp override for deterministic runs")
+	return cmd
+}
+
+func newHardenScoreCmd() *cobra.Command {
+	var repoRoot, inventoryPath, stateDir, outputPath, nowRaw string
+	cmd := &cobra.Command{
+		Use:   "score",
+		Short: "Score fuzzy and mixed phases for deterministic hardening candidacy",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(outputPath) == "" {
+				outputPath = filepath.Join(defaultStateDirPath(), "state", "hardening-audit", "scores.json")
+			}
+			now, err := parseOptionalNow(nowRaw)
+			if err != nil {
+				return err
+			}
+			report, err := cmdHardenScore(repoRoot, inventoryPath, stateDir, outputPath, now)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Wrote %s (%d candidates, %d top candidates)\n", outputPath, len(report.Candidates), len(report.TopCandidates))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repoRoot, "repo-root", ".", "Repository root containing .xylem/")
+	cmd.Flags().StringVar(&inventoryPath, "inventory", "", "Path to the inventory JSON")
+	cmd.Flags().StringVar(&stateDir, "state-dir", "", "State directory containing phases/<vessel>/summary.json")
+	cmd.Flags().StringVar(&outputPath, "output", "", "Path to write the scores JSON")
+	cmd.Flags().StringVar(&nowRaw, "now", "", "Optional RFC3339 timestamp override for deterministic runs")
+	cmd.MarkFlagRequired("inventory") //nolint:errcheck
+	return cmd
+}
+
+func newHardenFileIssuesCmd() *cobra.Command {
+	var proposalsPath, outputPath, repo string
+	var labels []string
+	cmd := &cobra.Command{
+		Use:   "file-issues",
+		Short: "Create or dedupe hardening issues from ranked proposals",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(outputPath) == "" {
+				outputPath = filepath.Join(defaultStateDirPath(), "state", "hardening-audit", "filed-issues.json")
+			}
+			result, err := cmdHardenFileIssues(repo, proposalsPath, outputPath, labels)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Wrote %s (%d created, %d existing)\n", outputPath, len(result.Created), len(result.Existing))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repo, "repo", "", "GitHub repository slug (owner/name); defaults to repo from config")
+	cmd.Flags().StringVar(&proposalsPath, "proposals", "", "Path to the ranked proposals JSON")
+	cmd.Flags().StringVar(&outputPath, "output", "", "Path to write the filed-issues JSON")
+	cmd.Flags().StringSliceVar(&labels, "labels", []string{"enhancement", "ready-for-work"}, "Labels to apply to new issues")
+	cmd.MarkFlagRequired("proposals") //nolint:errcheck
+	return cmd
+}
+
+func newHardenTrackCmd() *cobra.Command {
+	var repoRoot, proposalsPath, filedPath, ledgerPath, nowRaw string
+	cmd := &cobra.Command{
+		Use:   "track",
+		Short: "Append this hardening audit run to docs/hardening-ledger.md",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			now, err := parseOptionalNow(nowRaw)
+			if err != nil {
+				return err
+			}
+			if err := cmdHardenTrack(repoRoot, proposalsPath, filedPath, ledgerPath, now); err != nil {
+				return err
+			}
+			fmt.Printf("Updated %s\n", ledgerPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repoRoot, "repo-root", ".", "Repository root containing docs/")
+	cmd.Flags().StringVar(&proposalsPath, "proposals", "", "Path to the ranked proposals JSON")
+	cmd.Flags().StringVar(&filedPath, "filed", "", "Path to the filed-issues JSON")
+	cmd.Flags().StringVar(&ledgerPath, "ledger", hardening.DefaultLedgerPath, "Ledger markdown path relative to the repo root")
+	cmd.Flags().StringVar(&nowRaw, "now", "", "Optional RFC3339 timestamp override for deterministic runs")
+	cmd.MarkFlagRequired("proposals") //nolint:errcheck
+	cmd.MarkFlagRequired("filed")     //nolint:errcheck
+	return cmd
+}
+
+func cmdHardenInventory(repoRoot, workflowDir, outputPath string, now time.Time) (*hardening.Inventory, error) {
+	repoRoot = defaultRepoRoot(repoRoot)
+	if strings.TrimSpace(outputPath) == "" {
+		outputPath = filepath.Join(defaultStateDirPath(), "state", "hardening-audit", "inventory.json")
+	}
+	inventory, err := hardening.GenerateInventory(repoRoot, workflowDir, now)
+	if err != nil {
+		return nil, fmt.Errorf("generate inventory: %w", err)
+	}
+	if err := hardening.WriteJSON(outputPath, inventory); err != nil {
+		return nil, err
+	}
+	return inventory, nil
+}
+
+func cmdHardenScore(repoRoot, inventoryPath, stateDir, outputPath string, now time.Time) (*hardening.ScoreReport, error) {
+	if strings.TrimSpace(outputPath) == "" {
+		outputPath = filepath.Join(defaultStateDirPath(), "state", "hardening-audit", "scores.json")
+	}
+	if strings.TrimSpace(stateDir) == "" {
+		stateDir = defaultStateDirPath()
+	}
+	inventory, err := hardening.LoadInventory(inventoryPath)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(repoRoot) != "" {
+		inventory.RepoRoot = defaultRepoRoot(repoRoot)
+	}
+	report, err := hardening.ScoreInventory(inventory, stateDir, now)
+	if err != nil {
+		return nil, fmt.Errorf("score inventory: %w", err)
+	}
+	if err := hardening.WriteJSON(outputPath, report); err != nil {
+		return nil, err
+	}
+	return report, nil
+}
+
+func cmdHardenFileIssues(repo, proposalsPath, outputPath string, labels []string) (*hardening.FileResult, error) {
+	if strings.TrimSpace(outputPath) == "" {
+		outputPath = filepath.Join(defaultStateDirPath(), "state", "hardening-audit", "filed-issues.json")
+	}
+	if strings.TrimSpace(repo) == "" {
+		if deps == nil || deps.cfg == nil || strings.TrimSpace(deps.cfg.Repo) == "" {
+			return nil, fmt.Errorf("file-issues requires --repo or loaded config repo")
+		}
+		repo = deps.cfg.Repo
+	}
+	proposals, err := hardening.LoadProposals(proposalsPath)
+	if err != nil {
+		return nil, err
+	}
+	result, err := hardening.FileIssues(context.Background(), &realCmdRunner{}, repo, proposals, labels)
+	if err != nil {
+		return nil, err
+	}
+	if err := hardening.WriteJSON(outputPath, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func cmdHardenTrack(repoRoot, proposalsPath, filedPath, ledgerPath string, now time.Time) error {
+	repoRoot = defaultRepoRoot(repoRoot)
+	proposals, err := hardening.LoadProposals(proposalsPath)
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(filedPath)
+	if err != nil {
+		return fmt.Errorf("read filed issues %q: %w", filedPath, err)
+	}
+	var filed hardening.FileResult
+	if err := json.Unmarshal(data, &filed); err != nil {
+		return fmt.Errorf("parse filed issues %q: %w", filedPath, err)
+	}
+	if err := hardening.AppendLedger(repoRoot, ledgerPath, proposals, &filed, now); err != nil {
+		return err
+	}
+	return nil
+}
+
+func parseOptionalNow(nowRaw string) (time.Time, error) {
+	if strings.TrimSpace(nowRaw) == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, nowRaw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse --now: %w", err)
+	}
+	return parsed, nil
+}
+
+func defaultRepoRoot(repoRoot string) string {
+	if strings.TrimSpace(repoRoot) != "" {
+		return repoRoot
+	}
+	return "."
+}
+
+func defaultStateDirPath() string {
+	if deps != nil && deps.cfg != nil && strings.TrimSpace(deps.cfg.StateDir) != "" {
+		return deps.cfg.StateDir
+	}
+	return ".xylem"
+}
+
+func countInventoryPhases(inventory *hardening.Inventory) int {
+	if inventory == nil {
+		return 0
+	}
+	total := 0
+	for _, workflow := range inventory.Workflows {
+		total += len(workflow.Phases)
+	}
+	return total
+}

--- a/cli/cmd/xylem/harden_test.go
+++ b/cli/cmd/xylem/harden_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/hardening"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmdHardenInventoryUsesDefaultOutput(t *testing.T) {
+	cfg := &config.Config{StateDir: filepath.Join(t.TempDir(), ".xylem")}
+	originalDeps := deps
+	t.Cleanup(func() { deps = originalDeps })
+	deps = &appDeps{cfg: cfg}
+
+	repoRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".xylem", "workflows"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".xylem", "prompts", "hardening-audit"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".xylem", "prompts", "hardening-audit", "rank.md"), []byte("Write exactly one JSON file."), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".xylem", "workflows", "hardening-audit.yaml"), []byte(`
+name: hardening-audit
+phases:
+  - name: rank
+    prompt_file: .xylem/prompts/hardening-audit/rank.md
+    max_turns: 20
+`), 0o644))
+
+	inventory, err := cmdHardenInventory(repoRoot, ".xylem/workflows", "", time.Date(2026, time.April, 10, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	assert.NotNil(t, inventory)
+	assert.FileExists(t, filepath.Join(cfg.StateDir, "state", "hardening-audit", "inventory.json"))
+}
+
+func TestCmdHardenTrackAppendsLedger(t *testing.T) {
+	repoRoot := t.TempDir()
+	proposalsPath := filepath.Join(repoRoot, "proposals.json")
+	filedPath := filepath.Join(repoRoot, "filed.json")
+	require.NoError(t, hardening.WriteJSON(proposalsPath, []hardening.Proposal{{
+		PhaseID:             "hardening-audit/rank",
+		Workflow:            "hardening-audit",
+		Phase:               "rank",
+		Title:               "[harden] hardening-audit/rank",
+		Body:                "body",
+		CLISignature:        "xylem harden score",
+		PackageLocation:     "cli/internal/hardening",
+		EstimatedComplexity: "medium",
+		TestCases:           []string{"writes scores"},
+	}}))
+	data, err := json.Marshal(hardening.FileResult{
+		Created: []hardening.FiledIssue{{
+			PhaseID: "hardening-audit/rank",
+			Title:   "[harden] hardening-audit/rank",
+			Number:  12,
+			URL:     "https://github.com/owner/repo/issues/12",
+			Created: true,
+		}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filedPath, data, 0o644))
+
+	err = cmdHardenTrack(repoRoot, proposalsPath, filedPath, "docs/hardening-ledger.md", time.Date(2026, time.April, 10, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(repoRoot, "docs", "hardening-ledger.md"))
+}
+
+func TestHardenInventoryBypassesToolLookup(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".xylem.yml")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".xylem", "workflows"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".xylem", "prompts", "hardening-audit"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem", "prompts", "hardening-audit", "rank.md"), []byte("Write exactly one JSON file."), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".xylem", "workflows", "hardening-audit.yaml"), []byte(`
+name: hardening-audit
+phases:
+  - name: rank
+    prompt_file: .xylem/prompts/hardening-audit/rank.md
+    max_turns: 20
+`), 0o644))
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+repo: owner/repo
+state_dir: ".xylem"
+providers:
+  claude:
+    kind: claude
+    command: "claude"
+    flags: "--dangerously-skip-permissions"
+    tiers:
+      high: "claude-opus-4-6"
+      med: "claude-sonnet-4-6"
+      low: "claude-haiku-4-5"
+  copilot:
+    kind: copilot
+    command: "copilot"
+    flags: "--yolo --autopilot"
+    tiers:
+      high: "gpt-5.4"
+      med: "gpt-5.2-codex"
+      low: "gpt-5-mini"
+llm_routing:
+  default_tier: med
+  tiers:
+    high:
+      providers: [claude]
+    med:
+      providers: [claude, copilot]
+    low:
+      providers: [copilot, claude]
+sources:
+  hardening:
+    type: scheduled
+    repo: owner/repo
+    schedule: "@monthly"
+    tasks:
+      monthly:
+        workflow: hardening-audit
+        ref: hardening-audit
+`), 0o644))
+
+	orig, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(orig))
+	})
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"--config", configPath, "harden", "inventory", "--repo-root", ".", "--workflow-dir", ".xylem/workflows"})
+
+	out := captureStdout(func() {
+		require.NoError(t, cmd.Execute())
+	})
+	assert.Contains(t, out, "Wrote")
+	assert.FileExists(t, filepath.Join(dir, ".xylem", "state", "hardening-audit", "inventory.json"))
+}

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -42,6 +42,7 @@ var expectedSelfHostingWorkflows = []string{
 	"continuous-improvement",
 	"continuous-simplicity",
 	"diagnose-failures",
+	"hardening-audit",
 	"implement-harness",
 	"ingest-field-reports",
 	"initiative-tracker",

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -40,11 +40,14 @@ func newRootCmd() *cobra.Command {
 			// local-only commands that only parse config, workflow YAML, and
 			// local state; they don't shell out to git or gh.
 			// continuous-improvement select is another local-only helper used
-			// by a command phase.
+			// by a command phase. harden inventory/score/track are the same.
 			skipTooling := cmd.Name() == "visualize" ||
 				strings.HasPrefix(commandPath, "xylem visualize") ||
 				cmd.Name() == "review" ||
 				commandPath == "xylem continuous-improvement select" ||
+				commandPath == "xylem harden inventory" ||
+				commandPath == "xylem harden score" ||
+				commandPath == "xylem harden track" ||
 				commandPath == "xylem field-report generate" ||
 				commandPath == "xylem daemon stop"
 
@@ -92,6 +95,7 @@ func newRootCmd() *cobra.Command {
 		newBootstrapCmd(),
 		newContinuousImprovementCmd(),
 		newContinuousSimplicityCmd(),
+		newHardenCmd(),
 		newDtuCmd(),
 		newShimDispatchCmd(),
 		newScanCmd(),

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -1261,6 +1261,8 @@ func parseScheduleValue(value string) (time.Duration, error) {
 		return 24 * time.Hour, nil
 	case "@weekly":
 		return 7 * 24 * time.Hour, nil
+	case "@monthly":
+		return 30 * 24 * time.Hour, nil
 	}
 	interval, err := time.ParseDuration(value)
 	if err != nil {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -2173,6 +2173,24 @@ func TestSmoke_S36_ScheduledSourceLoads(t *testing.T) {
 	assert.Equal(t, "sota-gap-analysis", sourceCfg.Tasks["weekly"].Ref)
 }
 
+func TestSmoke_S36b_ScheduledSourceAllowsMonthlyAlias(t *testing.T) {
+	cfg := validConfig()
+	cfg.Sources = map[string]SourceConfig{
+		"hardening-audit": {
+			Type:     "scheduled",
+			Repo:     "owner/repo",
+			Schedule: "@monthly",
+			Tasks: map[string]Task{
+				"monthly": {Workflow: "hardening-audit", Ref: "hardening-audit"},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	require.NoError(t, err)
+	assert.Equal(t, "@monthly", cfg.Sources["hardening-audit"].Schedule)
+}
+
 func TestSmoke_S37_ScheduledSourceAllowsMissingRef(t *testing.T) {
 	cfg := validConfig()
 	cfg.Sources = map[string]SourceConfig{

--- a/cli/internal/hardening/hardening.go
+++ b/cli/internal/hardening/hardening.go
@@ -425,7 +425,7 @@ func AppendLedger(repoRoot, ledgerPath string, proposals []Proposal, filed *File
 		existing.WriteString("\n")
 	}
 	existing.WriteString("\n")
-	existing.WriteString(fmt.Sprintf("## %s\n\n", now.Format(time.RFC3339)))
+	fmt.Fprintf(&existing, "## %s\n\n", now.Format(time.RFC3339))
 
 	if len(proposals) == 0 {
 		existing.WriteString("- No fuzzy or mixed phases were promoted to issue proposals in this run.\n")
@@ -449,12 +449,12 @@ func AppendLedger(repoRoot, ledgerPath string, proposals []Proposal, filed *File
 					status = fmt.Sprintf("matched existing issue #%d", item.Number)
 				}
 			}
-			existing.WriteString(fmt.Sprintf("- `%s` — %s\n", proposal.PhaseID, status))
-			existing.WriteString(fmt.Sprintf("  - Proposed CLI: `%s`\n", strings.TrimSpace(proposal.CLISignature)))
-			existing.WriteString(fmt.Sprintf("  - Package: `%s`\n", strings.TrimSpace(proposal.PackageLocation)))
-			existing.WriteString(fmt.Sprintf("  - Estimated complexity: `%s`\n", strings.TrimSpace(proposal.EstimatedComplexity)))
+			fmt.Fprintf(&existing, "- `%s` — %s\n", proposal.PhaseID, status)
+			fmt.Fprintf(&existing, "  - Proposed CLI: `%s`\n", strings.TrimSpace(proposal.CLISignature))
+			fmt.Fprintf(&existing, "  - Package: `%s`\n", strings.TrimSpace(proposal.PackageLocation))
+			fmt.Fprintf(&existing, "  - Estimated complexity: `%s`\n", strings.TrimSpace(proposal.EstimatedComplexity))
 			for _, testCase := range proposal.TestCases {
-				existing.WriteString(fmt.Sprintf("  - Test case: %s\n", strings.TrimSpace(testCase)))
+				fmt.Fprintf(&existing, "  - Test case: %s\n", strings.TrimSpace(testCase))
 			}
 		}
 	}

--- a/cli/internal/hardening/hardening.go
+++ b/cli/internal/hardening/hardening.go
@@ -1,0 +1,754 @@
+package hardening
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/review"
+	workflowpkg "github.com/nicholls-inc/xylem/cli/internal/workflow"
+)
+
+const (
+	InventoryVersion = 1
+	ScoreVersion     = 1
+
+	ClassificationDeterministic = "deterministic"
+	ClassificationFuzzy         = "fuzzy"
+	ClassificationMixed         = "mixed"
+
+	DefaultLedgerPath = "docs/hardening-ledger.md"
+	defaultIssueLabel = "[harden]"
+	historyWindow     = 30 * 24 * time.Hour
+)
+
+var hardRulePattern = regexp.MustCompile(`(?i)\b(if|else|otherwise|must|only|exact|required|valid values)\b`)
+
+var structuredOutputMarkers = []string{
+	"json",
+	"yaml",
+	"schema",
+	"structured output",
+	"write exactly one json file",
+	"write a json file",
+	"must validate",
+	"result:",
+	"issues_created:",
+	"report_status:",
+	"follow_up:",
+}
+
+var patternMatchingMarkers = []string{
+	"label",
+	"labels",
+	"git",
+	"branch",
+	"pull request",
+	"grep",
+	"regex",
+	"file contents",
+	"workflow yaml",
+	"queue.jsonl",
+	".xylem/phases",
+	"summary.json",
+	"gh issue",
+	"status label",
+}
+
+type Inventory struct {
+	Version     int                 `json:"version"`
+	GeneratedAt string              `json:"generated_at"`
+	RepoRoot    string              `json:"repo_root"`
+	WorkflowDir string              `json:"workflow_dir"`
+	Workflows   []WorkflowInventory `json:"workflows"`
+}
+
+type WorkflowInventory struct {
+	Name        string           `json:"name"`
+	Path        string           `json:"path"`
+	Description string           `json:"description,omitempty"`
+	Class       string           `json:"class,omitempty"`
+	Phases      []PhaseInventory `json:"phases"`
+}
+
+type PhaseInventory struct {
+	ID                   string   `json:"id"`
+	DisplayName          string   `json:"display_name"`
+	Workflow             string   `json:"workflow"`
+	WorkflowPath         string   `json:"workflow_path"`
+	Phase                string   `json:"phase"`
+	Type                 string   `json:"type"`
+	PromptPath           string   `json:"prompt_path,omitempty"`
+	PromptExcerpt        string   `json:"prompt_excerpt,omitempty"`
+	PromptLines          int      `json:"prompt_lines,omitempty"`
+	Classification       string   `json:"classification"`
+	StructuredSignals    []string `json:"structured_signals,omitempty"`
+	PatternSignals       []string `json:"pattern_signals,omitempty"`
+	DeterministicSignals []string `json:"deterministic_signals,omitempty"`
+	HardRuleCount        int      `json:"hard_rule_count,omitempty"`
+}
+
+type ScoreReport struct {
+	Version       int              `json:"version"`
+	GeneratedAt   string           `json:"generated_at"`
+	RepoRoot      string           `json:"repo_root"`
+	WindowStart   string           `json:"window_start"`
+	WindowEnd     string           `json:"window_end"`
+	Candidates    []CandidateScore `json:"candidates"`
+	TopCandidates []CandidateScore `json:"top_candidates"`
+	Warnings      []string         `json:"warnings,omitempty"`
+}
+
+type CandidateScore struct {
+	ID             string        `json:"id"`
+	DisplayName    string        `json:"display_name"`
+	Workflow       string        `json:"workflow"`
+	WorkflowPath   string        `json:"workflow_path"`
+	Phase          string        `json:"phase"`
+	Type           string        `json:"type"`
+	PromptPath     string        `json:"prompt_path,omitempty"`
+	PromptExcerpt  string        `json:"prompt_excerpt,omitempty"`
+	Classification string        `json:"classification"`
+	Score          int           `json:"score"`
+	Criteria       ScoreCriteria `json:"criteria"`
+	Reasons        []string      `json:"reasons"`
+}
+
+type ScoreCriteria struct {
+	StructuredOutput      bool `json:"structured_output"`
+	PatternMatching       bool `json:"pattern_matching"`
+	FailureCount30d       int  `json:"failure_count_30d"`
+	HardRuleCount         int  `json:"hard_rule_count"`
+	GoReplacementFeasible bool `json:"go_replacement_feasible"`
+}
+
+type Proposal struct {
+	PhaseID             string   `json:"phase_id"`
+	Workflow            string   `json:"workflow"`
+	Phase               string   `json:"phase"`
+	Title               string   `json:"title"`
+	Body                string   `json:"body"`
+	CLISignature        string   `json:"cli_signature"`
+	PackageLocation     string   `json:"package_location"`
+	EstimatedComplexity string   `json:"estimated_complexity"`
+	TestCases           []string `json:"test_cases"`
+	Score               int      `json:"score,omitempty"`
+}
+
+type FiledIssue struct {
+	PhaseID string `json:"phase_id"`
+	Title   string `json:"title"`
+	Number  int    `json:"number,omitempty"`
+	URL     string `json:"url,omitempty"`
+	Created bool   `json:"created"`
+}
+
+type FileResult struct {
+	Created  []FiledIssue `json:"created"`
+	Existing []FiledIssue `json:"existing"`
+}
+
+type CommandRunner interface {
+	RunOutput(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type issueSummary struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	URL    string `json:"url"`
+}
+
+func GenerateInventory(repoRoot, workflowDir string, now time.Time) (*Inventory, error) {
+	absRepoRoot, err := resolveRepoRoot(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	absWorkflowDir, err := resolveWithinRoot(absRepoRoot, workflowDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve workflow dir: %w", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(absWorkflowDir, "*.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("glob workflow files: %w", err)
+	}
+	sort.Strings(matches)
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no workflow yaml files found in %s", absWorkflowDir)
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+
+	inventory := &Inventory{
+		Version:     InventoryVersion,
+		GeneratedAt: now.Format(time.RFC3339),
+		RepoRoot:    absRepoRoot,
+		WorkflowDir: filepath.ToSlash(mustRelative(absRepoRoot, absWorkflowDir)),
+		Workflows:   make([]WorkflowInventory, 0, len(matches)),
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("get working dir: %w", err)
+	}
+	if err := os.Chdir(absRepoRoot); err != nil {
+		return nil, fmt.Errorf("chdir repo root: %w", err)
+	}
+	defer func() {
+		_ = os.Chdir(originalWD)
+	}()
+
+	for _, workflowPath := range matches {
+		wf, err := workflowpkg.Load(workflowPath)
+		if err != nil {
+			return nil, fmt.Errorf("inventory workflow %s: %w", filepath.Base(workflowPath), err)
+		}
+		item := WorkflowInventory{
+			Name:        wf.Name,
+			Path:        filepath.ToSlash(mustRelative(absRepoRoot, workflowPath)),
+			Description: wf.Description,
+			Class:       string(wf.Class),
+			Phases:      make([]PhaseInventory, 0, len(wf.Phases)),
+		}
+		for _, phase := range wf.Phases {
+			item.Phases = append(item.Phases, buildPhaseInventory(absRepoRoot, workflowPath, wf.Name, phase))
+		}
+		inventory.Workflows = append(inventory.Workflows, item)
+	}
+
+	return inventory, nil
+}
+
+func ScoreInventory(inventory *Inventory, stateDir string, now time.Time) (*ScoreReport, error) {
+	if inventory == nil {
+		return nil, fmt.Errorf("inventory is required")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+	windowStart := now.Add(-historyWindow)
+	absStateDir, err := resolveStateDir(inventory.RepoRoot, stateDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve state dir: %w", err)
+	}
+
+	runs, _, warnings, err := review.LoadRuns(absStateDir, 0)
+	if err != nil {
+		return nil, fmt.Errorf("load run history: %w", err)
+	}
+	failures := countPhaseFailures(runs, windowStart, now)
+
+	report := &ScoreReport{
+		Version:       ScoreVersion,
+		GeneratedAt:   now.Format(time.RFC3339),
+		RepoRoot:      inventory.RepoRoot,
+		WindowStart:   windowStart.Format(time.RFC3339),
+		WindowEnd:     now.Format(time.RFC3339),
+		Candidates:    []CandidateScore{},
+		TopCandidates: []CandidateScore{},
+		Warnings:      append([]string(nil), warnings...),
+	}
+
+	for _, workflowItem := range inventory.Workflows {
+		for _, phase := range workflowItem.Phases {
+			if phase.Classification == ClassificationDeterministic {
+				continue
+			}
+			candidate := scorePhase(phase, failures[phase.ID])
+			report.Candidates = append(report.Candidates, candidate)
+		}
+	}
+	sort.Slice(report.Candidates, func(i, j int) bool {
+		if report.Candidates[i].Score != report.Candidates[j].Score {
+			return report.Candidates[i].Score > report.Candidates[j].Score
+		}
+		if report.Candidates[i].Criteria.FailureCount30d != report.Candidates[j].Criteria.FailureCount30d {
+			return report.Candidates[i].Criteria.FailureCount30d > report.Candidates[j].Criteria.FailureCount30d
+		}
+		if report.Candidates[i].Criteria.HardRuleCount != report.Candidates[j].Criteria.HardRuleCount {
+			return report.Candidates[i].Criteria.HardRuleCount > report.Candidates[j].Criteria.HardRuleCount
+		}
+		return report.Candidates[i].ID < report.Candidates[j].ID
+	})
+
+	topCount := min(3, len(report.Candidates))
+	report.TopCandidates = append(report.TopCandidates, report.Candidates[:topCount]...)
+	return report, nil
+}
+
+func LoadInventory(path string) (*Inventory, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read inventory %q: %w", path, err)
+	}
+	var inventory Inventory
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		return nil, fmt.Errorf("parse inventory %q: %w", path, err)
+	}
+	return &inventory, nil
+}
+
+func LoadProposals(path string) ([]Proposal, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read proposals %q: %w", path, err)
+	}
+	var proposals []Proposal
+	if err := json.Unmarshal(data, &proposals); err != nil {
+		return nil, fmt.Errorf("parse proposals %q: %w", path, err)
+	}
+	seen := make(map[string]struct{}, len(proposals))
+	for i := range proposals {
+		if err := validateProposal(proposals[i]); err != nil {
+			return nil, fmt.Errorf("proposals[%d]: %w", i, err)
+		}
+		if _, ok := seen[proposals[i].Title]; ok {
+			return nil, fmt.Errorf("duplicate proposal title %q", proposals[i].Title)
+		}
+		seen[proposals[i].Title] = struct{}{}
+	}
+	return proposals, nil
+}
+
+func WriteJSON(path string, value any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create parent dir for %q: %w", path, err)
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal json for %q: %w", path, err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write json %q: %w", path, err)
+	}
+	return nil
+}
+
+func FileIssues(ctx context.Context, runner CommandRunner, repo string, proposals []Proposal, labels []string) (*FileResult, error) {
+	if runner == nil {
+		return nil, fmt.Errorf("runner is required")
+	}
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return nil, fmt.Errorf("repo is required")
+	}
+	if len(labels) == 0 {
+		labels = []string{"enhancement", "ready-for-work"}
+	}
+	openIssues, err := loadOpenIssues(ctx, runner, repo, defaultIssueLabel)
+	if err != nil {
+		return nil, err
+	}
+	result := &FileResult{}
+	for _, proposal := range proposals {
+		if existing, ok := openIssues[proposal.Title]; ok {
+			result.Existing = append(result.Existing, FiledIssue{
+				PhaseID: proposal.PhaseID,
+				Title:   proposal.Title,
+				Number:  existing.Number,
+				URL:     existing.URL,
+				Created: false,
+			})
+			continue
+		}
+		args := []string{"issue", "create", "--repo", repo, "--title", proposal.Title, "--body", proposal.Body}
+		for _, label := range labels {
+			args = append(args, "--label", label)
+		}
+		out, err := runner.RunOutput(ctx, "gh", args...)
+		if err != nil {
+			return nil, fmt.Errorf("create issue %q: %w", proposal.Title, err)
+		}
+		rawURL := strings.TrimSpace(string(out))
+		number, err := issueNumberFromURL(rawURL)
+		if err != nil {
+			return nil, fmt.Errorf("parse created issue url %q: %w", rawURL, err)
+		}
+		result.Created = append(result.Created, FiledIssue{
+			PhaseID: proposal.PhaseID,
+			Title:   proposal.Title,
+			Number:  number,
+			URL:     rawURL,
+			Created: true,
+		})
+		openIssues[proposal.Title] = issueSummary{Number: number, Title: proposal.Title, URL: rawURL}
+	}
+	return result, nil
+}
+
+func AppendLedger(repoRoot, ledgerPath string, proposals []Proposal, filed *FileResult, now time.Time) error {
+	absRepoRoot, err := resolveRepoRoot(repoRoot)
+	if err != nil {
+		return err
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+	if strings.TrimSpace(ledgerPath) == "" {
+		ledgerPath = DefaultLedgerPath
+	}
+	absLedgerPath, err := resolveWithinRoot(absRepoRoot, ledgerPath)
+	if err != nil {
+		return fmt.Errorf("resolve ledger path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(absLedgerPath), 0o755); err != nil {
+		return fmt.Errorf("create ledger dir: %w", err)
+	}
+
+	var existing strings.Builder
+	if data, err := os.ReadFile(absLedgerPath); err == nil {
+		existing.Write(data)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read ledger: %w", err)
+	} else {
+		existing.WriteString("# Hardening Ledger\n\n")
+		existing.WriteString("This file records scheduled hardening-audit runs and the workflow phases they proposed to harden.\n")
+	}
+
+	if !strings.HasSuffix(existing.String(), "\n") {
+		existing.WriteString("\n")
+	}
+	existing.WriteString("\n")
+	existing.WriteString(fmt.Sprintf("## %s\n\n", now.Format(time.RFC3339)))
+
+	if len(proposals) == 0 {
+		existing.WriteString("- No fuzzy or mixed phases were promoted to issue proposals in this run.\n")
+	} else {
+		statusByTitle := make(map[string]FiledIssue, len(proposals))
+		if filed != nil {
+			for _, item := range filed.Created {
+				statusByTitle[item.Title] = item
+			}
+			for _, item := range filed.Existing {
+				statusByTitle[item.Title] = item
+			}
+		}
+		for _, proposal := range proposals {
+			status := "recorded"
+			if item, ok := statusByTitle[proposal.Title]; ok {
+				switch {
+				case item.Created:
+					status = fmt.Sprintf("opened issue #%d", item.Number)
+				case item.Number > 0:
+					status = fmt.Sprintf("matched existing issue #%d", item.Number)
+				}
+			}
+			existing.WriteString(fmt.Sprintf("- `%s` — %s\n", proposal.PhaseID, status))
+			existing.WriteString(fmt.Sprintf("  - Proposed CLI: `%s`\n", strings.TrimSpace(proposal.CLISignature)))
+			existing.WriteString(fmt.Sprintf("  - Package: `%s`\n", strings.TrimSpace(proposal.PackageLocation)))
+			existing.WriteString(fmt.Sprintf("  - Estimated complexity: `%s`\n", strings.TrimSpace(proposal.EstimatedComplexity)))
+			for _, testCase := range proposal.TestCases {
+				existing.WriteString(fmt.Sprintf("  - Test case: %s\n", strings.TrimSpace(testCase)))
+			}
+		}
+	}
+
+	if err := os.WriteFile(absLedgerPath, []byte(existing.String()), 0o644); err != nil {
+		return fmt.Errorf("write ledger: %w", err)
+	}
+	return nil
+}
+
+func buildPhaseInventory(repoRoot, workflowPath, workflowName string, phase workflowpkg.Phase) PhaseInventory {
+	phaseType := strings.TrimSpace(phase.Type)
+	if phaseType == "" {
+		phaseType = "prompt"
+	}
+	item := PhaseInventory{
+		ID:           workflowName + "/" + phase.Name,
+		DisplayName:  workflowName + "/" + phase.Name,
+		Workflow:     workflowName,
+		WorkflowPath: filepath.ToSlash(mustRelative(repoRoot, workflowPath)),
+		Phase:        phase.Name,
+		Type:         phaseType,
+	}
+	if phaseType == "command" {
+		item.Classification = ClassificationDeterministic
+		item.DeterministicSignals = []string{"command-phase"}
+		return item
+	}
+
+	promptPath := strings.TrimSpace(phase.PromptFile)
+	item.PromptPath = filepath.ToSlash(promptPath)
+	content := readPrompt(repoRoot, promptPath)
+	item.PromptExcerpt = promptExcerpt(content)
+	item.PromptLines = lineCount(content)
+	item.StructuredSignals = detectMarkers(content, structuredOutputMarkers)
+	item.PatternSignals = detectMarkers(content, patternMatchingMarkers)
+	item.HardRuleCount = countHardRules(content)
+
+	switch {
+	case len(item.StructuredSignals) > 0 || len(item.PatternSignals) > 0 || item.HardRuleCount >= 3:
+		item.Classification = ClassificationMixed
+	default:
+		item.Classification = ClassificationFuzzy
+	}
+	return item
+}
+
+func scorePhase(phase PhaseInventory, failureCount int) CandidateScore {
+	criteria := ScoreCriteria{
+		StructuredOutput:      len(phase.StructuredSignals) > 0,
+		PatternMatching:       len(phase.PatternSignals) > 0,
+		FailureCount30d:       failureCount,
+		HardRuleCount:         phase.HardRuleCount,
+		GoReplacementFeasible: phase.PromptLines > 0 && phase.PromptLines <= 100 && (len(phase.StructuredSignals) > 0 || len(phase.PatternSignals) > 0 || phase.HardRuleCount >= 3),
+	}
+
+	score := 0
+	reasons := make([]string, 0, 6)
+	if criteria.StructuredOutput {
+		score += 3
+		reasons = append(reasons, "phase already emits or requests structured output that could be schema-validated")
+	}
+	if criteria.PatternMatching {
+		score += 2
+		reasons = append(reasons, "prompt mostly reads labels, git state, or file patterns that map well to deterministic CLI logic")
+	}
+	if criteria.FailureCount30d >= 2 {
+		score += 3 + min(2, criteria.FailureCount30d-2)
+		reasons = append(reasons, fmt.Sprintf("phase failed %d times in the last 30 days", criteria.FailureCount30d))
+	}
+	if criteria.HardRuleCount >= 3 {
+		score += 2
+		reasons = append(reasons, fmt.Sprintf("prompt already encodes %d explicit rules or branches", criteria.HardRuleCount))
+	} else if criteria.HardRuleCount > 0 {
+		score++
+		reasons = append(reasons, fmt.Sprintf("prompt already encodes %d explicit rules or branches", criteria.HardRuleCount))
+	}
+	if criteria.GoReplacementFeasible {
+		score += 2
+		reasons = append(reasons, "scope looks small enough for a focused Go helper")
+	}
+	if phase.Classification == ClassificationMixed {
+		score++
+		reasons = append(reasons, "phase is mixed rather than purely fuzzy, so it is already close to deterministic")
+	}
+
+	return CandidateScore{
+		ID:             phase.ID,
+		DisplayName:    phase.DisplayName,
+		Workflow:       phase.Workflow,
+		WorkflowPath:   phase.WorkflowPath,
+		Phase:          phase.Phase,
+		Type:           phase.Type,
+		PromptPath:     phase.PromptPath,
+		PromptExcerpt:  phase.PromptExcerpt,
+		Classification: phase.Classification,
+		Score:          score,
+		Criteria:       criteria,
+		Reasons:        reasons,
+	}
+}
+
+func countPhaseFailures(runs []review.LoadedRun, windowStart, windowEnd time.Time) map[string]int {
+	counts := make(map[string]int)
+	for _, run := range runs {
+		endedAt := run.Summary.EndedAt.UTC()
+		if endedAt.Before(windowStart) || endedAt.After(windowEnd) {
+			continue
+		}
+		for _, phase := range run.Summary.Phases {
+			if phase.Status != "failed" {
+				continue
+			}
+			counts[run.Summary.Workflow+"/"+phase.Name]++
+		}
+	}
+	return counts
+}
+
+func readPrompt(repoRoot, promptPath string) string {
+	if strings.TrimSpace(promptPath) == "" {
+		return ""
+	}
+	absPath := promptPath
+	if !filepath.IsAbs(absPath) {
+		absPath = filepath.Join(repoRoot, filepath.FromSlash(promptPath))
+	}
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func promptExcerpt(content string) string {
+	lines := strings.Split(strings.TrimSpace(content), "\n")
+	trimmed := make([]string, 0, min(12, len(lines)))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		trimmed = append(trimmed, line)
+		if len(trimmed) == 12 {
+			break
+		}
+	}
+	excerpt := strings.Join(trimmed, "\n")
+	if len(excerpt) > 900 {
+		excerpt = excerpt[:900] + "..."
+	}
+	return excerpt
+}
+
+func lineCount(content string) int {
+	if strings.TrimSpace(content) == "" {
+		return 0
+	}
+	return strings.Count(content, "\n") + 1
+}
+
+func detectMarkers(content string, markers []string) []string {
+	content = strings.ToLower(content)
+	var hits []string
+	for _, marker := range markers {
+		if strings.Contains(content, marker) {
+			hits = append(hits, marker)
+		}
+	}
+	return hits
+}
+
+func countHardRules(content string) int {
+	count := 0
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if hardRulePattern.MatchString(line) {
+			count++
+		}
+	}
+	return count
+}
+
+func validateProposal(proposal Proposal) error {
+	if strings.TrimSpace(proposal.PhaseID) == "" {
+		return fmt.Errorf("phase_id is required")
+	}
+	if strings.TrimSpace(proposal.Title) == "" {
+		return fmt.Errorf("title is required")
+	}
+	if !strings.HasPrefix(strings.TrimSpace(proposal.Title), defaultIssueLabel+" ") {
+		return fmt.Errorf("title must start with %q", defaultIssueLabel+" ")
+	}
+	if strings.TrimSpace(proposal.Body) == "" {
+		return fmt.Errorf("body is required")
+	}
+	if strings.TrimSpace(proposal.CLISignature) == "" {
+		return fmt.Errorf("cli_signature is required")
+	}
+	if strings.TrimSpace(proposal.PackageLocation) == "" {
+		return fmt.Errorf("package_location is required")
+	}
+	if strings.TrimSpace(proposal.EstimatedComplexity) == "" {
+		return fmt.Errorf("estimated_complexity is required")
+	}
+	if len(proposal.TestCases) == 0 {
+		return fmt.Errorf("test_cases must not be empty")
+	}
+	return nil
+}
+
+func loadOpenIssues(ctx context.Context, runner CommandRunner, repo, search string) (map[string]issueSummary, error) {
+	args := []string{"search", "issues", "--repo", repo, "--state", "open", "--json", "number,title,url", "--limit", "100"}
+	if strings.TrimSpace(search) != "" {
+		args = append(args, "--search", search)
+	}
+	out, err := runner.RunOutput(ctx, "gh", args...)
+	if err != nil {
+		return nil, fmt.Errorf("search open issues in %s: %w", repo, err)
+	}
+	var issues []issueSummary
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return nil, fmt.Errorf("parse issue search output: %w", err)
+	}
+	index := make(map[string]issueSummary, len(issues))
+	for _, item := range issues {
+		index[item.Title] = item
+	}
+	return index, nil
+}
+
+func issueNumberFromURL(raw string) (int, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, err
+	}
+	number, err := strconv.Atoi(path.Base(parsed.Path))
+	if err != nil {
+		return 0, err
+	}
+	return number, nil
+}
+
+func resolveRepoRoot(repoRoot string) (string, error) {
+	if strings.TrimSpace(repoRoot) == "" {
+		repoRoot = "."
+	}
+	absPath, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve repo root %q: %w", repoRoot, err)
+	}
+	return absPath, nil
+}
+
+func resolveStateDir(repoRoot, stateDir string) (string, error) {
+	if strings.TrimSpace(stateDir) == "" {
+		stateDir = ".xylem"
+	}
+	return resolveWithinRoot(repoRoot, stateDir)
+}
+
+func resolveWithinRoot(repoRoot, target string) (string, error) {
+	if strings.TrimSpace(target) == "" {
+		return repoRoot, nil
+	}
+	absTarget := target
+	if !filepath.IsAbs(absTarget) {
+		absTarget = filepath.Join(repoRoot, filepath.FromSlash(target))
+	}
+	absTarget = filepath.Clean(absTarget)
+	rel, err := filepath.Rel(repoRoot, absTarget)
+	if err != nil {
+		return "", fmt.Errorf("rel path: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q escapes repo root %q", target, repoRoot)
+	}
+	return absTarget, nil
+}
+
+func mustRelative(base, target string) string {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return target
+	}
+	return rel
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cli/internal/hardening/hardening_test.go
+++ b/cli/internal/hardening/hardening_test.go
@@ -1,0 +1,223 @@
+package hardening
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRunner struct {
+	calls   [][]string
+	outputs map[string][]byte
+}
+
+func (m *mockRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	m.calls = append(m.calls, call)
+	if m.outputs == nil {
+		return nil, nil
+	}
+	return m.outputs[strings.Join(call, " ")], nil
+}
+
+func TestGenerateInventoryClassifiesPromptAndCommandPhases(t *testing.T) {
+	repoRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".xylem", "workflows"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".xylem", "prompts", "hardening-audit"), 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".xylem", "prompts", "hardening-audit", "rank.md"), []byte(
+		"Read `.xylem/state/hardening-audit/scores.json` and write exactly one JSON file.\nIf the score is low, otherwise explain why.\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".xylem", "prompts", "hardening-audit", "review.md"), []byte(
+		"Review the repository and explain whether the maintenance direction still feels right.\n"), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".xylem", "workflows", "hardening-audit.yaml"), []byte(`
+name: hardening-audit
+class: harness-maintenance
+phases:
+  - name: inventory
+    type: command
+    run: echo inventory
+  - name: rank
+    prompt_file: .xylem/prompts/hardening-audit/rank.md
+    max_turns: 20
+  - name: review
+    prompt_file: .xylem/prompts/hardening-audit/review.md
+    max_turns: 20
+`), 0o644))
+
+	inventory, err := GenerateInventory(repoRoot, ".xylem/workflows", time.Date(2026, time.April, 10, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.Len(t, inventory.Workflows, 1)
+	require.Len(t, inventory.Workflows[0].Phases, 3)
+
+	commandPhase := inventory.Workflows[0].Phases[0]
+	assert.Equal(t, ClassificationDeterministic, commandPhase.Classification)
+
+	mixedPhase := inventory.Workflows[0].Phases[1]
+	assert.Equal(t, ClassificationMixed, mixedPhase.Classification)
+	assert.NotEmpty(t, mixedPhase.StructuredSignals)
+	assert.NotZero(t, mixedPhase.HardRuleCount)
+
+	fuzzyPhase := inventory.Workflows[0].Phases[2]
+	assert.Equal(t, ClassificationFuzzy, fuzzyPhase.Classification)
+	assert.Empty(t, fuzzyPhase.StructuredSignals)
+	assert.Empty(t, fuzzyPhase.PatternSignals)
+}
+
+func TestGenerateInventoryFailsWhenWorkflowValidationFails(t *testing.T) {
+	repoRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".xylem", "workflows"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".xylem", "workflows", "broken.yaml"), []byte(`
+name: broken
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/missing.md
+    max_turns: 20
+`), 0o644))
+
+	_, err := GenerateInventory(repoRoot, ".xylem/workflows", time.Time{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prompt_file not found")
+}
+
+func TestScoreInventoryUsesRecentFailuresAndRanksTopCandidates(t *testing.T) {
+	repoRoot := t.TempDir()
+	stateDir := filepath.Join(repoRoot, ".xylem")
+	require.NoError(t, os.MkdirAll(filepath.Join(stateDir, "phases", "issue-1"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(stateDir, "phases", "issue-2"), 0o755))
+
+	writeSummary := func(vesselID string, endedAt time.Time) {
+		t.Helper()
+		summary := &runner.VesselSummary{
+			VesselID:   vesselID,
+			Workflow:   "hardening-audit",
+			State:      "failed",
+			StartedAt:  endedAt.Add(-5 * time.Minute),
+			EndedAt:    endedAt,
+			DurationMS: 300000,
+			Phases: []runner.PhaseSummary{
+				{Name: "rank", Type: "prompt", Status: "failed"},
+			},
+		}
+		require.NoError(t, runner.SaveVesselSummary(stateDir, summary))
+	}
+	writeSummary("issue-1", time.Date(2026, time.April, 1, 10, 0, 0, 0, time.UTC))
+	writeSummary("issue-2", time.Date(2026, time.April, 7, 10, 0, 0, 0, time.UTC))
+
+	inventory := &Inventory{
+		Version:     InventoryVersion,
+		GeneratedAt: "2026-04-10T00:00:00Z",
+		RepoRoot:    repoRoot,
+		WorkflowDir: ".xylem/workflows",
+		Workflows: []WorkflowInventory{{
+			Name: "hardening-audit",
+			Path: ".xylem/workflows/hardening-audit.yaml",
+			Phases: []PhaseInventory{
+				{
+					ID:             "hardening-audit/rank",
+					DisplayName:    "hardening-audit/rank",
+					Workflow:       "hardening-audit",
+					WorkflowPath:   ".xylem/workflows/hardening-audit.yaml",
+					Phase:          "rank",
+					Type:           "prompt",
+					PromptPath:     ".xylem/prompts/hardening-audit/rank.md",
+					PromptExcerpt:  "Write exactly one JSON file and inspect git labels.",
+					PromptLines:    12,
+					Classification: ClassificationMixed,
+					StructuredSignals: []string{
+						"json",
+					},
+					PatternSignals: []string{
+						"label",
+						"git",
+					},
+					HardRuleCount: 4,
+				},
+				{
+					ID:             "hardening-audit/review",
+					DisplayName:    "hardening-audit/review",
+					Workflow:       "hardening-audit",
+					WorkflowPath:   ".xylem/workflows/hardening-audit.yaml",
+					Phase:          "review",
+					Type:           "prompt",
+					PromptPath:     ".xylem/prompts/hardening-audit/review.md",
+					PromptExcerpt:  "Review overall quality.",
+					PromptLines:    20,
+					Classification: ClassificationFuzzy,
+				},
+			},
+		}},
+	}
+
+	report, err := ScoreInventory(inventory, ".xylem", time.Date(2026, time.April, 10, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.Len(t, report.Candidates, 2)
+	require.NotEmpty(t, report.TopCandidates)
+	assert.Equal(t, "hardening-audit/rank", report.TopCandidates[0].ID)
+	assert.Equal(t, 2, report.TopCandidates[0].Criteria.FailureCount30d)
+	assert.True(t, report.TopCandidates[0].Criteria.GoReplacementFeasible)
+	assert.Greater(t, report.TopCandidates[0].Score, report.Candidates[1].Score)
+}
+
+func TestFileIssuesCreatesAndDedupes(t *testing.T) {
+	searchOut, err := json.Marshal([]issueSummary{{
+		Number: 7,
+		Title:  "[harden] hardening-audit/review",
+		URL:    "https://github.com/owner/repo/issues/7",
+	}})
+	require.NoError(t, err)
+
+	runner := &mockRunner{
+		outputs: map[string][]byte{
+			"gh search issues --repo owner/repo --state open --json number,title,url --limit 100 --search [harden]":                          searchOut,
+			"gh issue create --repo owner/repo --title [harden] hardening-audit/rank --body body --label enhancement --label ready-for-work": []byte("https://github.com/owner/repo/issues/9\n"),
+		},
+	}
+
+	result, err := FileIssues(context.Background(), runner, "owner/repo", []Proposal{
+		{PhaseID: "hardening-audit/rank", Title: "[harden] hardening-audit/rank", Body: "body", CLISignature: "xylem harden score", PackageLocation: "cli/internal/hardening", EstimatedComplexity: "medium", TestCases: []string{"writes scores"}},
+		{PhaseID: "hardening-audit/review", Title: "[harden] hardening-audit/review", Body: "body", CLISignature: "xylem harden inventory", PackageLocation: "cli/internal/hardening", EstimatedComplexity: "small", TestCases: []string{"writes inventory"}},
+	}, []string{"enhancement", "ready-for-work"})
+	require.NoError(t, err)
+
+	require.Len(t, result.Created, 1)
+	assert.Equal(t, 9, result.Created[0].Number)
+	require.Len(t, result.Existing, 1)
+	assert.Equal(t, 7, result.Existing[0].Number)
+}
+
+func TestAppendLedgerCreatesMarkdownHistory(t *testing.T) {
+	repoRoot := t.TempDir()
+	err := AppendLedger(repoRoot, DefaultLedgerPath, []Proposal{{
+		PhaseID:             "hardening-audit/rank",
+		Title:               "[harden] hardening-audit/rank",
+		CLISignature:        "xylem harden score",
+		PackageLocation:     "cli/internal/hardening",
+		EstimatedComplexity: "medium",
+		TestCases:           []string{"writes scores.json", "counts recent failures"},
+	}}, &FileResult{
+		Created: []FiledIssue{{
+			PhaseID: "hardening-audit/rank",
+			Title:   "[harden] hardening-audit/rank",
+			Number:  42,
+			URL:     "https://github.com/owner/repo/issues/42",
+			Created: true,
+		}},
+	}, time.Date(2026, time.April, 10, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(repoRoot, DefaultLedgerPath))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "# Hardening Ledger")
+	assert.Contains(t, string(data), "2026-04-10T00:00:00Z")
+	assert.Contains(t, string(data), "opened issue #42")
+	assert.Contains(t, string(data), "xylem harden score")
+}

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -127,6 +127,7 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, sortedKeys(composed.Workflows), "implement-harness")
+	assert.Contains(t, sortedKeys(composed.Workflows), "hardening-audit")
 	assert.Contains(t, sortedKeys(composed.Workflows), "continuous-improvement")
 	assert.Contains(t, sortedKeys(composed.Workflows), "continuous-simplicity")
 	assert.Contains(t, sortedKeys(composed.Workflows), "sota-gap-analysis")
@@ -136,10 +137,12 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	assert.Contains(t, sortedKeys(composed.Workflows), "ingest-field-reports")
 	assert.Contains(t, sortedKeys(composed.Prompts), "implement-harness/pr_draft")
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/verify")
+	assert.Contains(t, sortedKeys(composed.Prompts), "hardening-audit/rank")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-impl")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-pr-lifecycle")
 	assert.Contains(t, sortedKeys(composed.Sources), "continuous-improvement")
 	assert.Contains(t, sortedKeys(composed.Sources), "continuous-simplicity")
+	assert.Contains(t, sortedKeys(composed.Sources), "hardening-audit")
 	assert.Contains(t, sortedKeys(composed.Sources), "sota-gap")
 	assert.Contains(t, sortedKeys(composed.Sources), "initiative-tracker")
 	assert.Contains(t, sortedKeys(composed.Sources), "ingest-field-reports")
@@ -188,6 +191,42 @@ func TestSmoke_S3_SelfHostingProfileScaffoldsContinuousImprovementScheduledWorkf
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/plan")
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/implement")
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/verify")
+}
+
+func TestSmoke_S4_SelfHostingProfileScaffoldsMonthlyHardeningAuditWorkflow(t *testing.T) {
+	t.Parallel()
+
+	composed, err := Compose("core", "self-hosting-xylem")
+	require.NoError(t, err)
+
+	var source config.SourceConfig
+	require.NoError(t, yaml.Unmarshal(composed.Sources["hardening-audit"], &source))
+	assert.Equal(t, "scheduled", source.Type)
+	assert.Equal(t, "{{ .Repo }}", source.Repo)
+	assert.Equal(t, "@monthly", source.Schedule)
+	require.Contains(t, source.Tasks, "monthly-hardening-audit")
+	assert.Equal(t, "hardening-audit", source.Tasks["monthly-hardening-audit"].Workflow)
+	assert.Equal(t, "hardening-audit", source.Tasks["monthly-hardening-audit"].Ref)
+
+	var wf workflowpkg.Workflow
+	require.NoError(t, yaml.Unmarshal(composed.Workflows["hardening-audit"], &wf))
+	assert.Equal(t, "hardening-audit", wf.Name)
+	assert.Equal(t, workflowpkg.ClassHarnessMaintenance, wf.Class)
+	require.Len(t, wf.Phases, 5)
+	assert.Equal(t, "inventory", wf.Phases[0].Name)
+	assert.Equal(t, "command", wf.Phases[0].Type)
+	assert.Contains(t, wf.Phases[0].Run, "harden inventory")
+	assert.Equal(t, "evaluate", wf.Phases[1].Name)
+	assert.Equal(t, "command", wf.Phases[1].Type)
+	assert.Contains(t, wf.Phases[1].Run, "harden score")
+	assert.Equal(t, ".xylem/prompts/hardening-audit/rank.md", wf.Phases[2].PromptFile)
+	assert.Equal(t, "file_issues", wf.Phases[3].Name)
+	assert.Equal(t, "command", wf.Phases[3].Type)
+	assert.Contains(t, wf.Phases[3].Run, "harden file-issues")
+	assert.Equal(t, "track", wf.Phases[4].Name)
+	assert.Contains(t, wf.Phases[4].Run, "docs/hardening-ledger.md")
+
+	assert.Contains(t, sortedKeys(composed.Prompts), "hardening-audit/rank")
 }
 
 func TestAdaptRepoWorkflowAssetParsesCleanly(t *testing.T) {

--- a/cli/internal/profiles/self-hosting-xylem/prompts/hardening-audit/rank.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/hardening-audit/rank.md
@@ -1,0 +1,46 @@
+Use the deterministic hardening inventory and score report to draft up to three hardening issue proposals.
+
+Read these files:
+
+1. `.xylem/state/hardening-audit/inventory.json`
+2. `.xylem/state/hardening-audit/scores.json`
+
+Focus on `top_candidates` from `scores.json`. For each candidate you keep:
+
+1. Read the current prompt file referenced by `prompt_path`.
+2. Decide whether the phase should be hardened now.
+3. Draft a stable workflow-qualified issue title so unrelated `analyze` or `implement` phases do not dedupe into one bucket.
+
+Write `.xylem/state/hardening-audit/proposals.json` as a JSON array with at most 3 objects shaped like:
+
+```json
+[
+  {
+    "phase_id": "hardening-audit/rank",
+    "workflow": "hardening-audit",
+    "phase": "rank",
+    "title": "[harden] hardening-audit/rank",
+    "body": "## Why harden now\n...\n\n## Current prompt excerpt\n```text\n...\n```\n\n## Proposed CLI signature\n`xylem harden ...`\n\n## Suggested package location\n`cli/internal/...`\n\n## Estimated complexity\nmedium\n\n## Test cases\n1. ...\n2. ...",
+    "cli_signature": "xylem harden ...",
+    "package_location": "cli/internal/...",
+    "estimated_complexity": "small|medium|large",
+    "test_cases": ["...", "..."],
+    "score": 9
+  }
+]
+```
+
+Requirements:
+
+1. Keep the proposal count at 3 or fewer.
+2. Every title must begin with `[harden] `.
+3. Every body must include:
+   - the current prompt excerpt
+   - a proposed CLI signature
+   - a suggested Go package location
+   - an estimated complexity
+   - concrete tests the deterministic CLI must pass
+4. Prefer proposals whose score clearly beats the rest of the field.
+5. If nothing should be filed this month, write `[]` to the proposals file instead of using `XYLEM_NOOP`.
+
+After writing the file, print a short summary listing the chosen `phase_id` values and titles.

--- a/cli/internal/profiles/self-hosting-xylem/workflows/hardening-audit.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/hardening-audit.yaml
@@ -1,0 +1,44 @@
+name: hardening-audit
+class: harness-maintenance
+description: "Monthly audit that identifies fuzzy workflow phases ready to harden into deterministic CLI tools"
+phases:
+  - name: inventory
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem --config ../.xylem.yml harden inventory \
+        --repo-root .. \
+        --workflow-dir ../.xylem/workflows \
+        --output ../.xylem/state/hardening-audit/inventory.json
+  - name: evaluate
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem --config ../.xylem.yml harden score \
+        --repo-root .. \
+        --inventory ../.xylem/state/hardening-audit/inventory.json \
+        --state-dir ../.xylem \
+        --output ../.xylem/state/hardening-audit/scores.json
+  - name: rank
+    prompt_file: .xylem/prompts/hardening-audit/rank.md
+    max_turns: 40
+  - name: file_issues
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem --config ../.xylem.yml harden file-issues \
+        --proposals ../.xylem/state/hardening-audit/proposals.json \
+        --output ../.xylem/state/hardening-audit/filed-issues.json
+  - name: track
+    type: command
+    run: |
+      set -euo pipefail
+      cd cli
+      go run ./cmd/xylem --config ../.xylem.yml harden track \
+        --repo-root .. \
+        --proposals ../.xylem/state/hardening-audit/proposals.json \
+        --filed ../.xylem/state/hardening-audit/filed-issues.json \
+        --ledger docs/hardening-ledger.md

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -59,6 +59,15 @@ sources:
       weekly-self-gap-analysis:
         workflow: sota-gap-analysis
         ref: sota-gap-analysis
+  hardening-audit:
+    type: scheduled
+    repo: "{{ .Repo }}"
+    schedule: "@monthly"
+    timeout: "90m"
+    tasks:
+      monthly-hardening-audit:
+        workflow: hardening-audit
+        ref: hardening-audit
   continuous-simplicity:
     type: scheduled
     repo: "{{ .Repo }}"

--- a/cli/internal/source/scheduled.go
+++ b/cli/internal/source/scheduled.go
@@ -155,6 +155,8 @@ func parseSchedule(value string) (time.Duration, error) {
 		return 24 * time.Hour, nil
 	case "@weekly":
 		return 7 * 24 * time.Hour, nil
+	case "@monthly":
+		return 30 * 24 * time.Hour, nil
 	}
 
 	interval, err := time.ParseDuration(value)

--- a/cli/internal/source/scheduled_test.go
+++ b/cli/internal/source/scheduled_test.go
@@ -60,6 +60,14 @@ func TestParseSchedule(t *testing.T) {
 	if got != 7*24*time.Hour {
 		t.Fatalf("parseSchedule(@weekly) = %s, want 168h", got)
 	}
+
+	got, err = parseSchedule("@monthly")
+	if err != nil {
+		t.Fatalf("parseSchedule(@monthly) error = %v", err)
+	}
+	if got != 30*24*time.Hour {
+		t.Fatalf("parseSchedule(@monthly) = %s, want 720h", got)
+	}
 }
 
 func TestScheduleWindow(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `xylem harden` inventory, score, file-issues, and track commands backed by `cli/internal/hardening`
- scaffold the self-hosting monthly `hardening-audit` workflow and prompt assets, including `@monthly` schedule support
- cover the new wiring with command, config, profile, and scheduled-source tests

Closes #155
Issue: https://github.com/nicholls-inc/xylem/issues/155