### PR TITLE
Add scheduled backlog refinement workflow

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -151,6 +151,16 @@ sources:
         workflow: continuous-improvement
         ref: continuous-improvement
 
+  backlog-refinement:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "@daily"
+    timeout: "60m"
+    tasks:
+      daily-backlog-refinement:
+        workflow: backlog-refinement
+        ref: backlog-refinement
+
   harness-gap-analysis:
     type: scheduled
     repo: nicholls-inc/xylem
@@ -191,7 +201,10 @@ daemon:
   auto_merge_branch_pattern: "^(feat|fix|chore)/issue-\\d+"
   auto_merge_reviewer: "copilot-pull-request-reviewer"
 
-concurrency: 3
+concurrency:
+  global: 3
+  per_class:
+    backlog-refinement: 1
 max_turns: 80
 timeout: "45m"
 state_dir: ".xylem"

--- a/.xylem/prompts/backlog-refinement/analyze.md
+++ b/.xylem/prompts/backlog-refinement/analyze.md
@@ -1,0 +1,155 @@
+Review the xylem GitHub backlog and prepare a conservative issue-hygiene action plan.
+
+## Inputs
+
+Read these files first:
+
+1. `.xylem/state/backlog-refinement/open-issues.json`
+2. `.xylem/state/backlog-refinement/merged-prs.json`
+3. `.xylem/state/backlog-refinement/labels.json`
+
+The open-issues snapshot is the primary backlog input. The merged-PR snapshot is there so you
+can detect open issues that appear to have been resolved by a merged pull request. The labels
+snapshot tells you which labels already exist in the repository.
+
+## Goal
+
+Produce a **conservative** refinement pass that improves backlog hygiene without closing issues or
+removing labels.
+
+You may use `gh issue view <number> --repo nicholls-inc/xylem --json ...` for targeted follow-up
+checks when the snapshots are insufficient, especially to:
+
+- confirm whether dependency issues are still open
+- inspect issue comments before posting a new cross-reference
+- verify that a merged PR truly references an issue with a `closes` / `fixes` style keyword
+
+Keep follow-up API calls focused. Prefer the snapshots over re-querying the full backlog.
+
+## Allowed actions
+
+You may plan only these mutations:
+
+1. **Add labels** that already exist in the repository
+2. **Post comments** on issues
+
+Do **not** plan any of the following:
+
+- issue closure
+- label removal
+- body rewrites
+- milestone/assignee changes
+- creation of new repository labels
+
+## Heuristics
+
+Build a lightweight dependency view from issue bodies. Treat `Depends On`, `Blocked By`, and direct
+issue references as dependency signals when the meaning is clear.
+
+Plan actions only when confidence is high:
+
+1. **Ready for work**
+   - If an open issue is missing `ready-for-work`, and every dependency appears resolved, and the
+     issue description is concrete enough to act on, add `ready-for-work`.
+   - If the issue is still labeled `blocked`, do not remove that label. Add a comment explaining
+     that dependencies appear resolved and that a human should confirm the issue is ready.
+
+2. **Blocked labeling**
+   - If an issue clearly depends on an open issue and is missing `blocked`, add `blocked`.
+
+3. **Priority labels**
+   - If the repository already contains `priority-high`, `priority-medium`, or `priority-low`,
+     you may add **at most one** of them.
+   - Prefer `priority-high` only when the issue blocks multiple open issues or is clearly on the
+     critical path for active harness work.
+   - Prefer `priority-medium` for single-blocker issues with active downstream work.
+   - Prefer `priority-low` only when the signal is strong and additive value is clear.
+   - If those labels do not exist, record the priority insight in the summary instead of inventing
+     labels or creating substitute labels.
+
+4. **Merged-PR closure suggestions**
+   - If a merged PR clearly references an open issue with `closes #N`, `fixes #N`, or similar,
+     do not close the issue yourself.
+   - Post a comment on the issue that links the merged PR and recommends human review for closure.
+
+5. **Duplicate linking**
+   - Only act on duplicates when confidence is high.
+   - Add comments on both issues with cross-references and a short explanation of the overlap.
+   - Before planning the comment, inspect current issue comments and skip the action if the same
+     cross-link already exists.
+
+## Action budget
+
+Keep the run small and reviewable:
+
+- no more than **12** issue actions total
+- no more than **1** planned comment per issue unless duplicate cross-linking requires one on each side
+
+If there are more candidates, choose the highest-signal ones and list the remainder in the summary.
+
+## Output files
+
+Write both of these files:
+
+1. `.xylem/state/backlog-refinement/actions.json`
+2. `.xylem/state/backlog-refinement/summary.md`
+
+### `actions.json` contract
+
+Write valid JSON with this exact shape:
+
+```json
+{
+  "version": 1,
+  "generated_at": "RFC3339",
+  "actions": [
+    {
+      "issue_number": 123,
+      "kind": "ready-for-work|blocked|priority|closure-review|duplicate-link",
+      "reason": "one sentence",
+      "confidence": 0.0,
+      "add_labels": ["ready-for-work"],
+      "comment": "Markdown comment or empty string"
+    }
+  ]
+}
+```
+
+Rules:
+
+- `add_labels` must contain only labels that already exist and are not already on the issue
+- `comment` may be empty, but never null
+- `confidence` must be between `0` and `1`
+- if there are no safe actions, still write a valid file with `"actions": []`
+
+### `summary.md` contract
+
+Write concise markdown with these sections:
+
+```markdown
+# Backlog Refinement Summary
+
+## Snapshot
+- Open issues scanned: N
+- Merged PRs scanned: N
+- Planned actions: N
+
+## Planned actions
+- `#123` — add `ready-for-work` because ...
+
+## Priority insights
+- ...
+
+## Follow-up recommended
+- ...
+
+## Skipped for caution
+- ...
+```
+
+The summary should explain what was acted on, what was intentionally left alone, and any backlog
+items that look important but were too ambiguous for automation.
+
+After writing both files, print one line:
+
+`Backlog refinement plan written: .xylem/state/backlog-refinement/actions.json`

--- a/.xylem/prompts/backlog-refinement/report.md
+++ b/.xylem/prompts/backlog-refinement/report.md
@@ -1,0 +1,24 @@
+Read `.xylem/state/backlog-refinement/summary.md` and tighten it for human review.
+
+## Goal
+
+Produce a concise final summary that emphasizes:
+
+1. Which labels/comments were planned
+2. Which issues may be ready for work
+3. Which issues may be stale because a merged PR already references them
+4. Which ambiguous cases were intentionally skipped
+
+## Output
+
+Rewrite `.xylem/state/backlog-refinement/summary.md` in place if it needs cleanup. Keep the same
+section headings:
+
+- `# Backlog Refinement Summary`
+- `## Snapshot`
+- `## Planned actions`
+- `## Priority insights`
+- `## Follow-up recommended`
+- `## Skipped for caution`
+
+Do not introduce any new GitHub mutations in this phase.

--- a/.xylem/workflows/backlog-refinement.yaml
+++ b/.xylem/workflows/backlog-refinement.yaml
@@ -1,0 +1,87 @@
+name: backlog-refinement
+class: harness-maintenance
+description: "Daily GitHub backlog hygiene sweep for duplicate signals, dependency drift, and ready-for-work labeling"
+phases:
+  - name: collect
+    type: command
+    run: |
+      set -euo pipefail
+      STATE_DIR=".xylem/state/backlog-refinement"
+      mkdir -p "$STATE_DIR"
+
+      gh issue list --repo nicholls-inc/xylem \
+        --state open \
+        --limit 200 \
+        --json number,title,body,labels,updatedAt,url \
+        > "$STATE_DIR/open-issues.json"
+
+      gh pr list --repo nicholls-inc/xylem \
+        --state merged \
+        --limit 200 \
+        --json number,title,body,mergedAt,url \
+        > "$STATE_DIR/merged-prs.json"
+
+      gh api repos/nicholls-inc/xylem/labels?per_page=100 \
+        > "$STATE_DIR/labels.json"
+
+      ISSUE_COUNT=$(jq 'length' "$STATE_DIR/open-issues.json")
+      PR_COUNT=$(jq 'length' "$STATE_DIR/merged-prs.json")
+      echo "Collected ${ISSUE_COUNT} open issues and ${PR_COUNT} merged pull requests"
+      if [ "$ISSUE_COUNT" -eq 0 ]; then
+        echo "XYLEM_NOOP: no open issues to refine"
+      fi
+    noop:
+      match: XYLEM_NOOP
+  - name: analyze
+    prompt_file: .xylem/prompts/backlog-refinement/analyze.md
+    max_turns: 50
+  - name: report
+    prompt_file: .xylem/prompts/backlog-refinement/report.md
+    max_turns: 20
+  - name: apply_actions
+    type: command
+    run: |
+      set -euo pipefail
+      ACTIONS_FILE=".xylem/state/backlog-refinement/actions.json"
+      if [ ! -f "$ACTIONS_FILE" ]; then
+        echo "ERROR: analyze phase did not produce $ACTIONS_FILE"
+        exit 1
+      fi
+
+      ACTION_COUNT=$(jq '.actions | length' "$ACTIONS_FILE")
+      if [ "$ACTION_COUNT" -eq 0 ]; then
+        echo "No backlog refinement actions planned"
+        exit 0
+      fi
+
+      LABEL_EDITS=0
+      COMMENTS=0
+      while IFS= read -r action; do
+        ISSUE_NUMBER=$(echo "$action" | jq -r '.issue_number')
+        LABELS=$(echo "$action" | jq -r '.add_labels | map(select(length > 0)) | join(",")')
+        COMMENT=$(echo "$action" | jq -r '.comment // ""')
+
+        if [ -n "$LABELS" ]; then
+          gh issue edit "$ISSUE_NUMBER" --repo nicholls-inc/xylem --add-label "$LABELS"
+          LABEL_EDITS=$((LABEL_EDITS + 1))
+        fi
+
+        if [ -n "$COMMENT" ]; then
+          gh issue comment "$ISSUE_NUMBER" --repo nicholls-inc/xylem --body "$COMMENT"
+          COMMENTS=$((COMMENTS + 1))
+        fi
+
+        sleep 1
+      done < <(jq -c '.actions[]' "$ACTIONS_FILE")
+
+      echo "Applied ${ACTION_COUNT} backlog actions (${LABEL_EDITS} label edits, ${COMMENTS} comments)"
+  - name: persist_summary
+    type: command
+    run: |
+      set -euo pipefail
+      SUMMARY_FILE=".xylem/state/backlog-refinement/summary.md"
+      if [ ! -f "$SUMMARY_FILE" ]; then
+        echo "ERROR: analyze phase did not produce $SUMMARY_FILE"
+        exit 1
+      fi
+      echo "Summary ready: $SUMMARY_FILE"

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -39,6 +39,7 @@ var expectedCoreWorkflows = []string{
 
 var expectedSelfHostingWorkflows = []string{
 	"audit",
+	"backlog-refinement",
 	"continuous-improvement",
 	"continuous-simplicity",
 	"diagnose-failures",

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -134,10 +134,13 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	assert.Contains(t, sortedKeys(composed.Workflows), "unblock-wave")
 	assert.Contains(t, sortedKeys(composed.Workflows), "diagnose-failures")
 	assert.Contains(t, sortedKeys(composed.Workflows), "initiative-tracker")
+	assert.Contains(t, sortedKeys(composed.Workflows), "backlog-refinement")
 	assert.Contains(t, sortedKeys(composed.Workflows), "ingest-field-reports")
 	assert.Contains(t, sortedKeys(composed.Prompts), "implement-harness/pr_draft")
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/verify")
 	assert.Contains(t, sortedKeys(composed.Prompts), "hardening-audit/rank")
+	assert.Contains(t, sortedKeys(composed.Prompts), "backlog-refinement/analyze")
+	assert.Contains(t, sortedKeys(composed.Prompts), "backlog-refinement/report")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-impl")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-pr-lifecycle")
 	assert.Contains(t, sortedKeys(composed.Sources), "continuous-improvement")
@@ -145,10 +148,12 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	assert.Contains(t, sortedKeys(composed.Sources), "hardening-audit")
 	assert.Contains(t, sortedKeys(composed.Sources), "sota-gap")
 	assert.Contains(t, sortedKeys(composed.Sources), "initiative-tracker")
+	assert.Contains(t, sortedKeys(composed.Sources), "backlog-refinement")
 	assert.Contains(t, sortedKeys(composed.Sources), "ingest-field-reports")
 	require.Len(t, composed.ConfigOverlays, 2)
 
 	assert.Contains(t, sortedKeys(composed.Scripts), "post-discussion.sh")
+	assert.Contains(t, joinOverlays(composed.ConfigOverlays), "concurrency:\n  global: 3\n  per_class:\n    backlog-refinement: 1")
 
 	implementHarnessWorkflow := string(composed.Workflows["implement-harness"])
 	assert.Contains(t, implementHarnessWorkflow, `--repo nicholls-inc/xylem`)
@@ -227,6 +232,47 @@ func TestSmoke_S4_SelfHostingProfileScaffoldsMonthlyHardeningAuditWorkflow(t *te
 	assert.Contains(t, wf.Phases[4].Run, "docs/hardening-ledger.md")
 
 	assert.Contains(t, sortedKeys(composed.Prompts), "hardening-audit/rank")
+}
+
+func TestSmoke_S5_SelfHostingProfileScaffoldsDailyBacklogRefinementWorkflow(t *testing.T) {
+	t.Parallel()
+
+	composed, err := Compose("core", "self-hosting-xylem")
+	require.NoError(t, err)
+
+	var source config.SourceConfig
+	require.NoError(t, yaml.Unmarshal(composed.Sources["backlog-refinement"], &source))
+	assert.Equal(t, "scheduled", source.Type)
+	assert.Equal(t, "{{ .Repo }}", source.Repo)
+	assert.Equal(t, "@daily", source.Schedule)
+	require.Contains(t, source.Tasks, "daily-backlog-refinement")
+	assert.Equal(t, "backlog-refinement", source.Tasks["daily-backlog-refinement"].Workflow)
+	assert.Equal(t, "backlog-refinement", source.Tasks["daily-backlog-refinement"].Ref)
+
+	var wf workflowpkg.Workflow
+	require.NoError(t, yaml.Unmarshal(composed.Workflows["backlog-refinement"], &wf))
+	assert.Equal(t, "backlog-refinement", wf.Name)
+	assert.Equal(t, workflowpkg.ClassHarnessMaintenance, wf.Class)
+	require.Len(t, wf.Phases, 5)
+	assert.Equal(t, "collect", wf.Phases[0].Name)
+	assert.Equal(t, "command", wf.Phases[0].Type)
+	assert.Contains(t, wf.Phases[0].Run, "gh issue list --repo nicholls-inc/xylem")
+	assert.Contains(t, wf.Phases[0].Run, "gh pr list --repo nicholls-inc/xylem")
+	assert.Contains(t, wf.Phases[0].Run, "labels?per_page=100")
+	assert.NotNil(t, wf.Phases[0].NoOp)
+	assert.Equal(t, "XYLEM_NOOP", wf.Phases[0].NoOp.Match)
+	assert.Equal(t, ".xylem/prompts/backlog-refinement/analyze.md", wf.Phases[1].PromptFile)
+	assert.Equal(t, ".xylem/prompts/backlog-refinement/report.md", wf.Phases[2].PromptFile)
+	assert.Equal(t, "apply_actions", wf.Phases[3].Name)
+	assert.Equal(t, "command", wf.Phases[3].Type)
+	assert.Contains(t, wf.Phases[3].Run, "gh issue edit")
+	assert.Contains(t, wf.Phases[3].Run, "gh issue comment")
+	assert.Equal(t, "persist_summary", wf.Phases[4].Name)
+	assert.Equal(t, "command", wf.Phases[4].Type)
+	assert.Contains(t, wf.Phases[4].Run, "summary.md")
+
+	assert.Contains(t, sortedKeys(composed.Prompts), "backlog-refinement/analyze")
+	assert.Contains(t, sortedKeys(composed.Prompts), "backlog-refinement/report")
 }
 
 func TestAdaptRepoWorkflowAssetParsesCleanly(t *testing.T) {

--- a/cli/internal/profiles/self-hosting-xylem/prompts/backlog-refinement/analyze.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/backlog-refinement/analyze.md
@@ -1,0 +1,155 @@
+Review the xylem GitHub backlog and prepare a conservative issue-hygiene action plan.
+
+## Inputs
+
+Read these files first:
+
+1. `.xylem/state/backlog-refinement/open-issues.json`
+2. `.xylem/state/backlog-refinement/merged-prs.json`
+3. `.xylem/state/backlog-refinement/labels.json`
+
+The open-issues snapshot is the primary backlog input. The merged-PR snapshot is there so you
+can detect open issues that appear to have been resolved by a merged pull request. The labels
+snapshot tells you which labels already exist in the repository.
+
+## Goal
+
+Produce a **conservative** refinement pass that improves backlog hygiene without closing issues or
+removing labels.
+
+You may use `gh issue view <number> --repo nicholls-inc/xylem --json ...` for targeted follow-up
+checks when the snapshots are insufficient, especially to:
+
+- confirm whether dependency issues are still open
+- inspect issue comments before posting a new cross-reference
+- verify that a merged PR truly references an issue with a `closes` / `fixes` style keyword
+
+Keep follow-up API calls focused. Prefer the snapshots over re-querying the full backlog.
+
+## Allowed actions
+
+You may plan only these mutations:
+
+1. **Add labels** that already exist in the repository
+2. **Post comments** on issues
+
+Do **not** plan any of the following:
+
+- issue closure
+- label removal
+- body rewrites
+- milestone/assignee changes
+- creation of new repository labels
+
+## Heuristics
+
+Build a lightweight dependency view from issue bodies. Treat `Depends On`, `Blocked By`, and direct
+issue references as dependency signals when the meaning is clear.
+
+Plan actions only when confidence is high:
+
+1. **Ready for work**
+   - If an open issue is missing `ready-for-work`, and every dependency appears resolved, and the
+     issue description is concrete enough to act on, add `ready-for-work`.
+   - If the issue is still labeled `blocked`, do not remove that label. Add a comment explaining
+     that dependencies appear resolved and that a human should confirm the issue is ready.
+
+2. **Blocked labeling**
+   - If an issue clearly depends on an open issue and is missing `blocked`, add `blocked`.
+
+3. **Priority labels**
+   - If the repository already contains `priority-high`, `priority-medium`, or `priority-low`,
+     you may add **at most one** of them.
+   - Prefer `priority-high` only when the issue blocks multiple open issues or is clearly on the
+     critical path for active harness work.
+   - Prefer `priority-medium` for single-blocker issues with active downstream work.
+   - Prefer `priority-low` only when the signal is strong and additive value is clear.
+   - If those labels do not exist, record the priority insight in the summary instead of inventing
+     labels or creating substitute labels.
+
+4. **Merged-PR closure suggestions**
+   - If a merged PR clearly references an open issue with `closes #N`, `fixes #N`, or similar,
+     do not close the issue yourself.
+   - Post a comment on the issue that links the merged PR and recommends human review for closure.
+
+5. **Duplicate linking**
+   - Only act on duplicates when confidence is high.
+   - Add comments on both issues with cross-references and a short explanation of the overlap.
+   - Before planning the comment, inspect current issue comments and skip the action if the same
+     cross-link already exists.
+
+## Action budget
+
+Keep the run small and reviewable:
+
+- no more than **12** issue actions total
+- no more than **1** planned comment per issue unless duplicate cross-linking requires one on each side
+
+If there are more candidates, choose the highest-signal ones and list the remainder in the summary.
+
+## Output files
+
+Write both of these files:
+
+1. `.xylem/state/backlog-refinement/actions.json`
+2. `.xylem/state/backlog-refinement/summary.md`
+
+### `actions.json` contract
+
+Write valid JSON with this exact shape:
+
+```json
+{
+  "version": 1,
+  "generated_at": "RFC3339",
+  "actions": [
+    {
+      "issue_number": 123,
+      "kind": "ready-for-work|blocked|priority|closure-review|duplicate-link",
+      "reason": "one sentence",
+      "confidence": 0.0,
+      "add_labels": ["ready-for-work"],
+      "comment": "Markdown comment or empty string"
+    }
+  ]
+}
+```
+
+Rules:
+
+- `add_labels` must contain only labels that already exist and are not already on the issue
+- `comment` may be empty, but never null
+- `confidence` must be between `0` and `1`
+- if there are no safe actions, still write a valid file with `"actions": []`
+
+### `summary.md` contract
+
+Write concise markdown with these sections:
+
+```markdown
+# Backlog Refinement Summary
+
+## Snapshot
+- Open issues scanned: N
+- Merged PRs scanned: N
+- Planned actions: N
+
+## Planned actions
+- `#123` — add `ready-for-work` because ...
+
+## Priority insights
+- ...
+
+## Follow-up recommended
+- ...
+
+## Skipped for caution
+- ...
+```
+
+The summary should explain what was acted on, what was intentionally left alone, and any backlog
+items that look important but were too ambiguous for automation.
+
+After writing both files, print one line:
+
+`Backlog refinement plan written: .xylem/state/backlog-refinement/actions.json`

--- a/cli/internal/profiles/self-hosting-xylem/prompts/backlog-refinement/report.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/backlog-refinement/report.md
@@ -1,0 +1,24 @@
+Read `.xylem/state/backlog-refinement/summary.md` and tighten it for human review.
+
+## Goal
+
+Produce a concise final summary that emphasizes:
+
+1. Which labels/comments were planned
+2. Which issues may be ready for work
+3. Which issues may be stale because a merged PR already references them
+4. Which ambiguous cases were intentionally skipped
+
+## Output
+
+Rewrite `.xylem/state/backlog-refinement/summary.md` in place if it needs cleanup. Keep the same
+section headings:
+
+- `# Backlog Refinement Summary`
+- `## Snapshot`
+- `## Planned actions`
+- `## Priority insights`
+- `## Follow-up recommended`
+- `## Skipped for caution`
+
+Do not introduce any new GitHub mutations in this phase.

--- a/cli/internal/profiles/self-hosting-xylem/workflows/backlog-refinement.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/backlog-refinement.yaml
@@ -1,0 +1,87 @@
+name: backlog-refinement
+class: harness-maintenance
+description: "Daily GitHub backlog hygiene sweep for duplicate signals, dependency drift, and ready-for-work labeling"
+phases:
+  - name: collect
+    type: command
+    run: |
+      set -euo pipefail
+      STATE_DIR=".xylem/state/backlog-refinement"
+      mkdir -p "$STATE_DIR"
+
+      gh issue list --repo nicholls-inc/xylem \
+        --state open \
+        --limit 200 \
+        --json number,title,body,labels,updatedAt,url \
+        > "$STATE_DIR/open-issues.json"
+
+      gh pr list --repo nicholls-inc/xylem \
+        --state merged \
+        --limit 200 \
+        --json number,title,body,mergedAt,url \
+        > "$STATE_DIR/merged-prs.json"
+
+      gh api repos/nicholls-inc/xylem/labels?per_page=100 \
+        > "$STATE_DIR/labels.json"
+
+      ISSUE_COUNT=$(jq 'length' "$STATE_DIR/open-issues.json")
+      PR_COUNT=$(jq 'length' "$STATE_DIR/merged-prs.json")
+      echo "Collected ${ISSUE_COUNT} open issues and ${PR_COUNT} merged pull requests"
+      if [ "$ISSUE_COUNT" -eq 0 ]; then
+        echo "XYLEM_NOOP: no open issues to refine"
+      fi
+    noop:
+      match: XYLEM_NOOP
+  - name: analyze
+    prompt_file: .xylem/prompts/backlog-refinement/analyze.md
+    max_turns: 50
+  - name: report
+    prompt_file: .xylem/prompts/backlog-refinement/report.md
+    max_turns: 20
+  - name: apply_actions
+    type: command
+    run: |
+      set -euo pipefail
+      ACTIONS_FILE=".xylem/state/backlog-refinement/actions.json"
+      if [ ! -f "$ACTIONS_FILE" ]; then
+        echo "ERROR: analyze phase did not produce $ACTIONS_FILE"
+        exit 1
+      fi
+
+      ACTION_COUNT=$(jq '.actions | length' "$ACTIONS_FILE")
+      if [ "$ACTION_COUNT" -eq 0 ]; then
+        echo "No backlog refinement actions planned"
+        exit 0
+      fi
+
+      LABEL_EDITS=0
+      COMMENTS=0
+      while IFS= read -r action; do
+        ISSUE_NUMBER=$(echo "$action" | jq -r '.issue_number')
+        LABELS=$(echo "$action" | jq -r '.add_labels | map(select(length > 0)) | join(",")')
+        COMMENT=$(echo "$action" | jq -r '.comment // ""')
+
+        if [ -n "$LABELS" ]; then
+          gh issue edit "$ISSUE_NUMBER" --repo nicholls-inc/xylem --add-label "$LABELS"
+          LABEL_EDITS=$((LABEL_EDITS + 1))
+        fi
+
+        if [ -n "$COMMENT" ]; then
+          gh issue comment "$ISSUE_NUMBER" --repo nicholls-inc/xylem --body "$COMMENT"
+          COMMENTS=$((COMMENTS + 1))
+        fi
+
+        sleep 1
+      done < <(jq -c '.actions[]' "$ACTIONS_FILE")
+
+      echo "Applied ${ACTION_COUNT} backlog actions (${LABEL_EDITS} label edits, ${COMMENTS} comments)"
+  - name: persist_summary
+    type: command
+    run: |
+      set -euo pipefail
+      SUMMARY_FILE=".xylem/state/backlog-refinement/summary.md"
+      if [ ! -f "$SUMMARY_FILE" ]; then
+        echo "ERROR: analyze phase did not produce $SUMMARY_FILE"
+        exit 1
+      fi
+      echo "Summary ready: $SUMMARY_FILE"

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -126,6 +126,16 @@ sources:
         workflow: initiative-tracker
         ref: initiative-tracker
 
+  backlog-refinement:
+    type: scheduled
+    repo: "{{ .Repo }}"
+    schedule: "@daily"
+    timeout: "60m"
+    tasks:
+      daily-backlog-refinement:
+        workflow: backlog-refinement
+        ref: backlog-refinement
+
   ingest-field-reports:
     type: scheduled
     repo: "{{ .Repo }}"
@@ -147,3 +157,8 @@ daemon:
   auto_upgrade: true
   auto_merge: true
   auto_merge_repo: "{{ .Repo }}"
+
+concurrency:
+  global: 3
+  per_class:
+    backlog-refinement: 1


### PR DESCRIPTION
## Summary
- add a checked-in backlog-refinement workflow and prompts for conservative GitHub issue hygiene sweeps
- wire the self-hosting profile and repo-local .xylem config to schedule a daily backlog-refinement vessel with its own concurrency cap
- extend profile/init coverage so the new workflow scaffolds cleanly and stays under test

Closes https://github.com/nicholls-inc/xylem/issues/268