### PR TITLE
feat(workflows): publish recurring reports to GitHub Discussions

### DIFF
--- a/cli/internal/phase/phase.go
+++ b/cli/internal/phase/phase.go
@@ -17,6 +17,7 @@ const (
 
 // TemplateData holds all data available to phase prompt templates.
 type TemplateData struct {
+	Date            string
 	Issue           IssueData
 	Phase           PhaseData
 	PreviousOutputs map[string]string // phase name → output text

--- a/cli/internal/profiles/core/workflows/workflow-health-report.yaml
+++ b/cli/internal/profiles/core/workflows/workflow-health-report.yaml
@@ -12,22 +12,18 @@ phases:
     max_turns: 20
   - name: post
     type: command
+    noop:
+      match: XYLEM_NOOP
+    output: discussion
+    discussion:
+      category: Reports
+      title_template: "[health] Weekly workflow health — {{.Date}}"
+      title_search_template: "[health] Weekly workflow health"
     run: |
       set -euo pipefail
       REPORT=".xylem/state/workflow-health-report.md"
       if [ ! -f "$REPORT" ]; then
-        echo "No health report to post"
+        echo "XYLEM_NOOP: no health report to post"
         exit 0
       fi
-      BODY=$(cat "$REPORT")
-      DATE=$(date -u +%Y-%m-%d)
-      SLUG="{{.Repo.Slug}}"
-      OWNER="${SLUG%%/*}"
-      NAME="${SLUG##*/}"
-      .xylem/scripts/post-discussion.sh \
-        --owner "$OWNER" \
-        --repo "$NAME" \
-        --category Reports \
-        --title "[health] Weekly workflow health — ${DATE}" \
-        --title-search "[health] Weekly workflow health" \
-        --body "$BODY"
+      cat "$REPORT"

--- a/cli/internal/profiles/self-hosting-xylem/prompts/portfolio-analyst/report.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/portfolio-analyst/report.md
@@ -10,7 +10,7 @@ The `analyze` phase has written its findings to:
 
 ## Your Task
 
-Read `.xylem/state/metrics/portfolio-analysis.md` and produce a polished, concise markdown summary suitable for posting as a GitHub issue comment.
+Read `.xylem/state/metrics/portfolio-analysis.md` and produce a polished, concise markdown summary suitable for posting to GitHub Discussions.
 
 Write the report to:
 

--- a/cli/internal/profiles/self-hosting-xylem/workflows/initiative-tracker.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/initiative-tracker.yaml
@@ -42,19 +42,18 @@ phases:
     max_turns: 30
   - name: post
     type: command
+    noop:
+      match: XYLEM_NOOP
+    output: discussion
+    discussion:
+      category: Initiatives
+      title_template: "[initiative] Status update — {{.Date}}"
+      title_search_template: "[initiative] Status update"
     run: |
       set -euo pipefail
       REPORT=".xylem/state/initiative/initiative-report.md"
       if [ ! -f "$REPORT" ]; then
-        echo "No initiative report to post"
+        echo "XYLEM_NOOP: no initiative report to post"
         exit 0
       fi
-      BODY=$(cat "$REPORT")
-      DATE=$(date -u +%Y-%m-%d)
-      .xylem/scripts/post-discussion.sh \
-        --owner nicholls-inc \
-        --repo xylem \
-        --category Initiatives \
-        --title "[initiative] Status update — ${DATE}" \
-        --title-search "[initiative] Status update" \
-        --body "$BODY"
+      cat "$REPORT"

--- a/cli/internal/profiles/self-hosting-xylem/workflows/portfolio-analyst.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/portfolio-analyst.yaml
@@ -23,19 +23,18 @@ phases:
     max_turns: 30
   - name: post
     type: command
+    noop:
+      match: XYLEM_NOOP
+    output: discussion
+    discussion:
+      category: Reports
+      title_template: "[portfolio] Weekly tracking {{.Date}}"
+      title_search_template: "[portfolio] Weekly tracking"
     run: |
       set -euo pipefail
       REPORT=".xylem/state/metrics/portfolio-report.md"
       if [ ! -f "$REPORT" ]; then
-        echo "No portfolio report to post"
+        echo "XYLEM_NOOP: no portfolio report to post"
         exit 0
       fi
-      BODY=$(cat "$REPORT")
-      DATE=$(date -u +%Y-%m-%d)
-      .xylem/scripts/post-discussion.sh \
-        --owner nicholls-inc \
-        --repo xylem \
-        --category Reports \
-        --title "[portfolio] Weekly tracking ${DATE}" \
-        --title-search "[portfolio] Weekly tracking" \
-        --body "$BODY"
+      cat "$REPORT"

--- a/cli/internal/runner/discussion.go
+++ b/cli/internal/runner/discussion.go
@@ -1,0 +1,260 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nicholls-inc/xylem/cli/internal/phase"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
+)
+
+const (
+	discussionResolveQuery = `query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    id
+    discussionCategories(first: 25) { nodes { id, name } }
+  }
+}`
+	discussionSearchQuery = `query($repoId: ID!, $catId: ID!) {
+  node(id: $repoId) {
+    ... on Repository {
+      discussions(first: 20, categoryId: $catId, orderBy: {field: CREATED_AT, direction: DESC}) {
+        nodes { id, title, url }
+      }
+    }
+  }
+}`
+	discussionCreateMutation = `mutation($repoId: ID!, $catId: ID!, $title: String!, $body: String!) {
+  createDiscussion(input: {repositoryId: $repoId, title: $title, body: $body, categoryId: $catId}) {
+    discussion { id, title, url }
+  }
+}`
+	discussionCommentMutation = `mutation($discussionId: ID!, $body: String!) {
+  addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+    comment { url }
+  }
+}`
+)
+
+type discussionPublisher struct {
+	runner CommandRunner
+}
+
+type discussionRef struct {
+	ID    string
+	Title string
+	URL   string
+}
+
+func (r *Runner) publishPhaseOutput(ctx context.Context, vessel queue.Vessel, p workflow.Phase, td phase.TemplateData, body string) error {
+	if p.Output == "" || phaseMatchedNoOp(&p, body) {
+		return nil
+	}
+
+	switch p.Output {
+	case "discussion":
+		repoSlug := r.resolveRepo(vessel)
+		if _, err := (discussionPublisher{runner: r.Runner}).Publish(ctx, repoSlug, p.Name, p.Discussion, td, body); err != nil {
+			return err
+		}
+		return nil
+	default:
+		return fmt.Errorf("phase %s: unsupported output target %q", p.Name, p.Output)
+	}
+}
+
+func (p discussionPublisher) Publish(ctx context.Context, repoSlug string, phaseName string, cfg *workflow.DiscussionOutput, td phase.TemplateData, body string) (string, error) {
+	if p.runner == nil {
+		return "", fmt.Errorf("publish discussion for phase %s: runner is required", phaseName)
+	}
+	if cfg == nil {
+		return "", fmt.Errorf("publish discussion for phase %s: discussion config is required", phaseName)
+	}
+
+	owner, repo, err := splitRepoSlug(repoSlug)
+	if err != nil {
+		return "", fmt.Errorf("publish discussion for phase %s: %w", phaseName, err)
+	}
+
+	title, err := renderDiscussionTemplate(phaseName, "discussion.title_template", cfg.TitleTemplate, td)
+	if err != nil {
+		return "", err
+	}
+	titleSearch := title
+	if strings.TrimSpace(cfg.TitleSearchTemplate) != "" {
+		titleSearch, err = renderDiscussionTemplate(phaseName, "discussion.title_search_template", cfg.TitleSearchTemplate, td)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	target, err := p.resolveTarget(ctx, owner, repo, cfg.Category)
+	if err != nil {
+		return "", fmt.Errorf("publish discussion for phase %s: %w", phaseName, err)
+	}
+
+	existing, err := p.findExisting(ctx, target.repoID, target.categoryID, titleSearch)
+	if err != nil {
+		return "", fmt.Errorf("publish discussion for phase %s: %w", phaseName, err)
+	}
+	if existing.ID != "" {
+		if err := p.comment(ctx, existing.ID, body); err != nil {
+			return "", fmt.Errorf("publish discussion for phase %s: comment existing discussion %q: %w", phaseName, existing.Title, err)
+		}
+		return existing.URL, nil
+	}
+
+	created, err := p.create(ctx, target.repoID, target.categoryID, title, body)
+	if err != nil {
+		return "", fmt.Errorf("publish discussion for phase %s: create discussion %q: %w", phaseName, title, err)
+	}
+	return created.URL, nil
+}
+
+func renderDiscussionTemplate(phaseName, field, tmpl string, td phase.TemplateData) (string, error) {
+	rendered, err := phase.RenderPrompt(tmpl, td)
+	if err != nil {
+		return "", fmt.Errorf("render %s for phase %s: %w", field, phaseName, err)
+	}
+	rendered = strings.TrimSpace(rendered)
+	if rendered == "" {
+		return "", fmt.Errorf("phase %s: %s rendered empty", phaseName, field)
+	}
+	if err := validateCommandRender(fmt.Sprintf("%s for phase %s", field, phaseName), rendered); err != nil {
+		return "", err
+	}
+	return rendered, nil
+}
+
+func splitRepoSlug(repoSlug string) (string, string, error) {
+	repoSlug = strings.TrimSpace(repoSlug)
+	parts := strings.Split(repoSlug, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", "", fmt.Errorf("repo slug %q must be in owner/repo form", repoSlug)
+	}
+	return parts[0], parts[1], nil
+}
+
+type discussionTarget struct {
+	repoID     string
+	categoryID string
+}
+
+func (p discussionPublisher) resolveTarget(ctx context.Context, owner, repo, category string) (discussionTarget, error) {
+	out, err := p.runner.RunOutput(ctx, "gh", "api", "graphql",
+		"-f", "query="+discussionResolveQuery,
+		"-f", "owner="+owner,
+		"-f", "repo="+repo)
+	if err != nil {
+		return discussionTarget{}, fmt.Errorf("resolve repo %s/%s: %w", owner, repo, err)
+	}
+
+	var resp struct {
+		Data struct {
+			Repository struct {
+				ID                   string `json:"id"`
+				DiscussionCategories struct {
+					Nodes []struct {
+						ID   string `json:"id"`
+						Name string `json:"name"`
+					} `json:"nodes"`
+				} `json:"discussionCategories"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return discussionTarget{}, fmt.Errorf("parse discussion target response: %w", err)
+	}
+	if resp.Data.Repository.ID == "" {
+		return discussionTarget{}, fmt.Errorf("could not resolve repository %s/%s", owner, repo)
+	}
+
+	for _, node := range resp.Data.Repository.DiscussionCategories.Nodes {
+		if node.Name == category {
+			return discussionTarget{repoID: resp.Data.Repository.ID, categoryID: node.ID}, nil
+		}
+	}
+	return discussionTarget{}, fmt.Errorf("discussion category %q not found in %s/%s", category, owner, repo)
+}
+
+func (p discussionPublisher) findExisting(ctx context.Context, repoID, categoryID, titlePrefix string) (discussionRef, error) {
+	out, err := p.runner.RunOutput(ctx, "gh", "api", "graphql",
+		"-f", "query="+discussionSearchQuery,
+		"-f", "repoId="+repoID,
+		"-f", "catId="+categoryID)
+	if err != nil {
+		return discussionRef{}, fmt.Errorf("search discussions: %w", err)
+	}
+
+	var resp struct {
+		Data struct {
+			Node struct {
+				Discussions struct {
+					Nodes []struct {
+						ID    string `json:"id"`
+						Title string `json:"title"`
+						URL   string `json:"url"`
+					} `json:"nodes"`
+				} `json:"discussions"`
+			} `json:"node"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return discussionRef{}, fmt.Errorf("parse discussion search response: %w", err)
+	}
+
+	for _, node := range resp.Data.Node.Discussions.Nodes {
+		if strings.HasPrefix(node.Title, titlePrefix) {
+			return discussionRef{ID: node.ID, Title: node.Title, URL: node.URL}, nil
+		}
+	}
+	return discussionRef{}, nil
+}
+
+func (p discussionPublisher) comment(ctx context.Context, discussionID, body string) error {
+	if _, err := p.runner.RunOutput(ctx, "gh", "api", "graphql",
+		"-f", "query="+discussionCommentMutation,
+		"-f", "discussionId="+discussionID,
+		"-f", "body="+body); err != nil {
+		return fmt.Errorf("add discussion comment: %w", err)
+	}
+	return nil
+}
+
+func (p discussionPublisher) create(ctx context.Context, repoID, categoryID, title, body string) (discussionRef, error) {
+	out, err := p.runner.RunOutput(ctx, "gh", "api", "graphql",
+		"-f", "query="+discussionCreateMutation,
+		"-f", "repoId="+repoID,
+		"-f", "catId="+categoryID,
+		"-f", "title="+title,
+		"-f", "body="+body)
+	if err != nil {
+		return discussionRef{}, err
+	}
+
+	var resp struct {
+		Data struct {
+			CreateDiscussion struct {
+				Discussion struct {
+					ID    string `json:"id"`
+					Title string `json:"title"`
+					URL   string `json:"url"`
+				} `json:"discussion"`
+			} `json:"createDiscussion"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return discussionRef{}, fmt.Errorf("parse create discussion response: %w", err)
+	}
+	if resp.Data.CreateDiscussion.Discussion.ID == "" {
+		return discussionRef{}, fmt.Errorf("create discussion response missing discussion id")
+	}
+	return discussionRef{
+		ID:    resp.Data.CreateDiscussion.Discussion.ID,
+		Title: resp.Data.CreateDiscussion.Discussion.Title,
+		URL:   resp.Data.CreateDiscussion.Discussion.URL,
+	}, nil
+}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -929,6 +929,24 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				return "failed"
 			}
 
+			if err := r.publishPhaseOutput(ctx, vessel, p, td, string(output)); err != nil {
+				phaseSpanStatus = "failed"
+				finishCurrentPhaseSpan(err)
+				log.Printf("%sphase %q failed while publishing output: %v", vesselLabel(vessel), p.Name, err)
+				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, err.Error()))
+				vessel.FailedPhase = p.Name
+				r.failUpdatedVessel(&vessel, fmt.Sprintf("phase %s: %v", p.Name, err))
+				if err := src.OnFail(ctx, vessel); err != nil {
+					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+				}
+				issueNum := r.parseIssueNum(vessel)
+				if issueNum > 0 && r.Reporter != nil {
+					r.logReporterError("post vessel-failed comment", vessel.ID,
+						r.Reporter.VesselFailed(ctx, issueNum, p.Name, err.Error(), ""))
+				}
+				return "failed"
+			}
+
 			// Store output for subsequent phases
 			previousOutputs[p.Name] = string(output)
 
@@ -2344,6 +2362,27 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				status:       "failed",
 				duration:     phaseDuration,
 				phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg),
+			}
+		}
+
+		if err := r.publishPhaseOutput(ctx, vessel, p, td, string(output)); err != nil {
+			phaseSpanStatus = "failed"
+			finishCurrentPhaseSpan(err)
+			log.Printf("%sphase %q failed while publishing output: %v", vesselLabel(vessel), p.Name, err)
+			vessel.FailedPhase = p.Name
+			r.failUpdatedVessel(&vessel, fmt.Sprintf("phase %s: %v", p.Name, err))
+			if err := src.OnFail(ctx, vessel); err != nil {
+				log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+			}
+			issueNum := r.parseIssueNum(vessel)
+			if issueNum > 0 && r.Reporter != nil {
+				r.logReporterError("post vessel-failed comment", vessel.ID,
+					r.Reporter.VesselFailed(ctx, issueNum, p.Name, err.Error(), ""))
+			}
+			return singlePhaseResult{
+				status:       "failed",
+				duration:     phaseDuration,
+				phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, err.Error()),
 			}
 		}
 
@@ -4032,6 +4071,7 @@ func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueDat
 		}
 	}
 	return phase.TemplateData{
+		Date:  r.runtimeNow().UTC().Format("2006-01-02"),
 		Issue: issueData,
 		Phase: phase.PhaseData{
 			Name:  phaseName,

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -202,6 +202,62 @@ func TestProp_PromptOnlyUsageAccumulatesEstimatedTotals(t *testing.T) {
 	})
 }
 
+func TestProp_SplitRepoSlugRoundTripsOwnerAndRepo(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		owner := rapid.StringMatching(`[a-z0-9][a-z0-9-]{0,15}`).Draw(t, "owner")
+		repo := rapid.StringMatching(`[a-z0-9][a-z0-9._-]{0,20}`).Draw(t, "repo")
+		gotOwner, gotRepo, err := splitRepoSlug(owner + "/" + repo)
+		if err != nil {
+			t.Fatalf("splitRepoSlug() error = %v", err)
+		}
+		if gotOwner != owner || gotRepo != repo {
+			t.Fatalf("splitRepoSlug() = (%q, %q), want (%q, %q)", gotOwner, gotRepo, owner, repo)
+		}
+	})
+}
+
+func TestProp_SplitRepoSlugTrimsSurroundingWhitespace(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		owner := rapid.StringMatching(`[a-z0-9][a-z0-9-]{0,15}`).Draw(t, "owner")
+		repo := rapid.StringMatching(`[a-z0-9][a-z0-9._-]{0,20}`).Draw(t, "repo")
+		gotOwner, gotRepo, err := splitRepoSlug(" \t" + owner + "/" + repo + "\n ")
+		if err != nil {
+			t.Fatalf("splitRepoSlug() error = %v", err)
+		}
+		if gotOwner != owner || gotRepo != repo {
+			t.Fatalf("splitRepoSlug() = (%q, %q), want (%q, %q)", gotOwner, gotRepo, owner, repo)
+		}
+	})
+}
+
+func TestProp_SplitRepoSlugRejectsMalformedInput(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		owner := rapid.StringMatching(`[a-z0-9][a-z0-9-]{0,15}`).Draw(t, "owner")
+		repo := rapid.StringMatching(`[a-z0-9][a-z0-9._-]{0,20}`).Draw(t, "repo")
+		malformed := rapid.SampledFrom([]string{
+			"",
+			owner,
+			repo,
+			"/" + repo,
+			owner + "/",
+			owner + "//" + repo,
+			owner + "/" + repo + "/extra",
+			owner + "/ ",
+			" /" + repo,
+		}).Draw(t, "malformed")
+		gotOwner, gotRepo, err := splitRepoSlug(malformed)
+		if err == nil {
+			t.Fatalf("splitRepoSlug(%q) error = nil, want error", malformed)
+		}
+		if gotOwner != "" || gotRepo != "" {
+			t.Fatalf("splitRepoSlug(%q) = (%q, %q), want empty parts on error", malformed, gotOwner, gotRepo)
+		}
+		if !strings.Contains(err.Error(), "owner/repo form") {
+			t.Fatalf("splitRepoSlug(%q) error = %q, want owner/repo guidance", malformed, err.Error())
+		}
+	})
+}
+
 func TestProp_BudgetExceededIsMonotonic(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		records := rapid.SliceOfN(rapid.Float64Range(0.0, 1.0), 1, 20).Draw(t, "costs")

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -536,6 +536,21 @@ func writeWorkflowFile(t *testing.T, dir, name string, phases []testPhase) {
 			phaseYAML.WriteString("    noop:\n")
 			fmt.Fprintf(&phaseYAML, "      match: %q\n", p.noopMatch)
 		}
+		if p.output != "" {
+			fmt.Fprintf(&phaseYAML, "    output: %s\n", p.output)
+		}
+		if p.discussionCategory != "" || p.discussionTitleTemplate != "" || p.discussionTitleSearchTemplate != "" {
+			phaseYAML.WriteString("    discussion:\n")
+			if p.discussionCategory != "" {
+				fmt.Fprintf(&phaseYAML, "      category: %q\n", p.discussionCategory)
+			}
+			if p.discussionTitleTemplate != "" {
+				fmt.Fprintf(&phaseYAML, "      title_template: %q\n", p.discussionTitleTemplate)
+			}
+			if p.discussionTitleSearchTemplate != "" {
+				fmt.Fprintf(&phaseYAML, "      title_search_template: %q\n", p.discussionTitleSearchTemplate)
+			}
+		}
 		if p.gate != "" {
 			fmt.Fprintf(&phaseYAML, "    gate:\n%s\n", p.gate)
 		}
@@ -849,15 +864,19 @@ func TestBuildCommandWorkflowBased(t *testing.T) {
 }
 
 type testPhase struct {
-	name          string
-	promptContent string
-	maxTurns      int
-	noopMatch     string
-	gate          string
-	allowedTools  string
-	phaseType     string   // "command" or "" for prompt (default)
-	run           string   // shell command for type=command
-	dependsOn     []string // explicit phase dependencies
+	name                          string
+	promptContent                 string
+	maxTurns                      int
+	noopMatch                     string
+	gate                          string
+	allowedTools                  string
+	phaseType                     string // "command" or "" for prompt (default)
+	run                           string // shell command for type=command
+	output                        string
+	discussionCategory            string
+	discussionTitleTemplate       string
+	discussionTitleSearchTemplate string
+	dependsOn                     []string // explicit phase dependencies
 }
 
 // --- Tests ---
@@ -937,6 +956,247 @@ func TestPhasePolicyIntents_ClassifiesHighRiskPromptActions(t *testing.T) {
 	assert.Equal(t, "pr_create", intents[3].Action)
 	assert.Equal(t, "owner/repo", intents[3].Resource)
 	assert.Equal(t, "prompt", intents[1].Metadata["classified_from"])
+}
+
+func TestSmoke_S5_DiscussionOutputCreatesDiscussion(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Sources["scheduled"] = config.SourceConfig{Type: "scheduled", Repo: "owner/repo"}
+
+	writeWorkflowFile(t, dir, "weekly-report", []testPhase{{
+		name:                    "report",
+		promptContent:           "Generate weekly report",
+		maxTurns:                5,
+		output:                  "discussion",
+		discussionCategory:      "Reports",
+		discussionTitleTemplate: "Velocity Report — {{.Date}}",
+	}})
+	withTestWorkingDir(t, dir)
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "scheduled-1",
+		Source:    "scheduled",
+		Workflow:  "weekly-report",
+		Meta:      map[string]string{"config_source": "scheduled"},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	dequeued, err := q.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, dequeued)
+
+	var discussionTitle string
+	var discussionBody string
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Generate weekly report": []byte("## Weekly report\n\nAll green."),
+		},
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name != "gh" {
+				return nil, nil, false
+			}
+			joined := strings.Join(args, " ")
+			switch {
+			case strings.Contains(joined, discussionResolveQuery):
+				return []byte(`{"data":{"repository":{"id":"R_1","discussionCategories":{"nodes":[{"id":"C_1","name":"Reports"}]}}}}`), nil, true
+			case strings.Contains(joined, discussionSearchQuery):
+				return []byte(`{"data":{"node":{"discussions":{"nodes":[]}}}}`), nil, true
+			case strings.Contains(joined, discussionCreateMutation):
+				for i := 0; i+1 < len(args); i++ {
+					switch {
+					case args[i] == "-f" && strings.HasPrefix(args[i+1], "title="):
+						discussionTitle = strings.TrimPrefix(args[i+1], "title=")
+					case args[i] == "-f" && strings.HasPrefix(args[i+1], "body="):
+						discussionBody = strings.TrimPrefix(args[i+1], "body=")
+					}
+				}
+				return []byte(`{"data":{"createDiscussion":{"discussion":{"id":"D_1","title":"Velocity Report — 2026-04-11","url":"https://github.com/owner/repo/discussions/1"}}}}`), nil, true
+			default:
+				return nil, nil, false
+			}
+		},
+	}
+
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"scheduled": &source.Scheduled{Repo: "owner/repo"},
+	}
+
+	outcome := r.runVessel(context.Background(), *dequeued)
+	assert.Equal(t, "completed", outcome)
+	assert.Equal(t, queue.StateCompleted, loadSingleVessel(t, q).State)
+	assert.Equal(t, "## Weekly report\n\nAll green.", discussionBody)
+	assert.Contains(t, discussionTitle, "Velocity Report — ")
+	assert.NotContains(t, discussionTitle, "{{")
+	assert.True(t, hasRunOutputCallContaining(cmdRunner, "gh api graphql", "discussionCategories"))
+	assert.True(t, hasRunOutputCallContaining(cmdRunner, "gh api graphql", "discussions(first: 20"))
+	assert.True(t, hasRunOutputCallContaining(cmdRunner, "gh api graphql", "createDiscussion"))
+}
+
+func TestSmoke_S6_DiscussionOutputCommentsExistingDiscussionByTitlePrefix(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Sources["scheduled"] = config.SourceConfig{Type: "scheduled", Repo: "owner/repo"}
+
+	writeWorkflowFile(t, dir, "weekly-report", []testPhase{{
+		name:                          "report",
+		promptContent:                 "Generate weekly report",
+		maxTurns:                      5,
+		output:                        "discussion",
+		discussionCategory:            "Reports",
+		discussionTitleTemplate:       "Velocity Report — {{.Date}}",
+		discussionTitleSearchTemplate: "Velocity Report",
+	}})
+	withTestWorkingDir(t, dir)
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "scheduled-2",
+		Source:    "scheduled",
+		Workflow:  "weekly-report",
+		Meta:      map[string]string{"config_source": "scheduled"},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	dequeued, err := q.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, dequeued)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Generate weekly report": []byte("## Weekly report\n\nExisting thread."),
+		},
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name != "gh" {
+				return nil, nil, false
+			}
+			joined := strings.Join(args, " ")
+			switch {
+			case strings.Contains(joined, discussionResolveQuery):
+				return []byte(`{"data":{"repository":{"id":"R_1","discussionCategories":{"nodes":[{"id":"C_1","name":"Reports"}]}}}}`), nil, true
+			case strings.Contains(joined, discussionSearchQuery):
+				return []byte(`{"data":{"node":{"discussions":{"nodes":[{"id":"D_1","title":"Velocity Report — 2026-04-01","url":"https://github.com/owner/repo/discussions/1"}]}}}}`), nil, true
+			case strings.Contains(joined, discussionCommentMutation):
+				return []byte(`{"data":{"addDiscussionComment":{"comment":{"url":"https://github.com/owner/repo/discussions/1#discussioncomment-1"}}}}`), nil, true
+			default:
+				return nil, nil, false
+			}
+		},
+	}
+
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"scheduled": &source.Scheduled{Repo: "owner/repo"},
+	}
+
+	outcome := r.runVessel(context.Background(), *dequeued)
+	assert.Equal(t, "completed", outcome)
+	assert.Equal(t, queue.StateCompleted, loadSingleVessel(t, q).State)
+	assert.True(t, hasRunOutputCallContaining(cmdRunner, "gh api graphql", "addDiscussionComment"))
+	assert.False(t, hasRunOutputCallContaining(cmdRunner, "gh api graphql", "createDiscussion"))
+}
+
+func TestSmoke_S7_DiscussionOutputFailsWithoutRepoSlug(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Sources["manual-scheduled"] = config.SourceConfig{Type: "scheduled"}
+
+	writeWorkflowFile(t, dir, "weekly-report", []testPhase{{
+		name:                    "report",
+		promptContent:           "Generate weekly report",
+		maxTurns:                5,
+		output:                  "discussion",
+		discussionCategory:      "Reports",
+		discussionTitleTemplate: "Velocity Report — {{.Date}}",
+	}})
+	withTestWorkingDir(t, dir)
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "scheduled-3",
+		Source:    "manual",
+		Workflow:  "weekly-report",
+		Meta:      map[string]string{"config_source": "manual-scheduled"},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	dequeued, err := q.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, dequeued)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Generate weekly report": []byte("## Weekly report\n\nMissing repo."),
+		},
+	}
+
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+
+	outcome := r.runVessel(context.Background(), *dequeued)
+	assert.Equal(t, "failed", outcome)
+
+	final := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, final.State)
+	assert.Contains(t, final.Error, `phase report: publish discussion for phase report: repo slug "" must be in owner/repo form`)
+	assert.False(t, hasRunOutputCallContaining(cmdRunner, "gh api graphql", "createDiscussion"))
+}
+
+func TestSmoke_S8_DiscussionOutputSkipsPublishOnNoOp(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Sources["scheduled"] = config.SourceConfig{Type: "scheduled", Repo: "owner/repo"}
+
+	writeWorkflowFile(t, dir, "weekly-report", []testPhase{{
+		name:                    "post",
+		phaseType:               "command",
+		run:                     "cat .xylem/state/report.md",
+		noopMatch:               "XYLEM_NOOP",
+		output:                  "discussion",
+		discussionCategory:      "Reports",
+		discussionTitleTemplate: "Velocity Report — {{.Date}}",
+	}})
+	withTestWorkingDir(t, dir)
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "scheduled-4",
+		Source:    "scheduled",
+		Workflow:  "weekly-report",
+		Meta:      map[string]string{"config_source": "scheduled"},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	dequeued, err := q.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, dequeued)
+
+	cmdRunner := &mockCmdRunner{
+		gateOutput: []byte("XYLEM_NOOP: no weekly report available yet\n"),
+	}
+
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"scheduled": &source.Scheduled{Repo: "owner/repo"},
+	}
+
+	outcome := r.runVessel(context.Background(), *dequeued)
+	assert.Equal(t, "completed", outcome)
+	assert.Equal(t, queue.StateCompleted, loadSingleVessel(t, q).State)
+	assert.False(t, hasRunOutputCallContaining(cmdRunner, "gh api graphql", "createDiscussion"))
+	assert.False(t, hasRunOutputCallContaining(cmdRunner, "gh api graphql", "addDiscussionComment"))
 }
 
 func TestPhasePolicyIntents_IgnoresHighRiskPhrasesFromRenderedPromptContext(t *testing.T) {

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -59,23 +59,32 @@ const (
 
 // Phase represents a single step in a workflow's execution pipeline.
 type Phase struct {
-	Name         string   `yaml:"name"`
-	Type         string   `yaml:"type,omitempty"` // "prompt" (default) or "command"
-	Run          string   `yaml:"run,omitempty"`  // shell command for type=command, supports template variables
-	PromptFile   string   `yaml:"prompt_file"`
-	MaxTurns     int      `yaml:"max_turns"`
-	LLM          *string  `yaml:"llm,omitempty"`
-	Model        *string  `yaml:"model,omitempty"`
-	Tier         *string  `yaml:"tier,omitempty"`
-	NoOp         *NoOp    `yaml:"noop,omitempty"`
-	Gate         *Gate    `yaml:"gate,omitempty"`
-	AllowedTools *string  `yaml:"allowed_tools,omitempty"`
-	DependsOn    []string `yaml:"depends_on,omitempty"`
+	Name         string            `yaml:"name"`
+	Type         string            `yaml:"type,omitempty"` // "prompt" (default) or "command"
+	Run          string            `yaml:"run,omitempty"`  // shell command for type=command, supports template variables
+	PromptFile   string            `yaml:"prompt_file"`
+	MaxTurns     int               `yaml:"max_turns"`
+	LLM          *string           `yaml:"llm,omitempty"`
+	Model        *string           `yaml:"model,omitempty"`
+	Tier         *string           `yaml:"tier,omitempty"`
+	Output       string            `yaml:"output,omitempty"`
+	Discussion   *DiscussionOutput `yaml:"discussion,omitempty"`
+	NoOp         *NoOp             `yaml:"noop,omitempty"`
+	Gate         *Gate             `yaml:"gate,omitempty"`
+	AllowedTools *string           `yaml:"allowed_tools,omitempty"`
+	DependsOn    []string          `yaml:"depends_on,omitempty"`
 }
 
 // NoOp defines an early-success completion rule for a phase.
 type NoOp struct {
 	Match string `yaml:"match"`
+}
+
+// DiscussionOutput defines GitHub Discussions publishing for a phase output.
+type DiscussionOutput struct {
+	Category            string `yaml:"category"`
+	TitleTemplate       string `yaml:"title_template"`
+	TitleSearchTemplate string `yaml:"title_search_template,omitempty"`
 }
 
 // GateEvidence describes the verification evidence metadata attached to a gate.
@@ -295,6 +304,10 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 			}
 		}
 
+		if err := validatePhaseOutput(p); err != nil {
+			return err
+		}
+
 		if p.AllowedTools != nil && *p.AllowedTools == "" {
 			return fmt.Errorf("phase %q: allowed_tools must not be empty when specified", p.Name)
 		}
@@ -458,6 +471,32 @@ func validateDependencyCycles(phases []Phase) error {
 func validateNoOp(phaseName string, n *NoOp) error {
 	if strings.TrimSpace(n.Match) == "" {
 		return fmt.Errorf("phase %q: noop: match is required", phaseName)
+	}
+	return nil
+}
+
+func validatePhaseOutput(p Phase) error {
+	switch p.Output {
+	case "", "discussion":
+	default:
+		return fmt.Errorf("phase %q: output must be \"discussion\" when specified, got %q", p.Name, p.Output)
+	}
+
+	if p.Output == "" {
+		if p.Discussion != nil {
+			return fmt.Errorf("phase %q: discussion config requires output: discussion", p.Name)
+		}
+		return nil
+	}
+
+	if p.Discussion == nil {
+		return fmt.Errorf("phase %q: discussion config is required when output is %q", p.Name, p.Output)
+	}
+	if strings.TrimSpace(p.Discussion.Category) == "" {
+		return fmt.Errorf("phase %q: discussion.category is required when output is %q", p.Name, p.Output)
+	}
+	if strings.TrimSpace(p.Discussion.TitleTemplate) == "" {
+		return fmt.Errorf("phase %q: discussion.title_template is required when output is %q", p.Name, p.Output)
 	}
 	return nil
 }

--- a/cli/internal/workflow/workflow_prop_test.go
+++ b/cli/internal/workflow/workflow_prop_test.go
@@ -48,6 +48,17 @@ func genInvalidWorkflowClass() *rapid.Generator[string] {
 	})
 }
 
+func genInvalidPhaseOutputType() *rapid.Generator[string] {
+	return rapid.Custom(func(t *rapid.T) string {
+		for {
+			output := rapid.StringMatching(`[a-z][a-z-]{0,15}`).Draw(t, "output")
+			if output != "discussion" {
+				return output
+			}
+		}
+	})
+}
+
 func TestPropValidateGateAcceptsRecognizedEvidenceLevels(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		level := genRecognizedGateEvidenceLevel().Draw(t, "level")
@@ -167,5 +178,18 @@ func TestPropWorkflowTierYAMLRoundTripPreservesPointerSemantics(t *testing.T) {
 
 		assertOptional("workflow tier", wf.Tier, roundTripped.Tier)
 		assertOptional("phase tier", wf.Phases[0].Tier, roundTripped.Phases[0].Tier)
+	})
+}
+
+func TestPropValidatePhaseOutputRejectsUnknownOutputTypes(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		output := genInvalidPhaseOutputType().Draw(t, "output")
+		err := validatePhaseOutput(Phase{Name: "report", Output: output})
+		if err == nil {
+			t.Fatalf("validatePhaseOutput() error = nil for output %q", output)
+		}
+		if !strings.Contains(err.Error(), output) {
+			t.Fatalf("validatePhaseOutput() error = %q, want mention of %q", err.Error(), output)
+		}
 	})
 }

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -235,6 +235,143 @@ phases:
 	assert.Equal(t, "", e.TrustBoundary)
 }
 
+func TestSmoke_S1_DiscussionOutputParsesTemplates(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/report.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: report
+    prompt_file: prompts/report.md
+    max_turns: 10
+    output: discussion
+    discussion:
+      category: Reports
+      title_template: "Velocity Report — {{.Date}}"
+      title_search_template: "Velocity Report"
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, "discussion", got.Phases[0].Output)
+	require.NotNil(t, got.Phases[0].Discussion)
+	assert.Equal(t, "Reports", got.Phases[0].Discussion.Category)
+	assert.Equal(t, "Velocity Report — {{.Date}}", got.Phases[0].Discussion.TitleTemplate)
+	assert.Equal(t, "Velocity Report", got.Phases[0].Discussion.TitleSearchTemplate)
+}
+
+func TestSmoke_S2_DiscussionOutputRequiresConfig(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/report.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: report
+    prompt_file: prompts/report.md
+    max_turns: 10
+    output: discussion
+`)
+
+	_, err := Load(path)
+	requireErrorContains(t, err, `phase "report": discussion config is required when output is "discussion"`)
+}
+
+func TestSmoke_S3_DiscussionConfigRequiresOutputDiscussion(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/report.md")
+
+	path := writeWorkflowFile(t, dir, "test-workflow", `name: test-workflow
+phases:
+  - name: report
+    prompt_file: prompts/report.md
+    max_turns: 10
+    discussion:
+      category: Reports
+      title_template: "Velocity Report — {{.Date}}"
+`)
+
+	_, err := Load(path)
+	requireErrorContains(t, err, `phase "report": discussion config requires output: discussion`)
+}
+
+func TestSmoke_S4_DiscussionOutputRequiresCategoryAndTitle(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "missing category",
+			yaml: `name: test-workflow
+phases:
+  - name: report
+    prompt_file: prompts/report.md
+    max_turns: 10
+    output: discussion
+    discussion:
+      title_template: "Velocity Report — {{.Date}}"
+`,
+			want: `phase "report": discussion.category is required when output is "discussion"`,
+		},
+		{
+			name: "blank category",
+			yaml: `name: test-workflow
+phases:
+  - name: report
+    prompt_file: prompts/report.md
+    max_turns: 10
+    output: discussion
+    discussion:
+      category: "   "
+      title_template: "Velocity Report — {{.Date}}"
+`,
+			want: `phase "report": discussion.category is required when output is "discussion"`,
+		},
+		{
+			name: "missing title template",
+			yaml: `name: test-workflow
+phases:
+  - name: report
+    prompt_file: prompts/report.md
+    max_turns: 10
+    output: discussion
+    discussion:
+      category: Reports
+`,
+			want: `phase "report": discussion.title_template is required when output is "discussion"`,
+		},
+		{
+			name: "blank title template",
+			yaml: `name: test-workflow
+phases:
+  - name: report
+    prompt_file: prompts/report.md
+    max_turns: 10
+    output: discussion
+    discussion:
+      category: Reports
+      title_template: "   "
+`,
+			want: `phase "report": discussion.title_template is required when output is "discussion"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			chdirTemp(t, dir)
+			createPromptFile(t, dir, "prompts/report.md")
+
+			path := writeWorkflowFile(t, dir, "test-workflow", tt.yaml)
+			_, err := Load(path)
+			requireErrorContains(t, err, tt.want)
+		})
+	}
+}
+
 func TestLoadWorkflowAllowAdditiveProtectedWritesDefaultsFalse(t *testing.T) {
 	dir := t.TempDir()
 	chdirTemp(t, dir)

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -27,6 +27,8 @@ Workflow (YAML definition)
 
 Each phase produces output that subsequent phases can reference. Gates act as checkpoints -- if a gate fails and retries are exhausted, the vessel is marked as failed. If a gate is a label gate, the vessel enters a `waiting` state until a human applies the required label on GitHub. Live gates also persist step evidence under `.xylem/phases/<vessel-id>/evidence/`.
 
+Phases can also publish their final output to GitHub Discussions by setting `output: discussion`. In that mode, xylem uses the phase output as the discussion body and renders the configured discussion title templates with the same Go-template data available to prompts. If the phase also declares a `noop` matcher and the output matches it, xylem skips publication and completes early just like any other no-op phase.
+
 The built-in workflows scaffolded by `xylem init` are profile-driven. The core profile seeds delivery workflows such as `fix-bug` and `implement-feature`, plus recurring operator workflows such as `lessons`, `context-weight-audit`, `workflow-health-report`, and `security-compliance`. Repo-specific overlays such as `implement-harness` and `continuous-improvement` are not part of the base core scaffold and must be added through an overlay profile or checked-in repo assets. The workflow format also supports `type: command` phases for deterministic shell steps inside the same execution pipeline.
 
 In this repository, `continuous-improvement` is a concrete example of mixing both styles: a deterministic `select_focus` command phase picks the next focus area and persists rotation state, then prompt phases analyze, plan, implement, and verify one small scheduled improvement.
@@ -80,6 +82,15 @@ phases:
   - name: smoke_test
     type: command                                  # Optional shell-command phase
     run: "make smoke-test"
+
+  - name: weekly_report
+    type: command
+    run: "cat .xylem/state/weekly-report.md"
+    output: discussion
+    discussion:
+      category: Reports
+      title_template: "Weekly Report — {{.Date}}"
+      title_search_template: "Weekly Report"
 ```
 
 ### Field reference
@@ -110,6 +121,8 @@ Protected-surface write allowances are intentionally narrow. `allow_additive_pro
 | `llm` | No | Provider override for this prompt phase. Valid values: `claude`, `copilot`. |
 | `model` | No | Model override for this prompt phase. Provider-specific string. |
 | `noop` | No | Early-success completion rule checked against the phase output before any gate runs. |
+| `output` | No | Optional post-phase output target. Supported values: `discussion`. |
+| `discussion` | No | GitHub Discussions publishing config. Requires `output: discussion`. |
 | `allowed_tools` | No | Tool restriction string for prompt phases. Passed through to the provider CLI. Use this instead of top-level `claude.allowed_tools`, which is rejected by config validation. |
 | `gate` | No | Quality gate that must pass after this phase completes. |
 | `depends_on` | No | List of phase names this phase depends on. Enables parallel execution -- phases without dependency relationships can execute concurrently. Validated for duplicate entries, self-references, references to unknown phase names, and dependency cycles. |
@@ -119,6 +132,16 @@ Protected-surface write allowances are intentionally narrow. `allow_additive_pro
 | Field | Required | Description |
 |-------|----------|-------------|
 | `match` | Yes | Substring marker that, when present in successful phase output, completes the workflow early. |
+
+**Discussion output fields (when `output: discussion`):**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `discussion.category` | Yes | GitHub Discussions category name to post into. |
+| `discussion.title_template` | Yes | Go template rendered into the discussion title. |
+| `discussion.title_search_template` | No | Prefix used to find an existing discussion to comment on instead of creating a new one. Defaults to the rendered title. |
+
+Discussion title templates can use the normal phase template data plus `{{.Date}}`, which resolves to the current UTC date in `YYYY-MM-DD` form.
 
 **Gate fields (when `type: command`):**
 


### PR DESCRIPTION
## Summary
- Routes workflow-generated reports and informational content to GitHub Discussions instead of issue comments or ad hoc posting scripts.
- Adds first-class workflow support for `output: discussion`, including title templating, existing-thread lookup, no-op skip behavior, and runner-side publishing.
- Linked issue: https://github.com/nicholls-inc/xylem/issues/273

## Smoke scenarios covered
- S1 — Discussion output parses templates
- S2 — Discussion output requires config
- S3 — Discussion config requires `output: discussion`
- S4 — Discussion output requires category and title
- S5 — Discussion output creates discussion
- S6 — Discussion output comments existing discussion by title prefix
- S7 — Discussion output fails without repo slug
- S8 — Discussion output skips publish on no-op

## Changes summary
- Added `cli/internal/runner/discussion.go` with `discussionPublisher`, GraphQL queries/mutations, `splitRepoSlug`, and discussion create/comment flow.
- Updated `cli/internal/runner/runner.go` to call `publishPhaseOutput` from vessel and single-phase execution paths and fail the vessel when discussion publication fails.
- Updated `cli/internal/workflow/workflow.go` to add `Phase.Output`, `DiscussionOutput`, and `validatePhaseOutput`, with matching unit/property coverage in `workflow_test.go` and `workflow_prop_test.go`.
- Updated `cli/internal/phase/phase.go` to expose `TemplateData.Date` for reusable discussion title templates.
- Converted `cli/internal/profiles/core/workflows/workflow-health-report.yaml`, `cli/internal/profiles/self-hosting-xylem/workflows/initiative-tracker.yaml`, and `cli/internal/profiles/self-hosting-xylem/workflows/portfolio-analyst.yaml` to emit report bodies and publish them through workflow discussion output; updated `cli/internal/profiles/self-hosting-xylem/prompts/portfolio-analyst/report.md` accordingly.
- Documented discussion outputs in `docs/workflows.md` and added runner coverage in `cli/internal/runner/runner_test.go` and `runner_prop_test.go`.

## Test plan
- `cd cli && goimports -l .`
- `cd cli && go vet ./...`
- `cd cli && golangci-lint run`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #273