### PR TITLE
Fix scanner dry-run parity for completed issue refs

### DIFF
--- a/cli/cmd/xylem/scan.go
+++ b/cli/cmd/xylem/scan.go
@@ -52,7 +52,15 @@ func dryRunScan(cfg *config.Config, q *queue.Queue, runner scanner.CommandRunner
 	tmpFile.Close()
 	defer os.Remove(tmpFile.Name())
 
+	seed, err := q.List()
+	if err != nil {
+		return fmt.Errorf("load queue for dry-run: %w", err)
+	}
+
 	dryQ := queue.New(tmpFile.Name())
+	if err := dryQ.ReplaceAll(seed); err != nil {
+		return fmt.Errorf("seed dry-run queue: %w", err)
+	}
 	s := scanner.New(cfg, dryQ, runner)
 	s.RunHooks = false
 	result, err := s.Scan(context.Background())
@@ -63,7 +71,11 @@ func dryRunScan(cfg *config.Config, q *queue.Queue, runner scanner.CommandRunner
 		fmt.Println("Scanning is paused.")
 		return nil
 	}
-	vessels, _ := dryQ.List()
+	vessels, err := dryQ.List()
+	if err != nil {
+		return fmt.Errorf("list dry-run candidates: %w", err)
+	}
+	vessels = vessels[len(seed):]
 	if len(vessels) == 0 {
 		fmt.Println("No new issues found.")
 		return nil

--- a/cli/cmd/xylem/scan_test.go
+++ b/cli/cmd/xylem/scan_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
@@ -164,6 +165,47 @@ func TestScanDryRun(t *testing.T) {
 	}
 }
 
+func TestScanDryRunUsesLiveQueueContext(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeScanConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newScanMock()
+
+	existing := queue.Vessel{
+		ID:        "issue-1",
+		Source:    "github-issue",
+		Ref:       "https://github.com/owner/repo/issues/1",
+		Workflow:  "fix-bug",
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+		Meta:      map[string]string{"issue_num": "1"},
+	}
+	if _, err := q.Enqueue(existing); err != nil {
+		t.Fatalf("seed queue: %v", err)
+	}
+
+	issues := []ghIssueJSON{
+		{Number: 1, Title: "fix null", URL: existing.Ref,
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "bug"}}},
+	}
+	stubScanCommands(r, cfg, issues)
+
+	out := captureStdout(func() {
+		if err := dryRunScan(cfg, q, r); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "No new issues found.") {
+		t.Fatalf("expected dry-run to honor existing queue state, got: %s", out)
+	}
+	if strings.Contains(out, "issue-1") {
+		t.Fatalf("expected dry-run to suppress already-pending issue, got: %s", out)
+	}
+}
+
 func TestScanNormalMode(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeScanConfig(dir)
@@ -195,6 +237,64 @@ func TestScanNormalMode(t *testing.T) {
 	}
 	if vessels[0].ID != "issue-2" {
 		t.Errorf("expected vessel ID issue-2, got %s", vessels[0].ID)
+	}
+}
+
+func TestScanReenqueuesCompletedIssue(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeScanConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newScanMock()
+
+	completed := queue.Vessel{
+		ID:        "issue-3",
+		Source:    "github-issue",
+		Ref:       "https://github.com/owner/repo/issues/3",
+		Workflow:  "fix-bug",
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+		Meta:      map[string]string{"issue_num": "3"},
+	}
+	if _, err := q.Enqueue(completed); err != nil {
+		t.Fatalf("enqueue seed vessel: %v", err)
+	}
+	if err := q.Update(completed.ID, queue.StateRunning, ""); err != nil {
+		t.Fatalf("mark running: %v", err)
+	}
+	if err := q.Update(completed.ID, queue.StateCompleted, ""); err != nil {
+		t.Fatalf("mark completed: %v", err)
+	}
+
+	issues := []ghIssueJSON{
+		{Number: 3, Title: "still open bug", URL: completed.Ref,
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "bug"}}},
+	}
+	stubScanCommands(r, cfg, issues)
+
+	out := captureStdout(func() {
+		if err := cmdScan(cfg, q, r, false); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Added 1") {
+		t.Fatalf("expected completed issue to be re-enqueued, got: %s", out)
+	}
+
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("list queue: %v", err)
+	}
+	if len(vessels) != 2 {
+		t.Fatalf("expected original and re-enqueued vessels, got %d", len(vessels))
+	}
+	if vessels[1].ID != "issue-3" {
+		t.Fatalf("expected re-enqueued vessel to reuse issue id, got %s", vessels[1].ID)
+	}
+	if vessels[1].State != queue.StatePending {
+		t.Fatalf("expected re-enqueued vessel to be pending, got %s", vessels[1].State)
 	}
 }
 

--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -137,8 +137,8 @@ func (q *Queue) Enqueue(vessel Vessel) (bool, error) {
 			for _, v := range vessels {
 				if v.Ref == vessel.Ref {
 					switch v.State {
-					case StatePending, StateRunning, StateWaiting, StateCompleted:
-						return nil // already active or completed, skip silently
+					case StatePending, StateRunning, StateWaiting:
+						return nil // already active, skip silently
 					}
 				}
 			}
@@ -287,6 +287,18 @@ func (q *Queue) List() ([]Vessel, error) {
 		return readErr
 	})
 	return vessels, err
+}
+
+// ReplaceAll rewrites the queue contents with vessels in their current order.
+func (q *Queue) ReplaceAll(vessels []Vessel) error {
+	return q.withLock(func() error {
+		copied := make([]Vessel, len(vessels))
+		copy(copied, vessels)
+		for i := range copied {
+			copied[i].NormalizeWorkflowClass()
+		}
+		return q.writeAllVessels(copied)
+	})
 }
 
 func (q *Queue) FindByID(id string) (*Vessel, error) {

--- a/cli/internal/queue/queue_test.go
+++ b/cli/internal/queue/queue_test.go
@@ -587,8 +587,7 @@ func TestEnqueueIdempotentDuplicateRef(t *testing.T) {
 }
 
 func TestEnqueueAfterTerminalState(t *testing.T) {
-	// Completed vessels block re-enqueue (prevents scanner re-scan loop).
-	t.Run("after completed blocks re-enqueue", func(t *testing.T) {
+	t.Run("after completed", func(t *testing.T) {
 		q, _ := newTestQueue(t)
 		vessel := testVessel(42)
 		if _, err := q.Enqueue(vessel); err != nil {
@@ -606,18 +605,17 @@ func TestEnqueueAfterTerminalState(t *testing.T) {
 		if err != nil {
 			t.Fatalf("re-enqueue: %v", err)
 		}
-		if enqueued {
-			t.Fatal("expected re-enqueue to be blocked after completed state")
+		if !enqueued {
+			t.Fatal("expected re-enqueue to succeed after completed state")
 		}
 	})
 
-	// Failed, cancelled, and timed_out vessels allow re-enqueue.
 	tests := []struct {
 		name        string
 		transitions []VesselState
 	}{
-		{"after failed", []VesselState{StateRunning, StateFailed}},
 		{"after cancelled", []VesselState{StateCancelled}},
+		{"after failed", []VesselState{StateRunning, StateFailed}},
 		{"after timed_out", []VesselState{StateRunning, StateWaiting, StateTimedOut}},
 	}
 


### PR DESCRIPTION
## Summary\n- seed dry-run scans from the live queue so preview output uses the same dedup and retry context as daemon scans\n- allow enqueue after a completed vessel so still-open issues can be scanned back into pending work\n- add regression tests for dry-run queue fidelity and completed-issue re-enqueue behavior\n\nCloses https://github.com/nicholls-inc/xylem/issues/354