### PR TITLE
test: cover stale retry worktree recovery

### DIFF
--- a/cli/internal/recovery/recovery_test.go
+++ b/cli/internal/recovery/recovery_test.go
@@ -554,10 +554,15 @@ func TestSmoke_S10_NextRetryVesselPreservesRecoveryLineageMetadata(t *testing.T)
 		Ref:            "https://github.com/owner/repo/issues/42",
 		Workflow:       "fix-bug",
 		WorkflowDigest: "wf-launch-snapshot",
-		State:          queue.StateFailed,
-		Error:          "temporary failure from upstream 503",
-		FailedPhase:    "verify",
-		GateOutput:     "503 Service Unavailable",
+		CurrentPhase:   2,
+		WorktreePath:   "/tmp/worktrees/issue-42",
+		PhaseOutputs: map[string]string{
+			"plan": "/tmp/.xylem/phases/issue-42/plan.output",
+		},
+		State:       queue.StateFailed,
+		Error:       "temporary failure from upstream 503",
+		FailedPhase: "verify",
+		GateOutput:  "503 Service Unavailable",
 		Meta: map[string]string{
 			"issue_num":                "42",
 			"source_input_fingerprint": "src-fingerprint",
@@ -607,6 +612,9 @@ func TestSmoke_S10_NextRetryVesselPreservesRecoveryLineageMetadata(t *testing.T)
 	assert.NotEmpty(t, retry.Meta[MetaRemediationFingerprint])
 	assert.Equal(t, "updated title", retry.Meta["issue_title"])
 	assert.Empty(t, retry.WorkflowDigest)
+	assert.Zero(t, retry.CurrentPhase)
+	assert.Empty(t, retry.WorktreePath)
+	assert.Nil(t, retry.PhaseOutputs)
 }
 
 func TestSaveRejectsUnsafeVesselID(t *testing.T) {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -340,11 +340,17 @@ func (m *mockWorktree) Remove(_ context.Context, worktreePath string) error {
 }
 
 type trackingWorktree struct {
-	lastBranch string
+	lastBranch  string
+	path        string
+	createCalls int
 }
 
 func (tw *trackingWorktree) Create(_ context.Context, branchName string) (string, error) {
+	tw.createCalls++
 	tw.lastBranch = branchName
+	if tw.path != "" {
+		return tw.path, nil
+	}
 	return ".claude/worktrees/" + branchName, nil
 }
 
@@ -1703,6 +1709,42 @@ func TestDrainSingleVessel(t *testing.T) {
 	if vessels[0].State != queue.StateCompleted {
 		t.Errorf("expected vessel completed, got %s", vessels[0].State)
 	}
+}
+
+func TestEnsureWorktreeRecreatesMissingInheritedPath(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	vessel := queue.Vessel{
+		ID:           "issue-99-retry-1",
+		Source:       "manual",
+		Workflow:     "fix-bug",
+		Ref:          "retry-spec",
+		State:        queue.StatePending,
+		CreatedAt:    time.Now().UTC(),
+		CurrentPhase: 2,
+		WorktreePath: filepath.Join(dir, "missing-worktree"),
+		PhaseOutputs: map[string]string{"plan": filepath.Join(dir, ".xylem", "phases", "issue-99", "plan.output")},
+	}
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	recreatedPath := filepath.Join(dir, "recreated-worktree")
+	wt := &trackingWorktree{path: recreatedPath}
+	r := New(cfg, q, wt, &mockCmdRunner{})
+
+	worktreePath, ok := r.ensureWorktree(context.Background(), &vessel, &source.Manual{})
+	require.True(t, ok)
+	require.Equal(t, recreatedPath, worktreePath)
+	require.Equal(t, recreatedPath, vessel.WorktreePath)
+	require.Equal(t, 1, wt.createCalls)
+	require.Equal(t, "task/issue-99-retry-1-retry-spec", wt.lastBranch)
+
+	stored, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	require.Equal(t, recreatedPath, stored.WorktreePath)
+	require.Equal(t, 2, stored.CurrentPhase)
+	require.Equal(t, vessel.PhaseOutputs, stored.PhaseOutputs)
 }
 
 // TestWS6S29NilHarnessFieldsRunsNormally verifies that a runner without


### PR DESCRIPTION
## Summary
- add recovery coverage proving `NextRetryVessel` resets inherited worktree resume fields
- add runner coverage proving a missing inherited worktree path is recreated and persisted without losing resume metadata
- backfill the regression surface around issue #356 without changing runtime behavior already present on `main`

Closes https://github.com/nicholls-inc/xylem/issues/356