### PR TITLE
feat: add recovery refresh escape hatch for suppressed retry decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ See the [Workflows Guide](docs/workflows.md) for template variables, custom work
 | `xylem daemon stop` | Stop the daemon and suppress supervisor restarts |
 | `xylem enqueue` | Manually enqueue a task |
 | `xylem retry` | Retry a failed vessel with failure context, or restart from scratch |
+| `xylem recovery refresh` | Refresh a suppressed failure-review decision so retries are allowed again |
 | `xylem status` | Show queue state and vessel summary |
 | `xylem pause` / `resume` | Pause and resume scanning |
 | `xylem cancel` | Cancel a pending vessel |
@@ -186,6 +187,7 @@ xylem daemon-supervisor             # Auto-restart wrapper around xylem daemon
 xylem daemon stop                   # Stop the daemon without triggering a restart
 xylem enqueue --workflow fix-bug \
   --ref "https://github.com/owner/repo/issues/99"  # Ad-hoc task
+xylem recovery refresh issue-158-fresh-retry-1     # Re-enable retry after reviewing a suppressed failure-review
 xylem status --json | jq '.[] | select(.state == "failed")'  # Query failures
 xylem dtu load --manifest cli/internal/dtu/testdata/issue-label-gate.yaml        # Seed DTU state from the repo's example fixture
 xylem dtu materialize --manifest cli/internal/dtu/testdata/issue-label-gate.yaml # Prepare DTU runtime and shims

--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -38,7 +38,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "bootstrap", "continuous-improvement", "continuous-simplicity", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report"}
+	expected := []string{"init", "bootstrap", "continuous-improvement", "continuous-simplicity", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "recovery", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/recovery_cmd.go
+++ b/cli/cmd/xylem/recovery_cmd.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/recovery"
+)
+
+func newRecoveryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "recovery",
+		Short: "Inspect and update persisted recovery decisions",
+	}
+	cmd.AddCommand(newRecoveryRefreshCmd())
+	return cmd
+}
+
+func newRecoveryRefreshCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "refresh <vessel-id>",
+		Short: "Refresh a suppressed recovery decision so the vessel can be retried",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmdRecoveryRefresh(deps.cfg, args[0])
+		},
+	}
+}
+
+func cmdRecoveryRefresh(cfg *config.Config, vesselID string) error {
+	if cfg == nil {
+		return fmt.Errorf("recovery refresh: config must not be nil")
+	}
+	artifact, err := recovery.RefreshRetryDecisionForVessel(cfg.StateDir, vesselID, recovery.RefreshOptions{
+		ReviewedAt: commandNow(),
+	})
+	if err != nil {
+		return fmt.Errorf("recovery refresh: %w", err)
+	}
+	fmt.Printf(
+		"Refreshed recovery decision for %s; retry is now allowed with action %s\n",
+		artifact.VesselID,
+		artifact.RecoveryAction,
+	)
+	return nil
+}

--- a/cli/cmd/xylem/retry_test.go
+++ b/cli/cmd/xylem/retry_test.go
@@ -149,6 +149,58 @@ func TestSmoke_S1c_RetryCommandAllowsUpdatedDiagnosisDecision(t *testing.T) {
 	assert.Equal(t, "enqueued", loaded.RetryOutcome)
 }
 
+func TestSmoke_S1d_RecoveryRefreshThenRetryCreatesNewVessel(t *testing.T) {
+	q := newRetryTestQueue(t)
+	cfg := newRetryTestConfig(t)
+	now := time.Now().UTC()
+	v := queue.Vessel{
+		ID:        "issue-158-fresh-retry-1",
+		Source:    "github-issue",
+		Workflow:  "fix-bug",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	}
+	_, err := q.Enqueue(v)
+	require.NoError(t, err)
+	require.NoError(t, q.Update(v.ID, queue.StateRunning, ""))
+	require.NoError(t, q.Update(v.ID, queue.StateFailed, "panic: chdir missing worktree"))
+
+	artifact := &recovery.Artifact{
+		SchemaVersion:           "v1",
+		VesselID:                v.ID,
+		State:                   string(queue.StateFailed),
+		FailureFingerprint:      "fail-worktree-missing",
+		RecoveryClass:           recovery.ClassUnknown,
+		Confidence:              0.79,
+		RecoveryAction:          recovery.ActionHumanEscalation,
+		DecisionSource:          recovery.DecisionSourceDiagnosis,
+		Rationale:               "needs human review",
+		EvidencePaths:           []string{"phases/issue-158-fresh-retry-1/summary.json"},
+		RetryPreconditions:      []string{"Refresh the recovery decision after a human reviews the cited artifacts."},
+		RetrySuppressed:         true,
+		RetryOutcome:            "suppressed",
+		RequiresDecisionRefresh: true,
+		CreatedAt:               now.Add(time.Minute),
+	}
+	require.NoError(t, recovery.Save(cfg.StateDir, artifact))
+
+	require.NoError(t, cmdRecoveryRefresh(cfg, v.ID))
+	require.NoError(t, cmdRetry(q, cfg, v.ID, true))
+
+	retry, err := q.FindByID("issue-158-fresh-retry-1-retry-1")
+	require.NoError(t, err)
+	require.NotNil(t, retry)
+	assert.Equal(t, queue.StatePending, retry.State)
+	assert.Equal(t, v.ID, retry.RetryOf)
+	assert.Equal(t, "decision", retry.Meta[recovery.MetaUnlockedBy])
+
+	loaded, err := recovery.Load(filepath.Join(cfg.StateDir, recovery.RelativePath(v.ID)))
+	require.NoError(t, err)
+	assert.Equal(t, recovery.ActionRetry, loaded.RecoveryAction)
+	assert.False(t, loaded.RetrySuppressed)
+	assert.Equal(t, "enqueued", loaded.RetryOutcome)
+}
+
 func TestRetryCreatesNewVessel(t *testing.T) {
 	q := newRetryTestQueue(t)
 	cfg := newRetryTestConfig(t)

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -44,6 +44,8 @@ func newRootCmd() *cobra.Command {
 			skipTooling := cmd.Name() == "visualize" ||
 				strings.HasPrefix(commandPath, "xylem visualize") ||
 				cmd.Name() == "review" ||
+				cmd.Name() == "recovery" ||
+				strings.HasPrefix(commandPath, "xylem recovery") ||
 				commandPath == "xylem continuous-improvement select" ||
 				commandPath == "xylem harden inventory" ||
 				commandPath == "xylem harden score" ||
@@ -103,6 +105,7 @@ func newRootCmd() *cobra.Command {
 		newReviewCmd(),
 		newGapReportCmd(),
 		newLessonsCmd(),
+		newRecoveryCmd(),
 		newEnqueueCmd(),
 		newStatusCmd(),
 		newPauseCmd(),

--- a/cli/internal/recovery/recovery.go
+++ b/cli/internal/recovery/recovery.go
@@ -164,6 +164,11 @@ type DiagnosisInput struct {
 	Artifact *Artifact
 }
 
+type RefreshOptions struct {
+	ReviewedAt time.Time
+	Rationale  string
+}
+
 type RemediationState struct {
 	SourceInputFP    string
 	HarnessDigest    string
@@ -536,6 +541,82 @@ func LoadForVessel(stateDir, vesselID string) (*Artifact, error) {
 		return nil, fmt.Errorf("load recovery artifact: invalid vessel ID: %w", err)
 	}
 	return Load(Path(stateDir, vesselID))
+}
+
+func RefreshRetryDecision(artifact *Artifact, opts RefreshOptions) (*Artifact, error) {
+	if artifact == nil {
+		return nil, fmt.Errorf("refresh retry decision: artifact must not be nil")
+	}
+
+	updated := cloneArtifact(artifact)
+	reviewedAt := opts.ReviewedAt.UTC()
+	if reviewedAt.IsZero() {
+		reviewedAt = time.Now().UTC()
+	}
+
+	updated.SchemaVersion = schemaVersion
+	updated.DecisionSource = DecisionSourceDiagnosis
+	updated.RecoveryAction = ActionRetry
+	updated.Confidence = max(updated.Confidence, 0.8)
+	updated.Rationale = strings.TrimSpace(opts.Rationale)
+	if updated.Rationale == "" {
+		updated.Rationale = fmt.Sprintf(
+			"A human refreshed the failure-review decision at %s after reviewing the cited artifacts and verifying that the relevant fix landed.",
+			reviewedAt.Format(time.RFC3339),
+		)
+	}
+	if len(updated.EvidencePaths) == 0 {
+		updated.EvidencePaths = []string{filepath.ToSlash(filepath.Join("phases", updated.VesselID, "summary.json"))}
+	}
+	updated.RetryPreconditions = []string{
+		"Review the cited artifacts and confirm the relevant fix landed before retrying.",
+	}
+	updated.FollowUpRoute = ""
+	updated.RetrySuppressed = false
+	updated.RetryOutcome = "not_attempted"
+	updated.UnlockDimension = "decision"
+	updated.RequiresDecisionRefresh = false
+	updated.RetryAfter = nil
+	switch {
+	case updated.RetryCap <= 0:
+		updated.RetryCap = max(DefaultRetryCap, updated.RetryCount+1)
+	case updated.RetryCap <= updated.RetryCount:
+		updated.RetryCap = updated.RetryCount + 1
+	}
+
+	updated.DecisionDigest = DecisionDigest(updated)
+	if updated.RemediationEpoch == "" {
+		updated.RemediationEpoch = strconv.Itoa(max(updated.RetryCount, 0))
+	}
+	updated.RemediationFP = ComputeRemediationFingerprint(RemediationState{
+		SourceInputFP:    updated.SourceInputFP,
+		HarnessDigest:    updated.HarnessDigest,
+		WorkflowDigest:   updated.WorkflowDigest,
+		DecisionDigest:   updated.DecisionDigest,
+		RemediationEpoch: updated.RemediationEpoch,
+	})
+	if err := Validate(updated); err != nil {
+		return nil, fmt.Errorf("refresh retry decision: %w", err)
+	}
+	return updated, nil
+}
+
+func RefreshRetryDecisionForVessel(stateDir, vesselID string, opts RefreshOptions) (*Artifact, error) {
+	if err := validatePathComponent(vesselID); err != nil {
+		return nil, fmt.Errorf("refresh retry decision: invalid vessel ID: %w", err)
+	}
+	artifact, err := LoadForVessel(stateDir, vesselID)
+	if err != nil {
+		return nil, fmt.Errorf("refresh retry decision: %w", err)
+	}
+	updated, err := RefreshRetryDecision(artifact, opts)
+	if err != nil {
+		return nil, err
+	}
+	if err := Save(stateDir, updated); err != nil {
+		return nil, fmt.Errorf("refresh retry decision: %w", err)
+	}
+	return updated, nil
 }
 
 func NextRetryVessel(base, parent queue.Vessel, artifact *Artifact, q *queue.Queue, createdAt time.Time, unlockDimension string) queue.Vessel {

--- a/cli/internal/recovery/recovery_prop_test.go
+++ b/cli/internal/recovery/recovery_prop_test.go
@@ -120,3 +120,56 @@ func TestPropFailureFingerprintNormalizesWhitespaceAndCase(t *testing.T) {
 		}
 	})
 }
+
+func TestPropRefreshRetryDecisionAlwaysAuthorizesRetry(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		vesselID := rapid.StringMatching(`[a-z0-9-]{1,24}`).Draw(t, "vesselID")
+		retryCount := rapid.IntRange(0, 4).Draw(t, "retryCount")
+		retryCap := rapid.IntRange(0, retryCount).Draw(t, "retryCap")
+		artifact := &Artifact{
+			SchemaVersion:           schemaVersion,
+			VesselID:                vesselID,
+			State:                   string(queue.StateFailed),
+			FailureFingerprint:      "fail-" + vesselID,
+			RecoveryClass:           ClassUnknown,
+			Confidence:              0.79,
+			RecoveryAction:          ActionHumanEscalation,
+			DecisionSource:          DecisionSourceDiagnosis,
+			Rationale:               "needs human review",
+			EvidencePaths:           []string{"phases/" + vesselID + "/summary.json"},
+			RetryPreconditions:      []string{"Refresh the recovery decision after a human reviews the cited artifacts."},
+			RetrySuppressed:         true,
+			RetryOutcome:            "suppressed",
+			RetryCount:              retryCount,
+			RetryCap:                retryCap,
+			RequiresDecisionRefresh: true,
+			CreatedAt:               time.Unix(0, 0).UTC(),
+		}
+		before := DecisionDigest(artifact)
+
+		updated, err := RefreshRetryDecision(artifact, RefreshOptions{
+			ReviewedAt: time.Unix(int64(rapid.Int64().Draw(t, "reviewedAtUnix")), 0).UTC(),
+		})
+		if err != nil {
+			t.Fatalf("RefreshRetryDecision() error = %v", err)
+		}
+		if updated.RecoveryAction != ActionRetry {
+			t.Fatalf("RecoveryAction = %q, want %q", updated.RecoveryAction, ActionRetry)
+		}
+		if updated.RetrySuppressed {
+			t.Fatalf("RetrySuppressed = true, want false")
+		}
+		if updated.RequiresDecisionRefresh {
+			t.Fatalf("RequiresDecisionRefresh = true, want false")
+		}
+		if updated.RetryCap < updated.RetryCount+1 {
+			t.Fatalf("RetryCap = %d, want >= %d", updated.RetryCap, updated.RetryCount+1)
+		}
+		if updated.DecisionDigest == before {
+			t.Fatalf("DecisionDigest did not change")
+		}
+		if err := ValidateRetryAuthorization(updated); err != nil {
+			t.Fatalf("ValidateRetryAuthorization() error = %v", err)
+		}
+	})
+}

--- a/cli/internal/recovery/recovery_test.go
+++ b/cli/internal/recovery/recovery_test.go
@@ -293,34 +293,6 @@ func TestCountMatchingFailuresCountsTerminalMatchesOnly(t *testing.T) {
 	assert.Equal(t, 3, CountMatchingFailures(vessels, current, fingerprint))
 }
 
-func TestSmoke_S7_RetryReadyBlocksBeforeCooldownExpires(t *testing.T) {
-	now := time.Date(2026, time.April, 9, 10, 0, 0, 0, time.UTC)
-	retryAfter := now.Add(time.Minute)
-
-	decision := RetryReady(&Artifact{
-		RecoveryAction: ActionRetry,
-		RetryCount:     1,
-		RetryCap:       2,
-		RetryAfter:     &retryAfter,
-	}, now)
-
-	assert.Equal(t, RetryDecision{}, decision)
-}
-
-func TestSmoke_S8_RetryReadyBlocksWhenRetryCapReached(t *testing.T) {
-	now := time.Date(2026, time.April, 9, 10, 0, 0, 0, time.UTC)
-	retryAfter := now.Add(-time.Minute)
-
-	decision := RetryReady(&Artifact{
-		RecoveryAction: ActionRetry,
-		RetryCount:     2,
-		RetryCap:       2,
-		RetryAfter:     &retryAfter,
-	}, now)
-
-	assert.Equal(t, RetryDecision{}, decision)
-}
-
 func TestSmoke_S9_RemediationFingerprintIsStableForSameInputs(t *testing.T) {
 	first := remediationFingerprint("src-fingerprint", "cooldown", 1)
 	second := remediationFingerprint("src-fingerprint", "cooldown", 1)
@@ -644,4 +616,80 @@ func TestUpdateRetryOutcomeRejectsUnsafeVesselID(t *testing.T) {
 	if got := err.Error(); got == "" || !strings.Contains(got, "invalid vessel ID") {
 		t.Fatalf("UpdateRetryOutcome() error = %q, want invalid vessel ID", got)
 	}
+}
+
+func TestSmoke_S11_RefreshRetryDecisionReenablesSuppressedArtifact(t *testing.T) {
+	reviewedAt := time.Date(2026, time.April, 11, 7, 0, 0, 0, time.UTC)
+	artifact := &Artifact{
+		SchemaVersion:           schemaVersion,
+		VesselID:                "issue-158-fresh-retry-1",
+		State:                   string(queue.StateFailed),
+		FailureFingerprint:      "fail-worktree-missing",
+		RecoveryClass:           ClassUnknown,
+		Confidence:              0.79,
+		RecoveryAction:          ActionHumanEscalation,
+		DecisionSource:          DecisionSourceDiagnosis,
+		Rationale:               "needs human review",
+		EvidencePaths:           []string{"phases/issue-158-fresh-retry-1/summary.json"},
+		RetryPreconditions:      []string{"Refresh the recovery decision after a human reviews the cited artifacts."},
+		RetrySuppressed:         true,
+		RetryOutcome:            "suppressed",
+		RetryCount:              1,
+		RetryCap:                0,
+		RequiresDecisionRefresh: true,
+		SourceInputFP:           "src-same",
+		HarnessDigest:           "har-same",
+		WorkflowDigest:          "wf-same",
+		RemediationEpoch:        "1",
+		CreatedAt:               reviewedAt.Add(-time.Hour),
+	}
+	before := DecisionDigest(artifact)
+
+	updated, err := RefreshRetryDecision(artifact, RefreshOptions{ReviewedAt: reviewedAt})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assert.Equal(t, ActionRetry, updated.RecoveryAction)
+	assert.False(t, updated.RetrySuppressed)
+	assert.False(t, updated.RequiresDecisionRefresh)
+	assert.Equal(t, "not_attempted", updated.RetryOutcome)
+	assert.Equal(t, "decision", updated.UnlockDimension)
+	assert.GreaterOrEqual(t, updated.RetryCap, updated.RetryCount+1)
+	assert.Nil(t, updated.RetryAfter)
+	assert.NotEqual(t, before, updated.DecisionDigest)
+	assert.NoError(t, ValidateRetryAuthorization(updated))
+	assert.Contains(t, updated.Rationale, reviewedAt.Format(time.RFC3339))
+}
+
+func TestRefreshRetryDecisionForVesselPersistsUpdatedArtifact(t *testing.T) {
+	stateDir := t.TempDir()
+	artifact := &Artifact{
+		SchemaVersion:           schemaVersion,
+		VesselID:                "issue-159",
+		State:                   string(queue.StateFailed),
+		FailureFingerprint:      "fail-worktree-missing",
+		RecoveryClass:           ClassUnknown,
+		Confidence:              0.79,
+		RecoveryAction:          ActionHumanEscalation,
+		DecisionSource:          DecisionSourceDiagnosis,
+		Rationale:               "needs human review",
+		EvidencePaths:           []string{"phases/issue-159/summary.json"},
+		RetryPreconditions:      []string{"Refresh the recovery decision after a human reviews the cited artifacts."},
+		RetrySuppressed:         true,
+		RetryOutcome:            "suppressed",
+		RequiresDecisionRefresh: true,
+		CreatedAt:               time.Date(2026, time.April, 11, 7, 0, 0, 0, time.UTC),
+	}
+	require.NoError(t, Save(stateDir, artifact))
+
+	updated, err := RefreshRetryDecisionForVessel(stateDir, artifact.VesselID, RefreshOptions{
+		ReviewedAt: time.Date(2026, time.April, 11, 8, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	loaded, err := Load(filepath.Join(stateDir, RelativePath(artifact.VesselID)))
+	require.NoError(t, err)
+	assert.Equal(t, ActionRetry, loaded.RecoveryAction)
+	assert.False(t, loaded.RetrySuppressed)
+	assert.Equal(t, updated.DecisionDigest, loaded.DecisionDigest)
 }

--- a/cli/internal/source/github_test.go
+++ b/cli/internal/source/github_test.go
@@ -263,6 +263,112 @@ func TestSmoke_S2_GitHubScanAutoRetriesEligibleTransientFailure(t *testing.T) {
 	assert.Equal(t, "1", vessels[0].Meta[recovery.MetaRetryCount])
 }
 
+func TestSmoke_S2b_GitHubScanRetriesAfterRecoveryRefreshChangesDecisionDigest(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{{
+		Number: 158,
+		Title:  "missing worktree panic",
+		Body:   "same body",
+		URL:    "https://github.com/owner/repo/issues/158",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}},
+	}}
+	issueBytes, _ := json.Marshal(issues)
+	r.set(issueBytes, "gh", "search", "issues",
+		"--repo", "owner/repo",
+		"--state", "open",
+		"--json", "number,title,body,url,labels",
+		"--limit", "20",
+		"--label", "bug")
+
+	fingerprint := githubSourceFingerprint("missing worktree panic", "same body", []string{"bug"})
+	_, err := q.Enqueue(queue.Vessel{
+		ID:       "issue-158-fresh-retry-1",
+		Source:   "github-issue",
+		Ref:      issues[0].URL,
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":                "158",
+			"source_input_fingerprint": fingerprint,
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = q.Dequeue()
+	require.NoError(t, err)
+	require.NoError(t, q.Update("issue-158-fresh-retry-1", queue.StateFailed, "panic: chdir missing worktree"))
+
+	blocked := &recovery.Artifact{
+		SchemaVersion:           "v1",
+		VesselID:                "issue-158-fresh-retry-1",
+		State:                   string(queue.StateFailed),
+		FailureFingerprint:      "fail-worktree-missing",
+		RecoveryClass:           recovery.ClassUnknown,
+		Confidence:              0.79,
+		RecoveryAction:          recovery.ActionHumanEscalation,
+		DecisionSource:          recovery.DecisionSourceDiagnosis,
+		Rationale:               "needs human review",
+		EvidencePaths:           []string{"phases/issue-158-fresh-retry-1/summary.json"},
+		RetryPreconditions:      []string{"Refresh the recovery decision after a human reviews the cited artifacts."},
+		RetrySuppressed:         true,
+		RetryOutcome:            "suppressed",
+		RequiresDecisionRefresh: true,
+		SourceInputFP:           fingerprint,
+		HarnessDigest:           "har-same",
+		WorkflowDigest:          "wf-same",
+		RemediationEpoch:        "1",
+		CreatedAt:               time.Now().UTC().Add(-time.Hour),
+	}
+	blocked.DecisionDigest = recovery.DecisionDigest(blocked)
+	blocked.RemediationFP = recovery.ComputeRemediationFingerprint(recovery.RemediationState{
+		SourceInputFP:    blocked.SourceInputFP,
+		HarnessDigest:    blocked.HarnessDigest,
+		WorkflowDigest:   blocked.WorkflowDigest,
+		DecisionDigest:   blocked.DecisionDigest,
+		RemediationEpoch: blocked.RemediationEpoch,
+	})
+	require.NoError(t, recovery.Save(dir, blocked))
+
+	failed, err := q.FindByID(blocked.VesselID)
+	require.NoError(t, err)
+	require.NotNil(t, failed)
+	failed.Meta = recovery.ApplyToMeta(failed.Meta, blocked)
+	require.NoError(t, q.UpdateVessel(*failed))
+
+	_, err = recovery.RefreshRetryDecisionForVessel(dir, blocked.VesselID, recovery.RefreshOptions{
+		ReviewedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	g := &GitHub{
+		Repo: "owner/repo",
+		Tasks: map[string]GitHubTask{"fix": {
+			Labels:   []string{"bug"},
+			Workflow: "fix-bug",
+		}},
+		StateDir:              dir,
+		Queue:                 q,
+		CmdRunner:             r,
+		HarnessDigestResolver: func() string { return "har-same" },
+		WorkflowDigestResolver: func(string) string {
+			return "wf-same"
+		},
+	}
+
+	vessels, err := g.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "issue-158-fresh-retry-1-retry-1", vessels[0].ID)
+	assert.Equal(t, blocked.VesselID, vessels[0].RetryOf)
+	assert.Equal(t, "decision", vessels[0].Meta[recovery.MetaUnlockedBy])
+	assert.Equal(t, string(recovery.ActionRetry), vessels[0].Meta[recovery.MetaAction])
+}
+
 func TestSmoke_S2_GitHubScanAutoRetriesEligibleTransientFailureIgnoresStaleBranchWithoutPR(t *testing.T) {
 	t.Parallel()
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -617,6 +617,8 @@ xylem retry <vessel-id> [flags]
 
 This failure context is available to prompt templates so the retried session can avoid repeating the same mistakes.
 
+If retry is blocked by a persisted `failure-review.json` decision such as `human_escalation` with `requires_decision_refresh: true`, run `xylem recovery refresh <vessel-id>` first to replace the suppressed decision with an explicit retry-authorized refresh.
+
 ### Examples
 
 ```bash
@@ -630,6 +632,42 @@ xylem retry issue-42 --from-scratch
 # Retry again after another failure
 xylem retry issue-42
 # Created retry vessel issue-42-retry-2 (retrying issue-42)
+```
+
+---
+
+## xylem recovery refresh
+
+Refresh a persisted `failure-review.json` decision for a failed vessel so retries are allowed again after a human reviews the cited artifacts and confirms the relevant fix landed.
+
+### Usage
+
+```
+xylem recovery refresh <vessel-id>
+```
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `vessel-id` | Yes | The failed or timed-out vessel whose persisted recovery decision should be refreshed. |
+
+### Behavior
+
+1. Loads `<state_dir>/phases/<vessel-id>/failure-review.json`.
+2. Rewrites the persisted decision to `recovery_action: retry` with explicit retry preconditions.
+3. Clears `retry_suppressed` and `requires_decision_refresh`.
+4. Writes a new decision digest so remediation-aware scanner dedup logic can see that the decision changed.
+5. Leaves the failed vessel's queue record untouched; the next retry or scan consumes the refreshed artifact.
+
+### Examples
+
+```bash
+# Re-enable retry for a previously suppressed vessel after reviewing the failure artifacts
+xylem recovery refresh issue-158-fresh-retry-1
+
+# Then retry it immediately
+xylem retry issue-158-fresh-retry-1 --from-scratch
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Implements [#358](https://github.com/nicholls-inc/xylem/issues/358).
- Adds `xylem recovery refresh <vessel-id>` so operators can rewrite a suppressed `failure-review.json` decision into an explicit retry authorization after the runtime fix lands.
- Refreshing the artifact clears `retry_suppressed` and `requires_decision_refresh`, rewrites the `decision_digest`, and lets both `xylem retry` and remediation-aware scanner retry flows unblock without touching shared harness or workflow files.

## Smoke scenarios covered
- `S11` — `RefreshRetryDecisionReenablesSuppressedArtifact`
- `S1d` — `RecoveryRefreshThenRetryCreatesNewVessel`
- `S2b` — `GitHubScanRetriesAfterRecoveryRefreshChangesDecisionDigest`

## Changes summary
- **Added:** `cli/cmd/xylem/recovery_cmd.go`
- **Modified:** `cli/cmd/xylem/root.go`, `cli/cmd/xylem/cobra_test.go`, `cli/cmd/xylem/retry_test.go`
- **Modified:** `cli/internal/recovery/recovery.go`, `cli/internal/recovery/recovery_test.go`, `cli/internal/recovery/recovery_prop_test.go`
- **Modified:** `cli/internal/source/github_test.go`
- **Modified:** `README.md`, `docs/cli-reference.md`
- **Key types/functions:** `recovery.RefreshRetryDecision`, `recovery.RefreshRetryDecisionForVessel`, `main.newRecoveryCmd`, `main.newRecoveryRefreshCmd`, `main.cmdRecoveryRefresh`

## Test plan
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #358