### PR TITLE
Add daemon release cadence auto-merge wiring

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -151,6 +151,16 @@ sources:
         workflow: continuous-improvement
         ref: continuous-improvement
 
+  release-cadence:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "4h"
+    timeout: "15m"
+    tasks:
+      label-mature-release-pr:
+        workflow: release-cadence
+        ref: release-cadence
+
   backlog-refinement:
     type: scheduled
     repo: nicholls-inc/xylem
@@ -198,7 +208,7 @@ daemon:
   auto_merge: true
   auto_merge_repo: nicholls-inc/xylem
   auto_merge_labels: [ready-to-merge]
-  auto_merge_branch_pattern: "^(feat|fix|chore)/issue-\\d+"
+  auto_merge_branch_pattern: "^((feat|fix|chore)/issue-[0-9]+|release-please--.+)"
   auto_merge_reviewer: "copilot-pull-request-reviewer"
 
 concurrency:

--- a/.xylem/HARNESS.md
+++ b/.xylem/HARNESS.md
@@ -83,12 +83,14 @@ CI runs, in order: `goimports -l .`, `go vet`, `golangci-lint`, `go build`, `go 
 # PR auto-admin-merge contract
 
 The daemon auto-merge loop applies to vessel-produced pull requests on
-xylem-managed issue branches that carry the required merge labels:
+xylem-managed issue branches, plus mature `release-please` pull requests,
+when they carry the required merge labels:
 
-- `ready-to-merge` is the daemon's merge-readiness signal for vessel PRs.
+- `ready-to-merge` is the daemon's merge-readiness signal for vessel PRs and promoted `release-please` PRs.
 - The `no-auto-admin-merge` label is an immediate opt-out and leaves the PR for manual handling.
 - Auto-admin-merge only fires when the PR is `MERGEABLE`, CI is fully green, and there is no active `CHANGES_REQUESTED` review state.
-- Human-authored PRs that do not match the xylem issue-branch + merge-label contract remain outside this path and still require normal manual merge decisions.
+- The scheduled `release-cadence` workflow is the only path that promotes a `release-please` PR into this merge loop; those PRs do not require `harness-impl`.
+- Human-authored PRs that do not match the xylem issue-branch or promoted `release-please` contract remain outside this path and still require normal manual merge decisions.
 
 Separately, the checked-in self-hosting `merge-pr` workflow remains scoped to
 `harness-impl` pull requests, so self-hosted harness PRs carry both

--- a/.xylem/workflows/release-cadence.yaml
+++ b/.xylem/workflows/release-cadence.yaml
@@ -1,0 +1,9 @@
+name: release-cadence
+class: harness-maintenance
+description: "Periodically promote mature release-please PRs into the daemon auto-merge path"
+phases:
+  - name: label_ready
+    type: command
+    run: xylem release-cadence label-ready --repo nicholls-inc/xylem
+    noop:
+      match: XYLEM_NOOP

--- a/cli/cmd/xylem/automerge_test.go
+++ b/cli/cmd/xylem/automerge_test.go
@@ -16,7 +16,7 @@ func xylemAutoMergeSettings(t *testing.T) autoMergeSettings {
 	settings, err := newAutoMergeSettings(config.DaemonConfig{
 		AutoMergeRepo:          "nicholls-inc/xylem",
 		AutoMergeLabels:        []string{"ready-to-merge"},
-		AutoMergeBranchPattern: `^(feat|fix|chore)/issue-\d+`,
+		AutoMergeBranchPattern: `^((feat|fix|chore)/issue-[0-9]+|release-please--.+)`,
 		AutoMergeReviewer:      "copilot-pull-request-reviewer",
 	})
 	require.NoError(t, err)
@@ -122,7 +122,7 @@ func TestXylemBranchPattern(t *testing.T) {
 		{"fix/issue-99-99", true},
 		{"chore/issue-1-1", true},
 		{"main", false},
-		{"release-please--branches--main--components--xylem", false},
+		{"release-please--branches--main--components--xylem", true},
 		{"worktree-agent-abc", false},
 		{"docs/smoke-scenarios-unit-1", false},
 		{"feat/self-healing-daemon", false},
@@ -336,6 +336,19 @@ func TestDecideAutoMergeAction(t *testing.T) {
 				HeadRefName: "feat/issue-1-1", State: "OPEN", Mergeable: "MERGEABLE",
 				Labels: mergeReadyLabels, StatusCheckRollup: greenChecks, ReviewDecision: "APPROVED",
 				LatestReviews: copilotReviewed,
+			},
+			want: actionAdminMerge,
+		},
+		{
+			name: "release-please PR with merge-ready label admin-merges",
+			pr: prSummary{
+				HeadRefName:       "release-please--branches--main--components--xylem",
+				State:             "OPEN",
+				Mergeable:         "MERGEABLE",
+				Labels:            mergeReadyLabels,
+				StatusCheckRollup: greenChecks,
+				ReviewDecision:    "APPROVED",
+				LatestReviews:     copilotReviewed,
 			},
 			want: actionAdminMerge,
 		},

--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -38,7 +38,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "bootstrap", "continuous-improvement", "continuous-simplicity", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "recovery", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report"}
+	expected := []string{"init", "bootstrap", "continuous-improvement", "continuous-simplicity", "release-cadence", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "recovery", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -49,6 +49,7 @@ var expectedSelfHostingWorkflows = []string{
 	"initiative-tracker",
 	"metrics-collector",
 	"portfolio-analyst",
+	"release-cadence",
 	"sota-gap-analysis",
 	"unblock-wave",
 }
@@ -682,6 +683,7 @@ func TestSmoke_S5_CorePlusSelfHostingOverlayScaffoldsOverlayWorkflows(t *testing
 	assert.Equal(t, expectedWorkflows, scaffoldedWorkflowNames(t, dir))
 	assert.Contains(t, output, "Created .xylem/workflows/continuous-simplicity.yaml")
 	assert.Contains(t, output, "Created .xylem/workflows/implement-harness.yaml")
+	assert.Contains(t, output, "Created .xylem/workflows/release-cadence.yaml")
 	assert.Contains(t, output, "Created .xylem/workflows/unblock-wave.yaml")
 
 	lockData, err := os.ReadFile(filepath.Join(dir, ".xylem", "profile.lock"))
@@ -694,6 +696,10 @@ func TestSmoke_S5_CorePlusSelfHostingOverlayScaffoldsOverlayWorkflows(t *testing
 	assert.Equal(t, []string{"core", "self-hosting-xylem"}, cfg.Profiles)
 	assert.Contains(t, cfg.Sources, "harness-impl")
 	assert.Contains(t, cfg.Sources, "harness-pr-lifecycle")
+	assert.Contains(t, cfg.Sources, "release-cadence")
+	assert.Equal(t, []string{"ready-to-merge"}, cfg.Daemon.EffectiveAutoMergeLabels())
+	assert.Equal(t, "^((feat|fix|chore)/issue-[0-9]+|release-please--.+)", cfg.Daemon.EffectiveAutoMergeBranchPattern())
+	assert.Equal(t, "copilot-pull-request-reviewer", cfg.Daemon.EffectiveAutoMergeReviewer())
 	require.NoError(t, cfg.Validate())
 }
 

--- a/cli/cmd/xylem/release_cadence.go
+++ b/cli/cmd/xylem/release_cadence.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholls-inc/xylem/cli/internal/releasecadence"
+)
+
+var applyReleaseCadenceReadyLabel = releasecadence.ApplyReadyLabel
+
+func newReleaseCadenceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "release-cadence",
+		Short: "Deterministic helpers for release-please merge cadence",
+	}
+	cmd.AddCommand(newReleaseCadenceLabelReadyCmd())
+	return cmd
+}
+
+func newReleaseCadenceLabelReadyCmd() *cobra.Command {
+	var repo string
+	var readyLabel string
+	var optOutLabel string
+	var minAge time.Duration
+	var minCommits int
+	var nowRaw string
+
+	cmd := &cobra.Command{
+		Use:   "label-ready",
+		Short: "Label a mature release-please PR as ready for daemon auto-merge",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			now, err := parseOptionalNow(nowRaw)
+			if err != nil {
+				return err
+			}
+			result, err := cmdReleaseCadenceLabelReady(context.Background(), repo, readyLabel, optOutLabel, minAge, minCommits, now, &realCmdRunner{})
+			if err != nil {
+				return err
+			}
+			if result.Action == releasecadence.ActionNoop {
+				fmt.Printf("XYLEM_NOOP: %s\n", result.Reason)
+				return nil
+			}
+			fmt.Printf("Applied %s to release PR #%d after %s with %d queued commit(s)\n",
+				result.ReadyLabel,
+				result.PRNumber,
+				result.Age.Round(24*time.Hour),
+				result.CommitCount,
+			)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repo, "repo", "", "GitHub repository slug (owner/name); defaults to repo from config")
+	cmd.Flags().StringVar(&readyLabel, "ready-label", releasecadence.DefaultReadyLabel, "Label to apply once the release PR is mature")
+	cmd.Flags().StringVar(&optOutLabel, "opt-out-label", releasecadence.DefaultOptOutLabel, "Opt-out label that blocks automatic release labeling")
+	cmd.Flags().DurationVar(&minAge, "min-age", releasecadence.DefaultMinAge, "Minimum release PR age before labeling it ready")
+	cmd.Flags().IntVar(&minCommits, "min-commits", releasecadence.DefaultMinCommits, "Minimum queued release PR commit count before labeling it ready")
+	cmd.Flags().StringVar(&nowRaw, "now", "", "Optional RFC3339 timestamp override for deterministic runs")
+	return cmd
+}
+
+func cmdReleaseCadenceLabelReady(ctx context.Context, repo, readyLabel, optOutLabel string, minAge time.Duration, minCommits int, now time.Time, runner releasecadence.CommandRunner) (*releasecadence.Result, error) {
+	if strings.TrimSpace(repo) == "" {
+		if deps == nil || deps.cfg == nil {
+			return nil, fmt.Errorf("release-cadence label-ready requires --repo or loaded config")
+		}
+		repo = detectLessonsRepo(deps.cfg)
+	}
+	if strings.TrimSpace(repo) == "" {
+		return nil, fmt.Errorf("release-cadence label-ready requires --repo or loaded config repo")
+	}
+	result, err := applyReleaseCadenceReadyLabel(ctx, runner, releasecadence.Options{
+		Repo:        repo,
+		ReadyLabel:  readyLabel,
+		OptOutLabel: optOutLabel,
+		MinAge:      minAge,
+		MinCommits:  minCommits,
+		Now:         now,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("apply release cadence ready label: %w", err)
+	}
+	return result, nil
+}

--- a/cli/cmd/xylem/release_cadence_test.go
+++ b/cli/cmd/xylem/release_cadence_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/releasecadence"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type releaseCadenceRunnerStub struct{}
+
+func (releaseCadenceRunnerStub) RunOutput(context.Context, string, ...string) ([]byte, error) {
+	return nil, nil
+}
+
+func TestCmdReleaseCadenceLabelReadyUsesConfigRepo(t *testing.T) {
+	setupTestDeps(t)
+	original := applyReleaseCadenceReadyLabel
+	t.Cleanup(func() {
+		applyReleaseCadenceReadyLabel = original
+	})
+
+	var got releasecadence.Options
+	applyReleaseCadenceReadyLabel = func(_ context.Context, _ releasecadence.CommandRunner, opts releasecadence.Options) (*releasecadence.Result, error) {
+		got = opts
+		return &releasecadence.Result{Action: releasecadence.ActionNoop, Reason: "already satisfied"}, nil
+	}
+
+	now := time.Date(2026, time.April, 11, 12, 0, 0, 0, time.UTC)
+	result, err := cmdReleaseCadenceLabelReady(context.Background(), "", releasecadence.DefaultReadyLabel, releasecadence.DefaultOptOutLabel, releasecadence.DefaultMinAge, releasecadence.DefaultMinCommits, now, releaseCadenceRunnerStub{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, releasecadence.ActionNoop, result.Action)
+	assert.Equal(t, "owner/repo", got.Repo)
+	assert.Equal(t, now, got.Now)
+}

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -97,6 +97,7 @@ func newRootCmd() *cobra.Command {
 		newBootstrapCmd(),
 		newContinuousImprovementCmd(),
 		newContinuousSimplicityCmd(),
+		newReleaseCadenceCmd(),
 		newHardenCmd(),
 		newDtuCmd(),
 		newShimDispatchCmd(),

--- a/cli/internal/dtu/release_cadence_test.go
+++ b/cli/internal/dtu/release_cadence_test.go
@@ -1,0 +1,85 @@
+package dtu_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	dtu "github.com/nicholls-inc/xylem/cli/internal/dtu"
+	"github.com/nicholls-inc/xylem/cli/internal/releasecadence"
+)
+
+func TestFixtureReleaseCadenceMatureAddsReadyLabel(t *testing.T) {
+	env := newScenarioEnv(t, "release-cadence-mature.yaml")
+	now := time.Date(2026, time.April, 11, 12, 0, 0, 0, time.UTC)
+
+	result, err := releasecadence.ApplyReadyLabel(context.Background(), env.cmdRunner, releasecadence.Options{
+		Repo: "owner/repo",
+		Now:  now,
+	})
+	if err != nil {
+		t.Fatalf("ApplyReadyLabel() error = %v", err)
+	}
+	if result == nil || result.Action != releasecadence.ActionLabeled {
+		t.Fatalf("result = %#v, want labeled result", result)
+	}
+	if result.CommitCount != 6 {
+		t.Fatalf("CommitCount = %d, want 6", result.CommitCount)
+	}
+	assertStringSliceEqual(t, readPRLabels(t, env.store, "owner/repo", 3), []string{"ready-to-merge"})
+
+	events := readEvents(t, env.store)
+	editCalls := filterShimEvents(events, dtu.EventKindShimInvocation, "gh", []string{"pr", "edit", "3", "--repo", "owner/repo", "--add-label", "ready-to-merge"})
+	if len(editCalls) != 1 {
+		t.Fatalf("len(pr edit calls) = %d, want 1", len(editCalls))
+	}
+}
+
+func TestFixtureReleaseCadenceBelowThresholdNoops(t *testing.T) {
+	env := newScenarioEnv(t, "release-cadence-below-threshold.yaml")
+	now := time.Date(2026, time.April, 11, 12, 0, 0, 0, time.UTC)
+
+	result, err := releasecadence.ApplyReadyLabel(context.Background(), env.cmdRunner, releasecadence.Options{
+		Repo: "owner/repo",
+		Now:  now,
+	})
+	if err != nil {
+		t.Fatalf("ApplyReadyLabel() error = %v", err)
+	}
+	if result == nil || result.Action != releasecadence.ActionNoop {
+		t.Fatalf("result = %#v, want noop result", result)
+	}
+	if result.CommitCount != 3 {
+		t.Fatalf("CommitCount = %d, want 3", result.CommitCount)
+	}
+	assertStringSliceEqual(t, readPRLabels(t, env.store, "owner/repo", 3), nil)
+
+	events := readEvents(t, env.store)
+	editCalls := filterShimEvents(events, dtu.EventKindShimInvocation, "gh", []string{"pr", "edit", "3", "--repo", "owner/repo", "--add-label", "ready-to-merge"})
+	if len(editCalls) != 0 {
+		t.Fatalf("len(pr edit calls) = %d, want 0", len(editCalls))
+	}
+}
+
+func TestFixtureReleaseCadenceOptOutNoops(t *testing.T) {
+	env := newScenarioEnv(t, "release-cadence-opt-out.yaml")
+	now := time.Date(2026, time.April, 11, 12, 0, 0, 0, time.UTC)
+
+	result, err := releasecadence.ApplyReadyLabel(context.Background(), env.cmdRunner, releasecadence.Options{
+		Repo: "owner/repo",
+		Now:  now,
+	})
+	if err != nil {
+		t.Fatalf("ApplyReadyLabel() error = %v", err)
+	}
+	if result == nil || result.Action != releasecadence.ActionNoop {
+		t.Fatalf("result = %#v, want noop result", result)
+	}
+	assertStringSliceEqual(t, readPRLabels(t, env.store, "owner/repo", 3), []string{"no-auto-admin-merge"})
+
+	events := readEvents(t, env.store)
+	editCalls := filterShimEvents(events, dtu.EventKindShimInvocation, "gh", []string{"pr", "edit", "3", "--repo", "owner/repo", "--add-label", "ready-to-merge"})
+	if len(editCalls) != 0 {
+		t.Fatalf("len(pr edit calls) = %d, want 0", len(editCalls))
+	}
+}

--- a/cli/internal/dtu/testdata/release-cadence-below-threshold.yaml
+++ b/cli/internal/dtu/testdata/release-cadence-below-threshold.yaml
@@ -1,0 +1,23 @@
+metadata:
+  name: release-cadence-below-threshold
+  scenario: release-please PR below commit threshold no-ops
+repositories:
+  - owner: owner
+    name: repo
+    default_branch: main
+    labels:
+      - name: ready-to-merge
+      - name: no-auto-admin-merge
+    pull_requests:
+      - number: 3
+        title: Release Please
+        body: accumulated changelog
+        state: open
+        created_at: 2026-04-01T12:00:00Z
+        base_branch: main
+        head_branch: release-please--branches--main
+        head_sha: aaa111
+        commits:
+          - oid: aaa111
+          - oid: bbb222
+          - oid: ccc333

--- a/cli/internal/dtu/testdata/release-cadence-mature.yaml
+++ b/cli/internal/dtu/testdata/release-cadence-mature.yaml
@@ -1,0 +1,26 @@
+metadata:
+  name: release-cadence-mature
+  scenario: mature release-please PR gets promoted into daemon auto-merge path
+repositories:
+  - owner: owner
+    name: repo
+    default_branch: main
+    labels:
+      - name: ready-to-merge
+      - name: no-auto-admin-merge
+    pull_requests:
+      - number: 3
+        title: Release Please
+        body: accumulated changelog
+        state: open
+        created_at: 2026-04-01T12:00:00Z
+        base_branch: main
+        head_branch: release-please--branches--main
+        head_sha: aaa111
+        commits:
+          - oid: aaa111
+          - oid: bbb222
+          - oid: ccc333
+          - oid: ddd444
+          - oid: eee555
+          - oid: fff666

--- a/cli/internal/dtu/testdata/release-cadence-opt-out.yaml
+++ b/cli/internal/dtu/testdata/release-cadence-opt-out.yaml
@@ -1,0 +1,27 @@
+metadata:
+  name: release-cadence-opt-out
+  scenario: opt-out label blocks release-please promotion
+repositories:
+  - owner: owner
+    name: repo
+    default_branch: main
+    labels:
+      - name: ready-to-merge
+      - name: no-auto-admin-merge
+    pull_requests:
+      - number: 3
+        title: Release Please
+        body: accumulated changelog
+        state: open
+        created_at: 2026-04-01T12:00:00Z
+        labels: [no-auto-admin-merge]
+        base_branch: main
+        head_branch: release-please--branches--main
+        head_sha: aaa111
+        commits:
+          - oid: aaa111
+          - oid: bbb222
+          - oid: ccc333
+          - oid: ddd444
+          - oid: eee555
+          - oid: fff666

--- a/cli/internal/dtu/types.go
+++ b/cli/internal/dtu/types.go
@@ -3,6 +3,7 @@ package dtu
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 const (
@@ -529,25 +530,32 @@ type Issue struct {
 
 // PullRequest describes a GitHub pull request.
 type PullRequest struct {
-	Number                int              `yaml:"number" json:"number"`
-	Title                 string           `yaml:"title" json:"title"`
-	Body                  string           `yaml:"body,omitempty" json:"body,omitempty"`
-	URL                   string           `yaml:"url,omitempty" json:"url,omitempty"`
-	State                 PullRequestState `yaml:"state,omitempty" json:"state,omitempty"`
-	Merged                bool             `yaml:"merged,omitempty" json:"merged,omitempty"`
-	AutoMergeEnabled      bool             `yaml:"auto_merge_enabled,omitempty" json:"auto_merge_enabled,omitempty"`
-	AutoMergeDeleteBranch bool             `yaml:"auto_merge_delete_branch,omitempty" json:"auto_merge_delete_branch,omitempty"`
-	Mergeable             string           `yaml:"mergeable,omitempty" json:"mergeable,omitempty"`
-	ReviewDecision        string           `yaml:"review_decision,omitempty" json:"review_decision,omitempty"`
-	Labels                []string         `yaml:"labels,omitempty" json:"labels,omitempty"`
-	BaseBranch            string           `yaml:"base_branch" json:"base_branch"`
-	HeadBranch            string           `yaml:"head_branch" json:"head_branch"`
-	HeadSHA               string           `yaml:"head_sha" json:"head_sha"`
-	Comments              []Comment        `yaml:"comments,omitempty" json:"comments,omitempty"`
-	Reviews               []Review         `yaml:"reviews,omitempty" json:"reviews,omitempty"`
-	ReviewRequests        []string         `yaml:"review_requests,omitempty" json:"review_requests,omitempty"`
-	ReviewThreads         []ReviewThread   `yaml:"review_threads,omitempty" json:"review_threads,omitempty"`
-	Checks                []Check          `yaml:"checks,omitempty" json:"checks,omitempty"`
+	Number                int                 `yaml:"number" json:"number"`
+	Title                 string              `yaml:"title" json:"title"`
+	Body                  string              `yaml:"body,omitempty" json:"body,omitempty"`
+	URL                   string              `yaml:"url,omitempty" json:"url,omitempty"`
+	CreatedAt             time.Time           `yaml:"created_at,omitempty" json:"created_at,omitempty"`
+	State                 PullRequestState    `yaml:"state,omitempty" json:"state,omitempty"`
+	Merged                bool                `yaml:"merged,omitempty" json:"merged,omitempty"`
+	AutoMergeEnabled      bool                `yaml:"auto_merge_enabled,omitempty" json:"auto_merge_enabled,omitempty"`
+	AutoMergeDeleteBranch bool                `yaml:"auto_merge_delete_branch,omitempty" json:"auto_merge_delete_branch,omitempty"`
+	Mergeable             string              `yaml:"mergeable,omitempty" json:"mergeable,omitempty"`
+	ReviewDecision        string              `yaml:"review_decision,omitempty" json:"review_decision,omitempty"`
+	Labels                []string            `yaml:"labels,omitempty" json:"labels,omitempty"`
+	BaseBranch            string              `yaml:"base_branch" json:"base_branch"`
+	HeadBranch            string              `yaml:"head_branch" json:"head_branch"`
+	HeadSHA               string              `yaml:"head_sha" json:"head_sha"`
+	Comments              []Comment           `yaml:"comments,omitempty" json:"comments,omitempty"`
+	Reviews               []Review            `yaml:"reviews,omitempty" json:"reviews,omitempty"`
+	ReviewRequests        []string            `yaml:"review_requests,omitempty" json:"review_requests,omitempty"`
+	ReviewThreads         []ReviewThread      `yaml:"review_threads,omitempty" json:"review_threads,omitempty"`
+	Checks                []Check             `yaml:"checks,omitempty" json:"checks,omitempty"`
+	Commits               []PullRequestCommit `yaml:"commits,omitempty" json:"commits,omitempty"`
+}
+
+// PullRequestCommit describes a commit visible through `gh pr view --json commits`.
+type PullRequestCommit struct {
+	OID string `yaml:"oid" json:"oid"`
 }
 
 // HasBlockingMergeChecks reports whether any check still prevents a queued

--- a/cli/internal/dtushim/shim.go
+++ b/cli/internal/dtushim/shim.go
@@ -1599,10 +1599,18 @@ func encodePR(state *dtu.State, repo *dtu.Repository, pr dtu.PullRequest, fields
 			out[field] = encodeLabels(pr.Labels)
 		case "state":
 			out[field] = prState(pr)
+		case "createdAt":
+			if !pr.CreatedAt.IsZero() {
+				out[field] = pr.CreatedAt.UTC().Format(time.RFC3339)
+			} else {
+				out[field] = time.Time{}.Format(time.RFC3339)
+			}
 		case "headRefName":
 			out[field] = pr.HeadBranch
 		case "headRefOid":
 			out[field] = pr.HeadSHA
+		case "commits":
+			out[field] = encodePRCommits(pr)
 		case "mergeable":
 			out[field] = prMergeable(pr)
 		case "reviewDecision":
@@ -1624,6 +1632,24 @@ func encodePR(state *dtu.State, repo *dtu.Repository, pr dtu.PullRequest, fields
 		case "mergeCommit":
 			out[field] = map[string]any{"oid": pr.HeadSHA}
 		}
+	}
+	return out
+}
+
+func encodePRCommits(pr dtu.PullRequest) []map[string]any {
+	if len(pr.Commits) == 0 {
+		if strings.TrimSpace(pr.HeadSHA) == "" {
+			return []map[string]any{}
+		}
+		return []map[string]any{{"oid": pr.HeadSHA}}
+	}
+	out := make([]map[string]any, 0, len(pr.Commits))
+	for _, commit := range pr.Commits {
+		oid := strings.TrimSpace(commit.OID)
+		if oid == "" {
+			continue
+		}
+		out = append(out, map[string]any{"oid": oid})
 	}
 	return out
 }

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -136,6 +136,7 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	assert.Contains(t, sortedKeys(composed.Workflows), "initiative-tracker")
 	assert.Contains(t, sortedKeys(composed.Workflows), "backlog-refinement")
 	assert.Contains(t, sortedKeys(composed.Workflows), "ingest-field-reports")
+	assert.Contains(t, sortedKeys(composed.Workflows), "release-cadence")
 	assert.Contains(t, sortedKeys(composed.Prompts), "implement-harness/pr_draft")
 	assert.Contains(t, sortedKeys(composed.Prompts), "continuous-improvement/verify")
 	assert.Contains(t, sortedKeys(composed.Prompts), "hardening-audit/rank")
@@ -150,10 +151,15 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	assert.Contains(t, sortedKeys(composed.Sources), "initiative-tracker")
 	assert.Contains(t, sortedKeys(composed.Sources), "backlog-refinement")
 	assert.Contains(t, sortedKeys(composed.Sources), "ingest-field-reports")
+	assert.Contains(t, sortedKeys(composed.Sources), "release-cadence")
 	require.Len(t, composed.ConfigOverlays, 2)
 
 	assert.Contains(t, sortedKeys(composed.Scripts), "post-discussion.sh")
-	assert.Contains(t, joinOverlays(composed.ConfigOverlays), "concurrency:\n  global: 3\n  per_class:\n    backlog-refinement: 1")
+	overlays := joinOverlays(composed.ConfigOverlays)
+	assert.Contains(t, overlays, "concurrency:\n  global: 3\n  per_class:\n    backlog-refinement: 1")
+	assert.Contains(t, overlays, `auto_merge_labels: [ready-to-merge]`)
+	assert.Contains(t, overlays, `auto_merge_branch_pattern: "^((feat|fix|chore)/issue-[0-9]+|release-please--.+)"`)
+	assert.Contains(t, overlays, `auto_merge_reviewer: "copilot-pull-request-reviewer"`)
 
 	implementHarnessWorkflow := string(composed.Workflows["implement-harness"])
 	assert.Contains(t, implementHarnessWorkflow, `--repo nicholls-inc/xylem`)
@@ -273,6 +279,33 @@ func TestSmoke_S5_SelfHostingProfileScaffoldsDailyBacklogRefinementWorkflow(t *t
 
 	assert.Contains(t, sortedKeys(composed.Prompts), "backlog-refinement/analyze")
 	assert.Contains(t, sortedKeys(composed.Prompts), "backlog-refinement/report")
+}
+
+func TestSmoke_S6_SelfHostingProfileScaffoldsReleaseCadenceWorkflow(t *testing.T) {
+	t.Parallel()
+
+	composed, err := Compose("core", "self-hosting-xylem")
+	require.NoError(t, err)
+
+	var source config.SourceConfig
+	require.NoError(t, yaml.Unmarshal(composed.Sources["release-cadence"], &source))
+	assert.Equal(t, "scheduled", source.Type)
+	assert.Equal(t, "{{ .Repo }}", source.Repo)
+	assert.Equal(t, "4h", source.Schedule)
+	require.Contains(t, source.Tasks, "label-mature-release-pr")
+	assert.Equal(t, "release-cadence", source.Tasks["label-mature-release-pr"].Workflow)
+	assert.Equal(t, "release-cadence", source.Tasks["label-mature-release-pr"].Ref)
+
+	var wf workflowpkg.Workflow
+	require.NoError(t, yaml.Unmarshal(composed.Workflows["release-cadence"], &wf))
+	assert.Equal(t, "release-cadence", wf.Name)
+	assert.Equal(t, workflowpkg.ClassHarnessMaintenance, wf.Class)
+	require.Len(t, wf.Phases, 1)
+	assert.Equal(t, "label_ready", wf.Phases[0].Name)
+	assert.Equal(t, "command", wf.Phases[0].Type)
+	assert.Contains(t, wf.Phases[0].Run, "xylem release-cadence label-ready --repo {{ .Repo }}")
+	require.NotNil(t, wf.Phases[0].NoOp)
+	assert.Equal(t, "XYLEM_NOOP", wf.Phases[0].NoOp.Match)
 }
 
 func TestAdaptRepoWorkflowAssetParsesCleanly(t *testing.T) {

--- a/cli/internal/profiles/self-hosting-xylem/workflows/release-cadence.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/release-cadence.yaml
@@ -1,0 +1,9 @@
+name: release-cadence
+class: harness-maintenance
+description: "Periodically promote mature release-please PRs into the daemon auto-merge path"
+phases:
+  - name: label_ready
+    type: command
+    run: xylem release-cadence label-ready --repo {{ .Repo }}
+    noop:
+      match: XYLEM_NOOP

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -86,6 +86,15 @@ sources:
       daily-rotation:
         workflow: continuous-improvement
         ref: continuous-improvement
+  release-cadence:
+    type: scheduled
+    repo: "{{ .Repo }}"
+    schedule: "4h"
+    timeout: "15m"
+    tasks:
+      label-mature-release-pr:
+        workflow: release-cadence
+        ref: release-cadence
   metrics-collector:
     type: scheduled
     repo: "{{ .Repo }}"
@@ -157,6 +166,9 @@ daemon:
   auto_upgrade: true
   auto_merge: true
   auto_merge_repo: "{{ .Repo }}"
+  auto_merge_labels: [ready-to-merge]
+  auto_merge_branch_pattern: "^((feat|fix|chore)/issue-[0-9]+|release-please--.+)"
+  auto_merge_reviewer: "copilot-pull-request-reviewer"
 
 concurrency:
   global: 3

--- a/cli/internal/releasecadence/releasecadence.go
+++ b/cli/internal/releasecadence/releasecadence.go
@@ -1,0 +1,252 @@
+package releasecadence
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultReadyLabel  = "ready-to-merge"
+	DefaultOptOutLabel = "no-auto-admin-merge"
+	DefaultMinAge      = 7 * 24 * time.Hour
+	DefaultMinCommits  = 5
+)
+
+type CommandRunner interface {
+	RunOutput(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type Action string
+
+const (
+	ActionNoop    Action = "noop"
+	ActionLabeled Action = "labeled"
+)
+
+type Options struct {
+	Repo        string
+	ReadyLabel  string
+	OptOutLabel string
+	MinAge      time.Duration
+	MinCommits  int
+	Now         time.Time
+}
+
+type Result struct {
+	Action      Action
+	PRNumber    int
+	URL         string
+	HeadRefName string
+	Age         time.Duration
+	CommitCount int
+	ReadyLabel  string
+	Reason      string
+}
+
+type prLabel struct {
+	Name string `json:"name"`
+}
+
+type pullRequest struct {
+	Number      int       `json:"number"`
+	Title       string    `json:"title"`
+	URL         string    `json:"url"`
+	HeadRefName string    `json:"headRefName"`
+	CreatedAt   time.Time `json:"createdAt"`
+	Labels      []prLabel `json:"labels"`
+}
+
+type prCommitView struct {
+	Commits []struct {
+		OID string `json:"oid"`
+	} `json:"commits"`
+}
+
+func MatchesReleasePR(headRefName, title string) bool {
+	head := strings.ToLower(strings.TrimSpace(headRefName))
+	name := strings.ToLower(strings.TrimSpace(title))
+	return strings.HasPrefix(head, "release-please") || strings.Contains(name, "release please")
+}
+
+func ApplyReadyLabel(ctx context.Context, runner CommandRunner, opts Options) (*Result, error) {
+	if runner == nil {
+		return nil, fmt.Errorf("release cadence requires a command runner")
+	}
+	opts = withDefaults(opts)
+	if opts.Repo == "" {
+		return nil, fmt.Errorf("release cadence requires a repo slug")
+	}
+
+	pr, err := findReleasePR(ctx, runner, opts.Repo)
+	if err != nil {
+		return nil, err
+	}
+	if pr == nil {
+		return &Result{Action: ActionNoop, Reason: "no open release-please PR found", ReadyLabel: opts.ReadyLabel}, nil
+	}
+
+	if hasLabel(pr.Labels, opts.OptOutLabel) {
+		return &Result{
+			Action:      ActionNoop,
+			PRNumber:    pr.Number,
+			URL:         pr.URL,
+			HeadRefName: pr.HeadRefName,
+			ReadyLabel:  opts.ReadyLabel,
+			Reason:      fmt.Sprintf("release PR #%d opted out via %q", pr.Number, opts.OptOutLabel),
+		}, nil
+	}
+	if hasLabel(pr.Labels, opts.ReadyLabel) {
+		return &Result{
+			Action:      ActionNoop,
+			PRNumber:    pr.Number,
+			URL:         pr.URL,
+			HeadRefName: pr.HeadRefName,
+			ReadyLabel:  opts.ReadyLabel,
+			Reason:      fmt.Sprintf("release PR #%d already has %q", pr.Number, opts.ReadyLabel),
+		}, nil
+	}
+	if pr.CreatedAt.IsZero() {
+		return &Result{
+			Action:      ActionNoop,
+			PRNumber:    pr.Number,
+			URL:         pr.URL,
+			HeadRefName: pr.HeadRefName,
+			ReadyLabel:  opts.ReadyLabel,
+			Reason:      fmt.Sprintf("release PR #%d is missing createdAt metadata", pr.Number),
+		}, nil
+	}
+
+	age := opts.Now.Sub(pr.CreatedAt)
+	if age < opts.MinAge {
+		return &Result{
+			Action:      ActionNoop,
+			PRNumber:    pr.Number,
+			URL:         pr.URL,
+			HeadRefName: pr.HeadRefName,
+			Age:         age,
+			ReadyLabel:  opts.ReadyLabel,
+			Reason:      fmt.Sprintf("release PR #%d is only %s old", pr.Number, roundDurationDay(age)),
+		}, nil
+	}
+
+	commitCount, err := releaseCommitCount(ctx, runner, opts.Repo, pr.Number)
+	if err != nil {
+		return nil, err
+	}
+	if commitCount < opts.MinCommits {
+		return &Result{
+			Action:      ActionNoop,
+			PRNumber:    pr.Number,
+			URL:         pr.URL,
+			HeadRefName: pr.HeadRefName,
+			Age:         age,
+			CommitCount: commitCount,
+			ReadyLabel:  opts.ReadyLabel,
+			Reason:      fmt.Sprintf("release PR #%d has only %d commit(s) queued", pr.Number, commitCount),
+		}, nil
+	}
+
+	if err := addReadyLabel(ctx, runner, opts.Repo, pr.Number, opts.ReadyLabel); err != nil {
+		return nil, err
+	}
+
+	return &Result{
+		Action:      ActionLabeled,
+		PRNumber:    pr.Number,
+		URL:         pr.URL,
+		HeadRefName: pr.HeadRefName,
+		Age:         age,
+		CommitCount: commitCount,
+		ReadyLabel:  opts.ReadyLabel,
+		Reason:      fmt.Sprintf("applied %q to release PR #%d", opts.ReadyLabel, pr.Number),
+	}, nil
+}
+
+func withDefaults(opts Options) Options {
+	opts.Repo = strings.TrimSpace(opts.Repo)
+	opts.ReadyLabel = strings.TrimSpace(opts.ReadyLabel)
+	if opts.ReadyLabel == "" {
+		opts.ReadyLabel = DefaultReadyLabel
+	}
+	opts.OptOutLabel = strings.TrimSpace(opts.OptOutLabel)
+	if opts.OptOutLabel == "" {
+		opts.OptOutLabel = DefaultOptOutLabel
+	}
+	if opts.MinAge <= 0 {
+		opts.MinAge = DefaultMinAge
+	}
+	if opts.MinCommits <= 0 {
+		opts.MinCommits = DefaultMinCommits
+	}
+	if opts.Now.IsZero() {
+		opts.Now = time.Now().UTC()
+	}
+	return opts
+}
+
+func findReleasePR(ctx context.Context, runner CommandRunner, repo string) (*pullRequest, error) {
+	out, err := runner.RunOutput(ctx, "gh", "pr", "list", "--repo", repo, "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt,labels")
+	if err != nil {
+		return nil, fmt.Errorf("list open pull requests: %w", err)
+	}
+
+	var prs []pullRequest
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("parse gh pr list output: %w", err)
+	}
+
+	candidates := make([]pullRequest, 0, len(prs))
+	for _, pr := range prs {
+		if MatchesReleasePR(pr.HeadRefName, pr.Title) {
+			candidates = append(candidates, pr)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].CreatedAt.Before(candidates[j].CreatedAt)
+	})
+	return &candidates[0], nil
+}
+
+func releaseCommitCount(ctx context.Context, runner CommandRunner, repo string, prNumber int) (int, error) {
+	out, err := runner.RunOutput(ctx, "gh", "pr", "view", fmt.Sprintf("%d", prNumber), "--repo", repo, "--json", "commits")
+	if err != nil {
+		return 0, fmt.Errorf("view release pull request #%d: %w", prNumber, err)
+	}
+
+	var view prCommitView
+	if err := json.Unmarshal(out, &view); err != nil {
+		return 0, fmt.Errorf("parse gh pr view output for #%d: %w", prNumber, err)
+	}
+	return len(view.Commits), nil
+}
+
+func addReadyLabel(ctx context.Context, runner CommandRunner, repo string, prNumber int, label string) error {
+	_, err := runner.RunOutput(ctx, "gh", "pr", "edit", fmt.Sprintf("%d", prNumber), "--repo", repo, "--add-label", label)
+	if err != nil {
+		return fmt.Errorf("add %q to release pull request #%d: %w", label, prNumber, err)
+	}
+	return nil
+}
+
+func hasLabel(labels []prLabel, want string) bool {
+	for _, label := range labels {
+		if strings.TrimSpace(label.Name) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func roundDurationDay(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	return d.Round(24 * time.Hour)
+}

--- a/cli/internal/releasecadence/releasecadence_test.go
+++ b/cli/internal/releasecadence/releasecadence_test.go
@@ -1,0 +1,165 @@
+package releasecadence
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type runnerStub struct {
+	calls     [][]string
+	responses map[string][]byte
+}
+
+func (r *runnerStub) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	r.calls = append(r.calls, call)
+	if out, ok := r.responses[strings.Join(call, "\x00")]; ok {
+		return out, nil
+	}
+	return nil, fmt.Errorf("unexpected call: %v", call)
+}
+
+func (r *runnerStub) hasCallPrefix(want ...string) bool {
+	for _, call := range r.calls {
+		if len(call) < len(want) {
+			continue
+		}
+		match := true
+		for i := range want {
+			if call[i] != want[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	return data
+}
+
+func commandKey(name string, args ...string) string {
+	return strings.Join(append([]string{name}, args...), "\x00")
+}
+
+func TestMatchesReleasePR(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, MatchesReleasePR("release-please--branches--main", "Release Please"))
+	assert.True(t, MatchesReleasePR("some-branch", "release please: bump version"))
+	assert.False(t, MatchesReleasePR("feat/issue-42-42", "Regular change"))
+}
+
+func TestApplyReadyLabelNoReleasePR(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 11, 12, 0, 0, 0, time.UTC)
+	runner := &runnerStub{
+		responses: map[string][]byte{
+			commandKey("gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt,labels"): []byte("[]"),
+		},
+	}
+
+	result, err := ApplyReadyLabel(context.Background(), runner, Options{Repo: "owner/repo", Now: now})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, ActionNoop, result.Action)
+	assert.Contains(t, result.Reason, "no open release-please PR")
+	assert.Len(t, runner.calls, 1)
+}
+
+func TestApplyReadyLabelSkipsYoungPR(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 11, 12, 0, 0, 0, time.UTC)
+	runner := &runnerStub{
+		responses: map[string][]byte{
+			commandKey("gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt,labels"): mustJSON(t, []map[string]any{{
+				"number":      21,
+				"title":       "Release Please",
+				"url":         "https://example/pr/21",
+				"headRefName": "release-please--branches--main",
+				"createdAt":   now.Add(-2 * 24 * time.Hour),
+				"labels":      []map[string]any{},
+			}}),
+		},
+	}
+
+	result, err := ApplyReadyLabel(context.Background(), runner, Options{Repo: "owner/repo", Now: now})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, ActionNoop, result.Action)
+	assert.Equal(t, 21, result.PRNumber)
+	assert.Contains(t, result.Reason, "only")
+	assert.False(t, runner.hasCallPrefix("gh", "pr", "view", "21", "--repo", "owner/repo"))
+}
+
+func TestApplyReadyLabelSkipsAlreadyReadyPR(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 11, 12, 0, 0, 0, time.UTC)
+	runner := &runnerStub{
+		responses: map[string][]byte{
+			commandKey("gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt,labels"): mustJSON(t, []map[string]any{{
+				"number":      21,
+				"title":       "Release Please",
+				"url":         "https://example/pr/21",
+				"headRefName": "release-please--branches--main",
+				"createdAt":   now.Add(-10 * 24 * time.Hour),
+				"labels":      []map[string]any{{"name": DefaultReadyLabel}},
+			}}),
+		},
+	}
+
+	result, err := ApplyReadyLabel(context.Background(), runner, Options{Repo: "owner/repo", Now: now})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, ActionNoop, result.Action)
+	assert.Contains(t, result.Reason, DefaultReadyLabel)
+	assert.False(t, runner.hasCallPrefix("gh", "api", "--method", "POST"))
+}
+
+func TestApplyReadyLabelAddsReadyLabelWhenMature(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 11, 12, 0, 0, 0, time.UTC)
+	runner := &runnerStub{
+		responses: map[string][]byte{
+			commandKey("gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt,labels"): mustJSON(t, []map[string]any{{
+				"number":      21,
+				"title":       "Release Please",
+				"url":         "https://example/pr/21",
+				"headRefName": "release-please--branches--main",
+				"createdAt":   now.Add(-10 * 24 * time.Hour),
+				"labels":      []map[string]any{},
+			}}),
+			commandKey("gh", "pr", "view", "21", "--repo", "owner/repo", "--json", "commits"): mustJSON(t, map[string]any{
+				"commits": []map[string]any{{"oid": "a"}, {"oid": "b"}, {"oid": "c"}, {"oid": "d"}, {"oid": "e"}},
+			}),
+			commandKey("gh", "pr", "edit", "21", "--repo", "owner/repo", "--add-label", DefaultReadyLabel): []byte(""),
+		},
+	}
+
+	result, err := ApplyReadyLabel(context.Background(), runner, Options{Repo: "owner/repo", Now: now})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, ActionLabeled, result.Action)
+	assert.Equal(t, 21, result.PRNumber)
+	assert.Equal(t, 5, result.CommitCount)
+	assert.Equal(t, DefaultReadyLabel, result.ReadyLabel)
+	assert.True(t, runner.hasCallPrefix("gh", "pr", "edit", "21", "--repo", "owner/repo", "--add-label", DefaultReadyLabel))
+}

--- a/cli/internal/review/harness_gap.go
+++ b/cli/internal/review/harness_gap.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/recovery"
+	"github.com/nicholls-inc/xylem/cli/internal/releasecadence"
 )
 
 const (
@@ -29,8 +30,6 @@ const (
 	harnessGapStaleConflictThreshold = 1
 	harnessGapRestartThreshold       = 1
 	harnessGapIdleBacklogThreshold   = 15 * time.Minute
-	harnessGapReleasePRAgeThreshold  = 7 * 24 * time.Hour
-	harnessGapReleasePRCommitMinimum = 5
 	harnessGapFailedBacklogThreshold = 3
 	harnessGapLocalSignalsLookback   = 24 * time.Hour
 	harnessGapDaemonLogFileName      = "daemon.log"
@@ -496,7 +495,7 @@ func detectReleaseCadenceGap(ctx context.Context, repo string, runner issueRunne
 	for i := range prs {
 		head := strings.ToLower(strings.TrimSpace(prs[i].HeadRefName))
 		title := strings.ToLower(strings.TrimSpace(prs[i].Title))
-		if strings.HasPrefix(head, "release-please") || strings.Contains(title, "release please") {
+		if releasecadence.MatchesReleasePR(head, title) {
 			releasePR = &prs[i]
 			break
 		}
@@ -505,7 +504,7 @@ func detectReleaseCadenceGap(ctx context.Context, repo string, runner issueRunne
 		return nil, nil
 	}
 	age := now.Sub(releasePR.CreatedAt)
-	if age < harnessGapReleasePRAgeThreshold {
+	if age < releasecadence.DefaultMinAge {
 		return nil, nil
 	}
 
@@ -520,7 +519,7 @@ func detectReleaseCadenceGap(ctx context.Context, repo string, runner issueRunne
 	if err := json.Unmarshal(commitOut, &details); err != nil {
 		return nil, fmt.Errorf("detect release cadence gap: parse gh pr view output: %w", err)
 	}
-	if len(details.Commits) < harnessGapReleasePRCommitMinimum {
+	if len(details.Commits) < releasecadence.DefaultMinCommits {
 		return nil, nil
 	}
 
@@ -529,7 +528,7 @@ func detectReleaseCadenceGap(ctx context.Context, repo string, runner issueRunne
 		"harness-gap-analysis: release-please cadence is drifting",
 		fmt.Sprintf("release PR #%d has been open for %s with %d queued commit(s)", releasePR.Number, age.Round(24*time.Hour), len(details.Commits)),
 		len(details.Commits),
-		harnessGapReleasePRCommitMinimum,
+		releasecadence.DefaultMinCommits,
 		[]string{
 			fmt.Sprintf("#%d opened at %s and still accumulating commits on `%s`", releasePR.Number, releasePR.CreatedAt.Format(time.RFC3339), releasePR.HeadRefName),
 		},

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -357,6 +357,62 @@ xylem review
 
 ---
 
+## xylem release-cadence
+
+Deterministic helpers for release-please merge cadence.
+
+### Usage
+
+```
+xylem release-cadence <subcommand> [flags]
+```
+
+### Subcommands
+
+#### `xylem release-cadence label-ready`
+
+Finds the open `release-please` pull request, checks whether it is mature enough to cut, and applies the ready label that feeds the daemon auto-merge loop.
+
+##### Usage
+
+```bash
+xylem release-cadence label-ready [flags]
+```
+
+##### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--repo` | `string` | config repo | GitHub repository slug (`owner/name`). If omitted, xylem falls back to the repo configured in `.xylem.yml`. |
+| `--ready-label` | `string` | `ready-to-merge` | Label added once the release PR is mature. |
+| `--opt-out-label` | `string` | `no-auto-admin-merge` | Label that blocks automatic promotion for the current release PR. |
+| `--min-age` | `duration` | `168h` | Minimum PR age before xylem marks the release PR ready. |
+| `--min-commits` | `int` | `5` | Minimum queued commit count before xylem marks the release PR ready. |
+| `--now` | `string` | current time | Optional RFC3339 timestamp override for deterministic tests and replay. |
+
+##### Behavior
+
+1. Lists open pull requests in the target repo and selects the `release-please` PR by branch/title shape.
+2. Returns a no-op if there is no release PR, if it already has the ready label, or if the opt-out label is present.
+3. Checks PR age and queued commit count against the configured thresholds.
+4. Applies the ready label with `gh pr edit --add-label` once the PR is mature.
+5. Prints `XYLEM_NOOP: ...` for no-op cases so scheduled workflows can short-circuit cleanly.
+
+##### Examples
+
+```bash
+# Use the repo from .xylem.yml
+xylem release-cadence label-ready
+
+# Check a different repository with stricter release thresholds
+xylem release-cadence label-ready \
+  --repo owner/repo \
+  --min-age 72h \
+  --min-commits 8
+```
+
+---
+
 ## xylem lessons
 
 Synthesize recurring failed-run patterns into institutional-memory proposals for `.xylem/HARNESS.md`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,9 @@ daemon:
 | `upgrade_interval` | string | `"5m"` | No | How often the daemon re-runs auto-upgrade checks while the loop is running. Must be a valid Go duration string. |
 | `auto_merge` | boolean | `false` | No | Enables the merge-ready Copilot review + auto-merge cycle for xylem-authored PRs. |
 | `auto_merge_repo` | string | current repo remote | No | Optional `owner/name` override for auto-merge GitHub operations. |
+| `auto_merge_labels` | list of strings | `["ready-to-merge"]` | No | Labels a PR must carry before the daemon considers it eligible for auto-merge. Blank entries are ignored. |
+| `auto_merge_branch_pattern` | string | `".*"` | No | Regular expression applied to the PR head branch. Only matching branches participate in daemon auto-merge. |
+| `auto_merge_reviewer` | string | `""` | No | Optional GitHub reviewer login requested before the daemon performs the admin merge. Empty disables reviewer requests. |
 
 ### `daemon.stall_monitor`
 
@@ -260,6 +263,15 @@ sources:
       analyze-gaps:
         workflow: harness-gap-analysis
         ref: harness-gap-analysis
+
+  release-cadence:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "4h"
+    tasks:
+      label-mature-release-pr:
+        workflow: release-cadence
+        ref: release-cadence
 ```
 
 `continuous-improvement` is another scheduled self-hosting workflow. It runs a deterministic rotation helper before the prompt phases, persists its focus history under `<state_dir>/state/continuous-improvement/state.json`, writes the current focus brief to `<state_dir>/state/continuous-improvement/current-selection.json`, and then drives a small improvement PR through the normal workflow pipeline.
@@ -277,6 +289,35 @@ sources:
 ```
 
 To opt out, omit or delete the scheduled `continuous-improvement` source from your config; likewise, omit `harness-gap-analysis` if you do not want the sibling scheduled review. No separate feature flag is required.
+
+`release-cadence` is the self-hosting sibling that periodically promotes a mature `release-please` PR into the daemon auto-merge path. It is intentionally a two-step policy:
+
+1. the scheduled helper checks the release PR age and queued commit count, then adds `ready-to-merge`;
+2. the daemon auto-merge loop performs the usual mergeability, green-CI, and review checks before merging.
+
+The bundled `self-hosting-xylem` profile scaffolds that full contract for you: it installs the `release-cadence` scheduled source and narrows `daemon.auto_merge_branch_pattern` to xylem issue branches plus `release-please`, so unrelated human-authored PRs stay outside the auto-admin-merge path.
+
+```yaml
+sources:
+  release-cadence:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "4h"
+    timeout: "15m"
+    tasks:
+      label-mature-release-pr:
+        workflow: release-cadence
+        ref: release-cadence
+
+daemon:
+  auto_merge: true
+  auto_merge_repo: nicholls-inc/xylem
+  auto_merge_labels: [ready-to-merge]
+  auto_merge_branch_pattern: "^((feat|fix|chore)/issue-[0-9]+|release-please--.+)"
+  auto_merge_reviewer: "copilot-pull-request-reviewer"
+```
+
+Use the `no-auto-admin-merge` label on the release PR when you want to pause automatic cutting for a cycle without disabling the scheduled source.
 
 ### `status_labels`
 


### PR DESCRIPTION
## Summary
- add the release-cadence helper, workflow, and DTU coverage for promoting mature release-please PRs into the daemon auto-merge path
- scaffold the self-hosting profile with the release cadence source plus explicit auto-merge labels, branch pattern, and reviewer settings
- document the release cadence contract and generated config behavior

Closes https://github.com/nicholls-inc/xylem/issues/245