### PR TITLE
Fix stall detector retry chains for long implement phases

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -314,7 +314,7 @@ func Load(path string) (*Config, error) {
 			ScanInterval:  "60s",
 			DrainInterval: "30s",
 			StallMonitor: StallMonitorConfig{
-				PhaseStallThreshold:  "10m",
+				PhaseStallThreshold:  "30m",
 				ScannerIdleThreshold: "5m",
 				OrphanCheckEnabled:   true,
 			},

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -179,8 +179,8 @@ claude:
 	if cfg.Daemon.DrainInterval != "30s" {
 		t.Fatalf("Daemon.DrainInterval = %q, want 30s", cfg.Daemon.DrainInterval)
 	}
-	if cfg.Daemon.StallMonitor.PhaseStallThreshold != "10m" {
-		t.Fatalf("Daemon.StallMonitor.PhaseStallThreshold = %q, want 10m", cfg.Daemon.StallMonitor.PhaseStallThreshold)
+	if cfg.Daemon.StallMonitor.PhaseStallThreshold != "30m" {
+		t.Fatalf("Daemon.StallMonitor.PhaseStallThreshold = %q, want 30m", cfg.Daemon.StallMonitor.PhaseStallThreshold)
 	}
 	if cfg.Daemon.StallMonitor.ScannerIdleThreshold != "5m" {
 		t.Fatalf("Daemon.StallMonitor.ScannerIdleThreshold = %q, want 5m", cfg.Daemon.StallMonitor.ScannerIdleThreshold)

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -4057,6 +4057,14 @@ func (r *Runner) trackedProcess(vesselID string) (trackedProcess, bool) {
 	return proc, ok
 }
 
+func (r *Runner) liveTrackedProcess(vesselID string) (trackedProcess, bool) {
+	proc, ok := r.trackedProcess(vesselID)
+	if !ok || proc.Exited || !processAlive(proc.PID) {
+		return trackedProcess{}, false
+	}
+	return proc, true
+}
+
 func processAlive(pid int) bool {
 	if pid <= 0 {
 		return false
@@ -4359,6 +4367,10 @@ func (r *Runner) CheckStalledVessels(ctx context.Context) []StallFinding {
 				}
 				continue
 			}
+		}
+
+		if _, ok := r.liveTrackedProcess(vessel.ID); ok {
+			continue
 		}
 
 		phaseName, modifiedAt, err := r.latestPhaseActivity(vessel.ID)

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -310,6 +310,49 @@ func (b *blockingPhaseCmdRunner) RunPhase(ctx context.Context, _ string, stdin i
 	}
 }
 
+type observedBlockingPhaseCmdRunner struct {
+	started   chan struct{}
+	release   chan struct{}
+	startOnce sync.Once
+}
+
+func newObservedBlockingPhaseCmdRunner() *observedBlockingPhaseCmdRunner {
+	return &observedBlockingPhaseCmdRunner{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (b *observedBlockingPhaseCmdRunner) RunOutput(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (b *observedBlockingPhaseCmdRunner) RunProcess(_ context.Context, _ string, _ string, _ ...string) error {
+	return nil
+}
+
+func (b *observedBlockingPhaseCmdRunner) RunPhase(ctx context.Context, dir string, stdin io.Reader, name string, args ...string) ([]byte, error) {
+	return b.RunPhaseObserved(ctx, dir, stdin, nil, name, args...)
+}
+
+func (b *observedBlockingPhaseCmdRunner) RunPhaseObserved(ctx context.Context, _ string, stdin io.Reader, observer PhaseProcessObserver, _ string, _ ...string) ([]byte, error) {
+	if _, err := io.ReadAll(stdin); err != nil {
+		return nil, err
+	}
+	if observer != nil {
+		pid := os.Getpid()
+		observer.ProcessStarted(pid)
+		defer observer.ProcessExited(pid)
+	}
+	b.startOnce.Do(func() { close(b.started) })
+	select {
+	case <-b.release:
+		return []byte("observed output"), nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
 type mockWorktree struct {
 	mu           sync.Mutex
 	createErr    error
@@ -8167,7 +8210,7 @@ func TestCheckHungVesselsWritesTraceableSummary(t *testing.T) {
 	assert.Equal(t, timeoutSpan.SpanContext().SpanID().String(), summary.Trace.SpanID)
 }
 
-func TestSmoke_S1_PhaseStalledVesselTimesOut(t *testing.T) {
+func TestSmoke_S1_UntrackedPhaseStalledVesselTimesOut(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 2)
 	cfg.StateDir = filepath.Join(dir, ".xylem")
@@ -8202,6 +8245,98 @@ func TestSmoke_S1_PhaseStalledVesselTimesOut(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, queue.StateTimedOut, updated.State)
 	assert.Contains(t, updated.Error, "phase stalled: no output for")
+}
+
+func TestCheckStalledVesselsDoesNotTimeoutLiveTrackedSubprocessWithOldOutput(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "10m"
+	cfg.Daemon.StallMonitor.OrphanCheckEnabled = true
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:        "live-1",
+		Source:    "manual",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	})
+	vessel, _ := q.Dequeue()
+	require.NotNil(t, vessel)
+
+	outputPath := filepath.Join(cfg.StateDir, "phases", vessel.ID, "implement.output")
+	require.NoError(t, os.MkdirAll(filepath.Dir(outputPath), 0o755))
+	require.NoError(t, os.WriteFile(outputPath, []byte(""), 0o644))
+	old := now.Add(-11 * time.Minute)
+	require.NoError(t, os.Chtimes(outputPath, old, old))
+	require.NoError(t, q.UpdateVessel(*vessel))
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	r.markProcessStarted(vessel.ID, "implement", os.Getpid())
+
+	findings := r.CheckStalledVessels(context.Background())
+	require.Empty(t, findings)
+
+	updated, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	assert.Equal(t, queue.StateRunning, updated.State)
+	assert.Empty(t, updated.Error)
+}
+
+func TestCheckStalledVesselsDoesNotTimeoutObservedLivePhaseWithOldOutput(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "10m"
+	cfg.Daemon.StallMonitor.OrphanCheckEnabled = true
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{{
+		name:          "implement",
+		promptContent: "Implement the fix",
+		maxTurns:      5,
+	}})
+	withTestWorkingDir(t, dir)
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	_, err := q.Enqueue(queue.Vessel{
+		ID:        "observed-live-1",
+		Source:    "manual",
+		Workflow:  "fix-bug",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	})
+	require.NoError(t, err)
+
+	vessel, err := q.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, vessel)
+
+	cmdRunner := newObservedBlockingPhaseCmdRunner()
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+
+	done := make(chan string, 1)
+	go func() {
+		done <- r.runVessel(context.Background(), *vessel)
+	}()
+
+	<-cmdRunner.started
+
+	outputPath := filepath.Join(cfg.StateDir, "phases", vessel.ID, "implement.output")
+	old := now.Add(-11 * time.Minute)
+	require.NoError(t, os.Chtimes(outputPath, old, old))
+
+	findings := r.CheckStalledVessels(context.Background())
+	require.Empty(t, findings)
+
+	updated, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	assert.Equal(t, queue.StateRunning, updated.State)
+	assert.Empty(t, updated.Error)
+
+	close(cmdRunner.release)
+	assert.Equal(t, "completed", <-done)
 }
 
 func TestSmoke_S3_OrphanedRunningVesselTimesOut(t *testing.T) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,7 +108,7 @@ daemon:
   scan_interval: "60s"   # how often the daemon scans for new work
   drain_interval: "30s"  # how often the daemon drains pending vessels
   stall_monitor:
-    phase_stall_threshold: "10m"   # mark running vessels timed_out after no phase output activity
+    phase_stall_threshold: "30m"   # mark untracked running vessels timed_out after stale phase output activity
     scanner_idle_threshold: "5m"   # warn when queue stays idle while GitHub backlog exists
     orphan_check_enabled: true      # repair running vessels with no live tracked subprocess
 ```
@@ -151,7 +151,7 @@ daemon:
 
 | Field | Type | Default | Required | Description |
 |-------|------|---------|----------|-------------|
-| `phase_stall_threshold` | string | `"10m"` | No | Maximum time since the most recent `*.output` activity for a running vessel before it is marked `timed_out`. Must be a valid Go duration string. |
+| `phase_stall_threshold` | string | `"30m"` | No | Maximum time since the most recent `*.output` activity for a running vessel that has no live tracked subprocess before it is marked `timed_out`. Must be a valid Go duration string. |
 | `scanner_idle_threshold` | string | `"5m"` | No | How long the queue may remain idle before xylem warns that GitHub backlog still exists. Must be a valid Go duration string. |
 | `orphan_check_enabled` | boolean | `true` | No | When enabled, the daemon repairs running vessels that have no live tracked subprocess by transitioning them to `timed_out`. |
 


### PR DESCRIPTION
## Summary
- raise the default daemon phase stall threshold from 10m to 30m
- skip phase-stall timeout when the runner still has a live tracked subprocess for the vessel
- add regressions for stale untracked output versus live tracked and observed long-running phases

Closes https://github.com/nicholls-inc/xylem/issues/362