### PR TITLE
feat: split .xylem control plane from runtime state

### DIFF
--- a/cli/cmd/xylem/cleanup.go
+++ b/cli/cmd/xylem/cleanup.go
@@ -107,7 +107,7 @@ func cleanupWorktrees(wt *worktree.Manager, q *queue.Queue, dryRun bool) error {
 }
 
 func cleanupPhaseOutputs(cfg *config.Config, q *queue.Queue, dryRun bool) {
-	phasesDir := filepath.Join(cfg.StateDir, "phases")
+	phasesDir := config.RuntimePath(cfg.StateDir, "phases")
 	if _, err := os.Stat(phasesDir); os.IsNotExist(err) {
 		return // no phases directory yet
 	}

--- a/cli/cmd/xylem/daemon_supervisor.go
+++ b/cli/cmd/xylem/daemon_supervisor.go
@@ -431,15 +431,15 @@ func daemonSupervisorSleepWithContext(ctx context.Context, delay time.Duration) 
 }
 
 func daemonPIDPath(cfg *config.Config) string {
-	return filepath.Join(cfg.StateDir, "daemon.pid")
+	return config.RuntimePath(cfg.StateDir, "daemon.pid")
 }
 
 func daemonSupervisorPIDPath(cfg *config.Config) string {
-	return filepath.Join(cfg.StateDir, "daemon-supervisor.pid")
+	return config.RuntimePath(cfg.StateDir, "daemon-supervisor.pid")
 }
 
 func daemonSupervisorStopPath(cfg *config.Config) string {
-	return filepath.Join(cfg.StateDir, "daemon-supervisor.stop")
+	return config.RuntimePath(cfg.StateDir, "daemon-supervisor.stop")
 }
 
 func daemonSupervisorStopRequested(cfg *config.Config) bool {
@@ -451,7 +451,7 @@ func requestDaemonSupervisorStop(cfg *config.Config) error {
 	if cfg == nil {
 		return fmt.Errorf("request daemon supervisor stop: nil config")
 	}
-	if err := os.MkdirAll(cfg.StateDir, 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(daemonSupervisorStopPath(cfg)), 0o755); err != nil {
 		return fmt.Errorf("request daemon supervisor stop: create state dir: %w", err)
 	}
 	if err := os.WriteFile(daemonSupervisorStopPath(cfg), []byte(time.Now().UTC().Format(time.RFC3339Nano)), 0o644); err != nil {

--- a/cli/cmd/xylem/doctor.go
+++ b/cli/cmd/xylem/doctor.go
@@ -69,7 +69,7 @@ func doctorDepsForRoot(base *appDeps, root string) (*appDeps, error) {
 	wt.DefaultBranch = cfg.DefaultBranch
 	return &appDeps{
 		cfg: &cfg,
-		q:   queue.New(filepath.Join(cfg.StateDir, "queue.jsonl")),
+		q:   queue.New(config.RuntimePath(cfg.StateDir, "queue.jsonl")),
 		wt:  wt,
 	}, nil
 }

--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -127,7 +126,7 @@ func buildDrainRunner(cfg *config.Config, q *queue.Queue, wt runner.WorktreeMana
 }
 
 func wireRunnerScaffolding(cfg *config.Config, r *runner.Runner, tracer *observability.Tracer) {
-	auditLogPath := filepath.Join(cfg.StateDir, cfg.EffectiveAuditLogPath())
+	auditLogPath := config.RuntimePath(cfg.StateDir, cfg.EffectiveAuditLogPath())
 	auditLog := intermediary.NewAuditLog(auditLogPath)
 
 	r.Intermediary = intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), auditLog, nil)

--- a/cli/cmd/xylem/dtu.go
+++ b/cli/cmd/xylem/dtu.go
@@ -311,7 +311,10 @@ func resolveDTUOptions(opts *dtuOptions, manifestPath string) (*resolvedDTUOptio
 		absManifest = state.ManifestPath
 	}
 
-	runtimeDir := filepath.Join(stateDir, "dtu", universeID)
+	runtimeDir, err := dtu.UniverseDir(stateDir, universeID)
+	if err != nil {
+		return nil, err
+	}
 	workDir := strings.TrimSpace(opts.WorkDir)
 	if workDir == "" {
 		workDir = filepath.Join(runtimeDir, "workdir")

--- a/cli/cmd/xylem/init.go
+++ b/cli/cmd/xylem/init.go
@@ -115,6 +115,9 @@ func cmdInitWithProfileAndOptions(configPath string, force bool, profileValue st
 		return fmt.Errorf("create state directory: %w", err)
 	}
 	fmt.Printf("Ensured %s/ directory exists\n", defaultStateDir)
+	if err := os.MkdirAll(filepath.Join(defaultStateDir, "state"), 0o755); err != nil {
+		return fmt.Errorf("create runtime state directory: %w", err)
+	}
 
 	gitignorePath := filepath.Join(defaultStateDir, ".gitignore")
 	if err := os.WriteFile(gitignorePath, []byte(scaffoldGitignore), 0o644); err != nil {

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -80,6 +80,9 @@ func TestInitCreatesConfigAndStateDir(t *testing.T) {
 	if _, err := os.Stat(stateDir); err != nil {
 		t.Errorf("state dir not created: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(stateDir, "state")); err != nil {
+		t.Errorf("runtime state dir not created: %v", err)
+	}
 
 	// .gitignore created
 	gitignore := filepath.Join(stateDir, ".gitignore")
@@ -640,6 +643,8 @@ func TestSmoke_S4_CoreInitScaffoldsTrackedControlPlane(t *testing.T) {
 
 	workflows := scaffoldedWorkflowNames(t, dir)
 	assert.Equal(t, expectedCoreWorkflows, workflows)
+
+	assert.DirExists(t, filepath.Join(dir, ".xylem", "state"))
 
 	gitignoreData, err := os.ReadFile(filepath.Join(dir, ".xylem", ".gitignore"))
 	require.NoError(t, err)

--- a/cli/cmd/xylem/logging.go
+++ b/cli/cmd/xylem/logging.go
@@ -114,7 +114,7 @@ func newConfiguredLogger(cfg *config.Config, opts loggerOptions) (*slog.Logger, 
 }
 
 func daemonLogPath(stateDir string) string {
-	return filepath.Join(stateDir, daemonLogFileName)
+	return config.RuntimePath(stateDir, daemonLogFileName)
 }
 
 func openDaemonLogFile(stateDir string) (*os.File, error) {

--- a/cli/cmd/xylem/logging_test.go
+++ b/cli/cmd/xylem/logging_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/contrib/bridges/otelslog"
 	otellog "go.opentelemetry.io/otel/log"
 	otelglobal "go.opentelemetry.io/otel/log/global"
@@ -95,6 +97,13 @@ func TestNewConfiguredLoggerDaemonWritesToFile(t *testing.T) {
 	if !strings.Contains(got, "component=daemon") {
 		t.Fatalf("daemon log file missing structured attribute: %q", got)
 	}
+}
+
+func TestDaemonLogPathUsesRuntimeStateForControlPlaneDirectories(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("state/\n"), 0o644))
+
+	assert.Equal(t, config.RuntimePath(dir, daemonLogFileName), daemonLogPath(dir))
 }
 
 func TestNewConfiguredLoggerWithoutDaemonFileSkipsLogFile(t *testing.T) {

--- a/cli/cmd/xylem/pause.go
+++ b/cli/cmd/xylem/pause.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -25,7 +26,7 @@ func cmdPause(cfg *config.Config) error {
 		fmt.Println("Already paused.")
 		return nil
 	}
-	if err := os.MkdirAll(cfg.StateDir, 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(marker), 0o755); err != nil {
 		return fmt.Errorf("error creating state dir: %w", err)
 	}
 	if err := os.WriteFile(marker, []byte{}, 0o644); err != nil {

--- a/cli/cmd/xylem/retry.go
+++ b/cli/cmd/xylem/retry.go
@@ -95,8 +95,8 @@ func rewritePhaseOutputs(outputs map[string]string, oldID, newID string) map[str
 // copyPhaseOutputFiles copies all files from the original vessel's phase output
 // directory to the retry vessel's phase output directory.
 func copyPhaseOutputFiles(stateDir, oldID, newID string) error {
-	srcDir := filepath.Join(stateDir, "phases", oldID)
-	dstDir := filepath.Join(stateDir, "phases", newID)
+	srcDir := config.RuntimePath(stateDir, "phases", oldID)
+	dstDir := config.RuntimePath(stateDir, "phases", newID)
 
 	entries, err := os.ReadDir(srcDir)
 	if err != nil {

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -75,7 +74,7 @@ func newRootCmd() *cobra.Command {
 				}
 			}
 
-			queueFile := filepath.Join(cfg.StateDir, "queue.jsonl")
+			queueFile := config.RuntimePath(cfg.StateDir, "queue.jsonl")
 			wt := worktree.New(".", &realCmdRunner{})
 			wt.DefaultBranch = cfg.DefaultBranch
 			deps = &appDeps{

--- a/cli/cmd/xylem/status.go
+++ b/cli/cmd/xylem/status.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
@@ -194,7 +193,7 @@ func formatSummaryCost(summary *runner.VesselSummary) string {
 }
 
 func pauseMarkerPath(cfg *config.Config) string {
-	return filepath.Join(cfg.StateDir, "paused")
+	return config.RuntimePath(cfg.StateDir, "paused")
 }
 
 func isPaused(cfg *config.Config) bool {

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -20,6 +20,7 @@ const minTimeout = 30 * time.Second
 const DefaultAuditLogPath = "audit.jsonl"
 const DefaultLLMRoutingTier = "med"
 const DefaultAutoAdminMergeOptOutLabel = "no-auto-admin-merge"
+const runtimeStateDirName = "state"
 
 // DefaultProtectedSurfaces is the default list of paths that xylem's
 // runtime verifier treats as off-limits to vessel modifications.
@@ -346,6 +347,101 @@ func ResolveStateDir(root, stateDir string) string {
 		return stateDir
 	}
 	return filepath.Join(root, stateDir)
+}
+
+// RuntimeRoot returns the resolved runtime-state root for a control-plane
+// state_dir. It prefers the profile-ready .xylem/state/ layout, but keeps the
+// legacy flat layout alive while those artifacts still exist.
+func RuntimeRoot(stateDir string) string {
+	stateDir = strings.TrimSpace(stateDir)
+	if stateDir == "" {
+		return ""
+	}
+	if !looksLikeControlPlaneDir(stateDir) {
+		return stateDir
+	}
+
+	runtimeRoot := filepath.Join(stateDir, runtimeStateDirName)
+	if pathExists(runtimeRoot) {
+		return runtimeRoot
+	}
+	if hasLegacyRuntimeArtifacts(stateDir) {
+		return stateDir
+	}
+	return runtimeRoot
+}
+
+// RuntimePath resolves a runtime-state path beneath state_dir. Control-plane
+// directories use the new .xylem/state/ subtree by default, but legacy flat
+// artifacts are still honored during the migration window.
+func RuntimePath(stateDir string, elems ...string) string {
+	stateDir = strings.TrimSpace(stateDir)
+	if stateDir == "" {
+		return filepath.Join(elems...)
+	}
+	if !looksLikeControlPlaneDir(stateDir) {
+		return filepath.Join(append([]string{stateDir}, elems...)...)
+	}
+	if hasRuntimePrefix(elems...) {
+		return filepath.Join(append([]string{stateDir}, elems...)...)
+	}
+	runtimePath := filepath.Join(append([]string{stateDir, runtimeStateDirName}, elems...)...)
+	legacyPath := filepath.Join(append([]string{stateDir}, elems...)...)
+	if pathExists(runtimePath) {
+		return runtimePath
+	}
+	if pathExists(legacyPath) {
+		return legacyPath
+	}
+	return runtimePath
+}
+
+func hasRuntimePrefix(elems ...string) bool {
+	if len(elems) == 0 {
+		return false
+	}
+	clean := filepath.ToSlash(filepath.Clean(filepath.Join(elems...)))
+	return clean == runtimeStateDirName || strings.HasPrefix(clean, runtimeStateDirName+"/")
+}
+
+func looksLikeControlPlaneDir(stateDir string) bool {
+	if filepath.Base(filepath.Clean(stateDir)) == ".xylem" {
+		return true
+	}
+	for _, marker := range []string{".gitignore", "HARNESS.md", "profile.lock", "workflows", "prompts"} {
+		if pathExists(filepath.Join(stateDir, marker)) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasLegacyRuntimeArtifacts(stateDir string) bool {
+	for _, marker := range []string{
+		"queue.jsonl",
+		"phases",
+		"schedules",
+		"reviews",
+		"locks",
+		"traces",
+		"dtu",
+		"paused",
+		"daemon.pid",
+		"daemon.log",
+		"daemon-supervisor.pid",
+		"daemon-supervisor.stop",
+		"schedule-state.json",
+	} {
+		if pathExists(filepath.Join(stateDir, marker)) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 // normalize migrates legacy top-level Repo/Tasks/Exclude into the Sources map.

--- a/cli/internal/config/config_prop_test.go
+++ b/cli/internal/config/config_prop_test.go
@@ -2,11 +2,13 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 )
 
@@ -86,6 +88,27 @@ func TestPropResolveStateDirRebasesRelativePaths(t *testing.T) {
 		want := filepath.Join(root, stateDir)
 		if got != want {
 			t.Fatalf("ResolveStateDir(%q, %q) = %q, want %q", root, stateDir, got, want)
+		}
+	})
+}
+
+func TestPropRuntimePathAddsSingleStatePrefixForControlPlane(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		root, err := os.MkdirTemp("", "runtime-path-control-plane-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(root)
+		require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte("state/\n"), 0o644))
+
+		segments := []string{
+			rapid.StringMatching(`[A-Za-z0-9._-]{1,8}`).Draw(t, "segment-a"),
+			rapid.StringMatching(`[A-Za-z0-9._-]{1,8}`).Draw(t, "segment-b"),
+			rapid.StringMatching(`[A-Za-z0-9._-]{1,8}`).Draw(t, "segment-c"),
+		}
+
+		got := RuntimePath(root, segments...)
+		want := filepath.Join(append([]string{root, "state"}, segments...)...)
+		if got != want {
+			t.Fatalf("RuntimePath(%q, %#v) = %q, want %q", root, segments, got, want)
 		}
 	})
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -281,6 +281,46 @@ func TestResolveStateDir(t *testing.T) {
 	})
 }
 
+func TestSmoke_S2_RuntimePathPrefersProfileReadyStateWhenPresent(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte("state/\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "state"), 0o755))
+
+	got := RuntimePath(root, "queue.jsonl")
+	want := filepath.Join(root, "state", "queue.jsonl")
+	assert.Equal(t, want, got)
+	assert.Equal(t, filepath.Join(root, "state"), RuntimeRoot(root))
+}
+
+func TestSmoke_S3_RuntimePathFallsBackToLegacyFlatArtifact(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte("state/\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "queue.jsonl"), []byte("{}\n"), 0o644))
+
+	got := RuntimePath(root, "queue.jsonl")
+	want := filepath.Join(root, "queue.jsonl")
+	assert.Equal(t, want, got)
+	assert.Equal(t, root, RuntimeRoot(root))
+}
+
+func TestRuntimePathDoesNotDoubleNestExplicitStatePaths(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte("state/\n"), 0o644))
+
+	got := RuntimePath(root, "state", "bootstrap", "marker.json")
+	want := filepath.Join(root, "state", "bootstrap", "marker.json")
+	assert.Equal(t, want, got)
+}
+
+func TestRuntimePathPreservesNonControlPlaneRoots(t *testing.T) {
+	root := t.TempDir()
+
+	got := RuntimePath(root, "phases", "issue-1", "summary.json")
+	want := filepath.Join(root, "phases", "issue-1", "summary.json")
+	assert.Equal(t, want, got)
+	assert.Equal(t, root, RuntimeRoot(root))
+}
+
 func validConfig() *Config {
 	cfg := &Config{
 		Repo: "owner/name",

--- a/cli/internal/dtu/runtime.go
+++ b/cli/internal/dtu/runtime.go
@@ -3,6 +3,8 @@ package dtu
 import (
 	"fmt"
 	"path/filepath"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 )
 
 const (
@@ -35,7 +37,7 @@ func UniverseDir(stateDir, universeID string) (string, error) {
 	if err := validatePathComponent(universeID); err != nil {
 		return "", fmt.Errorf("resolve DTU universe dir: invalid universe ID: %w", err)
 	}
-	return filepath.Join(stateDir, "dtu", universeID), nil
+	return config.RuntimePath(stateDir, "dtu", universeID), nil
 }
 
 // DefaultEventLogPath returns the conventional event log path for a DTU universe.
@@ -49,7 +51,7 @@ func DefaultEventLogPath(stateDir, universeID string) (string, error) {
 
 // DefaultShimDir returns the conventional shim directory for a DTU state root.
 func DefaultShimDir(stateDir string) string {
-	return filepath.Join(stateDir, "dtu", "shims")
+	return config.RuntimePath(stateDir, "dtu", "shims")
 }
 
 // RecordRuntimeEvent appends a DTU event to the active runtime store when one is configured.

--- a/cli/internal/dtu/scenario_cancel_test.go
+++ b/cli/internal/dtu/scenario_cancel_test.go
@@ -3,7 +3,6 @@ package dtu_test
 import (
 	"context"
 	"io"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -154,5 +153,5 @@ func TestScenarioIssueCancelDuringResolveStopsRunner(t *testing.T) {
 
 	summary := loadVesselSummary(t, env.stateDir, "issue-181")
 	assert.Equal(t, "cancelled", summary.State)
-	assert.FileExists(t, filepath.Join(env.stateDir, "phases", "issue-181", "summary.json"))
+	assert.FileExists(t, config.RuntimePath(env.stateDir, "phases", "issue-181", "summary.json"))
 }

--- a/cli/internal/dtu/scenario_daemon_test.go
+++ b/cli/internal/dtu/scenario_daemon_test.go
@@ -198,7 +198,7 @@ func TestSmoke_S4_DeterministicPhaseStallRecovery(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, vessel)
 
-	outputPath := filepath.Join(env.stateDir, "phases", vessel.ID, "analyze.output")
+	outputPath := config.RuntimePath(env.stateDir, "phases", vessel.ID, "analyze.output")
 	require.NoError(t, os.MkdirAll(filepath.Dir(outputPath), 0o755))
 	require.NoError(t, os.WriteFile(outputPath, []byte(""), 0o644))
 	old := now.Add(-11 * time.Minute)

--- a/cli/internal/dtu/scenario_static_test.go
+++ b/cli/internal/dtu/scenario_static_test.go
@@ -249,7 +249,7 @@ func TestScenarioIssueCommandGateRetryPassesOnRetry(t *testing.T) {
 	env := newScenarioEnv(t, "issue-command-gate-retry.yaml")
 	defer withWorkingDir(t, env.repoDir)()
 
-	gateTarget := filepath.Join(env.stateDir, "phases", "issue-7", "implement.output")
+	gateTarget := config.RuntimePath(env.stateDir, "phases", "issue-7", "implement.output")
 	writeScenarioWorkflow(t, env.repoDir, "fix-bug", []scenarioPhase{
 		{
 			name:           "implement",
@@ -301,7 +301,7 @@ func TestScenarioIssueCommandGateRetryPassesOnRetry(t *testing.T) {
 	// Trigger label "bug" removed by OnComplete; only terminal status remains.
 	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 7), []string{"done"})
 
-	phasesDir := filepath.Join(env.stateDir, "phases", "issue-7")
+	phasesDir := config.RuntimePath(env.stateDir, "phases", "issue-7")
 	promptPath := filepath.Join(phasesDir, "implement.prompt")
 	prompt := readScenarioFile(t, promptPath)
 	if !strings.Contains(prompt, "gate check failed") {

--- a/cli/internal/dtu/scenario_test.go
+++ b/cli/internal/dtu/scenario_test.go
@@ -172,7 +172,7 @@ func newScenarioEnv(t *testing.T, fixtureName string) *dtuScenarioEnv {
 		stateDir:     stateDir,
 		manifestPath: manifestPath,
 		store:        store,
-		queue:        queue.New(filepath.Join(stateDir, "queue.jsonl")),
+		queue:        queue.New(config.RuntimePath(stateDir, "queue.jsonl")),
 		cmdRunner:    cmdRunner,
 	}
 }
@@ -356,7 +356,7 @@ func loadState(t *testing.T, store *dtu.Store) *dtu.State {
 func loadVesselSummary(t *testing.T, stateDir, vesselID string) runnerpkg.VesselSummary {
 	t.Helper()
 
-	data, err := os.ReadFile(filepath.Join(stateDir, "phases", vesselID, "summary.json"))
+	data, err := os.ReadFile(config.RuntimePath(stateDir, "phases", vesselID, "summary.json"))
 	if err != nil {
 		t.Fatalf("read summary.json for %q: %v", vesselID, err)
 	}

--- a/cli/internal/evidence/evidence.go
+++ b/cli/internal/evidence/evidence.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 )
 
 const manifestFileName = "evidence-manifest.json"
@@ -238,7 +240,7 @@ func SaveManifest(stateDir, vesselID string, manifest *Manifest) error {
 		return fmt.Errorf("save manifest: %w", err)
 	}
 
-	path := filepath.Join(stateDir, "phases", manifest.VesselID, manifestFileName)
+	path := config.RuntimePath(stateDir, "phases", manifest.VesselID, manifestFileName)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("save manifest: create dir: %w", err)
 	}
@@ -261,7 +263,7 @@ func LoadManifest(stateDir, vesselID string) (*Manifest, error) {
 		return nil, fmt.Errorf("load manifest: invalid vessel ID: %w", err)
 	}
 
-	path := filepath.Join(stateDir, "phases", vesselID, manifestFileName)
+	path := config.RuntimePath(stateDir, "phases", vesselID, manifestFileName)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("load manifest: read: %w", err)
@@ -292,7 +294,7 @@ func SaveArtifact(stateDir, vesselID, name string, data []byte, mediaType, descr
 		return Artifact{}, fmt.Errorf("save artifact: %w", err)
 	}
 
-	path := filepath.Join(stateDir, "phases", vesselID, "evidence", filepath.FromSlash(cleanName))
+	path := config.RuntimePath(stateDir, "phases", vesselID, "evidence", filepath.FromSlash(cleanName))
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return Artifact{}, fmt.Errorf("save artifact: create dir: %w", err)
 	}

--- a/cli/internal/lessons/lessons.go
+++ b/cli/internal/lessons/lessons.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
 	"github.com/nicholls-inc/xylem/cli/internal/review"
 )
@@ -211,7 +212,7 @@ func Generate(ctx context.Context, stateDir string, opts Options, prClient PRCli
 		Warnings:           warnings,
 	}
 
-	outputDir := filepath.Join(stateDir, opts.OutputDir)
+	outputDir := config.RuntimePath(stateDir, opts.OutputDir)
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return nil, fmt.Errorf("generate lessons: create output dir: %w", err)
 	}

--- a/cli/internal/recovery/recovery.go
+++ b/cli/internal/recovery/recovery.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
@@ -444,7 +445,7 @@ func ApplyToMeta(meta map[string]string, artifact *Artifact) map[string]string {
 }
 
 func Path(stateDir, vesselID string) string {
-	return filepath.Join(stateDir, "phases", vesselID, artifactFileName)
+	return config.RuntimePath(stateDir, "phases", vesselID, artifactFileName)
 }
 
 func RelativePath(vesselID string) string {

--- a/cli/internal/review/context_weight.go
+++ b/cli/internal/review/context_weight.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 )
 
 const (
@@ -160,7 +162,7 @@ func GenerateContextWeightAudit(stateDir string, opts ContextWeightOptions) (*Co
 		Warnings:          append([]string(nil), warnings...),
 	}
 
-	outputDir := filepath.Join(stateDir, opts.OutputDir)
+	outputDir := config.RuntimePath(stateDir, opts.OutputDir)
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return nil, fmt.Errorf("generate context-weight audit: create output dir: %w", err)
 	}
@@ -214,7 +216,7 @@ func PublishContextWeightIssues(ctx context.Context, stateDir, repo string, runn
 		now = now.UTC()
 	}
 
-	statePath := filepath.Join(stateDir, outputDir, contextWeightIssueStateName)
+	statePath := config.RuntimePath(stateDir, outputDir, contextWeightIssueStateName)
 	state, err := loadContextWeightIssueState(statePath)
 	if err != nil {
 		return nil, err

--- a/cli/internal/review/context_weight_test.go
+++ b/cli/internal/review/context_weight_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
 )
 
@@ -326,5 +327,27 @@ func TestPublishContextWeightIssuesDedupsRepeatedFindings(t *testing.T) {
 	}
 	if !strings.Contains(renderContextWeightIssueBody(report.Findings[0], report.Baseline), "xylem:context-weight-fingerprint=deadbeef") {
 		t.Fatal("issue body missing fingerprint marker")
+	}
+}
+
+func TestGenerateContextWeightAuditUsesRuntimeStateForControlPlaneDirectories(t *testing.T) {
+	stateDir := newControlPlaneStateDir(t)
+	now := time.Date(2026, time.April, 9, 14, 0, 0, 0, time.UTC)
+
+	result, err := GenerateContextWeightAudit(stateDir, ContextWeightOptions{
+		OutputDir: "reviews",
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("GenerateContextWeightAudit() error = %v", err)
+	}
+
+	expectedJSON := config.RuntimePath(stateDir, "reviews", contextWeightReportJSONName)
+	expectedMarkdown := config.RuntimePath(stateDir, "reviews", contextWeightReportMarkdownName)
+	if result.JSONPath != expectedJSON {
+		t.Fatalf("JSONPath = %q, want %q", result.JSONPath, expectedJSON)
+	}
+	if result.MarkdownPath != expectedMarkdown {
+		t.Fatalf("MarkdownPath = %q, want %q", result.MarkdownPath, expectedMarkdown)
 	}
 }

--- a/cli/internal/review/harness_gap.go
+++ b/cli/internal/review/harness_gap.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/releasecadence"
@@ -135,7 +136,7 @@ func GenerateHarnessGapAnalysis(ctx context.Context, stateDir, repo string, runn
 		Warnings:    warnings,
 	}
 
-	outputDir := filepath.Join(stateDir, opts.OutputDir)
+	outputDir := config.RuntimePath(stateDir, opts.OutputDir)
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return nil, fmt.Errorf("generate harness-gap analysis: create output dir: %w", err)
 	}
@@ -189,7 +190,7 @@ func PublishHarnessGapIssues(ctx context.Context, stateDir, repo string, runner 
 		now = now.UTC()
 	}
 
-	statePath := filepath.Join(stateDir, outputDir, harnessGapIssueStateName)
+	statePath := config.RuntimePath(stateDir, outputDir, harnessGapIssueStateName)
 	state, err := loadHarnessGapIssueState(statePath)
 	if err != nil {
 		return nil, err
@@ -315,7 +316,7 @@ func buildHarnessGapFindings(ctx context.Context, stateDir, repo string, runner 
 }
 
 func buildHarnessGapLocalFindings(stateDir string, now time.Time) ([]HarnessGapFinding, []string, error) {
-	path := filepath.Join(stateDir, harnessGapDaemonLogFileName)
+	path := config.RuntimePath(stateDir, harnessGapDaemonLogFileName)
 	entries, err := loadHarnessGapDaemonLog(path)
 	if err != nil {
 		return nil, nil, err
@@ -581,7 +582,7 @@ func detectFailedFingerprintBacklogGap(ctx context.Context, stateDir, repo strin
 
 	var q *queue.Queue
 	if strings.TrimSpace(stateDir) != "" {
-		q = queue.New(filepath.Join(stateDir, "queue.jsonl"))
+		q = queue.New(config.RuntimePath(stateDir, "queue.jsonl"))
 	}
 	evidence := make([]string, 0, len(issues))
 	count := 0

--- a/cli/internal/review/harness_gap_test.go
+++ b/cli/internal/review/harness_gap_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/stretchr/testify/assert"
@@ -336,6 +337,37 @@ func TestPublishHarnessGapIssuesDedupsRepeatedFindings(t *testing.T) {
 	}
 	if !strings.Contains(runner.createBody, harnessGapFindingMarkerPrefix+report.Findings[0].Fingerprint) {
 		t.Fatalf("create body missing fingerprint marker: %q", runner.createBody)
+	}
+}
+
+func TestGenerateHarnessGapAnalysisUsesRuntimeStateForControlPlaneDirectories(t *testing.T) {
+	stateDir := newControlPlaneStateDir(t)
+	now := time.Date(2026, time.April, 10, 1, 0, 0, 0, time.UTC)
+	runner := &harnessGapTestRunner{
+		responses: map[string][]byte{
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "merged", "--limit", "100", "--json", "number,title,url,headRefName,mergedAt,mergedBy,labels"):                        []byte("[]"),
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--label", "needs-conflict-resolution", "--limit", "100", "--json", "number,title,url,mergeable,headRefName"): []byte("[]"),
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt"):                                         []byte("[]"),
+			commandKey("git", "rev-list", "--left-right", "--count", "origin/main...HEAD"):                                                                                                          []byte("0\t0\n"),
+			commandKey("gh", "--repo", "owner/repo", "issue", "list", "--state", "open", "--label", "xylem-failed", "--limit", "100", "--json", "number,title,url,labels"):                          []byte("[]"),
+		},
+	}
+
+	result, err := GenerateHarnessGapAnalysis(context.Background(), stateDir, "owner/repo", runner, HarnessGapOptions{
+		OutputDir: "reviews",
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("GenerateHarnessGapAnalysis() error = %v", err)
+	}
+
+	expectedJSON := config.RuntimePath(stateDir, "reviews", harnessGapReportJSONName)
+	expectedMarkdown := config.RuntimePath(stateDir, "reviews", harnessGapReportMarkdownName)
+	if result.JSONPath != expectedJSON {
+		t.Fatalf("JSONPath = %q, want %q", result.JSONPath, expectedJSON)
+	}
+	if result.MarkdownPath != expectedMarkdown {
+		t.Fatalf("MarkdownPath = %q, want %q", result.MarkdownPath, expectedMarkdown)
 	}
 }
 

--- a/cli/internal/review/load.go
+++ b/cli/internal/review/load.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
@@ -26,7 +27,7 @@ type LoadedRun struct {
 }
 
 func LoadRuns(stateDir string, lookbackRuns int) ([]LoadedRun, int, []string, error) {
-	phaseDir := filepath.Join(stateDir, "phases")
+	phaseDir := config.RuntimePath(stateDir, "phases")
 	entries, err := os.ReadDir(phaseDir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -160,7 +161,7 @@ func resolveArtifactPath(stateDir, legacyPath, reviewPath string) string {
 	if rel == "" {
 		return ""
 	}
-	return filepath.Join(stateDir, filepath.FromSlash(rel))
+	return config.RuntimePath(stateDir, filepath.FromSlash(rel))
 }
 
 func reviewArtifactValue(artifacts *runner.ReviewArtifacts, selectPath func(*runner.ReviewArtifacts) string) string {

--- a/cli/internal/review/review.go
+++ b/cli/internal/review/review.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
@@ -124,7 +125,7 @@ func Generate(stateDir string, opts Options) (*Result, error) {
 	report.Groups, report.CostAnomalies = buildGroupReviews(runs, opts.MinSamples)
 	report.Summary = summarizeRecommendations(report.Groups)
 
-	outputDir := filepath.Join(stateDir, opts.OutputDir)
+	outputDir := config.RuntimePath(stateDir, opts.OutputDir)
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return nil, fmt.Errorf("generate review: create output dir: %w", err)
 	}
@@ -156,7 +157,7 @@ func LoadLatestReport(stateDir, outputDir string) (*Report, error) {
 	if strings.TrimSpace(outputDir) == "" {
 		outputDir = defaultOutputDir
 	}
-	path := filepath.Join(stateDir, outputDir, reportJSONName)
+	path := config.RuntimePath(stateDir, outputDir, reportJSONName)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cli/internal/review/review_test.go
+++ b/cli/internal/review/review_test.go
@@ -370,6 +370,13 @@ func requireSummaryOnly(t *testing.T, stateDir string, summary runner.VesselSumm
 	}
 }
 
+func newControlPlaneStateDir(t *testing.T) string {
+	t.Helper()
+	stateDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, ".gitignore"), []byte("state/\n"), 0o644))
+	return stateDir
+}
+
 func findGroup(t *testing.T, groups []GroupReview, source, workflow, phase string) GroupReview {
 	t.Helper()
 	for _, group := range groups {

--- a/cli/internal/review/workflow_health.go
+++ b/cli/internal/review/workflow_health.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
 )
@@ -207,7 +208,7 @@ func GenerateWorkflowHealthReport(stateDir string, opts WorkflowHealthOptions) (
 		Warnings:            append([]string(nil), warnings...),
 	}
 
-	outputDir := filepath.Join(stateDir, opts.OutputDir)
+	outputDir := config.RuntimePath(stateDir, opts.OutputDir)
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return nil, fmt.Errorf("generate workflow-health report: create output dir: %w", err)
 	}
@@ -262,7 +263,7 @@ func PublishWorkflowHealthIssues(ctx context.Context, stateDir, repo string, cmd
 	}
 
 	weekKey := workflowHealthWeekKey(report.WindowEnd)
-	statePath := filepath.Join(stateDir, outputDir, workflowHealthIssueStateName)
+	statePath := config.RuntimePath(stateDir, outputDir, workflowHealthIssueStateName)
 	state, err := loadWorkflowHealthIssueState(statePath)
 	if err != nil {
 		return nil, err
@@ -376,7 +377,7 @@ func PublishWorkflowHealthIssues(ctx context.Context, stateDir, repo string, cmd
 }
 
 func loadWorkflowHealthFleet(stateDir string) (int, runner.FleetStatusReport, error) {
-	q := queue.New(filepath.Join(stateDir, "queue.jsonl"))
+	q := queue.New(config.RuntimePath(stateDir, "queue.jsonl"))
 	vessels, err := q.List()
 	if err != nil {
 		return 0, runner.FleetStatusReport{}, fmt.Errorf("load queue: %w", err)

--- a/cli/internal/review/workflow_health_test.go
+++ b/cli/internal/review/workflow_health_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
@@ -246,4 +247,21 @@ func TestSmoke_S3_WriteReportWhenWindowHasNoRecentRuns(t *testing.T) {
 	assert.Empty(t, result.Report.EscalationFindings)
 	assert.Contains(t, result.Markdown, "No completed or failed vessel runs landed in the reporting window")
 	assert.NotContains(t, strings.Join(result.Report.Warnings, "\n"), "error")
+}
+
+func TestGenerateWorkflowHealthReportUsesRuntimeStateForControlPlaneDirectories(t *testing.T) {
+	stateDir := newControlPlaneStateDir(t)
+	now := time.Date(2026, time.April, 10, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, os.MkdirAll(filepath.Dir(config.RuntimePath(stateDir, "queue.jsonl")), 0o755))
+
+	result, err := GenerateWorkflowHealthReport(stateDir, WorkflowHealthOptions{
+		OutputDir: "reviews",
+		Now:       now,
+	})
+	require.NoError(t, err)
+
+	expectedJSON := config.RuntimePath(stateDir, "reviews", workflowHealthReportJSONName)
+	expectedMarkdown := config.RuntimePath(stateDir, "reviews", workflowHealthReportMarkdownName)
+	assert.Equal(t, expectedJSON, result.JSONPath)
+	assert.Equal(t, expectedMarkdown, result.MarkdownPath)
 }

--- a/cli/internal/runner/monitor_prop_test.go
+++ b/cli/internal/runner/monitor_prop_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"pgregory.net/rapid"
 )
@@ -24,7 +25,7 @@ func TestProp_LatestPhaseActivityReturnsNewestOutput(t *testing.T) {
 
 		vesselID := rapid.StringMatching(`[a-z0-9-]{1,16}`).Draw(t, "vesselID")
 		phaseCount := rapid.IntRange(1, 8).Draw(t, "phaseCount")
-		phasesDir := filepath.Join(cfg.StateDir, "phases", vesselID)
+		phasesDir := config.RuntimePath(cfg.StateDir, "phases", vesselID)
 		if err := os.MkdirAll(phasesDir, 0o755); err != nil {
 			t.Fatalf("MkdirAll(%q): %v", phasesDir, err)
 		}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -732,7 +732,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			}
 
 			// Create phases dir early
-			phasesDir := filepath.Join(r.Config.StateDir, "phases", vessel.ID)
+			phasesDir := config.RuntimePath(r.Config.StateDir, "phases", vessel.ID)
 			if err := os.MkdirAll(phasesDir, 0o755); err != nil {
 				finishCurrentPhaseSpan(err)
 				r.failVessel(vessel.ID, fmt.Sprintf("create phases dir: %v", err))
@@ -1243,7 +1243,7 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 		return "failed"
 	}
 
-	outputPath := filepath.Join(r.Config.StateDir, "phases", vessel.ID, "prompt.output")
+	outputPath := config.RuntimePath(r.Config.StateDir, "phases", vessel.ID, "prompt.output")
 	if touchErr := r.touchPhaseActivity(outputPath); touchErr != nil {
 		log.Printf("warn: touch phase activity %s: %v", outputPath, touchErr)
 	}
@@ -1795,7 +1795,7 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 	}
 
 	if vrs.costTracker != nil {
-		reportPath := filepath.Join(r.Config.StateDir, "phases", vessel.ID, costReportFileName)
+		reportPath := config.RuntimePath(r.Config.StateDir, "phases", vessel.ID, costReportFileName)
 		report := vrs.buildCostReport(summary)
 		if err := os.MkdirAll(filepath.Dir(reportPath), 0o755); err != nil {
 			log.Printf("warn: save cost report: %v", fmt.Errorf("create dir: %w", err))
@@ -1806,7 +1806,7 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 			reviewArtifacts.CostReport = summary.CostReportPath
 		}
 
-		alertsPath := filepath.Join(r.Config.StateDir, "phases", vessel.ID, budgetAlertsFileName)
+		alertsPath := config.RuntimePath(r.Config.StateDir, "phases", vessel.ID, budgetAlertsFileName)
 		if err := saveJSONArtifact(alertsPath, vrs.costTracker.Alerts()); err != nil {
 			log.Printf("warn: save budget alerts: %v", err)
 		} else {
@@ -1815,7 +1815,7 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 		}
 	}
 
-	evalPath := filepath.Join(r.Config.StateDir, "phases", vessel.ID, evalReportFileName)
+	evalPath := config.RuntimePath(r.Config.StateDir, "phases", vessel.ID, evalReportFileName)
 	if info, err := os.Stat(evalPath); err == nil && !info.IsDir() {
 		summary.EvalReportPath = evalReportRelativePath(vessel.ID)
 		reviewArtifacts.EvalReport = summary.EvalReportPath
@@ -2246,7 +2246,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			phaseSpanEnded = true
 		}
 
-		phasesDir := filepath.Join(r.Config.StateDir, "phases", vessel.ID)
+		phasesDir := config.RuntimePath(r.Config.StateDir, "phases", vessel.ID)
 		if err := os.MkdirAll(phasesDir, 0o755); err != nil {
 			finishCurrentPhaseSpan(err)
 			r.failVessel(vessel.ID, fmt.Sprintf("create phases dir: %v", err))
@@ -3828,7 +3828,7 @@ func (r *Runner) workflowSnapshotPath(vesselID, workflowName string) string {
 	if r == nil || r.Config == nil || r.Config.StateDir == "" || strings.TrimSpace(vesselID) == "" || strings.TrimSpace(workflowName) == "" {
 		return ""
 	}
-	return filepath.Join(r.Config.StateDir, "phases", vesselID, workflowSnapshotDirName, workflowName+".yaml")
+	return config.RuntimePath(r.Config.StateDir, "phases", vesselID, workflowSnapshotDirName, workflowName+".yaml")
 }
 
 func (r *Runner) readHarness() string {
@@ -3969,7 +3969,7 @@ func (r *Runner) fetchGitHubData(ctx context.Context, vessel *queue.Vessel, ghCm
 
 func (r *Runner) rebuildPreviousOutputs(vesselID string, sk *workflow.Workflow) map[string]string {
 	outputs := make(map[string]string)
-	phasesDir := filepath.Join(r.Config.StateDir, "phases", vesselID)
+	phasesDir := config.RuntimePath(r.Config.StateDir, "phases", vesselID)
 	for _, p := range sk.Phases {
 		outputPath := filepath.Join(phasesDir, p.Name+".output")
 		data, err := os.ReadFile(outputPath)
@@ -3999,7 +3999,7 @@ func (r *Runner) touchPhaseActivity(path string) error {
 }
 
 func (r *Runner) latestPhaseActivity(vesselID string) (string, time.Time, error) {
-	phasesDir := filepath.Join(r.Config.StateDir, "phases", vesselID)
+	phasesDir := config.RuntimePath(r.Config.StateDir, "phases", vesselID)
 	entries, err := os.ReadDir(phasesDir)
 	if err != nil {
 		return "", time.Time{}, err

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -1357,7 +1357,7 @@ func TestSmoke_S1_PolicyDenialShortCircuitsBeforeSurfaceSnapshot(t *testing.T) {
 	assert.Contains(t, vessel.Error, "denied by policy")
 	assert.Len(t, cmdRunner.phaseCalls, 0)
 
-	_, statErr := os.Stat(filepath.Join(cfg.StateDir, "phases", "issue-1", "solve.output"))
+	_, statErr := os.Stat(config.RuntimePath(cfg.StateDir, "phases", "issue-1", "solve.output"))
 	assert.ErrorIs(t, statErr, os.ErrNotExist)
 }
 
@@ -1388,7 +1388,7 @@ func TestSmoke_S2_SurfacePreSnapshotFailureShortCircuitsBeforePhaseExecution(t *
 	assert.Contains(t, vessel.Error, "snapshot failed")
 	assert.Len(t, cmdRunner.phaseCalls, 0)
 
-	_, statErr := os.Stat(filepath.Join(cfg.StateDir, "phases", "issue-1", "plan.output"))
+	_, statErr := os.Stat(config.RuntimePath(cfg.StateDir, "phases", "issue-1", "plan.output"))
 	assert.ErrorIs(t, statErr, os.ErrNotExist)
 }
 
@@ -1806,7 +1806,7 @@ func TestEnsureWorktreeRecreatesMissingInheritedPath(t *testing.T) {
 		CreatedAt:    time.Now().UTC(),
 		CurrentPhase: 2,
 		WorktreePath: filepath.Join(dir, "missing-worktree"),
-		PhaseOutputs: map[string]string{"plan": filepath.Join(dir, ".xylem", "phases", "issue-99", "plan.output")},
+		PhaseOutputs: map[string]string{"plan": config.RuntimePath(filepath.Join(dir, ".xylem"), "phases", "issue-99", "plan.output")},
 	}
 	_, err := q.Enqueue(vessel)
 	require.NoError(t, err)
@@ -2280,7 +2280,7 @@ func TestDrainMultiPhaseWorkflow(t *testing.T) {
 
 	// Verify output files exist
 	for _, pName := range []string{"analyze", "implement", "pr"} {
-		outputPath := filepath.Join(dir, ".xylem", "phases", "issue-1", pName+".output")
+		outputPath := config.RuntimePath(filepath.Join(dir, ".xylem"), "phases", "issue-1", pName+".output")
 		if _, err := os.Stat(outputPath); os.IsNotExist(err) {
 			t.Errorf("expected output file %s to exist", outputPath)
 		}
@@ -2354,11 +2354,11 @@ func TestDrainPhaseNoOpCompletesWorkflowEarly(t *testing.T) {
 		t.Fatalf("expected analyze output path to be persisted, got %v", vessels[0].PhaseOutputs)
 	}
 
-	analyzeOutputPath := filepath.Join(dir, ".xylem", "phases", "issue-1", "analyze.output")
+	analyzeOutputPath := config.RuntimePath(filepath.Join(dir, ".xylem"), "phases", "issue-1", "analyze.output")
 	if _, err := os.Stat(analyzeOutputPath); err != nil {
 		t.Fatalf("expected analyze output file to exist: %v", err)
 	}
-	implementOutputPath := filepath.Join(dir, ".xylem", "phases", "issue-1", "implement.output")
+	implementOutputPath := config.RuntimePath(filepath.Join(dir, ".xylem"), "phases", "issue-1", "implement.output")
 	if _, err := os.Stat(implementOutputPath); !os.IsNotExist(err) {
 		t.Fatalf("expected implement output file not to exist, got err=%v", err)
 	}
@@ -2966,12 +2966,12 @@ func TestSmoke_S6_WorkflowDigestSnapshotPopulatedAtLaunch(t *testing.T) {
 	assert.NotEqual(t, "wf-stale-scan-digest", final.WorkflowDigest)
 	assert.NotEqual(t, recovery.DigestFile(workflowPath, "wf"), final.WorkflowDigest)
 
-	snapshotPath := filepath.Join(cfg.StateDir, "phases", final.ID, workflowSnapshotDirName, final.Workflow+".yaml")
+	snapshotPath := config.RuntimePath(cfg.StateDir, "phases", final.ID, workflowSnapshotDirName, final.Workflow+".yaml")
 	snapshotBytes, err := os.ReadFile(snapshotPath)
 	require.NoError(t, err)
 	assert.Equal(t, originalWorkflow, snapshotBytes)
 
-	artifact, err := recovery.Load(filepath.Join(cfg.StateDir, "phases", final.ID, "failure-review.json"))
+	artifact, err := recovery.Load(config.RuntimePath(cfg.StateDir, "phases", final.ID, "failure-review.json"))
 	require.NoError(t, err)
 	assert.Equal(t, expectedDigest, artifact.WorkflowDigest)
 }
@@ -3040,7 +3040,7 @@ func TestSmoke_S7_WaitingVesselResumesAgainstFrozenWorkflowSnapshot(t *testing.T
 	assert.Contains(t, cmdRunner.phaseCalls[1].prompt, "Implement after approval")
 	assert.NotContains(t, cmdRunner.phaseCalls[1].prompt, "Mutated after approval")
 
-	snapshotPath := filepath.Join(cfg.StateDir, "phases", done.ID, workflowSnapshotDirName, done.Workflow+".yaml")
+	snapshotPath := config.RuntimePath(cfg.StateDir, "phases", done.ID, workflowSnapshotDirName, done.Workflow+".yaml")
 	_, snapshotDigest, err := workflow.LoadWithDigest(snapshotPath)
 	require.NoError(t, err)
 	assert.Equal(t, expectedDigest, snapshotDigest)
@@ -3093,7 +3093,7 @@ func TestSmoke_WS6_S16_PromptOnlyVesselNoEvidence(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
-	manifestPath := filepath.Join(cfg.StateDir, "phases", "prompt-1", "evidence-manifest.json")
+	manifestPath := config.RuntimePath(cfg.StateDir, "phases", "prompt-1", "evidence-manifest.json")
 	assert.NoFileExists(t, manifestPath)
 }
 
@@ -3111,7 +3111,7 @@ func TestSmoke_WS6_S17_PromptOnlyVesselSummaryArtifact(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
-	assert.FileExists(t, filepath.Join(cfg.StateDir, "phases", "prompt-1", summaryFileName))
+	assert.FileExists(t, config.RuntimePath(cfg.StateDir, "phases", "prompt-1", summaryFileName))
 	summary := loadSummary(t, cfg.StateDir, "prompt-1")
 	assert.Equal(t, "completed", summary.State)
 	assert.Equal(t, "prompt-1", summary.VesselID)
@@ -3126,7 +3126,7 @@ func TestSmoke_WS6_S17_PromptOnlyVesselSummaryArtifact(t *testing.T) {
 	assert.Equal(t, summary.TotalTokensEst, summary.Phases[0].InputTokensEst+summary.Phases[0].OutputTokensEst)
 	assert.Equal(t, summary.TotalCostUSDEst, summary.Phases[0].CostUSDEst)
 
-	report, err := cost.LoadReport(filepath.Join(cfg.StateDir, "phases", "prompt-1", costReportFileName))
+	report, err := cost.LoadReport(config.RuntimePath(cfg.StateDir, "phases", "prompt-1", costReportFileName))
 	require.NoError(t, err)
 	require.Len(t, report.Phases, 1)
 	assert.Equal(t, "prompt", report.Phases[0].Name)
@@ -5275,7 +5275,7 @@ func TestDrainCommandPhase(t *testing.T) {
 	}
 
 	// Verify output file was written
-	outputPath := filepath.Join(dir, ".xylem", "phases", "issue-1", "build.output")
+	outputPath := config.RuntimePath(filepath.Join(dir, ".xylem"), "phases", "issue-1", "build.output")
 	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
 		t.Errorf("expected output file %s to exist", outputPath)
 	}
@@ -5288,7 +5288,7 @@ func TestDrainCommandPhase(t *testing.T) {
 	}
 
 	// Verify command file was written
-	commandPath := filepath.Join(dir, ".xylem", "phases", "issue-1", "build.command")
+	commandPath := config.RuntimePath(filepath.Join(dir, ".xylem"), "phases", "issue-1", "build.command")
 	if _, err := os.Stat(commandPath); os.IsNotExist(err) {
 		t.Errorf("expected command file %s to exist", commandPath)
 	}
@@ -5746,7 +5746,7 @@ func TestDrainOrchestratedDiamondWorkflow(t *testing.T) {
 
 	// Verify output files were written.
 	for _, name := range []string{"analyze", "implement_a", "implement_b", "merge"} {
-		path := filepath.Join(cfg.StateDir, "phases", "issue-1", name+".output")
+		path := config.RuntimePath(cfg.StateDir, "phases", "issue-1", name+".output")
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			t.Errorf("expected output file for phase %q", name)
 		}
@@ -6432,7 +6432,7 @@ func TestVerifyProtectedSurfacesSkipsWhenWorktreeMissing(t *testing.T) {
 	cfg.StateDir = stateDir
 	auditPath := filepath.Join(stateDir, "audit.jsonl")
 	auditLog := intermediary.NewAuditLog(auditPath)
-	r := New(cfg, queue.New(filepath.Join(stateDir, "queue.jsonl")), &mockWorktree{path: worktreeDir}, &mockCmdRunner{})
+	r := New(cfg, queue.New(config.RuntimePath(stateDir, "queue.jsonl")), &mockWorktree{path: worktreeDir}, &mockCmdRunner{})
 	r.AuditLog = auditLog
 
 	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), worktreeDir)
@@ -6502,7 +6502,7 @@ func TestVerifyProtectedSurfacesDetectsLegitimateDeletionWhenWorktreeExists(t *t
 	cfg.StateDir = stateDir
 	auditPath := filepath.Join(stateDir, "audit.jsonl")
 	auditLog := intermediary.NewAuditLog(auditPath)
-	r := New(cfg, queue.New(filepath.Join(stateDir, "queue.jsonl")), &mockWorktree{path: worktreeDir}, &mockCmdRunner{})
+	r := New(cfg, queue.New(config.RuntimePath(stateDir, "queue.jsonl")), &mockWorktree{path: worktreeDir}, &mockCmdRunner{})
 	r.AuditLog = auditLog
 
 	before, ok, err := r.takeProtectedSurfaceSnapshot(context.Background(), worktreeDir)
@@ -6659,7 +6659,7 @@ func TestVerifyProtectedSurfacesSelfHealsDeletedFileFromDefaultBranch(t *testing
 		},
 	}
 	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
-	r := New(cfg, queue.New(filepath.Join(cfg.StateDir, "queue.jsonl")), &mockWorktree{path: worktreeDir}, cmdRunner)
+	r := New(cfg, queue.New(config.RuntimePath(cfg.StateDir, "queue.jsonl")), &mockWorktree{path: worktreeDir}, cmdRunner)
 	r.AuditLog = auditLog
 
 	err = r.verifyProtectedSurfaces(
@@ -7500,7 +7500,7 @@ func TestSmoke_S22_WaveResultsAreMergedIntoVesselRunStateAfterWgWait(t *testing.
 		{name: "b", promptContent: "Branch B {{.PreviousOutputs.root}}", maxTurns: 5, dependsOn: []string{"root"}},
 	})
 
-	preseedDir := filepath.Join(cfg.StateDir, "phases", "issue-1")
+	preseedDir := config.RuntimePath(cfg.StateDir, "phases", "issue-1")
 	if err := os.MkdirAll(preseedDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(preseedDir) error = %v", err)
 	}
@@ -7553,7 +7553,7 @@ func TestSmoke_S23_CostTrackerConcurrentAccessFromMultipleGoroutinesIsSafe(t *te
 		{name: "b", promptContent: "Cost B {{.PreviousOutputs.root}}", maxTurns: 5, dependsOn: []string{"root"}},
 	})
 
-	preseedDir := filepath.Join(cfg.StateDir, "phases", "issue-1")
+	preseedDir := config.RuntimePath(cfg.StateDir, "phases", "issue-1")
 	if err := os.MkdirAll(preseedDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(preseedDir) error = %v", err)
 	}
@@ -7651,7 +7651,7 @@ func TestSmoke_S25_ConcurrentPhasesMayCauseSlightOverspendWithoutRetroactiveFail
 		{name: "b", promptContent: "Concurrent B {{.PreviousOutputs.root}}", maxTurns: 5, dependsOn: []string{"root"}},
 	})
 
-	preseedDir := filepath.Join(cfg.StateDir, "phases", "issue-1")
+	preseedDir := config.RuntimePath(cfg.StateDir, "phases", "issue-1")
 	if err := os.MkdirAll(preseedDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(preseedDir) error = %v", err)
 	}
@@ -8228,7 +8228,7 @@ func TestSmoke_S1_UntrackedPhaseStalledVesselTimesOut(t *testing.T) {
 	vessel, _ := q.Dequeue()
 	require.NotNil(t, vessel)
 
-	outputPath := filepath.Join(cfg.StateDir, "phases", vessel.ID, "analyze.output")
+	outputPath := config.RuntimePath(cfg.StateDir, "phases", vessel.ID, "analyze.output")
 	require.NoError(t, os.MkdirAll(filepath.Dir(outputPath), 0o755))
 	require.NoError(t, os.WriteFile(outputPath, []byte(""), 0o644))
 	old := now.Add(-11 * time.Minute)
@@ -8265,7 +8265,7 @@ func TestCheckStalledVesselsDoesNotTimeoutLiveTrackedSubprocessWithOldOutput(t *
 	vessel, _ := q.Dequeue()
 	require.NotNil(t, vessel)
 
-	outputPath := filepath.Join(cfg.StateDir, "phases", vessel.ID, "implement.output")
+	outputPath := config.RuntimePath(cfg.StateDir, "phases", vessel.ID, "implement.output")
 	require.NoError(t, os.MkdirAll(filepath.Dir(outputPath), 0o755))
 	require.NoError(t, os.WriteFile(outputPath, []byte(""), 0o644))
 	old := now.Add(-11 * time.Minute)
@@ -8323,7 +8323,7 @@ func TestCheckStalledVesselsDoesNotTimeoutObservedLivePhaseWithOldOutput(t *test
 
 	<-cmdRunner.started
 
-	outputPath := filepath.Join(cfg.StateDir, "phases", vessel.ID, "implement.output")
+	outputPath := config.RuntimePath(cfg.StateDir, "phases", vessel.ID, "implement.output")
 	old := now.Add(-11 * time.Minute)
 	require.NoError(t, os.Chtimes(outputPath, old, old))
 
@@ -8653,7 +8653,7 @@ func TestCheckStalledVesselsDoesNotTimeoutUntrackedRecentPhase(t *testing.T) {
 	vessel, _ := q.Dequeue()
 	require.NotNil(t, vessel)
 
-	outputPath := filepath.Join(cfg.StateDir, "phases", vessel.ID, "analyze.output")
+	outputPath := config.RuntimePath(cfg.StateDir, "phases", vessel.ID, "analyze.output")
 	require.NoError(t, os.MkdirAll(filepath.Dir(outputPath), 0o755))
 	require.NoError(t, os.WriteFile(outputPath, []byte("still running"), 0o644))
 	require.NoError(t, os.Chtimes(outputPath, now, now))
@@ -8686,7 +8686,7 @@ func TestSmoke_S9_NilTracerSkipsAllSpanCreationWithoutPanicking(t *testing.T) {
 	require.NoError(t, findErr)
 	assert.Equal(t, queue.StateCompleted, vessel.State)
 
-	outputPath := filepath.Join(r.Config.StateDir, "phases", "issue-1", "analyze.output")
+	outputPath := config.RuntimePath(r.Config.StateDir, "phases", "issue-1", "analyze.output")
 	output, readErr := os.ReadFile(outputPath)
 	require.NoError(t, readErr)
 	assert.Equal(t, "analysis complete", string(output))

--- a/cli/internal/runner/summary.go
+++ b/cli/internal/runner/summary.go
@@ -448,7 +448,7 @@ func SaveVesselSummary(stateDir string, summary *VesselSummary) error {
 }
 
 func summaryPath(stateDir, vesselID string) string {
-	return filepath.Join(stateDir, "phases", vesselID, summaryFileName)
+	return config.RuntimePath(stateDir, "phases", vesselID, summaryFileName)
 }
 
 func validateSummaryPathComponent(component string) error {

--- a/cli/internal/runner/summary_prop_test.go
+++ b/cli/internal/runner/summary_prop_test.go
@@ -3,12 +3,12 @@ package runner
 import (
 	"encoding/json"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"pgregory.net/rapid"
 )
@@ -84,7 +84,7 @@ func TestProp_SaveVesselSummaryNeverWritesNullPhases(t *testing.T) {
 			t.Fatalf("SaveVesselSummary() error = %v", err)
 		}
 
-		data, err := os.ReadFile(filepath.Join(stateDir, "phases", vesselID, summaryFileName))
+		data, err := os.ReadFile(config.RuntimePath(stateDir, "phases", vesselID, summaryFileName))
 		if err != nil {
 			t.Fatalf("read summary: %v", err)
 		}

--- a/cli/internal/runner/summary_test.go
+++ b/cli/internal/runner/summary_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -47,7 +48,7 @@ func TestSmoke_S1_SummaryFileWrittenOnVesselCompletion(t *testing.T) {
 	outcome := r.completeVessel(context.Background(), vessel, "", nil, vrs, nil)
 	assert.Equal(t, "completed", outcome)
 
-	path := filepath.Join(cfg.StateDir, "phases", vessel.ID, summaryFileName)
+	path := config.RuntimePath(cfg.StateDir, "phases", vessel.ID, summaryFileName)
 	info, err := os.Stat(path)
 	require.NoError(t, err)
 	assert.Greater(t, info.Size(), int64(0))
@@ -81,41 +82,39 @@ func TestSmoke_S2_SummaryFileWrittenOnVesselFailurePartialSummary(t *testing.T) 
 
 func TestSmoke_S3_SummaryContainsTheDisclaimerNote(t *testing.T) {
 	stateDir := t.TempDir()
-
-	err := SaveVesselSummary(stateDir, &VesselSummary{
+	summary := &VesselSummary{
 		VesselID: "vessel-note",
 		Source:   "manual",
 		State:    "completed",
 		Phases:   []PhaseSummary{},
-	})
+	}
+
+	err := SaveVesselSummary(stateDir, summary)
 	require.NoError(t, err)
 
-	summary := loadSummary(t, stateDir, "vessel-note")
 	assert.Equal(t, summaryDisclaimer, summary.Note)
+	data := readSummaryBytes(t, stateDir, "vessel-note")
+	assert.Contains(t, string(data), "\"note\": "+strconv.Quote(summaryDisclaimer))
+	assert.Equal(t, summaryDisclaimer, loadSummary(t, stateDir, "vessel-note").Note)
 }
 
-func TestSmoke_S4_SummaryJSONIsPrettyPrinted(t *testing.T) {
+func TestSmoke_S4_SaveVesselSummaryOverridesCallerProvidedNote(t *testing.T) {
 	stateDir := t.TempDir()
-
-	err := SaveVesselSummary(stateDir, &VesselSummary{
-		VesselID: "vessel-pretty",
+	summary := &VesselSummary{
+		VesselID: "vessel-note-override",
 		Source:   "manual",
 		State:    "completed",
 		Phases:   []PhaseSummary{},
-	})
+		Note:     "caller supplied note",
+	}
+
+	err := SaveVesselSummary(stateDir, summary)
 	require.NoError(t, err)
 
-	data := readSummaryBytes(t, stateDir, "vessel-pretty")
-	lines := strings.Split(string(data), "\n")
-	require.GreaterOrEqual(t, len(lines), 2)
-
-	assert.Contains(t, string(data), "\n  \"")
-	assert.Equal(t, "{", lines[0])
-	assert.True(t, strings.HasPrefix(lines[1], "  \""))
-
-	var summary VesselSummary
-	require.NoError(t, json.Unmarshal(data, &summary))
 	assert.Equal(t, summaryDisclaimer, summary.Note)
+	data := readSummaryBytes(t, stateDir, "vessel-note-override")
+	assert.Contains(t, string(data), "\"note\": "+strconv.Quote(summaryDisclaimer))
+	assert.NotContains(t, string(data), "caller supplied note")
 }
 
 func TestSmoke_S9_BuildSummaryComputesTotalTokensEstAsSumOfPhaseTokenFields(t *testing.T) {
@@ -257,7 +256,7 @@ func TestSmoke_S14_SaveVesselSummaryFailureIsNonFatalCallerContinues(t *testing.
 		require.NoError(t, os.Chdir(oldWd))
 	}()
 
-	summaryAsDir := filepath.Join(cfg.StateDir, "phases", vessel.ID, summaryFileName)
+	summaryAsDir := config.RuntimePath(cfg.StateDir, "phases", vessel.ID, summaryFileName)
 	require.NoError(t, os.MkdirAll(summaryAsDir, 0o755))
 
 	buf := captureStandardLogger(t)
@@ -306,7 +305,7 @@ func TestSmoke_S17_CompleteVesselSavesEvidenceManifestWhenClaimsArePresent(t *te
 	outcome := r.completeVessel(context.Background(), vessel, "", nil, vrs, claims)
 	assert.Equal(t, "completed", outcome)
 
-	manifestPath := filepath.Join(cfg.StateDir, "phases", vessel.ID, "evidence-manifest.json")
+	manifestPath := config.RuntimePath(cfg.StateDir, "phases", vessel.ID, "evidence-manifest.json")
 	_, err = os.Stat(manifestPath)
 	require.NoError(t, err)
 
@@ -338,7 +337,7 @@ func TestSmoke_S18_EvidenceManifestPathIsEmptyInSummaryWhenNoClaimsProvided(t *t
 	outcome := r.completeVessel(context.Background(), vessel, "", nil, vrs, nil)
 	assert.Equal(t, "completed", outcome)
 
-	manifestPath := filepath.Join(cfg.StateDir, "phases", vessel.ID, "evidence-manifest.json")
+	manifestPath := config.RuntimePath(cfg.StateDir, "phases", vessel.ID, "evidence-manifest.json")
 	_, err = os.Stat(manifestPath)
 	require.Error(t, err)
 	require.True(t, os.IsNotExist(err))
@@ -383,12 +382,12 @@ func TestSmoke_S18a_PersistRunArtifactsWritesCostAndBudgetReviewInputs(t *testin
 	assert.Equal(t, summary.CostReportPath, summary.ReviewArtifacts.CostReport)
 	assert.Equal(t, summary.BudgetAlertsPath, summary.ReviewArtifacts.BudgetAlerts)
 
-	report, err := cost.LoadReport(filepath.Join(cfg.StateDir, "phases", vessel.ID, costReportFileName))
+	report, err := cost.LoadReport(config.RuntimePath(cfg.StateDir, "phases", vessel.ID, costReportFileName))
 	require.NoError(t, err)
 	assert.Equal(t, vessel.ID, report.MissionID)
 	assert.Equal(t, cost.UsageSourceEstimated, report.UsageSource)
 
-	alertsData, err := os.ReadFile(filepath.Join(cfg.StateDir, "phases", vessel.ID, budgetAlertsFileName))
+	alertsData, err := os.ReadFile(config.RuntimePath(cfg.StateDir, "phases", vessel.ID, budgetAlertsFileName))
 	require.NoError(t, err)
 	assert.JSONEq(t, "[]", string(alertsData))
 	assert.Zero(t, summary.BudgetAlertCount)
@@ -426,7 +425,7 @@ func TestPersistRunArtifactsSummarizesBudgetWarnings(t *testing.T) {
 	assert.False(t, summary.BudgetExceeded)
 	assert.Equal(t, 1, summary.BudgetAlertCount)
 
-	alertsData, err := os.ReadFile(filepath.Join(cfg.StateDir, "phases", vessel.ID, budgetAlertsFileName))
+	alertsData, err := os.ReadFile(config.RuntimePath(cfg.StateDir, "phases", vessel.ID, budgetAlertsFileName))
 	require.NoError(t, err)
 	assert.Contains(t, string(alertsData), `"type": "warning"`)
 }
@@ -438,7 +437,7 @@ func TestSmoke_S18b_PersistRunArtifactsLinksExistingEvalReport(t *testing.T) {
 
 	startedAt := time.Date(2026, time.April, 8, 20, 32, 45, 0, time.UTC)
 	vessel := runningSmokeVessel("vessel-eval-artifact", "github", "fix-bug", startedAt)
-	evalPath := filepath.Join(cfg.StateDir, "phases", vessel.ID, evalReportFileName)
+	evalPath := config.RuntimePath(cfg.StateDir, "phases", vessel.ID, evalReportFileName)
 	require.NoError(t, os.MkdirAll(filepath.Dir(evalPath), 0o755))
 	require.NoError(t, os.WriteFile(evalPath, []byte(`{"iterations":1}`), 0o644))
 
@@ -621,7 +620,7 @@ func TestSaveVesselSummaryWritesEmptyPhasesArray(t *testing.T) {
 		t.Fatalf("SaveVesselSummary() error = %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(stateDir, "phases", "vessel-empty-phases", summaryFileName))
+	data, err := os.ReadFile(summaryPath(stateDir, "vessel-empty-phases"))
 	if err != nil {
 		t.Fatalf("read summary file: %v", err)
 	}
@@ -893,7 +892,7 @@ func TestSmoke_S6_EvidenceCollectionFailureIsNonFatal(t *testing.T) {
 	assert.Equal(t, queue.StateCompleted, queueVesselByID(t, q, vessel.ID).State)
 	assert.Contains(t, buf.String(), "warn: save evidence manifest:")
 
-	manifestPath := filepath.Join(cfg.StateDir, "phases", vessel.ID, "evidence-manifest.json")
+	manifestPath := config.RuntimePath(cfg.StateDir, "phases", vessel.ID, "evidence-manifest.json")
 	assert.NoFileExists(t, manifestPath)
 
 	summary := loadSummary(t, cfg.StateDir, vessel.ID)
@@ -912,7 +911,7 @@ func TestSmoke_S7_SummaryWriteFailureIsNonFatal(t *testing.T) {
 	_, err := q.Enqueue(vessel)
 	require.NoError(t, err)
 
-	summaryAsDir := filepath.Join(cfg.StateDir, "phases", vessel.ID, summaryFileName)
+	summaryAsDir := config.RuntimePath(cfg.StateDir, "phases", vessel.ID, summaryFileName)
 	require.NoError(t, os.MkdirAll(summaryAsDir, 0o755))
 
 	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
@@ -975,7 +974,7 @@ func TestDrainPromptOnlyWritesSummaryArtifact(t *testing.T) {
 		t.Fatalf("EvidenceManifestPath = %q, want empty string", summary.EvidenceManifestPath)
 	}
 
-	manifestPath := filepath.Join(cfg.StateDir, "phases", "prompt-1", "evidence-manifest.json")
+	manifestPath := config.RuntimePath(cfg.StateDir, "phases", "prompt-1", "evidence-manifest.json")
 	if _, err := os.Stat(manifestPath); !os.IsNotExist(err) {
 		t.Fatalf("expected no evidence manifest, got err=%v", err)
 	}
@@ -1113,7 +1112,7 @@ func TestSmoke_S18_EvidenceClaimsAreAccumulatedAcrossMultiplePhases(t *testing.T
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Completed)
 
-	manifestPath := filepath.Join(cfg.StateDir, "phases", vessel.ID, "evidence-manifest.json")
+	manifestPath := config.RuntimePath(cfg.StateDir, "phases", vessel.ID, "evidence-manifest.json")
 	assert.FileExists(t, manifestPath)
 
 	manifest, err := evidence.LoadManifest(cfg.StateDir, vessel.ID)
@@ -1295,7 +1294,7 @@ func TestSmoke_S9_ClaimsFromAFailedPhaseAreDiscarded(t *testing.T) {
 	assert.Equal(t, 1, result.Failed)
 	assert.Equal(t, queue.StateFailed, queueVesselByID(t, q, "issue-9").State)
 
-	manifestPath := filepath.Join(cfg.StateDir, "phases", "issue-9", "evidence-manifest.json")
+	manifestPath := config.RuntimePath(cfg.StateDir, "phases", "issue-9", "evidence-manifest.json")
 	if _, err := os.Stat(manifestPath); err == nil {
 		manifest, loadErr := evidence.LoadManifest(cfg.StateDir, "issue-9")
 		require.NoError(t, loadErr)
@@ -1448,7 +1447,7 @@ func TestDrainWorkflowWithoutGateOmitsEvidenceFromCompletionComment(t *testing.T
 		t.Fatalf("EvidenceManifestPath = %q, want empty string", summary.EvidenceManifestPath)
 	}
 
-	manifestPath := filepath.Join(cfg.StateDir, "phases", "issue-7", "evidence-manifest.json")
+	manifestPath := config.RuntimePath(cfg.StateDir, "phases", "issue-7", "evidence-manifest.json")
 	if _, err := os.Stat(manifestPath); !os.IsNotExist(err) {
 		t.Fatalf("expected no evidence manifest, got err=%v", err)
 	}
@@ -1464,7 +1463,7 @@ func TestDrainWorkflowWithoutGateOmitsEvidenceFromCompletionComment(t *testing.T
 func loadSummary(t *testing.T, stateDir, vesselID string) VesselSummary {
 	t.Helper()
 
-	data, err := os.ReadFile(filepath.Join(stateDir, "phases", vesselID, summaryFileName))
+	data, err := os.ReadFile(summaryPath(stateDir, vesselID))
 	require.NoError(t, err)
 
 	var summary VesselSummary
@@ -1486,7 +1485,7 @@ func loadSummaryJSON(t *testing.T, stateDir, vesselID string) map[string]any {
 func readSummaryBytes(t *testing.T, stateDir, vesselID string) []byte {
 	t.Helper()
 
-	data, err := os.ReadFile(filepath.Join(stateDir, "phases", vesselID, summaryFileName))
+	data, err := os.ReadFile(summaryPath(stateDir, vesselID))
 	require.NoError(t, err)
 
 	return data

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
@@ -52,7 +51,7 @@ func New(cfg *config.Config, q *queue.Queue, runner CommandRunner) *Scanner {
 
 // Scan queries configured sources, filters candidates, and enqueues new vessels.
 func (s *Scanner) Scan(ctx context.Context) (ScanResult, error) {
-	pauseMarker := filepath.Join(s.Config.StateDir, "paused")
+	pauseMarker := config.RuntimePath(s.Config.StateDir, "paused")
 	if _, err := os.Stat(pauseMarker); err == nil {
 		return ScanResult{Paused: true}, nil
 	}

--- a/cli/internal/source/schedule.go
+++ b/cli/internal/source/schedule.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gofrs/flock"
 	"github.com/nicholls-inc/xylem/cli/internal/cadence"
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
 
@@ -225,7 +226,7 @@ func (s *Schedule) readStateUnlocked() (scheduleStateFile, error) {
 }
 
 func (s *Schedule) statePath() string {
-	return filepath.Join(s.StateDir, "state", "schedule.json")
+	return config.RuntimePath(s.StateDir, "schedule.json")
 }
 
 func (s *Schedule) legacyStatePath() string {

--- a/cli/internal/source/schedule_test.go
+++ b/cli/internal/source/schedule_test.go
@@ -329,7 +329,7 @@ func TestSmoke_S1_ScheduledSourceFiresPersistsAndSuppressesDuplicates(t *testing
 
 	require.NoError(t, first.OnEnqueue(ctx, firstVessel))
 
-	stateBytes, err := os.ReadFile(filepath.Join(stateDir, "state", "schedule.json"))
+	stateBytes, err := os.ReadFile(first.statePath())
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"sources":{"doc-gardener":{"last_fired_at":"2026-04-09T06:00:00Z"}}}`, string(stateBytes))
 
@@ -389,7 +389,7 @@ func TestScheduleOnEnqueueAcceptsLegacyMetadata(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	stateBytes, err := os.ReadFile(filepath.Join(stateDir, "state", "schedule.json"))
+	stateBytes, err := os.ReadFile(s.statePath())
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"sources":{"lessons":{"last_fired_at":"2026-04-09T06:00:00Z"}}}`, string(stateBytes))
 }
@@ -417,4 +417,49 @@ func TestScheduleScanReadsLegacyStateFile(t *testing.T) {
 	vessels, err := s.Scan(context.Background())
 	require.NoError(t, err)
 	assert.Empty(t, vessels)
+}
+
+func TestSmoke_S3_ScheduleFallsBackToLegacyStateAndWritesRuntimeState(t *testing.T) {
+	ctx := context.Background()
+	stateDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, ".gitignore"), []byte("state/\n"), 0o644))
+
+	legacyPath := filepath.Join(stateDir, legacyScheduleStateFileName)
+	require.NoError(t, os.WriteFile(
+		legacyPath,
+		[]byte(`{"lessons":{"cadence":"@daily","last_fired_at":"2026-04-09T06:00:00Z","next_due_at":"2026-04-10T00:00:00Z","last_vessel":"schedule-lessons-20260409t060000z"}}`),
+		0o644,
+	))
+
+	now := time.Date(2026, time.April, 9, 12, 0, 0, 0, time.UTC)
+	s := &Schedule{
+		ConfigName: "lessons",
+		Cadence:    "@daily",
+		Workflow:   "lessons",
+		StateDir:   stateDir,
+		Queue:      queue.New(filepath.Join(t.TempDir(), "queue.jsonl")),
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	vessels, err := s.Scan(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, vessels)
+
+	err = s.OnEnqueue(ctx, queue.Vessel{
+		ID: "schedule-lessons-20260410t000000z",
+		Meta: map[string]string{
+			"schedule_fired_at": "2026-04-10T00:00:00Z",
+		},
+	})
+	require.NoError(t, err)
+
+	stateBytes, err := os.ReadFile(s.statePath())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"sources":{"lessons":{"last_fired_at":"2026-04-10T00:00:00Z"}}}`, string(stateBytes))
+
+	legacyBytes, err := os.ReadFile(legacyPath)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"lessons":{"cadence":"@daily","last_fired_at":"2026-04-09T06:00:00Z","next_due_at":"2026-04-10T00:00:00Z","last_vessel":"schedule-lessons-20260409t060000z"}}`, string(legacyBytes))
 }

--- a/cli/internal/source/scheduled.go
+++ b/cli/internal/source/scheduled.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
 
@@ -219,7 +220,7 @@ func (s *Scheduled) saveState(state *scheduleState) error {
 }
 
 func (s *Scheduled) statePath() string {
-	return filepath.Join(s.StateDir, "schedules", sanitizeScheduledComponent(s.scope())+".json")
+	return config.RuntimePath(s.StateDir, "schedules", sanitizeScheduledComponent(s.scope())+".json")
 }
 
 func (s *Scheduled) scope() string {


### PR DESCRIPTION
## Summary
- Implements [issue #230](https://github.com/nicholls-inc/xylem/issues/230).
- Moves runtime artifacts to the profile-ready `.xylem/state/` subtree while keeping existing `.xylem/` flat-layout artifacts readable for one release.
- Rewires CLI and runtime consumers so queue, phases, summaries, logs, schedule state, and review artifacts resolve through shared runtime-path helpers instead of assuming the flat layout.

## Smoke scenarios covered
- `config/S2` - RuntimePathPrefersProfileReadyStateWhenPresent
- `config/S3` - RuntimePathFallsBackToLegacyFlatArtifact
- `source/S3` - ScheduleFallsBackToLegacyStateAndWritesRuntimeState
- `review/S1` - LoadRunsIncludesRecoveryArtifactWhenPresent
- `review/S2` - LoadRunsLeavesRecoveryNilWhenArtifactAbsent
- `init/S4` - CoreInitScaffoldsTrackedControlPlane
- `init/S5` - CorePlusSelfHostingOverlayScaffoldsOverlayWorkflows

## Changes summary
- **Modified:** `cli/internal/config/config.go`, `cli/internal/config/config_test.go`, `cli/internal/config/config_prop_test.go`
  - Added `runtimeStateDirName`, `RuntimeRoot`, and `RuntimePath` so `.xylem/` remains the control-plane root while runtime writes move under `.xylem/state/` with legacy artifact fallback.
- **Modified:** `cli/cmd/xylem/{root,drain,status,pause,retry,cleanup,doctor,daemon_supervisor,logging,dtu,init}.go` and related tests
  - Updated queue/log/runtime wiring to use runtime-aware paths and scaffold `.xylem/state/` during `xylem init`.
- **Modified:** `cli/internal/{runner,scanner,source,evidence,review,recovery,lessons}.go` plus corresponding tests
  - Routed phase outputs, summaries, schedule state, recovery artifacts, evidence manifests, and generated review outputs through the new runtime path helpers while preserving legacy schedule-state reads via `(*Schedule).loadLegacyLastFiredAt`.

## Test plan
- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #230