### PR TITLE
feat: enforce workflow-class policy matrix in runner and intermediary

### DIFF
--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -130,6 +130,7 @@ func wireRunnerScaffolding(cfg *config.Config, r *runner.Runner, tracer *observa
 	auditLog := intermediary.NewAuditLog(auditLogPath)
 
 	r.Intermediary = intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), auditLog, nil)
+	r.Intermediary.SetMode(cfg.HarnessPolicyMode())
 	r.AuditLog = auditLog
 	r.Tracer = tracer
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -243,6 +243,7 @@ type ProtectedSurfacesConfig struct {
 }
 
 type PolicyConfig struct {
+	Mode  string             `yaml:"mode,omitempty"`
 	Rules []PolicyRuleConfig `yaml:"rules,omitempty"`
 }
 
@@ -723,6 +724,28 @@ func (c *Config) EffectiveAuditLogPath() string {
 	return DefaultAuditLogPath
 }
 
+// HarnessPolicyMode returns the effective policy mode for the harness.
+//
+// The zero-value (empty string) resolves to warn mode so that xylem ships in
+// observe-and-warn by default: guest repos can adopt the harness incrementally
+// without their existing workflows hitting the first deny rule cold. Operators
+// who want hard enforcement set harness.policy.mode: "enforce" explicitly.
+//
+// Values that fail to parse still fall back to warn (not enforce) so that a
+// typo in the config file cannot escalate a previously-permissive deployment
+// into a blocking one. Config load-time validation at validateHarness rejects
+// unknown modes up-front, so this branch is a belt-and-suspenders fallback.
+func (c *Config) HarnessPolicyMode() intermediary.PolicyMode {
+	if strings.TrimSpace(c.Harness.Policy.Mode) == "" {
+		return intermediary.PolicyModeWarn
+	}
+	mode, err := intermediary.ParsePolicyMode(c.Harness.Policy.Mode)
+	if err != nil {
+		return intermediary.PolicyModeWarn
+	}
+	return mode
+}
+
 func (c *Config) HarnessReviewCadence() string {
 	if !c.Harness.Review.Enabled {
 		return "manual"
@@ -919,28 +942,14 @@ func (c *Config) BuildIntermediaryPolicies() []intermediary.Policy {
 	}}
 }
 
-// DefaultPolicy returns the default intermediary policy. Protected control
-// surfaces are denied, and all currently classified execution actions —
-// including git_commit, git_push, and pr_create — are allowed so the daemon can
-// operate autonomously.
-//
-// Destructive git operations and deploy-class actions are not yet emitted as
-// separate intents at the runner/intermediary boundary; they currently inherit
-// the enclosing phase action. Operators who want human gates on those surfaces
-// can override the defaults with `harness.policy.rules` or workflow gates.
+// DefaultPolicy returns the default user policy layer. Workflow-class matrix
+// decisions are enforced separately inside the intermediary; this default layer
+// simply keeps autonomous execution unblocked unless operators opt into tighter
+// rules via harness.policy.rules.
 func DefaultPolicy() intermediary.Policy {
 	return intermediary.Policy{
 		Name: "default",
 		Rules: []intermediary.Rule{
-			// Protected control surfaces are denied.
-			{Action: "file_write", Resource: ".xylem/HARNESS.md", Effect: intermediary.Deny},
-			{Action: "file_write", Resource: ".xylem.yml", Effect: intermediary.Deny},
-			{Action: "file_write", Resource: ".xylem/workflows/*", Effect: intermediary.Deny},
-			{Action: "file_write", Resource: ".xylem/prompts/*/*.md", Effect: intermediary.Deny},
-			// All other actions — including git_commit, git_push, and pr_create
-			// — are allowed. Autonomous operation requires publication steps to
-			// complete without a built-in approval pause. Override via
-			// harness.policy for stricter rules.
 			{Action: "*", Resource: "*", Effect: intermediary.Allow},
 		},
 	}
@@ -969,6 +978,10 @@ func (c *Config) validateHarness() error {
 		default:
 			return fmt.Errorf("harness.policy.rules[%d]: invalid effect %q (must be allow, deny, or require_approval)", i, rule.Effect)
 		}
+	}
+
+	if _, err := intermediary.ParsePolicyMode(c.Harness.Policy.Mode); err != nil {
+		return fmt.Errorf("harness.policy.mode: %w", err)
 	}
 
 	if cadence := c.Harness.Review.Cadence; cadence != "" {

--- a/cli/internal/config/config_prop_test.go
+++ b/cli/internal/config/config_prop_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 )
@@ -172,6 +173,43 @@ func TestPropHarnessReviewOutputDirRejectsTraversal(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "harness.review.output_dir") {
 			t.Fatalf("validateHarness() error = %v, want harness.review.output_dir", err)
+		}
+	})
+}
+
+func TestPropHarnessPolicyModeDefaultsToWarn(t *testing.T) {
+	// Contract:
+	//   - Empty / whitespace-only / invalid modes resolve to warn (the zero-
+	//     value default per docs/plans/sota-gap-implementation-2026-04-11.md).
+	//   - "enforce" (case-insensitive, trimmed) resolves to enforce.
+	//   - "warn" (case-insensitive, trimmed) resolves to warn.
+	rapid.Check(t, func(t *rapid.T) {
+		mode := rapid.SampledFrom([]string{
+			"",
+			"warn",
+			"enforce",
+			" WARN ",
+			" ENFORCE ",
+			"observe",
+			" warn-only ",
+			"enforced",
+		}).Draw(t, "mode")
+		cfg := Config{
+			Harness: HarnessConfig{
+				Policy: PolicyConfig{Mode: mode},
+			},
+		}
+
+		got := cfg.HarnessPolicyMode()
+		switch strings.TrimSpace(strings.ToLower(mode)) {
+		case "enforce":
+			if got != intermediary.PolicyModeEnforce {
+				t.Fatalf("HarnessPolicyMode() = %q, want %q", got, intermediary.PolicyModeEnforce)
+			}
+		default:
+			if got != intermediary.PolicyModeWarn {
+				t.Fatalf("HarnessPolicyMode() = %q, want %q", got, intermediary.PolicyModeWarn)
+			}
 		}
 	})
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1904,7 +1905,9 @@ func newSmokeIntermediary(t *testing.T, cfg *Config) *intermediary.Intermediary 
 	t.Helper()
 
 	auditLog := intermediary.NewAuditLog(filepath.Join(t.TempDir(), "audit.jsonl"))
-	return intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), auditLog, nil)
+	inter := intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), auditLog, nil)
+	inter.SetMode(cfg.HarnessPolicyMode())
+	return inter
 }
 
 func TestSmoke_S1_FullConfigLoadsWithHarnessSection(t *testing.T) {
@@ -1918,6 +1921,7 @@ harness:
       - ".xylem/workflows/*.yaml"
       - ".xylem/prompts/*/*.md"
   policy:
+    mode: "warn"
     rules:
       - action: "file_write"
         resource: ".xylem/*"
@@ -1946,6 +1950,7 @@ cost:
 	assert.Equal(t, "audit.jsonl", cfg.Harness.AuditLog)
 	require.Len(t, cfg.Harness.ProtectedSurfaces.Paths, 4)
 	require.Len(t, cfg.Harness.Policy.Rules, 4)
+	assert.Equal(t, intermediary.PolicyModeWarn, cfg.HarnessPolicyMode())
 	require.NotNil(t, cfg.Observability.Enabled)
 	assert.True(t, *cfg.Observability.Enabled)
 	assert.Equal(t, 1.0, cfg.Observability.SampleRate)
@@ -2020,40 +2025,53 @@ func TestSmoke_S5_InvalidPolicyEffectRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "approve_maybe")
 }
 
+func TestSmoke_S5b_InvalidPolicyModeRejected(t *testing.T) {
+	path := writeSmokeConfigFile(t, `harness:
+  policy:
+    mode: "observe"
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "harness.policy.mode")
+	assert.Contains(t, err.Error(), "invalid policy mode")
+}
+
 func TestSmoke_S6_DefaultPolicyDeniesHarnessWrite(t *testing.T) {
-	result := newSmokeIntermediary(t, validConfig()).Evaluate(intermediary.Intent{
+	result := newSmokeIntermediary(t, validConfig()).EvaluateWithContext(intermediary.Intent{
 		Action:   "file_write",
 		Resource: ".xylem/HARNESS.md",
 		AgentID:  "vessel-001",
-	})
+	}, intermediary.EvaluationContext{WorkflowClass: policy.Delivery, VesselID: "vessel-001"})
 
 	assert.Equal(t, intermediary.Deny, result.Effect)
-	require.NotNil(t, result.MatchedRule)
-	assert.Equal(t, "file_write", result.MatchedRule.Action)
-	assert.Equal(t, ".xylem/HARNESS.md", result.MatchedRule.Resource)
+	assert.Equal(t, "write_control_plane", result.Operation)
+	assert.Equal(t, "delivery.no_control_plane_writes", result.RuleMatched)
+	assert.Equal(t, policy.Delivery, result.WorkflowClass)
 }
 
 func TestSmoke_S7_DefaultPolicyAllowsGitPush(t *testing.T) {
 	// Autonomous self-healing requires git_push to succeed without manual
 	// approval. Operators who want approval gates can override via
 	// harness.policy in .xylem.yml.
-	result := newSmokeIntermediary(t, validConfig()).Evaluate(intermediary.Intent{
+	result := newSmokeIntermediary(t, validConfig()).EvaluateWithContext(intermediary.Intent{
 		Action:   "git_push",
 		Resource: "main",
 		AgentID:  "vessel-002",
-	})
+	}, intermediary.EvaluationContext{WorkflowClass: policy.Delivery, VesselID: "vessel-002"})
 
 	assert.Equal(t, intermediary.Allow, result.Effect)
-	require.NotNil(t, result.MatchedRule)
-	assert.Equal(t, "*", result.MatchedRule.Action)
-	assert.Equal(t, "*", result.MatchedRule.Resource)
+	assert.Equal(t, "push_branch", result.Operation)
+	assert.Equal(t, "delivery.feature_branch_push_allowed", result.RuleMatched)
 }
 
 func TestDefaultPolicyAllowsClassifiedGitLifecycleActions(t *testing.T) {
 	tests := []struct {
-		name     string
-		action   string
-		resource string
+		name            string
+		action          string
+		resource        string
+		wantOperation   string
+		wantRuleMatched string
 	}{
 		{
 			name:     "git commit",
@@ -2061,43 +2079,54 @@ func TestDefaultPolicyAllowsClassifiedGitLifecycleActions(t *testing.T) {
 			resource: "*",
 		},
 		{
-			name:     "git push",
-			action:   "git_push",
-			resource: "main",
+			name:            "git push",
+			action:          "git_push",
+			resource:        "main",
+			wantOperation:   "push_branch",
+			wantRuleMatched: "delivery.feature_branch_push_allowed",
 		},
 		{
-			name:     "pull request create",
-			action:   "pr_create",
-			resource: "owner/name",
+			name:            "pull request create",
+			action:          "pr_create",
+			resource:        "owner/name",
+			wantOperation:   "create_pr",
+			wantRuleMatched: "delivery.pr_creation_allowed",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := newSmokeIntermediary(t, validConfig()).Evaluate(intermediary.Intent{
+			result := newSmokeIntermediary(t, validConfig()).EvaluateWithContext(intermediary.Intent{
 				Action:   tt.action,
 				Resource: tt.resource,
 				AgentID:  "vessel-009",
-			})
+			}, intermediary.EvaluationContext{WorkflowClass: policy.Delivery, VesselID: "vessel-009"})
 
 			assert.Equal(t, intermediary.Allow, result.Effect)
-			require.NotNil(t, result.MatchedRule)
-			assert.Equal(t, "*", result.MatchedRule.Action)
-			assert.Equal(t, "*", result.MatchedRule.Resource)
+			assert.Equal(t, policy.Delivery, result.WorkflowClass)
+			if tt.action == "git_commit" {
+				assert.Empty(t, result.Operation)
+				assert.NotNil(t, result.MatchedRule)
+				assert.Equal(t, "*", result.MatchedRule.Action)
+				assert.Equal(t, "*", result.MatchedRule.Resource)
+				return
+			}
+			assert.Equal(t, tt.wantOperation, result.Operation)
+			assert.Equal(t, tt.wantRuleMatched, result.RuleMatched)
 		})
 	}
 }
 
 func TestDefaultPolicyDeniesPromptFileWrite(t *testing.T) {
-	result := newSmokeIntermediary(t, validConfig()).Evaluate(intermediary.Intent{
+	result := newSmokeIntermediary(t, validConfig()).EvaluateWithContext(intermediary.Intent{
 		Action:   "file_write",
 		Resource: ".xylem/prompts/fix-bug/analyze.md",
 		AgentID:  "vessel-004",
-	})
+	}, intermediary.EvaluationContext{WorkflowClass: policy.Delivery, VesselID: "vessel-004"})
 
 	assert.Equal(t, intermediary.Deny, result.Effect)
-	require.NotNil(t, result.MatchedRule)
-	assert.Equal(t, ".xylem/prompts/*/*.md", result.MatchedRule.Resource)
+	assert.Equal(t, "write_control_plane", result.Operation)
+	assert.Equal(t, "delivery.no_control_plane_writes", result.RuleMatched)
 }
 
 func TestSmoke_S8_DefaultPolicyAllowsPhaseExecute(t *testing.T) {

--- a/cli/internal/dtu/scenario_ws1_test.go
+++ b/cli/internal/dtu/scenario_ws1_test.go
@@ -377,8 +377,8 @@ phases:
 	if vessel.State != queue.StateFailed {
 		t.Fatalf("vessel.State = %q, want %q", vessel.State, queue.StateFailed)
 	}
-	if !strings.Contains(vessel.Error, "violated protected surfaces") {
-		t.Fatalf("vessel.Error = %q, want to contain %q", vessel.Error, "violated protected surfaces")
+	if !strings.Contains(vessel.Error, "denied by policy") {
+		t.Fatalf("vessel.Error = %q, want to contain %q", vessel.Error, "denied by policy")
 	}
 	if !strings.Contains(vessel.Error, ".xylem.yml") {
 		t.Fatalf("vessel.Error = %q, want to contain %q", vessel.Error, ".xylem.yml")
@@ -388,14 +388,8 @@ phases:
 	if summary.State != string(queue.StateFailed) {
 		t.Fatalf("summary.State = %q, want %q", summary.State, queue.StateFailed)
 	}
-	if len(summary.Phases) != 1 {
-		t.Fatalf("len(summary.Phases) = %d, want 1", len(summary.Phases))
-	}
-	if summary.Phases[0].Name != "tamper" {
-		t.Fatalf("summary.Phases[0].Name = %q, want %q", summary.Phases[0].Name, "tamper")
-	}
-	if summary.Phases[0].Status != "failed" {
-		t.Fatalf("summary.Phases[0].Status = %q, want failed", summary.Phases[0].Status)
+	if len(summary.Phases) != 0 {
+		t.Fatalf("len(summary.Phases) = %d, want 0", len(summary.Phases))
 	}
 	if summary.EvidenceManifestPath != "" {
 		t.Fatalf("summary.EvidenceManifestPath = %q, want empty string", summary.EvidenceManifestPath)
@@ -415,14 +409,15 @@ phases:
 	foundViolation := false
 	for _, entry := range entries {
 		if entry.Decision == intermediary.Deny &&
-			strings.Contains(entry.Error, "violated protected surfaces") &&
-			strings.Contains(entry.Error, ".xylem.yml") {
+			entry.Operation == "write_control_plane" &&
+			entry.RuleMatched == "delivery.no_control_plane_writes" &&
+			strings.Contains(entry.Intent.Resource, ".xylem.yml") {
 			foundViolation = true
 			break
 		}
 	}
 	if !foundViolation {
-		t.Fatalf("audit log entries = %+v, want a deny entry describing the protected surface violation", entries)
+		t.Fatalf("audit log entries = %+v, want a deny write_control_plane entry for .xylem.yml", entries)
 	}
 }
 

--- a/cli/internal/intermediary/intermediary.go
+++ b/cli/internal/intermediary/intermediary.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 )
 
 // Effect represents the outcome of a policy evaluation.
@@ -25,6 +27,13 @@ const (
 	Deny Effect = "deny"
 	// RequireApproval pauses execution pending human review.
 	RequireApproval Effect = "require_approval"
+)
+
+type PolicyMode string
+
+const (
+	PolicyModeWarn    PolicyMode = "warn"
+	PolicyModeEnforce PolicyMode = "enforce"
 )
 
 // Intent represents a structured action request from an agent crossing the
@@ -52,20 +61,36 @@ type Policy struct {
 	Rules []Rule `json:"rules"`
 }
 
+type EvaluationContext struct {
+	WorkflowClass policy.Class
+	FilePath      string
+	VesselID      string
+}
+
 // PolicyResult captures the outcome of evaluating an intent against policies.
 type PolicyResult struct {
-	Effect      Effect `json:"effect"`
-	MatchedRule *Rule  `json:"matched_rule,omitempty"`
-	Reason      string `json:"reason"`
+	Effect        Effect       `json:"effect"`
+	MatchedRule   *Rule        `json:"matched_rule,omitempty"`
+	Reason        string       `json:"reason"`
+	WorkflowClass policy.Class `json:"-"`
+	Operation     string       `json:"-"`
+	RuleMatched   string       `json:"-"`
+	FilePath      string       `json:"-"`
+	VesselID      string       `json:"-"`
 }
 
 // AuditEntry records a single intermediary decision for the tamper-proof log.
 type AuditEntry struct {
-	Intent     Intent    `json:"intent"`
-	Decision   Effect    `json:"decision"`
-	Timestamp  time.Time `json:"timestamp"`
-	ApprovedBy string    `json:"approved_by,omitempty"`
-	Error      string    `json:"error,omitempty"`
+	Intent        Intent    `json:"intent"`
+	Decision      Effect    `json:"decision"`
+	Timestamp     time.Time `json:"timestamp"`
+	ApprovedBy    string    `json:"approved_by,omitempty"`
+	Error         string    `json:"error,omitempty"`
+	WorkflowClass string    `json:"workflow_class,omitempty"`
+	Operation     string    `json:"operation,omitempty"`
+	RuleMatched   string    `json:"rule_matched,omitempty"`
+	FilePath      string    `json:"file_path,omitempty"`
+	VesselID      string    `json:"vessel_id,omitempty"`
 }
 
 // AuditLog provides an append-only JSONL-backed audit log with file locking.
@@ -166,6 +191,7 @@ type Intermediary struct {
 	policies []Policy
 	auditLog *AuditLog
 	executor Executor
+	mode     PolicyMode
 }
 
 // NewIntermediary creates an intermediary with the given policies, audit log,
@@ -175,22 +201,48 @@ func NewIntermediary(policies []Policy, auditLog *AuditLog, executor Executor) *
 		policies: policies,
 		auditLog: auditLog,
 		executor: executor,
+		mode:     PolicyModeEnforce,
 	}
+}
+
+func ParsePolicyMode(s string) (PolicyMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", string(PolicyModeEnforce):
+		return PolicyModeEnforce, nil
+	case string(PolicyModeWarn):
+		return PolicyModeWarn, nil
+	default:
+		return "", fmt.Errorf("invalid policy mode %q (must be %q or %q)", s, PolicyModeWarn, PolicyModeEnforce)
+	}
+}
+
+func (i *Intermediary) SetMode(mode PolicyMode) {
+	i.mode = normalizePolicyMode(mode)
+}
+
+func (i *Intermediary) Mode() PolicyMode {
+	return normalizePolicyMode(i.mode)
+}
+
+func (i *Intermediary) ShouldBlock(effect Effect) bool {
+	return i.Mode() == PolicyModeEnforce && effect != Allow
 }
 
 // Submit validates an intent, evaluates it against policies, executes it if
 // allowed, and records an audit entry.
 //
-// INV: Denied intents never reach the executor.
+// INV: Denied intents never reach the executor in enforce mode.
 // INV: Every Submit call produces exactly one audit entry.
-// INV: RequireApproval intents are logged but not executed.
+// INV: RequireApproval intents are logged but not executed in enforce mode.
 func (i *Intermediary) Submit(ctx context.Context, intent Intent) (Effect, error) {
 	if err := ValidateIntent(intent); err != nil {
 		entry := AuditEntry{
-			Intent:    intent,
-			Decision:  Deny,
-			Timestamp: time.Now().UTC(),
-			Error:     err.Error(),
+			Intent:        intent,
+			Decision:      Deny,
+			Timestamp:     time.Now().UTC(),
+			Error:         err.Error(),
+			WorkflowClass: string(policy.Delivery),
+			VesselID:      intent.AgentID,
 		}
 		if appendErr := i.auditLog.Append(entry); appendErr != nil {
 			return Deny, fmt.Errorf("audit validation failure: %w", appendErr)
@@ -199,16 +251,9 @@ func (i *Intermediary) Submit(ctx context.Context, intent Intent) (Effect, error
 	}
 
 	result := i.Evaluate(intent)
+	entry := auditEntryForResult(intent, result)
 
-	entry := AuditEntry{
-		Intent:    intent,
-		Decision:  result.Effect,
-		Timestamp: time.Now().UTC(),
-	}
-
-	switch result.Effect {
-	case Allow:
-		// INV: Only allowed intents reach the executor.
+	if !i.ShouldBlock(result.Effect) && i.executor != nil {
 		if err := i.executor.Execute(ctx, intent); err != nil {
 			entry.Error = err.Error()
 			if appendErr := i.auditLog.Append(entry); appendErr != nil {
@@ -216,10 +261,6 @@ func (i *Intermediary) Submit(ctx context.Context, intent Intent) (Effect, error
 			}
 			return Allow, fmt.Errorf("execute intent: %w", err)
 		}
-	case RequireApproval:
-		// INV: RequireApproval intents are logged but not executed.
-	case Deny:
-		// INV: Denied intents never reach the executor.
 	}
 
 	if err := i.auditLog.Append(entry); err != nil {
@@ -228,27 +269,165 @@ func (i *Intermediary) Submit(ctx context.Context, intent Intent) (Effect, error
 	return result.Effect, nil
 }
 
+func auditEntryForResult(intent Intent, result PolicyResult) AuditEntry {
+	entry := AuditEntry{
+		Intent:        intent,
+		Decision:      result.Effect,
+		Timestamp:     time.Now().UTC(),
+		WorkflowClass: string(result.WorkflowClass),
+		Operation:     result.Operation,
+		RuleMatched:   result.RuleMatched,
+		FilePath:      result.FilePath,
+		VesselID:      result.VesselID,
+	}
+	if result.Effect != Allow && result.Reason != "" {
+		entry.Error = result.Reason
+	}
+	return entry
+}
+
+func normalizePolicyMode(mode PolicyMode) PolicyMode {
+	switch mode {
+	case PolicyModeWarn:
+		return PolicyModeWarn
+	default:
+		return PolicyModeEnforce
+	}
+}
+
+func defaultWorkflowClass(class policy.Class) policy.Class {
+	if class == "" {
+		return policy.Delivery
+	}
+	return class
+}
+
+func policyEffect(decision policy.Decision) Effect {
+	if decision.Allowed {
+		return Allow
+	}
+	return Deny
+}
+
+var controlPlanePatterns = []string{
+	".xylem/HARNESS.md",
+	".xylem.yml",
+	".xylem/workflows/*.yaml",
+	".xylem/prompts/*/*.md",
+}
+
+func IsControlPlaneResource(resource string) bool {
+	for _, pattern := range controlPlanePatterns {
+		if MatchGlob(pattern, resource) {
+			return true
+		}
+	}
+	return false
+}
+
+func classifyOperation(intent Intent) (policy.Operation, bool) {
+	switch intent.Action {
+	case "file_write", "write":
+		if IsControlPlaneResource(intent.Resource) {
+			return policy.OpWriteControlPlane, true
+		}
+	case "git_push":
+		return policy.OpPushBranch, true
+	case "pr_create":
+		return policy.OpCreatePR, true
+	case "merge_pr":
+		return policy.OpMergePR, true
+	case "reload", "reload_daemon":
+		return policy.OpReloadDaemon, true
+	case "read_secret", "read_secrets":
+		return policy.OpReadSecrets, true
+	case "commit_default_branch":
+		return policy.OpCommitDefaultBranch, true
+	}
+	return "", false
+}
+
+func policyRuleLabel(name string, index int) string {
+	return fmt.Sprintf("policy.%s[%d]", strings.ReplaceAll(strings.TrimSpace(name), " ", "_"), index)
+}
+
+func (i *Intermediary) evaluatePolicies(intent Intent) PolicyResult {
+	for _, policyDef := range i.policies {
+		for ruleIndex, rule := range policyDef.Rules {
+			if MatchGlob(rule.Action, intent.Action) && MatchGlob(rule.Resource, intent.Resource) {
+				matchedRule := rule
+				return PolicyResult{
+					Effect:      rule.Effect,
+					MatchedRule: &matchedRule,
+					Reason:      fmt.Sprintf("matched rule in policy %q", policyDef.Name),
+					RuleMatched: policyRuleLabel(policyDef.Name, ruleIndex),
+				}
+			}
+		}
+	}
+	return PolicyResult{
+		Effect: Deny,
+		Reason: "no matching rule; default deny",
+	}
+}
+
+// EvaluateWithContext checks an intent against the workflow-class matrix first,
+// then applies any configured glob rules as an additional tightening layer.
+func (i *Intermediary) EvaluateWithContext(intent Intent, evalCtx EvaluationContext) PolicyResult {
+	result := PolicyResult{
+		WorkflowClass: defaultWorkflowClass(evalCtx.WorkflowClass),
+		VesselID:      strings.TrimSpace(evalCtx.VesselID),
+	}
+	if result.VesselID == "" {
+		result.VesselID = intent.AgentID
+	}
+
+	if op, ok := classifyOperation(intent); ok {
+		result.Operation = string(op)
+		result.FilePath = strings.TrimSpace(evalCtx.FilePath)
+		if result.FilePath == "" && op == policy.OpWriteControlPlane {
+			result.FilePath = intent.Resource
+		}
+
+		classDecision := policy.Evaluate(result.WorkflowClass, op)
+		result.Effect = policyEffect(classDecision)
+		result.Reason = classDecision.Rule
+		result.RuleMatched = classDecision.Rule
+		if !classDecision.Allowed {
+			return result
+		}
+		if len(i.policies) == 0 {
+			return result
+		}
+	}
+
+	globResult := i.evaluatePolicies(intent)
+	globResult.WorkflowClass = result.WorkflowClass
+	globResult.VesselID = result.VesselID
+	if globResult.Operation == "" {
+		globResult.Operation = result.Operation
+	}
+	if globResult.FilePath == "" {
+		globResult.FilePath = result.FilePath
+	}
+
+	if result.Operation != "" {
+		if len(i.policies) == 0 {
+			return result
+		}
+		if globResult.Effect == Allow {
+			return result
+		}
+	}
+	return globResult
+}
+
 // Evaluate checks an intent against all policies using first-match semantics.
 //
 // INV: Policy evaluation is deterministic for the same input.
 // INV: Default effect is Deny if no rule matches.
 func (i *Intermediary) Evaluate(intent Intent) PolicyResult {
-	for _, policy := range i.policies {
-		for _, rule := range policy.Rules {
-			if MatchGlob(rule.Action, intent.Action) && MatchGlob(rule.Resource, intent.Resource) {
-				return PolicyResult{
-					Effect:      rule.Effect,
-					MatchedRule: &rule,
-					Reason:      fmt.Sprintf("matched rule in policy %q", policy.Name),
-				}
-			}
-		}
-	}
-	// INV: Default effect is Deny if no rule matches.
-	return PolicyResult{
-		Effect: Deny,
-		Reason: "no matching rule; default deny",
-	}
+	return i.EvaluateWithContext(intent, EvaluationContext{})
 }
 
 // ErrEmptyAction is returned when an intent has an empty Action field.

--- a/cli/internal/intermediary/intermediary.go
+++ b/cli/internal/intermediary/intermediary.go
@@ -257,9 +257,9 @@ func (i *Intermediary) Submit(ctx context.Context, intent Intent) (Effect, error
 		if err := i.executor.Execute(ctx, intent); err != nil {
 			entry.Error = err.Error()
 			if appendErr := i.auditLog.Append(entry); appendErr != nil {
-				return Allow, fmt.Errorf("audit execution failure: %w", appendErr)
+				return result.Effect, fmt.Errorf("audit execution failure: %w", appendErr)
 			}
-			return Allow, fmt.Errorf("execute intent: %w", err)
+			return result.Effect, fmt.Errorf("execute intent: %w", err)
 		}
 	}
 

--- a/cli/internal/intermediary/intermediary_prop_test.go
+++ b/cli/internal/intermediary/intermediary_prop_test.go
@@ -2,9 +2,11 @@ package intermediary
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"pgregory.net/rapid"
 )
@@ -198,6 +200,99 @@ func TestProp_DenyOnlyPolicyDeniesEverything(t *testing.T) {
 		result := inter.Evaluate(intent)
 		if result.Effect != Deny {
 			t.Fatalf("deny-only policy returned %q for %+v", result.Effect, intent)
+		}
+	})
+}
+
+func TestProp_AuditEntryRoundTrip(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		entry := AuditEntry{
+			Intent:        intentGen().Draw(t, "intent"),
+			Decision:      rapid.SampledFrom([]Effect{Allow, Deny, RequireApproval}).Draw(t, "decision"),
+			Timestamp:     time.Unix(rapid.Int64Range(0, 253402300799).Draw(t, "seconds"), 0).UTC(),
+			ApprovedBy:    rapid.StringMatching(`[A-Za-z0-9._/-]{0,24}`).Draw(t, "approvedBy"),
+			Error:         rapid.StringMatching(`[A-Za-z0-9._/ -]{0,40}`).Draw(t, "error"),
+			WorkflowClass: rapid.SampledFrom([]string{"", "delivery", "harness-maintenance", "ops"}).Draw(t, "workflowClass"),
+			Operation:     rapid.SampledFrom([]string{"", "write_control_plane", "push_branch", "commit_default_branch"}).Draw(t, "operation"),
+			RuleMatched:   rapid.StringMatching(`[A-Za-z0-9._/-]{0,40}`).Draw(t, "ruleMatched"),
+			FilePath:      rapid.StringMatching(`[A-Za-z0-9._/-]{0,60}`).Draw(t, "filePath"),
+			VesselID:      rapid.StringMatching(`[A-Za-z0-9._/-]{0,24}`).Draw(t, "vesselID"),
+		}
+
+		raw, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("json.Marshal() error = %v", err)
+		}
+
+		var got AuditEntry
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v", err)
+		}
+
+		if got.Intent.Action != entry.Intent.Action {
+			t.Fatalf("Intent.Action = %q, want %q", got.Intent.Action, entry.Intent.Action)
+		}
+		if got.Intent.Resource != entry.Intent.Resource {
+			t.Fatalf("Intent.Resource = %q, want %q", got.Intent.Resource, entry.Intent.Resource)
+		}
+		if got.Intent.AgentID != entry.Intent.AgentID {
+			t.Fatalf("Intent.AgentID = %q, want %q", got.Intent.AgentID, entry.Intent.AgentID)
+		}
+		if got.Intent.Justification != entry.Intent.Justification {
+			t.Fatalf("Intent.Justification = %q, want %q", got.Intent.Justification, entry.Intent.Justification)
+		}
+		if got.Intent.Metadata != nil {
+			t.Fatalf("Intent.Metadata = %+v, want nil", got.Intent.Metadata)
+		}
+		if got.Decision != entry.Decision {
+			t.Fatalf("Decision = %q, want %q", got.Decision, entry.Decision)
+		}
+		if !got.Timestamp.Equal(entry.Timestamp) {
+			t.Fatalf("Timestamp = %s, want %s", got.Timestamp.Format(time.RFC3339), entry.Timestamp.Format(time.RFC3339))
+		}
+		if got.ApprovedBy != entry.ApprovedBy {
+			t.Fatalf("ApprovedBy = %q, want %q", got.ApprovedBy, entry.ApprovedBy)
+		}
+		if got.Error != entry.Error {
+			t.Fatalf("Error = %q, want %q", got.Error, entry.Error)
+		}
+		if got.WorkflowClass != entry.WorkflowClass {
+			t.Fatalf("WorkflowClass = %q, want %q", got.WorkflowClass, entry.WorkflowClass)
+		}
+		if got.Operation != entry.Operation {
+			t.Fatalf("Operation = %q, want %q", got.Operation, entry.Operation)
+		}
+		if got.RuleMatched != entry.RuleMatched {
+			t.Fatalf("RuleMatched = %q, want %q", got.RuleMatched, entry.RuleMatched)
+		}
+		if got.FilePath != entry.FilePath {
+			t.Fatalf("FilePath = %q, want %q", got.FilePath, entry.FilePath)
+		}
+		if got.VesselID != entry.VesselID {
+			t.Fatalf("VesselID = %q, want %q", got.VesselID, entry.VesselID)
+		}
+
+		var rawFields map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &rawFields); err != nil {
+			t.Fatalf("json.Unmarshal(raw fields) error = %v", err)
+		}
+
+		for key, value := range map[string]string{
+			"approved_by":    entry.ApprovedBy,
+			"error":          entry.Error,
+			"workflow_class": entry.WorkflowClass,
+			"operation":      entry.Operation,
+			"rule_matched":   entry.RuleMatched,
+			"file_path":      entry.FilePath,
+			"vessel_id":      entry.VesselID,
+		} {
+			_, present := rawFields[key]
+			if value == "" && present {
+				t.Fatalf("%s unexpectedly serialized in %s", key, raw)
+			}
+			if value != "" && !present {
+				t.Fatalf("%s missing from %s", key, raw)
+			}
 		}
 	})
 }

--- a/cli/internal/intermediary/intermediary_test.go
+++ b/cli/internal/intermediary/intermediary_test.go
@@ -399,6 +399,40 @@ func TestSubmit_ExecutorErrorCaptured(t *testing.T) {
 	}
 }
 
+func TestSubmit_WarnModeExecutorErrorReturnsEvaluatedEffect(t *testing.T) {
+	execErr := errors.New("disk full")
+	exec := &mockExecutor{err: execErr}
+	al := newTestAuditLog(t)
+	inter := NewIntermediary([]Policy{{
+		Name:  "allow-all",
+		Rules: []Rule{{Action: "*", Resource: "*", Effect: Allow}},
+	}}, al, exec)
+	inter.SetMode(PolicyModeWarn)
+
+	intent := Intent{Action: "file_write", Resource: ".xylem/HARNESS.md", AgentID: "agent-1", Justification: "test"}
+	effect, err := inter.Submit(context.Background(), intent)
+	if effect != Deny {
+		t.Fatalf("warn-mode effect = %q, want %q", effect, Deny)
+	}
+	if err == nil || !strings.Contains(err.Error(), "disk full") {
+		t.Fatalf("expected executor error, got %v", err)
+	}
+
+	entries, err := al.Entries()
+	if err != nil {
+		t.Fatalf("read audit: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("audit entries: got %d, want 1", len(entries))
+	}
+	if entries[0].Decision != Deny {
+		t.Fatalf("audit decision: got %q, want %q", entries[0].Decision, Deny)
+	}
+	if entries[0].Error != "disk full" {
+		t.Fatalf("audit error: got %q, want %q", entries[0].Error, "disk full")
+	}
+}
+
 func TestSubmit_RequireApprovalNotExecuted(t *testing.T) {
 	exec := &mockExecutor{}
 	al := newTestAuditLog(t)

--- a/cli/internal/intermediary/intermediary_test.go
+++ b/cli/internal/intermediary/intermediary_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 )
 
 // mockExecutor records whether Execute was called and optionally returns an error.
@@ -194,6 +196,76 @@ func TestEvaluate(t *testing.T) {
 	}
 }
 
+func TestEvaluateWithContextWorkflowClassMatrix(t *testing.T) {
+	inter := NewIntermediary([]Policy{{
+		Name:  "default",
+		Rules: []Rule{{Action: "*", Resource: "*", Effect: Allow}},
+	}}, newTestAuditLog(t), &mockExecutor{})
+
+	deny := inter.EvaluateWithContext(Intent{
+		Action:   "file_write",
+		Resource: ".xylem/HARNESS.md",
+		AgentID:  "issue-1",
+	}, EvaluationContext{
+		WorkflowClass: policy.Delivery,
+		FilePath:      "/tmp/worktree/.xylem/HARNESS.md",
+		VesselID:      "issue-1",
+	})
+	if deny.Effect != Deny {
+		t.Fatalf("delivery write effect = %q, want %q", deny.Effect, Deny)
+	}
+	if deny.Operation != string(policy.OpWriteControlPlane) {
+		t.Fatalf("delivery write operation = %q, want %q", deny.Operation, policy.OpWriteControlPlane)
+	}
+	if deny.RuleMatched != "delivery.no_control_plane_writes" {
+		t.Fatalf("delivery write rule = %q, want %q", deny.RuleMatched, "delivery.no_control_plane_writes")
+	}
+	if deny.FilePath != "/tmp/worktree/.xylem/HARNESS.md" {
+		t.Fatalf("delivery write file path = %q", deny.FilePath)
+	}
+
+	allow := inter.EvaluateWithContext(Intent{
+		Action:   "file_write",
+		Resource: ".xylem/HARNESS.md",
+		AgentID:  "issue-2",
+	}, EvaluationContext{
+		WorkflowClass: policy.HarnessMaintenance,
+		FilePath:      "/tmp/worktree/.xylem/HARNESS.md",
+		VesselID:      "issue-2",
+	})
+	if allow.Effect != Allow {
+		t.Fatalf("harness-maintenance write effect = %q, want %q", allow.Effect, Allow)
+	}
+	if allow.RuleMatched != "harness_maintenance.worktree_writes_allowed" {
+		t.Fatalf("harness-maintenance write rule = %q, want %q", allow.RuleMatched, "harness_maintenance.worktree_writes_allowed")
+	}
+}
+
+func TestEvaluateWithContextUserRulesTightenMatrix(t *testing.T) {
+	inter := NewIntermediary([]Policy{{
+		Name:  "user",
+		Rules: []Rule{{Action: "git_push", Resource: "*", Effect: RequireApproval}},
+	}}, newTestAuditLog(t), &mockExecutor{})
+
+	result := inter.EvaluateWithContext(Intent{
+		Action:   "git_push",
+		Resource: "feature-1",
+		AgentID:  "issue-1",
+	}, EvaluationContext{
+		WorkflowClass: policy.Delivery,
+		VesselID:      "issue-1",
+	})
+	if result.Effect != RequireApproval {
+		t.Fatalf("git push effect = %q, want %q", result.Effect, RequireApproval)
+	}
+	if result.Operation != string(policy.OpPushBranch) {
+		t.Fatalf("git push operation = %q, want %q", result.Operation, policy.OpPushBranch)
+	}
+	if result.RuleMatched != "policy.user[0]" {
+		t.Fatalf("git push rule = %q, want %q", result.RuleMatched, "policy.user[0]")
+	}
+}
+
 func TestSubmit_AllowedIntentExecutes(t *testing.T) {
 	exec := &mockExecutor{}
 	al := newTestAuditLog(t)
@@ -223,6 +295,45 @@ func TestSubmit_AllowedIntentExecutes(t *testing.T) {
 	}
 	if entries[0].Decision != Allow {
 		t.Fatalf("audit decision: got %q, want %q", entries[0].Decision, Allow)
+	}
+}
+
+func TestSubmit_WarnModeExecutesDeniedIntent(t *testing.T) {
+	exec := &mockExecutor{}
+	al := newTestAuditLog(t)
+	inter := NewIntermediary([]Policy{{
+		Name:  "allow-all",
+		Rules: []Rule{{Action: "*", Resource: "*", Effect: Allow}},
+	}}, al, exec)
+	inter.SetMode(PolicyModeWarn)
+
+	intent := Intent{Action: "file_write", Resource: ".xylem/HARNESS.md", AgentID: "agent-1", Justification: "test"}
+	effect, err := inter.Submit(context.Background(), intent)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if effect != Deny {
+		t.Fatalf("warn-mode effect = %q, want %q", effect, Deny)
+	}
+	if exec.calls() != 1 {
+		t.Fatalf("executor calls: got %d, want 1", exec.calls())
+	}
+
+	entries, err := al.Entries()
+	if err != nil {
+		t.Fatalf("read audit: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("audit entries: got %d, want 1", len(entries))
+	}
+	if entries[0].Decision != Deny {
+		t.Fatalf("audit decision: got %q, want %q", entries[0].Decision, Deny)
+	}
+	if entries[0].WorkflowClass != "delivery" {
+		t.Fatalf("audit workflow class: got %q, want delivery", entries[0].WorkflowClass)
+	}
+	if entries[0].Operation != "write_control_plane" {
+		t.Fatalf("audit operation: got %q, want write_control_plane", entries[0].Operation)
 	}
 }
 

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -3202,7 +3202,6 @@ func indicatesControlPlaneWrite(rendered string) bool {
 		"touch ",
 		"echo ",
 		"printf ",
-		"cat ",
 		"tee ",
 		"sed ",
 		"cp ",
@@ -3889,9 +3888,12 @@ func (r *Runner) detectDefaultBranchAtPath(ctx context.Context, worktreePath str
 }
 
 func (r *Runner) recordProtectedSurfaceViolations(vessel queue.Vessel, p workflow.Phase, worktreePath, errMsg string, violations []surface.Violation) error {
-	workflowClass, _ := r.workflowClassForAudit(vessel)
+	workflowClass, workflowClassErr := r.workflowClassForAudit(vessel)
 	ruleMatched := ""
-	if classDecision := policy.Evaluate(workflowClass, policy.OpWriteControlPlane); !classDecision.Allowed {
+	if workflowClassErr != nil {
+		log.Printf("runner: determine workflow class for audit for vessel %s workflow %q: %v", vessel.ID, vessel.Workflow, workflowClassErr)
+		workflowClass = ""
+	} else if classDecision := policy.Evaluate(workflowClass, policy.OpWriteControlPlane); !classDecision.Allowed {
 		ruleMatched = classDecision.Rule
 	}
 	for _, violation := range violations {

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -28,6 +28,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/orchestrator"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
@@ -766,7 +767,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if wErr := os.WriteFile(filepath.Join(phasesDir, p.Name+".command"), []byte(rendered), 0o644); wErr != nil {
 					log.Printf("warn: write command file: %v", wErr)
 				}
-				if policyErr := r.enforcePhasePolicy(vessel, p, rendered, ""); policyErr != nil {
+				if policyErr := r.enforcePhasePolicy(ctx, vessel, sk, p, worktreePath, rendered, ""); policyErr != nil {
 					finishCurrentPhaseSpan(policyErr)
 					log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
 					vessel.FailedPhase = p.Name
@@ -832,7 +833,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if wErr := os.WriteFile(promptPath, []byte(rendered), 0o644); wErr != nil {
 					log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
 				}
-				if policyErr := r.enforcePhasePolicy(vessel, p, "", promptTemplate); policyErr != nil {
+				if policyErr := r.enforcePhasePolicy(ctx, vessel, sk, p, worktreePath, "", promptTemplate); policyErr != nil {
 					finishCurrentPhaseSpan(policyErr)
 					log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
 					vessel.FailedPhase = p.Name
@@ -2316,7 +2317,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if wErr := os.WriteFile(filepath.Join(phasesDir, p.Name+".command"), []byte(rendered), 0o644); wErr != nil {
 				log.Printf("warn: write command file: %v", wErr)
 			}
-			if policyErr := r.enforcePhasePolicy(vessel, p, rendered, ""); policyErr != nil {
+			if policyErr := r.enforcePhasePolicy(ctx, vessel, wf, p, worktreePath, rendered, ""); policyErr != nil {
 				finishCurrentPhaseSpan(policyErr)
 				log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
 				vessel.FailedPhase = p.Name
@@ -2381,7 +2382,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if wErr := os.WriteFile(promptPath, []byte(rendered), 0o644); wErr != nil {
 				log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
 			}
-			if policyErr := r.enforcePhasePolicy(vessel, p, "", promptTemplate); policyErr != nil {
+			if policyErr := r.enforcePhasePolicy(ctx, vessel, wf, p, worktreePath, "", promptTemplate); policyErr != nil {
 				finishCurrentPhaseSpan(policyErr)
 				log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
 				vessel.FailedPhase = p.Name
@@ -3007,17 +3008,38 @@ func phaseActionType(p *workflow.Phase) string {
 	return "phase_execute"
 }
 
-func (r *Runner) enforcePhasePolicy(vessel queue.Vessel, p workflow.Phase, renderedCommand, renderedPrompt string) error {
-	if r.Intermediary == nil {
-		return nil
+const harnessMaintenanceDefaultBranchRule = "policy.class.no-main-commits"
+
+var controlPlanePathRe = regexp.MustCompile(`(^|[^A-Za-z0-9._/-])(\.xylem/HARNESS\.md|\.xylem\.yml|\.xylem/workflows/[A-Za-z0-9._/-]+\.yaml|\.xylem/prompts/[A-Za-z0-9._/-]+\.md)([^A-Za-z0-9._/-]|$)`)
+
+func (r *Runner) enforcePhasePolicy(ctx context.Context, vessel queue.Vessel, sk *workflow.Workflow, p workflow.Phase, worktreePath, renderedCommand, renderedPrompt string) error {
+	workflowClass := policy.Delivery
+	if sk != nil && sk.Class != "" {
+		workflowClass = sk.Class
 	}
 
 	for _, intent := range r.phasePolicyIntents(vessel, p, renderedCommand, renderedPrompt) {
-		result := r.Intermediary.Evaluate(intent)
+		if guardErr := r.enforceDefaultBranchPushPolicy(ctx, vessel, workflowClass, p.Name, worktreePath, intent); guardErr != nil {
+			return guardErr
+		}
+		if r.Intermediary == nil {
+			continue
+		}
+
+		result := r.Intermediary.EvaluateWithContext(intent, intermediary.EvaluationContext{
+			WorkflowClass: workflowClass,
+			FilePath:      auditFilePath(worktreePath, intent.Resource),
+			VesselID:      vessel.ID,
+		})
 		entry := intermediary.AuditEntry{
-			Intent:    intent,
-			Decision:  result.Effect,
-			Timestamp: time.Now().UTC(),
+			Intent:        intent,
+			Decision:      result.Effect,
+			Timestamp:     time.Now().UTC(),
+			WorkflowClass: string(workflowClass),
+			Operation:     result.Operation,
+			RuleMatched:   result.RuleMatched,
+			FilePath:      result.FilePath,
+			VesselID:      vessel.ID,
 		}
 		if result.Effect != intermediary.Allow {
 			entry.Error = result.Reason
@@ -3025,7 +3047,7 @@ func (r *Runner) enforcePhasePolicy(vessel queue.Vessel, p workflow.Phase, rende
 		if err := r.appendAuditEntry(entry); err != nil {
 			return fmt.Errorf("record audit evidence: %w", err)
 		}
-		if result.Effect != intermediary.Allow {
+		if r.Intermediary.ShouldBlock(result.Effect) {
 			return formatPolicyDecisionError(p.Name, intent, result)
 		}
 	}
@@ -3083,6 +3105,9 @@ func (r *Runner) phasePolicyIntents(vessel queue.Vessel, p workflow.Phase, rende
 	}
 	if indicatesPRCreate(classificationText) {
 		appendIntent("pr_create", extractRepoFlag(classificationText, sourceRepo))
+	}
+	for _, resource := range extractControlPlaneWriteResources(classificationText) {
+		appendIntent("file_write", resource)
 	}
 
 	return intents
@@ -3161,6 +3186,65 @@ func indicatesPRCreate(rendered string) bool {
 		strings.Contains(lower, "create a pr")
 }
 
+func indicatesControlPlaneWrite(rendered string) bool {
+	lower := strings.ToLower(rendered)
+	markers := []string{
+		"write ",
+		"edit ",
+		"update ",
+		"modify ",
+		"change ",
+		"create ",
+		"append ",
+		"overwrite ",
+		"replace ",
+		"rewrite ",
+		"touch ",
+		"echo ",
+		"printf ",
+		"cat ",
+		"tee ",
+		"sed ",
+		"cp ",
+		"mv ",
+		">",
+		">>",
+	}
+	for _, marker := range markers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func extractControlPlaneWriteResources(rendered string) []string {
+	if !indicatesControlPlaneWrite(rendered) {
+		return nil
+	}
+	matches := controlPlanePathRe.FindAllStringSubmatch(rendered, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(matches))
+	resources := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if len(match) < 3 {
+			continue
+		}
+		resource := match[2]
+		if !intermediary.IsControlPlaneResource(resource) {
+			continue
+		}
+		if _, ok := seen[resource]; ok {
+			continue
+		}
+		seen[resource] = struct{}{}
+		resources = append(resources, resource)
+	}
+	return resources
+}
+
 func extractGitPushResource(rendered string) string {
 	fields := strings.Fields(rendered)
 	for i := 0; i < len(fields)-1; i++ {
@@ -3207,6 +3291,87 @@ func extractRepoFlag(rendered, fallback string) string {
 		return fallback
 	}
 	return "*"
+}
+
+func auditFilePath(worktreePath, resource string) string {
+	resource = strings.TrimSpace(resource)
+	if worktreePath == "" || resource == "" || !intermediary.IsControlPlaneResource(resource) {
+		return ""
+	}
+	if filepath.IsAbs(resource) {
+		return resource
+	}
+	return filepath.Join(worktreePath, filepath.FromSlash(resource))
+}
+
+func normalizeBranchRef(ref string) string {
+	ref = strings.TrimSpace(ref)
+	ref = strings.Trim(ref, "\"'")
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	if parts := strings.SplitN(ref, ":", 2); len(parts) == 2 {
+		ref = parts[1]
+	}
+	ref = strings.TrimPrefix(ref, "refs/heads/")
+	return ref
+}
+
+func pushTargetsDefaultBranch(resource, defaultBranch string) bool {
+	target := normalizeBranchRef(resource)
+	defaultBranch = normalizeBranchRef(defaultBranch)
+	return target != "" && defaultBranch != "" && target == defaultBranch
+}
+
+func (r *Runner) policyMode() intermediary.PolicyMode {
+	if r != nil && r.Config != nil {
+		return r.Config.HarnessPolicyMode()
+	}
+	if r != nil && r.Intermediary != nil {
+		return r.Intermediary.Mode()
+	}
+	return intermediary.PolicyModeEnforce
+}
+
+func (r *Runner) enforceDefaultBranchPushPolicy(ctx context.Context, vessel queue.Vessel, workflowClass policy.Class, phaseName, worktreePath string, intent intermediary.Intent) error {
+	if workflowClass != policy.HarnessMaintenance || intent.Action != "git_push" || worktreePath == "" {
+		return nil
+	}
+
+	defaultBranch, err := r.detectDefaultBranchAtPath(ctx, worktreePath)
+	if err != nil {
+		return fmt.Errorf("detect default branch for policy enforcement: %w", err)
+	}
+	if !pushTargetsDefaultBranch(intent.Resource, defaultBranch) {
+		return nil
+	}
+
+	if err := r.appendAuditEntry(intermediary.AuditEntry{
+		Intent:        intent,
+		Decision:      intermediary.Deny,
+		Timestamp:     time.Now().UTC(),
+		Error:         harnessMaintenanceDefaultBranchRule,
+		WorkflowClass: string(workflowClass),
+		Operation:     string(policy.OpCommitDefaultBranch),
+		RuleMatched:   harnessMaintenanceDefaultBranchRule,
+		VesselID:      vessel.ID,
+	}); err != nil {
+		return fmt.Errorf("record default branch push denial: %w", err)
+	}
+
+	if r.policyMode() == intermediary.PolicyModeWarn {
+		return nil
+	}
+
+	return formatPolicyDecisionError(phaseName, intent, intermediary.PolicyResult{
+		Effect:        intermediary.Deny,
+		Reason:        harnessMaintenanceDefaultBranchRule,
+		WorkflowClass: workflowClass,
+		Operation:     string(policy.OpCommitDefaultBranch),
+		RuleMatched:   harnessMaintenanceDefaultBranchRule,
+		VesselID:      vessel.ID,
+	})
 }
 
 func (r *Runner) takeProtectedSurfaceSnapshot(ctx context.Context, worktreePath string) (surface.Snapshot, bool, error) {
@@ -3333,7 +3498,7 @@ func (r *Runner) verifyProtectedSurfaces(vessel queue.Vessel, p workflow.Phase, 
 	}
 
 	errMsg := fmt.Sprintf("phase %q violated protected surfaces: %s", p.Name, formatViolations(violations))
-	if err := r.recordProtectedSurfaceViolations(vessel, p, errMsg, violations); err != nil {
+	if err := r.recordProtectedSurfaceViolations(vessel, p, worktreePath, errMsg, violations); err != nil {
 		return fmt.Errorf("%s (record audit evidence: %w)", errMsg, err)
 	}
 	if err := r.restoreDeletedProtectedSurfaces(context.Background(), worktreePath, violations); err != nil {
@@ -3723,7 +3888,12 @@ func (r *Runner) detectDefaultBranchAtPath(ctx context.Context, worktreePath str
 	return "", fmt.Errorf("could not detect default branch from origin")
 }
 
-func (r *Runner) recordProtectedSurfaceViolations(vessel queue.Vessel, p workflow.Phase, errMsg string, violations []surface.Violation) error {
+func (r *Runner) recordProtectedSurfaceViolations(vessel queue.Vessel, p workflow.Phase, worktreePath, errMsg string, violations []surface.Violation) error {
+	workflowClass, _ := r.workflowClassForAudit(vessel)
+	ruleMatched := ""
+	if classDecision := policy.Evaluate(workflowClass, policy.OpWriteControlPlane); !classDecision.Allowed {
+		ruleMatched = classDecision.Rule
+	}
 	for _, violation := range violations {
 		if err := r.appendAuditEntry(intermediary.AuditEntry{
 			Intent: intermediary.Intent{
@@ -3739,9 +3909,14 @@ func (r *Runner) recordProtectedSurfaceViolations(vessel queue.Vessel, p workflo
 					"workflow": vessel.Workflow,
 				},
 			},
-			Decision:  intermediary.Deny,
-			Timestamp: time.Now().UTC(),
-			Error:     errMsg,
+			Decision:      intermediary.Deny,
+			Timestamp:     time.Now().UTC(),
+			Error:         errMsg,
+			WorkflowClass: string(workflowClass),
+			Operation:     string(policy.OpWriteControlPlane),
+			RuleMatched:   ruleMatched,
+			FilePath:      auditFilePath(worktreePath, violation.Path),
+			VesselID:      vessel.ID,
 		}); err != nil {
 			return fmt.Errorf("append surface violation audit for %s: %w", violation.Path, err)
 		}
@@ -3752,6 +3927,9 @@ func (r *Runner) recordProtectedSurfaceViolations(vessel queue.Vessel, p workflo
 func (r *Runner) appendAuditEntry(entry intermediary.AuditEntry) error {
 	if r.AuditLog == nil {
 		return nil
+	}
+	if entry.VesselID == "" {
+		entry.VesselID = entry.Intent.AgentID
 	}
 	if err := r.AuditLog.Append(entry); err != nil {
 		return fmt.Errorf("append audit entry: %w", err)
@@ -3886,6 +4064,20 @@ func (r *Runner) writeWorkflowSnapshot(srcPath, snapshotPath string) error {
 func (r *Runner) loadWorkflow(name string) (*workflow.Workflow, string, error) {
 	path := filepath.Join(".xylem", "workflows", name+".yaml")
 	return workflow.LoadWithDigest(path)
+}
+
+func (r *Runner) workflowClassForAudit(vessel queue.Vessel) (policy.Class, error) {
+	if strings.TrimSpace(vessel.Workflow) == "" {
+		return policy.Delivery, nil
+	}
+	sk, _, err := r.loadWorkflow(vessel.Workflow)
+	if err != nil {
+		return policy.Delivery, fmt.Errorf("load workflow %q: %w", vessel.Workflow, err)
+	}
+	if sk == nil || sk.Class == "" {
+		return policy.Delivery, nil
+	}
+	return sk.Class, nil
 }
 
 func (r *Runner) workflowSnapshotPath(vesselID, workflowName string) string {

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -408,6 +408,26 @@ func TestProp_ResolvePhaseProviderChainPrefersMostSpecificTier(t *testing.T) {
 	})
 }
 
+func TestProp_PushTargetsDefaultBranchNormalizesRefspecs(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		branch := rapid.StringMatching(`[a-z0-9][a-z0-9._/-]{0,19}`).Draw(t, "branch")
+		resource := rapid.SampledFrom([]string{
+			branch,
+			"refs/heads/" + branch,
+			"HEAD:" + branch,
+			"refs/heads/source:refs/heads/" + branch,
+			" '" + branch + "' ",
+		}).Draw(t, "resource")
+
+		if !pushTargetsDefaultBranch(resource, branch) {
+			t.Fatalf("pushTargetsDefaultBranch(%q, %q) = false, want true", resource, branch)
+		}
+		if pushTargetsDefaultBranch(resource, branch+"-other") {
+			t.Fatalf("pushTargetsDefaultBranch(%q, %q) = true, want false", resource, branch+"-other")
+		}
+	})
+}
+
 func TestProp_BudgetExceededIsMonotonic(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		records := rapid.SliceOfN(rapid.Float64Range(0.0, 1.0), 1, 20).Draw(t, "costs")

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
@@ -637,8 +638,19 @@ func TestBuildCommand(t *testing.T) {
 	}
 }
 
+type testWorkflowOptions struct {
+	class                         string
+	allowAdditiveProtectedWrites  bool
+	allowCanonicalProtectedWrites bool
+}
+
 // writeWorkflowFile creates a workflow YAML and its prompt files in the given dir.
 func writeWorkflowFile(t *testing.T, dir, name string, phases []testPhase) {
+	t.Helper()
+	writeWorkflowFileWithOptions(t, dir, name, testWorkflowOptions{}, phases)
+}
+
+func writeWorkflowFileWithOptions(t *testing.T, dir, name string, opts testWorkflowOptions, phases []testPhase) {
 	t.Helper()
 	workflowDir := filepath.Join(dir, ".xylem", "workflows")
 	os.MkdirAll(workflowDir, 0o755)
@@ -691,7 +703,17 @@ func writeWorkflowFile(t *testing.T, dir, name string, phases []testPhase) {
 		}
 	}
 
-	workflowContent := fmt.Sprintf("name: %s\nphases:\n%s", name, phaseYAML.String())
+	workflowContent := fmt.Sprintf("name: %s\n", name)
+	if opts.class != "" {
+		workflowContent += fmt.Sprintf("class: %s\n", opts.class)
+	}
+	if opts.allowAdditiveProtectedWrites {
+		workflowContent += "allow_additive_protected_writes: true\n"
+	}
+	if opts.allowCanonicalProtectedWrites {
+		workflowContent += "allow_canonical_protected_writes: true\n"
+	}
+	workflowContent += fmt.Sprintf("phases:\n%s", phaseYAML.String())
 	os.WriteFile(filepath.Join(workflowDir, name+".yaml"), []byte(workflowContent), 0o644)
 }
 
@@ -1829,6 +1851,226 @@ func TestDrainSingleVessel(t *testing.T) {
 	if vessels[0].State != queue.StateCompleted {
 		t.Errorf("expected vessel completed, got %s", vessels[0].State)
 	}
+}
+
+func TestRunnerPolicyMatrixDeniesDeliveryControlPlaneWrite(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "delivery-write"))
+
+	writeWorkflowFileWithOptions(t, dir, "delivery-write", testWorkflowOptions{
+		class: string(policy.Delivery),
+	}, []testPhase{{
+		name:          "implement",
+		promptContent: "Write .xylem/HARNESS.md with the updated harness rules.",
+		maxTurns:      5,
+	}})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{}
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, cfg.EffectiveAuditLogPath()))
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.AuditLog = auditLog
+	r.Intermediary = intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), auditLog, nil)
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+	assert.Len(t, cmdRunner.phaseCalls, 0)
+
+	vessel := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, vessel.State)
+	assert.Contains(t, vessel.Error, "denied by policy")
+	assert.Contains(t, vessel.Error, ".xylem/HARNESS.md")
+
+	entries, err := auditLog.Entries()
+	require.NoError(t, err)
+	var writeEntry *intermediary.AuditEntry
+	for i := range entries {
+		if entries[i].Intent.Action == "file_write" && entries[i].Intent.Resource == ".xylem/HARNESS.md" {
+			writeEntry = &entries[i]
+			break
+		}
+	}
+	require.NotNil(t, writeEntry)
+	assert.Equal(t, intermediary.Deny, writeEntry.Decision)
+	assert.Equal(t, "delivery", writeEntry.WorkflowClass)
+	assert.Equal(t, "write_control_plane", writeEntry.Operation)
+	assert.Equal(t, "delivery.no_control_plane_writes", writeEntry.RuleMatched)
+	assert.Equal(t, vessel.ID, writeEntry.VesselID)
+	assert.Equal(t, filepath.Join(dir, ".xylem", "HARNESS.md"), writeEntry.FilePath)
+}
+
+func TestRunnerPolicyMatrixAllowsHarnessMaintenanceControlPlaneWrite(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "harness-write"))
+
+	writeWorkflowFileWithOptions(t, dir, "harness-write", testWorkflowOptions{
+		class:                        string(policy.HarnessMaintenance),
+		allowAdditiveProtectedWrites: true,
+	}, []testPhase{{
+		name:          "implement",
+		promptContent: "Write .xylem/HARNESS.md with the updated harness rules.",
+		maxTurns:      5,
+	}})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{"Write .xylem/HARNESS.md": []byte("done")},
+	}
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, cfg.EffectiveAuditLogPath()))
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.AuditLog = auditLog
+	r.Intermediary = intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), auditLog, nil)
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
+	assert.Len(t, cmdRunner.phaseCalls, 1)
+
+	entries, err := auditLog.Entries()
+	require.NoError(t, err)
+	var writeEntry *intermediary.AuditEntry
+	for i := range entries {
+		if entries[i].Intent.Action == "file_write" && entries[i].Intent.Resource == ".xylem/HARNESS.md" {
+			writeEntry = &entries[i]
+			break
+		}
+	}
+	require.NotNil(t, writeEntry)
+	assert.Equal(t, intermediary.Allow, writeEntry.Decision)
+	assert.Equal(t, "harness-maintenance", writeEntry.WorkflowClass)
+	assert.Equal(t, "write_control_plane", writeEntry.Operation)
+	assert.Equal(t, "harness_maintenance.worktree_writes_allowed", writeEntry.RuleMatched)
+	assert.Equal(t, filepath.Join(dir, ".xylem", "HARNESS.md"), writeEntry.FilePath)
+}
+
+func TestRunnerPolicyWarnModeLogsButAllowsControlPlaneWrite(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Harness.Policy.Mode = "warn"
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "warn-write"))
+
+	writeWorkflowFileWithOptions(t, dir, "warn-write", testWorkflowOptions{
+		class: string(policy.Delivery),
+	}, []testPhase{{
+		name:          "implement",
+		promptContent: "Write .xylem/HARNESS.md with the updated harness rules.",
+		maxTurns:      5,
+	}})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{"Write .xylem/HARNESS.md": []byte("done")},
+	}
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, cfg.EffectiveAuditLogPath()))
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.AuditLog = auditLog
+	r.Intermediary = intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), auditLog, nil)
+	r.Intermediary.SetMode(cfg.HarnessPolicyMode())
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
+	assert.Len(t, cmdRunner.phaseCalls, 1)
+
+	entries, err := auditLog.Entries()
+	require.NoError(t, err)
+	var writeEntry *intermediary.AuditEntry
+	for i := range entries {
+		if entries[i].Intent.Action == "file_write" && entries[i].Intent.Resource == ".xylem/HARNESS.md" {
+			writeEntry = &entries[i]
+			break
+		}
+	}
+	require.NotNil(t, writeEntry)
+	assert.Equal(t, intermediary.Deny, writeEntry.Decision)
+	assert.Equal(t, "delivery", writeEntry.WorkflowClass)
+	assert.Equal(t, "write_control_plane", writeEntry.Operation)
+	assert.Equal(t, "delivery.no_control_plane_writes", writeEntry.RuleMatched)
+}
+
+func TestRunnerHarnessMaintenanceDefaultBranchPushDeniedAtGitLayer(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	// HarnessPolicyMode() zero-value is warn per
+	// docs/plans/sota-gap-implementation-2026-04-11.md, so explicitly opt
+	// into enforce mode: this test is specifically asserting that git_push
+	// to the default branch is *blocked* (not just warned) when a harness-
+	// maintenance workflow runs under strict policy enforcement.
+	cfg.Harness.Policy.Mode = "enforce"
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "push-main"))
+
+	writeWorkflowFileWithOptions(t, dir, "push-main", testWorkflowOptions{
+		class: string(policy.HarnessMaintenance),
+	}, []testPhase{{
+		name:      "publish",
+		phaseType: "command",
+		run:       "git push origin main",
+	}})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name == "git" && len(args) >= 4 && args[2] == "symbolic-ref" {
+				return []byte("refs/remotes/origin/main\n"), nil, true
+			}
+			return nil, nil, false
+		},
+	}
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, cfg.EffectiveAuditLogPath()))
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.AuditLog = auditLog
+	r.Intermediary = intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), auditLog, nil)
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+	assert.Equal(t, 0, countRunOutputCalls(cmdRunner, "sh"))
+
+	vessel := loadSingleVessel(t, q)
+	assert.Equal(t, queue.StateFailed, vessel.State)
+	assert.Contains(t, vessel.Error, "denied by policy")
+	assert.Contains(t, vessel.Error, "git_push")
+
+	entries, err := auditLog.Entries()
+	require.NoError(t, err)
+	var guardEntry *intermediary.AuditEntry
+	for i := range entries {
+		if entries[i].Operation == "commit_default_branch" {
+			guardEntry = &entries[i]
+			break
+		}
+	}
+	require.NotNil(t, guardEntry)
+	assert.Equal(t, intermediary.Deny, guardEntry.Decision)
+	assert.Equal(t, "harness-maintenance", guardEntry.WorkflowClass)
+	assert.Equal(t, harnessMaintenanceDefaultBranchRule, guardEntry.RuleMatched)
+	assert.Equal(t, vessel.ID, guardEntry.VesselID)
+}
+
+func TestSmoke_S4_WorkflowClassEnforcement(t *testing.T) {
+	t.Run("delivery denies control-plane write", TestRunnerPolicyMatrixDeniesDeliveryControlPlaneWrite)
+	t.Run("harness-maintenance allows control-plane write", TestRunnerPolicyMatrixAllowsHarnessMaintenanceControlPlaneWrite)
+	t.Run("warn mode logs but allows control-plane write", TestRunnerPolicyWarnModeLogsButAllowsControlPlaneWrite)
+	t.Run("harness-maintenance default-branch push denied", TestRunnerHarnessMaintenanceDefaultBranchPushDeniedAtGitLayer)
 }
 
 func TestEnsureWorktreeRecreatesMissingInheritedPath(t *testing.T) {
@@ -6375,8 +6617,8 @@ func TestDrainOrchestratedProtectedSurfaceViolationFails(t *testing.T) {
 	if result.Failed != 1 {
 		t.Fatalf("expected 1 failed vessel, got failed=%d completed=%d", result.Failed, result.Completed)
 	}
-	if got := countRunOutputCalls(cmdRunner, "sh"); got != 1 {
-		t.Fatalf("countRunOutputCalls(sh) = %d, want 1 command invocation", got)
+	if got := countRunOutputCalls(cmdRunner, "sh"); got != 0 {
+		t.Fatalf("countRunOutputCalls(sh) = %d, want 0 command invocations", got)
 	}
 	if len(cmdRunner.phaseCalls) != 0 {
 		t.Fatalf("len(phaseCalls) = %d, want 0 dependent phase invocations", len(cmdRunner.phaseCalls))
@@ -6386,8 +6628,8 @@ func TestDrainOrchestratedProtectedSurfaceViolationFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
-	if !strings.Contains(vessels[0].Error, "violated protected surfaces") {
-		t.Fatalf("vessel.Error = %q, want to contain %q", vessels[0].Error, "violated protected surfaces")
+	if !strings.Contains(vessels[0].Error, "denied by policy") {
+		t.Fatalf("vessel.Error = %q, want to contain %q", vessels[0].Error, "denied by policy")
 	}
 	if !strings.Contains(vessels[0].Error, ".xylem.yml") {
 		t.Fatalf("vessel.Error = %q, want to contain %q", vessels[0].Error, ".xylem.yml")
@@ -6397,14 +6639,8 @@ func TestDrainOrchestratedProtectedSurfaceViolationFails(t *testing.T) {
 	if summary.State != "failed" {
 		t.Fatalf("summary.State = %q, want failed", summary.State)
 	}
-	if len(summary.Phases) != 1 {
-		t.Fatalf("len(summary.Phases) = %d, want 1", len(summary.Phases))
-	}
-	if summary.Phases[0].Name != "tamper" {
-		t.Fatalf("summary.Phases[0].Name = %q, want tamper", summary.Phases[0].Name)
-	}
-	if summary.Phases[0].Status != "failed" {
-		t.Fatalf("summary.Phases[0].Status = %q, want failed", summary.Phases[0].Status)
+	if len(summary.Phases) != 0 {
+		t.Fatalf("len(summary.Phases) = %d, want 0", len(summary.Phases))
 	}
 	if summary.EvidenceManifestPath != "" {
 		t.Fatalf("summary.EvidenceManifestPath = %q, want empty string", summary.EvidenceManifestPath)
@@ -6423,14 +6659,14 @@ func TestDrainOrchestratedProtectedSurfaceViolationFails(t *testing.T) {
 		if entry.Decision != intermediary.Deny {
 			t.Fatalf("file_write entry decision = %q, want %q", entry.Decision, intermediary.Deny)
 		}
-		if !strings.Contains(entry.Error, "violated protected surfaces") {
-			t.Fatalf("file_write entry error = %q, want to contain %q", entry.Error, "violated protected surfaces")
+		if entry.RuleMatched != "delivery.no_control_plane_writes" {
+			t.Fatalf("file_write entry rule = %q, want %q", entry.RuleMatched, "delivery.no_control_plane_writes")
 		}
 		if entry.Intent.Metadata["phase"] != "tamper" {
 			t.Fatalf("file_write entry phase metadata = %q, want tamper", entry.Intent.Metadata["phase"])
 		}
-		if entry.Intent.Metadata["before"] == "" || entry.Intent.Metadata["after"] == "" {
-			t.Fatalf("file_write entry missing before/after metadata: %+v", entry.Intent.Metadata)
+		if entry.Operation != "write_control_plane" {
+			t.Fatalf("file_write entry operation = %q, want %q", entry.Operation, "write_control_plane")
 		}
 	}
 	if !found {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -1106,6 +1106,24 @@ func TestPhasePolicyIntents_ClassifiesHighRiskPromptActions(t *testing.T) {
 	assert.Equal(t, "prompt", intents[1].Metadata["classified_from"])
 }
 
+func TestPhasePolicyIntents_DoesNotTreatCatReadAsControlPlaneWrite(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	r := New(cfg, nil, nil, nil)
+	vessel := queue.Vessel{
+		ID:       "issue-1",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		Meta:     map[string]string{"config_source": "github"},
+	}
+	phaseDef := workflow.Phase{Name: "inspect", Type: "command"}
+
+	intents := r.phasePolicyIntents(vessel, phaseDef, "cat .xylem.yml", "")
+	require.Len(t, intents, 1)
+	assert.Equal(t, "external_command", intents[0].Action)
+	assert.Equal(t, "inspect", intents[0].Resource)
+}
+
 func TestSmoke_S5_DiscussionOutputCreatesDiscussion(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)
@@ -7328,6 +7346,37 @@ phases:
 	assert.Equal(t, "file_write", entries[0].Intent.Action)
 	assert.Equal(t, ".xylem/workflows/doctor.yaml", entries[0].Intent.Resource)
 	assert.Equal(t, intermediary.Deny, entries[0].Decision)
+}
+
+func TestRecordProtectedSurfaceViolations_OmitsWorkflowClassWhenAuditLookupFails(t *testing.T) {
+	repoRoot := t.TempDir()
+	withTestWorkingDir(t, repoRoot)
+
+	cfg := makeTestConfig(repoRoot, 1)
+	cfg.StateDir = filepath.Join(repoRoot, ".xylem-state")
+	require.NoError(t, os.MkdirAll(cfg.StateDir, 0o755))
+
+	worktreeDir := filepath.Join(repoRoot, "worktree")
+	require.NoError(t, os.MkdirAll(worktreeDir, 0o755))
+
+	auditLog := intermediary.NewAuditLog(filepath.Join(cfg.StateDir, "audit.jsonl"))
+	r := New(cfg, queue.New(filepath.Join(repoRoot, "queue.jsonl")), &mockWorktree{path: worktreeDir}, &mockCmdRunner{})
+	r.AuditLog = auditLog
+
+	err := r.recordProtectedSurfaceViolations(
+		queue.Vessel{ID: "issue-missing-workflow", Source: "manual", Workflow: "missing-workflow"},
+		workflow.Phase{Name: "tamper"},
+		worktreeDir,
+		"violated protected surfaces",
+		[]surface.Violation{{Path: ".xylem.yml", Before: "abc", After: "xyz"}},
+	)
+	require.NoError(t, err)
+
+	entries, err := auditLog.Entries()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "", entries[0].WorkflowClass)
+	assert.Equal(t, "", entries[0].RuleMatched)
 }
 
 // TestCopyProtectedSurfaceFileAddsWorktreeExcludeEntry verifies that the


### PR DESCRIPTION
## Summary

- Implements [nicholls-inc/xylem#235](https://github.com/nicholls-inc/xylem/issues/235).
- Enforces the workflow-class matrix at phase launch and at the runner git layer, adds warn/enforce policy mode wiring, and extends audit entries with workflow class, operation, matched rule, file path, and vessel ID context.

## Smoke scenarios covered

- **S6, S18 — Policy deny prevents phase execution** (`ws1-policy-deny-blocks-phase`)
- **S7, S19 — Policy require_approval blocks phase** (`ws1-policy-require-approval`)

## Changes summary

- **Files added:** none
- **Files modified:** `cli/cmd/xylem/drain.go`, `cli/internal/config/config.go`, `cli/internal/config/config_prop_test.go`, `cli/internal/config/config_test.go`, `cli/internal/dtu/scenario_ws1_test.go`, `cli/internal/intermediary/intermediary.go`, `cli/internal/intermediary/intermediary_prop_test.go`, `cli/internal/intermediary/intermediary_test.go`, `cli/internal/runner/runner.go`, `cli/internal/runner/runner_prop_test.go`, `cli/internal/runner/runner_test.go`
- **Key types and functions:** `intermediary.PolicyMode`, `intermediary.EvaluationContext`, `intermediary.PolicyResult`, `intermediary.AuditEntry`, `(*Intermediary).EvaluateWithContext`, `(*Config).HarnessPolicyMode`, `(*Config).BuildIntermediaryPolicies`, `(*Runner).enforcePhasePolicy`, `(*Runner).enforceDefaultBranchPushPolicy`, `TestSmoke_S4_WorkflowClassEnforcement`

## Test plan

```bash
cd cli
go vet ./...
go build ./cmd/xylem
go test ./...
```

Fixes #235