### PR TITLE
feat: tier-aware LLM routing with provider-scoped env fallback

### DIFF
--- a/cli/cmd/xylem/exec.go
+++ b/cli/cmd/xylem/exec.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sort"
 	"sync"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
@@ -72,8 +73,12 @@ func (lw *limitedWriter) Len() int {
 
 type realCmdRunner struct {
 	// extraEnv holds additional KEY=VALUE pairs merged into the subprocess
-	// environment. Populated from claude.env and copilot.env in config.
+	// environment for non-phase subprocesses. Populated from all provider env
+	// blocks in config.
 	extraEnv []string
+	// providerEnv holds provider-scoped env vars for phase subprocesses so each
+	// LLM only receives its own credentials.
+	providerEnv map[string][]string
 }
 
 // newCmdRunner creates a realCmdRunner with extra env vars merged from
@@ -100,21 +105,49 @@ func newCmdRunner(cfg *config.Config) *realCmdRunner {
 	if cfg == nil {
 		return &realCmdRunner{}
 	}
-	var env []string
-	addEnv := func(k, v string) {
+	addEnv := func(dst *[]string, k, v string) {
 		expanded := os.ExpandEnv(v)
 		if expanded == "" {
 			return
 		}
-		env = append(env, k+"="+expanded)
+		*dst = append(*dst, k+"="+expanded)
 	}
-	for k, v := range cfg.Claude.Env {
-		addEnv(k, v)
+
+	providerEnv := make(map[string][]string, len(cfg.Providers))
+	var env []string
+	for name, provider := range cfg.Providers {
+		keys := make([]string, 0, len(provider.Env))
+		for k := range provider.Env {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := provider.Env[k]
+			addEnv(&env, k, v)
+			providerSlice := providerEnv[name]
+			addEnv(&providerSlice, k, v)
+			providerEnv[name] = providerSlice
+		}
 	}
-	for k, v := range cfg.Copilot.Env {
-		addEnv(k, v)
+	if len(providerEnv) == 0 {
+		keys := make([]string, 0, len(cfg.Claude.Env))
+		for k := range cfg.Claude.Env {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			addEnv(&env, k, cfg.Claude.Env[k])
+		}
+		keys = keys[:0]
+		for k := range cfg.Copilot.Env {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			addEnv(&env, k, cfg.Copilot.Env[k])
+		}
 	}
-	return &realCmdRunner{extraEnv: env}
+	return &realCmdRunner{extraEnv: env, providerEnv: providerEnv}
 }
 
 // cmdEnv returns the environment to use for a subprocess: the daemon's
@@ -166,18 +199,26 @@ func (r *realCmdRunner) RunProcessWithEnv(ctx context.Context, dir string, extra
 }
 
 func (r *realCmdRunner) RunPhase(ctx context.Context, dir string, stdin io.Reader, name string, args ...string) ([]byte, error) {
-	return r.runPhaseInternal(ctx, dir, stdin, nil, name, args...)
+	return r.runPhaseInternal(ctx, dir, r.cmdEnv(), stdin, nil, name, args...)
+}
+
+func (r *realCmdRunner) RunPhaseWithEnv(ctx context.Context, dir string, extraEnv []string, stdin io.Reader, name string, args ...string) ([]byte, error) {
+	return r.runPhaseInternal(ctx, dir, append(os.Environ(), extraEnv...), stdin, nil, name, args...)
 }
 
 func (r *realCmdRunner) RunPhaseObserved(ctx context.Context, dir string, stdin io.Reader, observer runner.PhaseProcessObserver, name string, args ...string) ([]byte, error) {
-	return r.runPhaseInternal(ctx, dir, stdin, observer, name, args...)
+	return r.runPhaseInternal(ctx, dir, r.cmdEnv(), stdin, observer, name, args...)
 }
 
-func (r *realCmdRunner) runPhaseInternal(ctx context.Context, dir string, stdin io.Reader, observer runner.PhaseProcessObserver, name string, args ...string) ([]byte, error) {
+func (r *realCmdRunner) RunPhaseObservedWithEnv(ctx context.Context, dir string, extraEnv []string, stdin io.Reader, observer runner.PhaseProcessObserver, name string, args ...string) ([]byte, error) {
+	return r.runPhaseInternal(ctx, dir, append(os.Environ(), extraEnv...), stdin, observer, name, args...)
+}
+
+func (r *realCmdRunner) runPhaseInternal(ctx context.Context, dir string, env []string, stdin io.Reader, observer runner.PhaseProcessObserver, name string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
 	cmd.Stdin = stdin
-	cmd.Env = r.cmdEnv()
+	cmd.Env = env
 
 	var stdout bytes.Buffer
 	stderr := newLimitedWriter(maxStderrBytes)

--- a/cli/cmd/xylem/exec_test.go
+++ b/cli/cmd/xylem/exec_test.go
@@ -91,6 +91,35 @@ func TestNewCmdRunner_MixedEnv(t *testing.T) {
 	}
 }
 
+func TestNewCmdRunner_BuildsPerProviderEnvMap(t *testing.T) {
+	t.Setenv("XYLEM_TEST_ANTHROPIC", "anthropic-secret")
+	t.Setenv("XYLEM_TEST_COPILOT", "copilot-secret")
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"claude": {
+				Kind: "claude",
+				Env: map[string]string{
+					"ANTHROPIC_API_KEY": "${XYLEM_TEST_ANTHROPIC}",
+				},
+			},
+			"copilot": {
+				Kind: "copilot",
+				Env: map[string]string{
+					"GITHUB_TOKEN": "${XYLEM_TEST_COPILOT}",
+				},
+			},
+		},
+	}
+
+	runner := newCmdRunner(cfg)
+	if got := runner.providerEnv["claude"]; len(got) != 1 || got[0] != "ANTHROPIC_API_KEY=anthropic-secret" {
+		t.Fatalf("claude provider env = %v", got)
+	}
+	if got := runner.providerEnv["copilot"]; len(got) != 1 || got[0] != "GITHUB_TOKEN=copilot-secret" {
+		t.Fatalf("copilot provider env = %v", got)
+	}
+}
+
 // TestRealCmdRunner_RunOutputInheritsEnv verifies that the non-phase
 // Run* methods now propagate extraEnv into the subprocess. Before the
 // fix, `gh`/`copilot` calls from the scanner and source commands
@@ -139,6 +168,45 @@ func TestRealCmdRunner_RunPhaseInheritsBaseEnv(t *testing.T) {
 	got := strings.TrimSpace(string(out))
 	if got != "inherited" {
 		t.Fatalf("expected RunPhase subprocess to see XYLEM_TEST_BASE_PROBE=inherited, got %q", got)
+	}
+}
+
+func TestRealCmdRunner_RunPhaseWithEnvIsolatesProviderEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh unavailable on windows")
+	}
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"claude": {
+				Kind: "claude",
+				Env: map[string]string{
+					"CLAUDE_ONLY_TOKEN": "anthropic-secret",
+				},
+			},
+			"copilot": {
+				Kind: "copilot",
+				Env: map[string]string{
+					"COPILOT_ONLY_TOKEN": "copilot-secret",
+				},
+			},
+		},
+	}
+	runner := newCmdRunner(cfg)
+
+	claudeOut, err := runner.RunPhaseWithEnv(context.Background(), ".", runner.providerEnv["claude"], nil, "sh", "-c", "printf '%s|%s' \"$CLAUDE_ONLY_TOKEN\" \"$COPILOT_ONLY_TOKEN\"")
+	if err != nil {
+		t.Fatalf("claude RunPhaseWithEnv failed: %v (output: %q)", err, string(claudeOut))
+	}
+	if got := strings.TrimSpace(string(claudeOut)); got != "anthropic-secret|" {
+		t.Fatalf("claude env = %q, want anthropic-secret|", got)
+	}
+
+	copilotOut, err := runner.RunPhaseWithEnv(context.Background(), ".", runner.providerEnv["copilot"], nil, "sh", "-c", "printf '%s|%s' \"$CLAUDE_ONLY_TOKEN\" \"$COPILOT_ONLY_TOKEN\"")
+	if err != nil {
+		t.Fatalf("copilot RunPhaseWithEnv failed: %v (output: %q)", err, string(copilotOut))
+	}
+	if got := strings.TrimSpace(string(copilotOut)); got != "|copilot-secret" {
+		t.Fatalf("copilot env = %q, want |copilot-secret", got)
 	}
 }
 

--- a/cli/internal/dtu/scenario_cancel_test.go
+++ b/cli/internal/dtu/scenario_cancel_test.go
@@ -49,6 +49,10 @@ func (r *blockingResolveScenarioCmdRunner) RunProcess(ctx context.Context, dir s
 }
 
 func (r *blockingResolveScenarioCmdRunner) RunPhase(ctx context.Context, _ string, stdin io.Reader, _ string, _ ...string) ([]byte, error) {
+	return r.RunPhaseWithEnv(ctx, "", nil, stdin, "")
+}
+
+func (r *blockingResolveScenarioCmdRunner) RunPhaseWithEnv(ctx context.Context, _ string, _ []string, stdin io.Reader, _ string, _ ...string) ([]byte, error) {
 	promptBytes, err := io.ReadAll(stdin)
 	if err != nil {
 		return nil, err

--- a/cli/internal/dtu/scenario_test.go
+++ b/cli/internal/dtu/scenario_test.go
@@ -196,16 +196,28 @@ func (r *dtuScenarioCmdRunner) RunProcess(ctx context.Context, _ string, name st
 }
 
 func (r *dtuScenarioCmdRunner) RunPhase(ctx context.Context, _ string, stdin io.Reader, name string, args ...string) ([]byte, error) {
-	return r.execute(ctx, stdin, name, args...)
+	return r.RunPhaseWithEnv(ctx, "", nil, stdin, name, args...)
 }
 
-func (r *dtuScenarioCmdRunner) execute(ctx context.Context, stdin io.Reader, name string, args ...string) ([]byte, error) {
+func (r *dtuScenarioCmdRunner) RunPhaseWithEnv(ctx context.Context, _ string, extraEnv []string, stdin io.Reader, name string, args ...string) ([]byte, error) {
+	if len(extraEnv) == 0 {
+		return r.execute(ctx, stdin, name, args...)
+	}
+	env := append(append([]string(nil), r.env...), extraEnv...)
+	return r.executeWithEnv(ctx, stdin, env, name, args...)
+}
+
+func (r *dtuScenarioCmdRunner) executeWithEnv(ctx context.Context, stdin io.Reader, env []string, name string, args ...string) ([]byte, error) {
 	var stdout, stderr bytes.Buffer
-	code := dtushim.Execute(ctx, name, args, stdin, &stdout, &stderr, r.env)
+	code := dtushim.Execute(ctx, name, args, stdin, &stdout, &stderr, env)
 	if code != 0 {
 		return stdout.Bytes(), &dtuExitError{code: code, stderr: stderr.String()}
 	}
 	return stdout.Bytes(), nil
+}
+
+func (r *dtuScenarioCmdRunner) execute(ctx context.Context, stdin io.Reader, name string, args ...string) ([]byte, error) {
+	return r.executeWithEnv(ctx, stdin, r.env, name, args...)
 }
 
 func withWorkingDir(t *testing.T, dir string) func() {

--- a/cli/internal/observability/vessel.go
+++ b/cli/internal/observability/vessel.go
@@ -85,6 +85,7 @@ type PhaseSpanData struct {
 	Workflow     string `json:"workflow"`
 	Provider     string `json:"provider"`
 	Model        string `json:"model"`
+	Tier         string `json:"tier,omitempty"`
 	RetryAttempt int    `json:"retry_attempt"`
 	SandboxMode  string `json:"sandbox_mode"`
 }
@@ -92,7 +93,7 @@ type PhaseSpanData struct {
 // PhaseSpanAttributes returns span attributes for a phase span.
 // The index is stringified, not stored as a numeric attribute.
 func PhaseSpanAttributes(data PhaseSpanData) []SpanAttribute {
-	return []SpanAttribute{
+	attrs := []SpanAttribute{
 		{Key: "xylem.phase.name", Value: data.Name},
 		{Key: "xylem.phase.index", Value: fmt.Sprintf("%d", data.Index)},
 		{Key: "xylem.phase.type", Value: data.Type},
@@ -102,6 +103,13 @@ func PhaseSpanAttributes(data PhaseSpanData) []SpanAttribute {
 		{Key: "xylem.phase.retry_attempt", Value: fmt.Sprintf("%d", data.RetryAttempt)},
 		{Key: "xylem.phase.sandbox_mode", Value: data.SandboxMode},
 	}
+	if data.Provider != "" {
+		attrs = append(attrs, SpanAttribute{Key: "llm.provider", Value: data.Provider})
+	}
+	if data.Tier != "" {
+		attrs = append(attrs, SpanAttribute{Key: "llm.tier", Value: data.Tier})
+	}
+	return attrs
 }
 
 // PhaseResultData holds phase result information for attribute extraction.
@@ -111,6 +119,9 @@ type PhaseResultData struct {
 	CostUSDEst             float64 `json:"cost_usd_est"`
 	DurationMS             int64   `json:"duration_ms"`
 	Status                 string  `json:"status"`
+	LLMProvider            string  `json:"llm_provider,omitempty"`
+	LLMModel               string  `json:"llm_model,omitempty"`
+	LLMTier                string  `json:"llm_tier,omitempty"`
 	UsageSource            string  `json:"usage_source,omitempty"`
 	UsageUnavailableReason string  `json:"usage_unavailable_reason,omitempty"`
 	OutputArtifactPath     string  `json:"output_artifact_path,omitempty"`
@@ -119,7 +130,7 @@ type PhaseResultData struct {
 // PhaseResultAttributes returns span attributes added to a phase span
 // after execution completes. Cost is formatted to six decimal places.
 func PhaseResultAttributes(data PhaseResultData) []SpanAttribute {
-	return []SpanAttribute{
+	attrs := []SpanAttribute{
 		{Key: "xylem.phase.input_tokens_est", Value: fmt.Sprintf("%d", data.InputTokensEst)},
 		{Key: "xylem.phase.output_tokens_est", Value: fmt.Sprintf("%d", data.OutputTokensEst)},
 		{Key: "xylem.phase.cost_usd_est", Value: fmt.Sprintf("%.6f", data.CostUSDEst)},
@@ -129,6 +140,17 @@ func PhaseResultAttributes(data PhaseResultData) []SpanAttribute {
 		{Key: "xylem.phase.usage_unavailable_reason", Value: data.UsageUnavailableReason},
 		{Key: "xylem.phase.output_artifact_path", Value: data.OutputArtifactPath},
 	}
+	if data.LLMProvider != "" {
+		attrs = append(attrs, SpanAttribute{Key: "xylem.phase.provider", Value: data.LLMProvider})
+		attrs = append(attrs, SpanAttribute{Key: "llm.provider", Value: data.LLMProvider})
+	}
+	if data.LLMModel != "" {
+		attrs = append(attrs, SpanAttribute{Key: "xylem.phase.model", Value: data.LLMModel})
+	}
+	if data.LLMTier != "" {
+		attrs = append(attrs, SpanAttribute{Key: "llm.tier", Value: data.LLMTier})
+	}
+	return attrs
 }
 
 // VesselCostData holds vessel-level cost telemetry attributes.

--- a/cli/internal/observability/vessel_prop_test.go
+++ b/cli/internal/observability/vessel_prop_test.go
@@ -25,7 +25,7 @@ func genGateType() *rapid.Generator[string] {
 }
 
 func combinedAttrs() []SpanAttribute {
-	attrs := make([]SpanAttribute, 0, 16)
+	attrs := make([]SpanAttribute, 0, 18)
 	attrs = append(attrs, VesselSpanAttributes(VesselSpanData{
 		ID:       "vessel-1",
 		Source:   "github",
@@ -39,6 +39,7 @@ func combinedAttrs() []SpanAttribute {
 		Workflow:     "fix-bug",
 		Provider:     "anthropic",
 		Model:        "claude-sonnet",
+		Tier:         "med",
 		RetryAttempt: 1,
 		SandboxMode:  "default",
 	})...)
@@ -131,20 +132,79 @@ func TestPropVesselAttrsKeysNamespaced(t *testing.T) {
 	})
 }
 
-func TestPropPhaseAttrsAlwaysEight(t *testing.T) {
+func TestPropPhaseAttrsCarryResolvedLLMFieldsWhenProviderAndTierSet(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		name := genVesselString().Draw(t, "name")
+		index := rapid.IntRange(0, 100).Draw(t, "index")
+		phaseType := genPhaseType().Draw(t, "phase_type")
+		workflow := genVesselString().Draw(t, "workflow")
+		provider := genNonEmptyVesselString().Draw(t, "provider")
+		model := genVesselString().Draw(t, "model")
+		tier := genNonEmptyVesselString().Draw(t, "tier")
+		retryAttempt := rapid.IntRange(0, 10).Draw(t, "retry_attempt")
+		sandboxMode := genVesselString().Draw(t, "sandbox_mode")
+		attrs := PhaseSpanAttributes(PhaseSpanData{
+			Name:         name,
+			Index:        index,
+			Type:         phaseType,
+			Workflow:     workflow,
+			Provider:     provider,
+			Model:        model,
+			Tier:         tier,
+			RetryAttempt: retryAttempt,
+			SandboxMode:  sandboxMode,
+		})
+		got := attrMap(attrs)
+		if got["xylem.phase.name"] != name {
+			t.Fatalf("xylem.phase.name = %q, want %q", got["xylem.phase.name"], name)
+		}
+		if got["xylem.phase.index"] != strconv.Itoa(index) {
+			t.Fatalf("xylem.phase.index = %q, want %q", got["xylem.phase.index"], strconv.Itoa(index))
+		}
+		if got["xylem.phase.type"] != phaseType {
+			t.Fatalf("xylem.phase.type = %q, want %q", got["xylem.phase.type"], phaseType)
+		}
+		if got["xylem.phase.workflow"] != workflow {
+			t.Fatalf("xylem.phase.workflow = %q, want %q", got["xylem.phase.workflow"], workflow)
+		}
+		if got["xylem.phase.provider"] != provider {
+			t.Fatalf("xylem.phase.provider = %q, want %q", got["xylem.phase.provider"], provider)
+		}
+		if got["xylem.phase.model"] != model {
+			t.Fatalf("xylem.phase.model = %q, want %q", got["xylem.phase.model"], model)
+		}
+		if got["xylem.phase.retry_attempt"] != strconv.Itoa(retryAttempt) {
+			t.Fatalf("xylem.phase.retry_attempt = %q, want %q", got["xylem.phase.retry_attempt"], strconv.Itoa(retryAttempt))
+		}
+		if got["xylem.phase.sandbox_mode"] != sandboxMode {
+			t.Fatalf("xylem.phase.sandbox_mode = %q, want %q", got["xylem.phase.sandbox_mode"], sandboxMode)
+		}
+		if got["llm.provider"] != provider {
+			t.Fatalf("llm.provider = %q, want %q", got["llm.provider"], provider)
+		}
+		if got["llm.tier"] != tier {
+			t.Fatalf("llm.tier = %q, want %q", got["llm.tier"], tier)
+		}
+	})
+}
+
+func TestPropPhaseAttrsOmitLLMKeysWhenProviderAndTierEmpty(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		attrs := PhaseSpanAttributes(PhaseSpanData{
 			Name:         genVesselString().Draw(t, "name"),
 			Index:        rapid.IntRange(0, 100).Draw(t, "index"),
 			Type:         genPhaseType().Draw(t, "phase_type"),
 			Workflow:     genVesselString().Draw(t, "workflow"),
-			Provider:     genVesselString().Draw(t, "provider"),
 			Model:        genVesselString().Draw(t, "model"),
 			RetryAttempt: rapid.IntRange(0, 10).Draw(t, "retry_attempt"),
 			SandboxMode:  genVesselString().Draw(t, "sandbox_mode"),
 		})
-		if len(attrs) != 8 {
-			t.Fatalf("expected 8 attributes, got %d", len(attrs))
+		got := attrMap(attrs)
+		if _, ok := got["llm.provider"]; ok {
+			t.Fatalf("llm.provider should be omitted, got %#v", got)
+		}
+		if _, ok := got["llm.tier"]; ok {
+			t.Fatalf("llm.tier should be omitted, got %#v", got)
 		}
 	})
 }

--- a/cli/internal/observability/vessel_test.go
+++ b/cli/internal/observability/vessel_test.go
@@ -50,7 +50,7 @@ func TestSmoke_S2_VesselSpanAttributesOmitsEmptyRef(t *testing.T) {
 	}
 }
 
-func TestSmoke_S3_PhaseSpanAttributesIncludesAllFields(t *testing.T) {
+func TestSmoke_S3_PhaseSpanAttributesIncludesResolvedPhaseAndLLMRoutingFields(t *testing.T) {
 	attrs := PhaseSpanAttributes(PhaseSpanData{
 		Name:         "analyse",
 		Index:        0,
@@ -58,14 +58,13 @@ func TestSmoke_S3_PhaseSpanAttributesIncludesAllFields(t *testing.T) {
 		Workflow:     "fix-bug",
 		Provider:     "anthropic",
 		Model:        "claude-sonnet-4-20250514",
+		Tier:         "med",
 		RetryAttempt: 2,
 		SandboxMode:  "dangerously-skip-permissions",
 	})
 	got := attrMap(attrs)
 
-	if len(attrs) != 8 {
-		t.Fatalf("expected 8 attributes, got %d", len(attrs))
-	}
+	require.Len(t, attrs, 10)
 
 	want := map[string]string{
 		"xylem.phase.name":          "analyse",
@@ -76,11 +75,23 @@ func TestSmoke_S3_PhaseSpanAttributesIncludesAllFields(t *testing.T) {
 		"xylem.phase.model":         "claude-sonnet-4-20250514",
 		"xylem.phase.retry_attempt": "2",
 		"xylem.phase.sandbox_mode":  "dangerously-skip-permissions",
+		"llm.provider":              "anthropic",
+		"llm.tier":                  "med",
 	}
 	for key, value := range want {
-		if got[key] != value {
-			t.Fatalf("%s = %q, want %q", key, got[key], value)
-		}
+		assert.Equal(t, value, got[key], key)
+	}
+}
+
+func TestPhaseSpanAttributesOmitsLLMProviderAndTierWhenUnset(t *testing.T) {
+	attrs := PhaseSpanAttributes(PhaseSpanData{Name: "analyse"})
+	got := attrMap(attrs)
+
+	if _, ok := got["llm.provider"]; ok {
+		t.Fatal("did not expect llm.provider attribute when provider is empty")
+	}
+	if _, ok := got["llm.tier"]; ok {
+		t.Fatal("did not expect llm.tier attribute when tier is empty")
 	}
 }
 
@@ -113,6 +124,34 @@ func TestSmoke_S4_PhaseResultAttributesFormatsTokensAndCost(t *testing.T) {
 		if got[key] != value {
 			t.Fatalf("%s = %q, want %q", key, got[key], value)
 		}
+	}
+}
+
+func TestPhaseResultAttributesIncludesResolvedLLMProviderAndTier(t *testing.T) {
+	attrs := PhaseResultAttributes(PhaseResultData{
+		InputTokensEst:     1200,
+		OutputTokensEst:    300,
+		CostUSDEst:         0.0081,
+		DurationMS:         4500,
+		Status:             "completed",
+		LLMProvider:        "copilot",
+		LLMModel:           "gpt-5-mini",
+		LLMTier:            "med",
+		OutputArtifactPath: "phases/vessel-1/analyse.output",
+	})
+	got := attrMap(attrs)
+
+	if got["xylem.phase.provider"] != "copilot" {
+		t.Fatalf("xylem.phase.provider = %q, want %q", got["xylem.phase.provider"], "copilot")
+	}
+	if got["xylem.phase.model"] != "gpt-5-mini" {
+		t.Fatalf("xylem.phase.model = %q, want %q", got["xylem.phase.model"], "gpt-5-mini")
+	}
+	if got["llm.provider"] != "copilot" {
+		t.Fatalf("llm.provider = %q, want %q", got["llm.provider"], "copilot")
+	}
+	if got["llm.tier"] != "med" {
+		t.Fatalf("llm.tier = %q, want %q", got["llm.tier"], "med")
 	}
 }
 

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -48,6 +48,7 @@ type CommandRunner interface {
 	RunOutput(ctx context.Context, name string, args ...string) ([]byte, error)
 	RunProcess(ctx context.Context, dir string, name string, args ...string) error
 	RunPhase(ctx context.Context, dir string, stdin io.Reader, name string, args ...string) ([]byte, error)
+	RunPhaseWithEnv(ctx context.Context, dir string, extraEnv []string, stdin io.Reader, name string, args ...string) ([]byte, error)
 }
 
 type PhaseProcessObserver interface {
@@ -57,6 +58,10 @@ type PhaseProcessObserver interface {
 
 type PhaseProcessRunner interface {
 	RunPhaseObserved(ctx context.Context, dir string, stdin io.Reader, observer PhaseProcessObserver, name string, args ...string) ([]byte, error)
+}
+
+type PhaseProcessEnvRunner interface {
+	RunPhaseObservedWithEnv(ctx context.Context, dir string, extraEnv []string, stdin io.Reader, observer PhaseProcessObserver, name string, args ...string) ([]byte, error)
 }
 
 // WorktreeManager abstracts worktree lifecycle for testing.
@@ -706,13 +711,18 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			var beforeSnapshot surface.Snapshot
 			var checkProtectedSurfaces bool
 			var promptForCost string
-			provider := resolveProvider(r.Config, srcCfg, sk, &p)
-			model := resolveModel(r.Config, srcCfg, sk, &p, provider)
+			tier, providerChain := resolvePhaseProviderChain(r.Config, srcCfg, vessel, sk, &p)
+			provider := ""
+			model := ""
+			if len(providerChain) > 0 {
+				provider = providerChain[0]
+				model = resolvePhaseModel(r.Config, srcCfg, sk, &p, provider, tier)
+			}
 			retryAttempt := 0
 			if p.Gate != nil && (p.Gate.Type == "command" || p.Gate.Type == "live") {
 				retryAttempt = providerAttempt(&p, vessel.GateRetries)
 			}
-			phaseSpan := startPhaseSpan(r.Tracer, ctx, r.Config, srcCfg, sk, p, i, retryAttempt)
+			phaseSpan := startPhaseSpan(r.Tracer, ctx, r.Config, sk, p, i, retryAttempt, "", "", tier)
 			phaseSpanEnded := false
 			var phaseDuration time.Duration
 			phaseSpanStatus := "running"
@@ -727,7 +737,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if phaseDuration == 0 {
 					phaseDuration = r.runtimeSince(phaseStart)
 				}
-				finishPhaseSpan(r.Tracer, phaseSpan, buildPhaseResultData(r.Config, srcCfg, sk, p, promptForCost, string(output), phaseDuration, phaseSpanStatus, phaseOutputArtifactPath), err)
+				finishPhaseSpan(r.Tracer, phaseSpan, buildPhaseResultData(r.Config, p, promptForCost, string(output), phaseDuration, phaseSpanStatus, phaseOutputArtifactPath, provider, model, tier), err)
 				phaseSpanEnded = true
 			}
 
@@ -853,16 +863,28 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					return "failed"
 				}
 				attempt := providerAttempt(&p, vessel.GateRetries)
-				cmd, args, phaseStdin := buildProviderPhaseArgs(r.Config, srcCfg, sk, &p, harnessContent, provider, rendered, attempt)
-				var stdinContent string
-				if phaseStdin != nil {
-					stdinContent = rendered
-				}
 				outputPath := filepath.Join(phasesDir, p.Name+".output")
 				if touchErr := r.touchPhaseActivity(outputPath); touchErr != nil {
 					log.Printf("warn: touch phase activity %s: %v", outputPath, touchErr)
 				}
-				output, runErr = r.runPhaseWithRateLimitRetry(ctx, vessel.ID, p.Name, worktreePath, stdinContent, cmd, args)
+				output, provider, model, runErr = r.runPhaseWithProviderFallback(ctx, vessel.ID, p.Name, worktreePath, providerChain, func(provider string) (providerInvocation, error) {
+					cmd, args, phaseStdin, model, err := buildProviderPhaseArgs(r.Config, srcCfg, sk, &p, harnessContent, provider, tier, rendered, attempt)
+					if err != nil {
+						return providerInvocation{}, err
+					}
+					stdinContent := ""
+					if phaseStdin != nil {
+						stdinContent = rendered
+					}
+					return providerInvocation{
+						Provider:     provider,
+						Model:        model,
+						Env:          providerEnvForName(r.Config, provider),
+						Command:      cmd,
+						Args:         args,
+						StdinContent: stdinContent,
+					}, nil
+				})
 			}
 
 			if r.vesselCancelled(ctx, vessel.ID) {
@@ -887,7 +909,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				phaseSpanStatus = "failed"
 				finishCurrentPhaseSpan(runErr)
 				log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
-				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()))
+				vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error(), provider, model))
 				vessel.FailedPhase = p.Name
 				r.failUpdatedVessel(&vessel, fmt.Sprintf("phase %s: %v", p.Name, runErr))
 				if err := src.OnFail(ctx, vessel); err != nil {
@@ -906,7 +928,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					phaseSpanStatus = "failed"
 					finishCurrentPhaseSpan(err)
 					log.Printf("%sphase %q violated protected surfaces: %v", vesselLabel(vessel), p.Name, err)
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error()))
+					vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error(), provider, model))
 					vessel.FailedPhase = p.Name
 					r.failUpdatedVessel(&vessel, err.Error())
 					if err := src.OnFail(ctx, vessel); err != nil {
@@ -926,7 +948,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			if vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() {
 				errMsg := fmt.Sprintf("budget exceeded after phase %q: estimated cost $%.4f, estimated tokens %d",
 					p.Name, vrs.costTracker.TotalCost(), vrs.costTracker.TotalTokens())
-				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg))
+				vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg, provider, model))
 				vessel.FailedPhase = p.Name
 				r.failUpdatedVessel(&vessel, errMsg)
 				if err := src.OnFail(ctx, vessel); err != nil {
@@ -946,7 +968,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				phaseSpanStatus = "failed"
 				finishCurrentPhaseSpan(err)
 				log.Printf("%sphase %q failed while publishing output: %v", vesselLabel(vessel), p.Name, err)
-				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, err.Error()))
+				vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, err.Error(), provider, model))
 				vessel.FailedPhase = p.Name
 				r.failUpdatedVessel(&vessel, fmt.Sprintf("phase %s: %v", p.Name, err))
 				if err := src.OnFail(ctx, vessel); err != nil {
@@ -1015,7 +1037,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			}
 
 			if phaseStatus == "no-op" {
-				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, ""))
+				vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, "", provider, model))
 				log.Printf("%sphase %q triggered no-op; completing workflow early", vesselLabel(vessel), p.Name)
 				finishCurrentPhaseSpan(nil)
 				if r.vesselCancelled(ctx, vessel.ID) {
@@ -1026,7 +1048,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 			// Handle gate
 			if p.Gate == nil {
-				vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, ""))
+				vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, "", provider, model))
 				finishCurrentPhaseSpan(nil)
 				break // no gate, proceed to next phase
 			}
@@ -1045,7 +1067,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				gateOut, passed, gateErr := gateResultExec.output, gateResultExec.passed, gateResultExec.err
 				if gateErr != nil {
 					phaseSpanStatus = "failed"
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error()))
+					vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error(), provider, model))
 					finishCurrentPhaseSpan(nil)
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate error: %v", p.Name, gateErr))
 					if err := src.OnFail(ctx, vessel); err != nil {
@@ -1056,7 +1078,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if passed {
 					log.Printf("%sgate passed for phase %q", vesselLabel(vessel), p.Name)
 					phaseSpanStatus = phaseStatus
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, gatePassedPointer(true), ""))
+					vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, gatePassedPointer(true), "", provider, model))
 					if gateResultExec.evidenceClaim != nil {
 						claims = append(claims, *gateResultExec.evidenceClaim)
 					}
@@ -1075,7 +1097,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				if vessel.GateRetries <= 0 {
 					log.Printf("%sgate failed for phase %q, retries exhausted", vesselLabel(vessel), p.Name)
 					phaseSpanStatus = "failed"
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted"))
+					vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted", provider, model))
 					finishCurrentPhaseSpan(nil)
 					vessel.FailedPhase = p.Name
 					vessel.GateOutput = gateOut
@@ -1116,7 +1138,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 						finishCurrentPhaseSpan(context.DeadlineExceeded)
 						return "timed_out"
 					}
-					vrs.addPhase(vrs.phaseSummary(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error()))
+					vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error(), provider, model))
 					phaseSpanStatus = "failed"
 					finishCurrentPhaseSpan(err)
 					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate retry interrupted: %v", p.Name, err))
@@ -1220,16 +1242,20 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 		return r.cancelVessel(vessel, worktreePath, vrs, nil)
 	}
 
-	cmd, args := buildPromptOnlyCmdArgs(r.Config, prompt)
-	provider := resolveProvider(r.Config, nil, nil, nil)
-	model := resolveModel(r.Config, nil, nil, nil, provider)
+	tier, providerChain := resolvePhaseProviderChain(r.Config, nil, vessel, nil, nil)
+	if len(providerChain) == 0 {
+		r.failVessel(vessel.ID, "no providers configured")
+		return "failed"
+	}
+	provider := providerChain[0]
+	model := resolvePhaseModel(r.Config, nil, nil, nil, provider, tier)
 	phaseDef := workflow.Phase{Name: "prompt"}
 	phaseStartedAt := r.runtimeNow()
 	beforeSnapshot, checkProtectedSurfaces, err := r.takeProtectedSurfaceSnapshot(ctx, worktreePath)
 	if err != nil {
 		snapErr := fmt.Errorf("protected surface snapshot failed: %w", err)
 		if vrs != nil {
-			vrs.addPhase(vrs.phaseSummary(r.Config, nil, nil, phaseDef, "", 0, 0, 0.0, r.runtimeSince(phaseStartedAt), "failed", nil, snapErr.Error()))
+			vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, nil, nil, phaseDef, "", 0, 0, 0.0, r.runtimeSince(phaseStartedAt), "failed", nil, snapErr.Error(), provider, model))
 		}
 		r.failVessel(vessel.ID, snapErr.Error())
 		if err := src.OnFail(ctx, vessel); err != nil {
@@ -1247,7 +1273,17 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 	if touchErr := r.touchPhaseActivity(outputPath); touchErr != nil {
 		log.Printf("warn: touch phase activity %s: %v", outputPath, touchErr)
 	}
-	output, runErr := r.runPhaseWithRateLimitRetry(ctx, vessel.ID, "prompt", worktreePath, prompt, cmd, args)
+	output, provider, model, runErr := r.runPhaseWithProviderFallback(ctx, vessel.ID, "prompt", worktreePath, providerChain, func(provider string) (providerInvocation, error) {
+		cmd, args := buildPromptOnlyCmdArgs(r.Config, provider, tier, prompt)
+		return providerInvocation{
+			Provider:     provider,
+			Model:        modelForProvider(r.Config, provider, tier),
+			Env:          providerEnvForName(r.Config, provider),
+			Command:      cmd,
+			Args:         args,
+			StdinContent: prompt,
+		}, nil
+	})
 	phaseDuration := r.runtimeSince(phaseStartedAt)
 	if r.vesselCancelled(ctx, vessel.ID) {
 		return r.cancelVessel(vessel, worktreePath, vrs, nil)
@@ -1257,7 +1293,7 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 	}
 	if runErr != nil {
 		if vrs != nil {
-			vrs.addPhase(vrs.phaseSummary(r.Config, nil, nil, phaseDef, "", 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()))
+			vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, nil, nil, phaseDef, "", 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error(), provider, model))
 		}
 		r.failVessel(vessel.ID, runErr.Error())
 		if err := src.OnFail(ctx, vessel); err != nil {
@@ -1273,7 +1309,7 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 	if checkProtectedSurfaces {
 		if err := r.verifyProtectedSurfaces(vessel, workflow.Phase{Name: "prompt-only"}, worktreePath, beforeSnapshot); err != nil {
 			if vrs != nil {
-				vrs.addPhase(vrs.phaseSummary(r.Config, nil, nil, phaseDef, "", 0, 0, 0.0, phaseDuration, "failed", nil, err.Error()))
+				vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, nil, nil, phaseDef, "", 0, 0, 0.0, phaseDuration, "failed", nil, err.Error(), provider, model))
 			}
 			r.failVessel(vessel.ID, err.Error())
 			if err := src.OnFail(ctx, vessel); err != nil {
@@ -1291,7 +1327,7 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 	var phaseResults []reporter.PhaseResult
 	if vrs != nil {
 		inputTokensEst, outputTokensEst, costUSDEst := vrs.recordLLMUsage(model, prompt, string(output), recordedAt)
-		phaseSummary := vrs.phaseSummary(r.Config, nil, nil, phaseDef, "", inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, "")
+		phaseSummary := vrs.phaseSummaryWithLLM(r.Config, nil, nil, phaseDef, "", inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, "", provider, model)
 		phaseReport := reporter.PhaseResult{
 			Name:                   phaseDef.Name,
 			Duration:               phaseDuration,
@@ -1461,18 +1497,24 @@ func (r *Runner) resolveSourceForVessel(vessel queue.Vessel) source.Source {
 // buildCommand constructs the LLM command and args from config and vessel.
 func buildCommand(cfg *config.Config, vessel *queue.Vessel) (string, []string, error) {
 	// Direct prompt mode
+	tier := resolveTier(cfg, *vessel, nil, nil)
+	_, providerChain := resolvePhaseProviderChain(cfg, nil, *vessel, nil, nil)
+	if len(providerChain) == 0 {
+		return "", nil, fmt.Errorf("no providers configured")
+	}
+	provider := providerChain[0]
 	if vessel.Prompt != "" {
 		prompt := vessel.Prompt
 		if vessel.Ref != "" {
 			prompt = fmt.Sprintf("Ref: %s\n\n%s", vessel.Ref, vessel.Prompt)
 		}
-		cmd, args := buildPromptOnlyCmdArgs(cfg, prompt)
+		cmd, args := buildPromptOnlyCmdArgs(cfg, provider, tier, prompt)
 		return cmd, args, nil
 	}
 
 	// Workflow-based mode: build command from flags (v2 phase-based execution will replace this)
 	wfPrompt := fmt.Sprintf("/%s %s", vessel.Workflow, vessel.Ref)
-	cmd, args := buildPromptOnlyCmdArgs(cfg, wfPrompt)
+	cmd, args := buildPromptOnlyCmdArgs(cfg, provider, tier, wfPrompt)
 	return cmd, args, nil
 }
 
@@ -2221,13 +2263,18 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		var beforeSnapshot surface.Snapshot
 		var checkProtectedSurfaces bool
 		var promptForCost string
-		provider := resolveProvider(r.Config, srcCfg, wf, &p)
-		model := resolveModel(r.Config, srcCfg, wf, &p, provider)
+		tier, providerChain := resolvePhaseProviderChain(r.Config, srcCfg, vessel, wf, &p)
+		provider := ""
+		model := ""
+		if len(providerChain) > 0 {
+			provider = providerChain[0]
+			model = resolvePhaseModel(r.Config, srcCfg, wf, &p, provider, tier)
+		}
 		retryAttempt := 0
 		if p.Gate != nil && (p.Gate.Type == "command" || p.Gate.Type == "live") {
 			retryAttempt = providerAttempt(&p, gateRetries)
 		}
-		phaseSpan := startPhaseSpan(r.Tracer, ctx, r.Config, srcCfg, wf, p, phaseIdx, retryAttempt)
+		phaseSpan := startPhaseSpan(r.Tracer, ctx, r.Config, wf, p, phaseIdx, retryAttempt, "", "", tier)
 		phaseSpanEnded := false
 		var phaseDuration time.Duration
 		phaseSpanStatus := "running"
@@ -2242,7 +2289,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if phaseDuration == 0 {
 				phaseDuration = r.runtimeSince(phaseStart)
 			}
-			finishPhaseSpan(r.Tracer, phaseSpan, buildPhaseResultData(r.Config, srcCfg, wf, p, promptForCost, string(output), phaseDuration, phaseSpanStatus, phaseOutputArtifactPath), err)
+			finishPhaseSpan(r.Tracer, phaseSpan, buildPhaseResultData(r.Config, p, promptForCost, string(output), phaseDuration, phaseSpanStatus, phaseOutputArtifactPath, provider, model, tier), err)
 			phaseSpanEnded = true
 		}
 
@@ -2365,16 +2412,28 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
 			}
 			attempt := providerAttempt(&p, gateRetries)
-			cmd, args, phaseStdin := buildProviderPhaseArgs(r.Config, srcCfg, wf, &p, harnessContent, provider, rendered, attempt)
-			var stdinContent string
-			if phaseStdin != nil {
-				stdinContent = rendered
-			}
 			outputPath := filepath.Join(phasesDir, p.Name+".output")
 			if touchErr := r.touchPhaseActivity(outputPath); touchErr != nil {
 				log.Printf("warn: touch phase activity %s: %v", outputPath, touchErr)
 			}
-			output, runErr = r.runPhaseWithRateLimitRetry(ctx, vessel.ID, p.Name, worktreePath, stdinContent, cmd, args)
+			output, provider, model, runErr = r.runPhaseWithProviderFallback(ctx, vessel.ID, p.Name, worktreePath, providerChain, func(provider string) (providerInvocation, error) {
+				cmd, args, phaseStdin, model, err := buildProviderPhaseArgs(r.Config, srcCfg, wf, &p, harnessContent, provider, tier, rendered, attempt)
+				if err != nil {
+					return providerInvocation{}, err
+				}
+				stdinContent := ""
+				if phaseStdin != nil {
+					stdinContent = rendered
+				}
+				return providerInvocation{
+					Provider:     provider,
+					Model:        model,
+					Env:          providerEnvForName(r.Config, provider),
+					Command:      cmd,
+					Args:         args,
+					StdinContent: stdinContent,
+				}, nil
+			})
 		}
 
 		if r.vesselCancelled(ctx, vessel.ID) {
@@ -2412,7 +2471,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			return singlePhaseResult{
 				status:       "failed",
 				duration:     phaseDuration,
-				phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error()),
+				phaseSummary: vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error(), provider, model),
 			}
 		}
 
@@ -2434,7 +2493,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				return singlePhaseResult{
 					status:       "failed",
 					duration:     phaseDuration,
-					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error()),
+					phaseSummary: vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error(), provider, model),
 				}
 			}
 		}
@@ -2459,7 +2518,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			return singlePhaseResult{
 				status:       "failed",
 				duration:     phaseDuration,
-				phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg),
+				phaseSummary: vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg, provider, model),
 			}
 		}
 
@@ -2480,7 +2539,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			return singlePhaseResult{
 				status:       "failed",
 				duration:     phaseDuration,
-				phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, err.Error()),
+				phaseSummary: vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, err.Error(), provider, model),
 			}
 		}
 
@@ -2513,7 +2572,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				output:        string(output),
 				status:        "no-op",
 				duration:      phaseDuration,
-				phaseSummary:  vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "no-op", nil, ""),
+				phaseSummary:  vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "no-op", nil, "", provider, model),
 				evidenceClaim: nil,
 			}
 		}
@@ -2532,7 +2591,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				output:        string(output),
 				status:        "completed",
 				duration:      phaseDuration,
-				phaseSummary:  vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, ""),
+				phaseSummary:  vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, "", provider, model),
 				evidenceClaim: nil,
 			}
 		}
@@ -2560,7 +2619,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					status:       "failed",
 					duration:     phaseDuration,
 					gateOut:      gateOut,
-					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error()),
+					phaseSummary: vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error(), provider, model),
 				}
 			}
 			if passed {
@@ -2571,7 +2630,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					output:        string(output),
 					status:        "completed",
 					duration:      phaseDuration,
-					phaseSummary:  vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", gatePassedPointer(true), ""),
+					phaseSummary:  vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", gatePassedPointer(true), "", provider, model),
 					evidenceClaim: gateResultExec.evidenceClaim,
 				}
 			}
@@ -2601,7 +2660,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					status:       "failed",
 					duration:     phaseDuration,
 					gateOut:      gateOut,
-					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted"),
+					phaseSummary: vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted", provider, model),
 				}
 			}
 			gateRetries--
@@ -2626,7 +2685,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					status:       "failed",
 					duration:     phaseDuration,
 					gateOut:      gateOut,
-					phaseSummary: vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error()),
+					phaseSummary: vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error(), provider, model),
 				}
 			}
 			phaseSpanStatus = "retrying"
@@ -2677,19 +2736,16 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			output:        string(output),
 			status:        "completed",
 			duration:      phaseDuration,
-			phaseSummary:  vrs.phaseSummary(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, ""),
+			phaseSummary:  vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, "", provider, model),
 			evidenceClaim: nil,
 		}
 	}
 }
 
-func startPhaseSpan(tracer *observability.Tracer, ctx context.Context, cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p workflow.Phase, phaseIdx int, retryAttempt int) observability.SpanContext {
+func startPhaseSpan(tracer *observability.Tracer, ctx context.Context, cfg *config.Config, wf *workflow.Workflow, p workflow.Phase, phaseIdx int, retryAttempt int, provider, model, tier string) observability.SpanContext {
 	if tracer == nil {
 		return observability.SpanContext{}
 	}
-
-	provider := resolveProvider(cfg, srcCfg, wf, &p)
-	model := resolveModel(cfg, srcCfg, wf, &p, provider)
 
 	return tracer.StartSpan(ctx, "phase:"+p.Name, observability.PhaseSpanAttributes(observability.PhaseSpanData{
 		Name:         p.Name,
@@ -2698,6 +2754,7 @@ func startPhaseSpan(tracer *observability.Tracer, ctx context.Context, cfg *conf
 		Workflow:     workflowName(wf),
 		Provider:     provider,
 		Model:        model,
+		Tier:         tier,
 		RetryAttempt: retryAttempt,
 		SandboxMode:  sandboxModeFromFlags(cfg),
 	}))
@@ -2845,11 +2902,14 @@ func (r *Runner) executeVerificationGate(ctx context.Context, phaseSpan observab
 	}
 }
 
-func buildPhaseResultData(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p workflow.Phase, renderedPrompt, output string, duration time.Duration, status string, outputArtifactPath string) observability.PhaseResultData {
+func buildPhaseResultData(cfg *config.Config, p workflow.Phase, renderedPrompt, output string, duration time.Duration, status string, outputArtifactPath, provider, model, tier string) observability.PhaseResultData {
 	data := observability.PhaseResultData{
 		DurationMS:         duration.Milliseconds(),
 		Status:             status,
 		OutputArtifactPath: outputArtifactPath,
+		LLMProvider:        provider,
+		LLMModel:           model,
+		LLMTier:            tier,
 	}
 	if phaseTypeLabel(p) != "prompt" {
 		data.UsageSource = string(cost.UsageSourceNotApplicable)
@@ -2857,8 +2917,6 @@ func buildPhaseResultData(cfg *config.Config, srcCfg *config.SourceConfig, wf *w
 		return data
 	}
 
-	provider := resolveProvider(cfg, srcCfg, wf, &p)
-	model := resolveModel(cfg, srcCfg, wf, &p, provider)
 	data.InputTokensEst = cost.EstimateTokens(renderedPrompt)
 	data.OutputTokensEst = cost.EstimateTokens(output)
 	data.CostUSDEst = cost.EstimateCost(data.InputTokensEst, data.OutputTokensEst, cost.LookupPricing(model))
@@ -4472,6 +4530,15 @@ const (
 	rateLimitBaseBackoff = 30 * time.Second
 )
 
+type providerInvocation struct {
+	Provider     string
+	Model        string
+	Env          []string
+	Command      string
+	Args         []string
+	StdinContent string
+}
+
 // isRateLimitError reports whether the error indicates a transient LLM
 // provider error that should be retried with backoff. This includes HTTP 429
 // rate limits (rate_limit_error), insufficient credit balance, and generic
@@ -4516,7 +4583,7 @@ func isRateLimitError(err error) bool {
 // stdinContent is re-wrapped in a fresh strings.Reader for each attempt;
 // pass "" for nil stdin.
 func (r *Runner) runPhaseWithRateLimitRetry(
-	ctx context.Context, vesselID, phaseName, dir, stdinContent, cmd string, args []string,
+	ctx context.Context, vesselID, phaseName, dir, stdinContent string, extraEnv []string, cmd string, args []string,
 ) ([]byte, error) {
 	for attempt := 0; attempt <= rateLimitMaxRetries; attempt++ {
 		var stdin io.Reader
@@ -4527,14 +4594,14 @@ func (r *Runner) runPhaseWithRateLimitRetry(
 			output []byte
 			err    error
 		)
-		if observedRunner, ok := r.Runner.(PhaseProcessRunner); ok {
-			output, err = observedRunner.RunPhaseObserved(ctx, dir, stdin, vesselProcessObserver{
+		if observedRunner, ok := r.Runner.(PhaseProcessEnvRunner); ok {
+			output, err = observedRunner.RunPhaseObservedWithEnv(ctx, dir, extraEnv, stdin, vesselProcessObserver{
 				r:         r,
 				vesselID:  vesselID,
 				phaseName: phaseName,
 			}, cmd, args...)
 		} else {
-			output, err = r.Runner.RunPhase(ctx, dir, stdin, cmd, args...)
+			output, err = r.Runner.RunPhaseWithEnv(ctx, dir, extraEnv, stdin, cmd, args...)
 		}
 		if err == nil || !isRateLimitError(err) {
 			return output, err
@@ -4553,18 +4620,116 @@ func (r *Runner) runPhaseWithRateLimitRetry(
 	return nil, nil
 }
 
-// buildPhaseArgs constructs the claude CLI arguments for a phase invocation.
-// Model resolution follows the hierarchy: Phase.Model > Workflow.Model > Source.Model > ClaudeConfig.DefaultModel.
-// When a model is resolved from the hierarchy, any --model flag in Claude.Flags is stripped to avoid duplication.
-func buildPhaseArgs(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, harnessContent string) []string {
+func (r *Runner) runPhaseWithProviderFallback(
+	ctx context.Context, vesselID, phaseName, dir string, providers []string, build func(provider string) (providerInvocation, error),
+) ([]byte, string, string, error) {
+	if len(providers) == 0 {
+		return nil, "", "", fmt.Errorf("no providers configured for phase %s", phaseName)
+	}
+	for idx, provider := range providers {
+		invocation, err := build(provider)
+		if err != nil {
+			return nil, "", "", err
+		}
+		output, err := r.runPhaseWithRateLimitRetry(
+			ctx,
+			vesselID,
+			phaseName,
+			dir,
+			invocation.StdinContent,
+			invocation.Env,
+			invocation.Command,
+			invocation.Args,
+		)
+		if err == nil {
+			return output, invocation.Provider, invocation.Model, nil
+		}
+		if !isRateLimitError(err) || idx == len(providers)-1 {
+			return output, invocation.Provider, invocation.Model, err
+		}
+		log.Printf("provider %s rate-limited, falling back to %s", invocation.Provider, providers[idx+1])
+	}
+	return nil, "", "", nil
+}
+
+func defaultRoutingTier(cfg *config.Config) string {
+	if cfg != nil && strings.TrimSpace(cfg.LLMRouting.DefaultTier) != "" {
+		return strings.TrimSpace(cfg.LLMRouting.DefaultTier)
+	}
+	return config.DefaultLLMRoutingTier
+}
+
+func providerConfigForName(cfg *config.Config, providerName string) (config.ProviderConfig, bool) {
+	if cfg == nil {
+		return config.ProviderConfig{}, false
+	}
+	if cfg.Providers != nil {
+		if provider, ok := cfg.Providers[providerName]; ok {
+			return provider, true
+		}
+	}
+	defaultTier := defaultRoutingTier(cfg)
+	switch providerName {
+	case "claude":
+		return config.ProviderConfig{
+			Kind:         "claude",
+			Command:      cfg.Claude.Command,
+			Flags:        cfg.Claude.Flags,
+			Tiers:        map[string]string{defaultTier: cfg.Claude.DefaultModel},
+			Env:          maps.Clone(cfg.Claude.Env),
+			AllowedTools: append([]string(nil), cfg.Claude.AllowedTools...),
+		}, cfg.Claude.Command != "" || cfg.Claude.DefaultModel != "" || len(cfg.Claude.Env) > 0 || len(cfg.Claude.AllowedTools) > 0
+	case "copilot":
+		return config.ProviderConfig{
+			Kind:    "copilot",
+			Command: cfg.Copilot.Command,
+			Flags:   cfg.Copilot.Flags,
+			Tiers:   map[string]string{defaultTier: cfg.Copilot.DefaultModel},
+			Env:     maps.Clone(cfg.Copilot.Env),
+		}, cfg.Copilot.Command != "" || cfg.Copilot.DefaultModel != "" || len(cfg.Copilot.Env) > 0
+	default:
+		return config.ProviderConfig{}, false
+	}
+}
+
+func expandedProviderEnv(env map[string]string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		value := os.ExpandEnv(env[key])
+		if value == "" {
+			continue
+		}
+		out = append(out, key+"="+value)
+	}
+	return out
+}
+
+func providerEnvForName(cfg *config.Config, providerName string) []string {
+	provider, ok := providerConfigForName(cfg, providerName)
+	if !ok {
+		return nil
+	}
+	return expandedProviderEnv(provider.Env)
+}
+
+// buildPhaseArgs constructs the claude-style CLI arguments for a phase invocation.
+func buildPhaseArgs(cfg *config.Config, providerName string, provider config.ProviderConfig, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, tier, harnessContent string) []string {
 	args := []string{"-p"}
 	args = append(args, "--max-turns", fmt.Sprintf("%d", p.MaxTurns))
 
-	model := resolveModel(cfg, srcCfg, wf, p, "claude")
+	model := resolvePhaseModel(cfg, srcCfg, wf, p, providerName, tier)
 
 	// Add flags, stripping --model if we resolved one from the hierarchy
-	if cfg.Claude.Flags != "" {
-		fields := strings.Fields(cfg.Claude.Flags)
+	if provider.Flags != "" {
+		fields := strings.Fields(provider.Flags)
 		if model != "" {
 			fields = stripModelFlag(fields)
 		}
@@ -4580,7 +4745,7 @@ func buildPhaseArgs(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflo
 		args = append(args, "--allowedTools", *p.AllowedTools)
 	}
 
-	for _, tool := range cfg.Claude.AllowedTools {
+	for _, tool := range provider.AllowedTools {
 		args = append(args, "--allowedTools", tool)
 	}
 
@@ -4593,10 +4758,7 @@ func buildPhaseArgs(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflo
 }
 
 // buildCopilotPhaseArgs constructs the GitHub Copilot CLI arguments for a phase invocation.
-// Model resolution follows the hierarchy: Phase.Model > Workflow.Model > Source.Model > CopilotConfig.DefaultModel.
-// The rendered prompt and harness content are combined into the -p flag value because
-// copilot has no --system-prompt equivalent.
-func buildCopilotPhaseArgs(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, harnessContent, renderedPrompt string) []string {
+func buildCopilotPhaseArgs(cfg *config.Config, providerName string, provider config.ProviderConfig, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, tier, harnessContent, renderedPrompt string) []string {
 	// Combine harness + prompt into a single prompt text for -p.
 	// Copilot has no --system-prompt or --append-system-prompt flag.
 	promptText := renderedPrompt
@@ -4606,12 +4768,12 @@ func buildCopilotPhaseArgs(cfg *config.Config, srcCfg *config.SourceConfig, wf *
 
 	args := []string{"-p", promptText, "-s"}
 
-	model := resolveModel(cfg, srcCfg, wf, p, "copilot")
+	model := resolvePhaseModel(cfg, srcCfg, wf, p, providerName, tier)
 
 	// Add user flags, stripping flags we always prepend to avoid duplication.
 	// -p/--prompt is value-aware (strips flag + its value); -s/--headless are boolean.
-	if cfg.Copilot.Flags != "" {
-		fields := strings.Fields(cfg.Copilot.Flags)
+	if provider.Flags != "" {
+		fields := strings.Fields(provider.Flags)
 		fields = stripPromptFlag(fields)
 		fields = stripBoolFlag(fields, "-s")
 		fields = stripBoolFlag(fields, "--silent")
@@ -4639,16 +4801,21 @@ func buildCopilotPhaseArgs(cfg *config.Config, srcCfg *config.SourceConfig, wf *
 // and returns the command binary, argument slice, and stdin reader for the phase invocation.
 // For providers that embed the prompt in CLI args (copilot -p <text>), stdin is nil.
 // For providers that read the prompt from stdin (claude -p), stdin carries the prompt.
-func buildProviderPhaseArgs(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, harnessContent, provider, renderedPrompt string, attempt int) (string, []string, io.Reader) {
-	switch provider {
+func buildProviderPhaseArgs(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, harnessContent, provider, tier, renderedPrompt string, attempt int) (string, []string, io.Reader, string, error) {
+	providerCfg, ok := providerConfigForName(cfg, provider)
+	if !ok {
+		return "", nil, nil, "", fmt.Errorf("provider %q is not configured", provider)
+	}
+	model := resolvePhaseModel(cfg, srcCfg, wf, p, provider, tier)
+	switch providerCfg.Kind {
 	case "copilot":
-		return cfg.Copilot.Command, appendDTUProviderArgs(buildCopilotPhaseArgs(cfg, srcCfg, wf, p, harnessContent, renderedPrompt), p, attempt), nil
-	default: // "claude"
+		return providerCfg.Command, appendDTUProviderArgs(buildCopilotPhaseArgs(cfg, provider, providerCfg, srcCfg, wf, p, tier, harnessContent, renderedPrompt), p, attempt), nil, model, nil
+	default:
 		var stdin io.Reader
 		if renderedPrompt != "" {
 			stdin = strings.NewReader(renderedPrompt)
 		}
-		return cfg.Claude.Command, appendDTUProviderArgs(buildPhaseArgs(cfg, srcCfg, wf, p, harnessContent), p, attempt), stdin
+		return providerCfg.Command, appendDTUProviderArgs(buildPhaseArgs(cfg, provider, providerCfg, srcCfg, wf, p, tier, harnessContent), p, attempt), stdin, model, nil
 	}
 }
 
@@ -4702,9 +4869,7 @@ func resolveTimeout(cfg *config.Config, srcCfg *config.SourceConfig) (time.Durat
 	return time.ParseDuration(raw)
 }
 
-// resolveProvider determines which LLM provider to use for a phase invocation.
-// Resolution order: Phase.LLM > Workflow.LLM > Source.LLM > Config.LLM, defaulting to "claude".
-func resolveProvider(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase) string {
+func resolveLegacyProvider(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase) string {
 	if p != nil && p.LLM != nil && *p.LLM != "" {
 		return *p.LLM
 	}
@@ -4720,11 +4885,7 @@ func resolveProvider(cfg *config.Config, srcCfg *config.SourceConfig, wf *workfl
 	return "claude"
 }
 
-// resolveModel determines the model string for a phase invocation.
-// Resolution order: Phase.Model > Workflow.Model > Source.Model > provider's DefaultModel.
-// The provider's DefaultModel ensures the fallback is always compatible with the
-// resolved provider, avoiding cross-provider model leaks (e.g. gpt-* sent to claude).
-func resolveModel(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, provider string) string {
+func resolveLegacyModel(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, provider string) string {
 	if p != nil && p.Model != nil && *p.Model != "" {
 		return *p.Model
 	}
@@ -4745,6 +4906,93 @@ func resolveModel(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.
 	}
 }
 
+func resolveTier(cfg *config.Config, vessel queue.Vessel, wf *workflow.Workflow, p *workflow.Phase) string {
+	if p != nil && p.Tier != nil && strings.TrimSpace(*p.Tier) != "" {
+		return strings.TrimSpace(*p.Tier)
+	}
+	if wf != nil && wf.Tier != nil && strings.TrimSpace(*wf.Tier) != "" {
+		return strings.TrimSpace(*wf.Tier)
+	}
+	if strings.TrimSpace(vessel.Tier) != "" {
+		return strings.TrimSpace(vessel.Tier)
+	}
+	return defaultRoutingTier(cfg)
+}
+
+func resolveProviderChain(cfg *config.Config, tier string) []string {
+	if cfg == nil {
+		return []string{"claude"}
+	}
+	if len(cfg.LLMRouting.Tiers) == 0 {
+		return []string{resolveLegacyProvider(cfg, nil, nil, nil)}
+	}
+	if routing, ok := cfg.LLMRouting.Tiers[tier]; ok && len(routing.Providers) > 0 {
+		return append([]string(nil), routing.Providers...)
+	}
+	defaultTier := defaultRoutingTier(cfg)
+	if tier != defaultTier {
+		log.Printf("warn: llm routing tier %q missing, falling back to default tier %q", tier, defaultTier)
+	}
+	if routing, ok := cfg.LLMRouting.Tiers[defaultTier]; ok && len(routing.Providers) > 0 {
+		return append([]string(nil), routing.Providers...)
+	}
+	return []string{resolveLegacyProvider(cfg, nil, nil, nil)}
+}
+
+func modelForProvider(cfg *config.Config, providerName, tier string) string {
+	provider, ok := providerConfigForName(cfg, providerName)
+	if !ok {
+		return ""
+	}
+	return provider.Tiers[tier]
+}
+
+func usesLegacyProviderOverride(srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase) bool {
+	if p != nil && p.Tier != nil {
+		return false
+	}
+	if wf != nil && wf.Tier != nil {
+		return false
+	}
+	if srcCfg != nil {
+		if strings.TrimSpace(srcCfg.LLM) != "" || strings.TrimSpace(srcCfg.Model) != "" {
+			return true
+		}
+	}
+	if p != nil {
+		if p.LLM != nil && strings.TrimSpace(*p.LLM) != "" {
+			return true
+		}
+		if p.Model != nil && strings.TrimSpace(*p.Model) != "" {
+			return true
+		}
+	}
+	if wf != nil {
+		if wf.LLM != nil && strings.TrimSpace(*wf.LLM) != "" {
+			return true
+		}
+		if wf.Model != nil && strings.TrimSpace(*wf.Model) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func resolvePhaseProviderChain(cfg *config.Config, srcCfg *config.SourceConfig, vessel queue.Vessel, wf *workflow.Workflow, p *workflow.Phase) (string, []string) {
+	tier := resolveTier(cfg, vessel, wf, p)
+	if usesLegacyProviderOverride(srcCfg, wf, p) {
+		return tier, []string{resolveLegacyProvider(cfg, srcCfg, wf, p)}
+	}
+	return tier, resolveProviderChain(cfg, tier)
+}
+
+func resolvePhaseModel(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, provider, tier string) string {
+	if usesLegacyProviderOverride(srcCfg, wf, p) && provider == resolveLegacyProvider(cfg, srcCfg, wf, p) {
+		return resolveLegacyModel(cfg, srcCfg, wf, p, provider)
+	}
+	return modelForProvider(cfg, provider, tier)
+}
+
 // stripBoolFlag removes all occurrences of a boolean flag (no value) from a slice of CLI tokens.
 func stripBoolFlag(fields []string, flag string) []string {
 	var out []string
@@ -4759,35 +5007,52 @@ func stripBoolFlag(fields []string, flag string) []string {
 // buildPromptOnlyCmdArgs returns the command and args for a prompt-only invocation.
 // For claude, the prompt is a positional argument after the -p boolean flag.
 // For copilot, the prompt is the value of the -p flag (-p <text>).
-func buildPromptOnlyCmdArgs(cfg *config.Config, prompt string) (string, []string) {
-	provider := resolveProvider(cfg, nil, nil, nil)
-	switch provider {
+func buildPromptOnlyCmdArgs(cfg *config.Config, provider, tier, prompt string) (string, []string) {
+	providerCfg, ok := providerConfigForName(cfg, provider)
+	if !ok {
+		return "", nil
+	}
+	model := modelForProvider(cfg, provider, tier)
+	switch providerCfg.Kind {
 	case "copilot":
-		cmd := cfg.Copilot.Command
+		cmd := providerCfg.Command
 		var args []string
 		if prompt != "" {
 			args = append(args, "-p", prompt, "-s")
 		}
-		if cfg.Copilot.Flags != "" {
-			fields := strings.Fields(cfg.Copilot.Flags)
+		if providerCfg.Flags != "" {
+			fields := strings.Fields(providerCfg.Flags)
 			fields = stripPromptFlag(fields)
 			fields = stripBoolFlag(fields, "-s")
 			fields = stripBoolFlag(fields, "--silent")
 			fields = stripBoolFlag(fields, "--headless") // legacy: strip if present
+			if model != "" {
+				fields = stripModelFlag(fields)
+			}
 			args = append(args, fields...)
 		}
+		if model != "" {
+			args = append(args, "--model", model)
+		}
 		return cmd, args
-	default: // "claude"
-		cmd := cfg.Claude.Command
+	default:
+		cmd := providerCfg.Command
 		args := []string{"-p"}
 		if prompt != "" {
 			args = append(args, prompt)
 		}
 		args = append(args, "--max-turns", fmt.Sprintf("%d", cfg.MaxTurns))
-		if cfg.Claude.Flags != "" {
-			args = append(args, strings.Fields(cfg.Claude.Flags)...)
+		if providerCfg.Flags != "" {
+			fields := strings.Fields(providerCfg.Flags)
+			if model != "" {
+				fields = stripModelFlag(fields)
+			}
+			args = append(args, fields...)
 		}
-		for _, tool := range cfg.Claude.AllowedTools {
+		if model != "" {
+			args = append(args, "--model", model)
+		}
+		for _, tool := range providerCfg.AllowedTools {
 			args = append(args, "--allowedTools", tool)
 		}
 		return cmd, args

--- a/cli/internal/runner/runner_fallback_test.go
+++ b/cli/internal/runner/runner_fallback_test.go
@@ -1,0 +1,234 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fallbackPhaseCall struct {
+	Command string
+	Args    []string
+	Env     []string
+	Prompt  string
+}
+
+type fallbackCmdRunner struct {
+	calls []fallbackPhaseCall
+}
+
+func (f *fallbackCmdRunner) RunOutput(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (f *fallbackCmdRunner) RunProcess(_ context.Context, _ string, _ string, _ ...string) error {
+	return nil
+}
+
+func (f *fallbackCmdRunner) RunPhase(ctx context.Context, dir string, stdin io.Reader, name string, args ...string) ([]byte, error) {
+	return f.RunPhaseWithEnv(ctx, dir, nil, stdin, name, args...)
+}
+
+func (f *fallbackCmdRunner) RunPhaseWithEnv(_ context.Context, _ string, extraEnv []string, stdin io.Reader, name string, args ...string) ([]byte, error) {
+	prompt := ""
+	if stdin != nil {
+		data, _ := io.ReadAll(stdin)
+		prompt = string(data)
+	}
+	f.calls = append(f.calls, fallbackPhaseCall{
+		Command: name,
+		Args:    append([]string(nil), args...),
+		Env:     append([]string(nil), extraEnv...),
+		Prompt:  prompt,
+	})
+	switch name {
+	case "claude-fallback":
+		return nil, errors.New("Credit balance is too low")
+	case "claude-hard-fail":
+		return nil, errors.New("exit status 1")
+	default:
+		return []byte("implemented"), nil
+	}
+}
+
+func TestRunPhaseWithProviderFallbackFallsBackAfterRateLimit(t *testing.T) {
+	t.Setenv("XYLEM_DTU_STATE_PATH", setupDTUClock(t))
+	tracer, rec := newTestTracer(t)
+
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 1,
+		MaxTurns:    50,
+		Timeout:     "30s",
+		StateDir:    filepath.Join(dir, ".xylem"),
+		Providers: map[string]config.ProviderConfig{
+			"primary": {
+				Kind:    "claude",
+				Command: "claude-fallback",
+				Tiers:   map[string]string{"med": "claude-med"},
+				Env: map[string]string{
+					"ANTHROPIC_API_KEY": "anthropic-secret",
+				},
+			},
+			"secondary": {
+				Kind:    "copilot",
+				Command: "copilot-success",
+				Tiers:   map[string]string{"med": "gpt-med"},
+				Env: map[string]string{
+					"GITHUB_TOKEN": "copilot-secret",
+				},
+			},
+		},
+		LLMRouting: config.LLMRoutingConfig{
+			DefaultTier: "med",
+			Tiers: map[string]config.TierRouting{
+				"med": {Providers: []string{"primary", "secondary"}},
+			},
+		},
+		Harness: config.HarnessConfig{
+			ProtectedSurfaces: config.ProtectedSurfacesConfig{
+				Paths: []string{
+					".xylem/HARNESS.md",
+					".xylem.yml",
+					".xylem/workflows/*.yaml",
+					".xylem/prompts/*/*.md",
+				},
+			},
+		},
+		Sources: map[string]config.SourceConfig{
+			"github": {
+				Type:    "github",
+				Repo:    "owner/repo",
+				Exclude: []string{"wontfix"},
+				Tasks:   map[string]config.Task{"fix-bugs": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	vessel := makeVessel(1, "fix-bug")
+	vessel.Tier = "med"
+	_, _ = q.Enqueue(vessel)
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{name: "implement", promptContent: "Fix the bug", maxTurns: 10},
+	})
+
+	oldWd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &fallbackCmdRunner{}
+	r := New(cfg, q, &mockWorktree{}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.Tracer = tracer
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Completed)
+	require.Len(t, cmdRunner.calls, 5)
+
+	last := cmdRunner.calls[len(cmdRunner.calls)-1]
+	assert.Equal(t, "copilot-success", last.Command)
+	assert.Contains(t, last.Args, "--model")
+	assert.True(t, containsArgSequence(last.Args, "--model", "gpt-med"))
+	assert.Contains(t, last.Env, "GITHUB_TOKEN=copilot-secret")
+	assert.NotContains(t, last.Env, "ANTHROPIC_API_KEY=anthropic-secret")
+	assert.True(t, containsArgSequence(last.Args, "-p", "Fix the bug"))
+
+	first := cmdRunner.calls[0]
+	assert.Equal(t, "claude-fallback", first.Command)
+	assert.True(t, containsArgSequence(first.Args, "--model", "claude-med"))
+	assert.Contains(t, first.Env, "ANTHROPIC_API_KEY=anthropic-secret")
+	assert.NotContains(t, first.Env, "GITHUB_TOKEN=copilot-secret")
+	assert.Equal(t, "Fix the bug", first.Prompt)
+
+	attrs := spanAttrMap(endedSpanByName(t, rec, "phase:implement"))
+	assert.Equal(t, "secondary", attrs["xylem.phase.provider"])
+	assert.Equal(t, "gpt-med", attrs["xylem.phase.model"])
+	assert.Equal(t, "secondary", attrs["llm.provider"])
+	assert.Equal(t, "med", attrs["llm.tier"])
+}
+
+func TestRunPhaseWithProviderFallbackDoesNotMaskRealFailures(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 1,
+		MaxTurns:    50,
+		Timeout:     "30s",
+		StateDir:    filepath.Join(dir, ".xylem"),
+		Providers: map[string]config.ProviderConfig{
+			"primary": {
+				Kind:    "claude",
+				Command: "claude-hard-fail",
+				Tiers:   map[string]string{"med": "claude-med"},
+			},
+			"secondary": {
+				Kind:    "copilot",
+				Command: "copilot-success",
+				Tiers:   map[string]string{"med": "gpt-med"},
+			},
+		},
+		LLMRouting: config.LLMRoutingConfig{
+			DefaultTier: "med",
+			Tiers: map[string]config.TierRouting{
+				"med": {Providers: []string{"primary", "secondary"}},
+			},
+		},
+		Harness: config.HarnessConfig{
+			ProtectedSurfaces: config.ProtectedSurfacesConfig{
+				Paths: []string{
+					".xylem/HARNESS.md",
+					".xylem.yml",
+					".xylem/workflows/*.yaml",
+					".xylem/prompts/*/*.md",
+				},
+			},
+		},
+		Sources: map[string]config.SourceConfig{
+			"github": {
+				Type:    "github",
+				Repo:    "owner/repo",
+				Exclude: []string{"wontfix"},
+				Tasks:   map[string]config.Task{"fix-bugs": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	vessel := makeVessel(1, "fix-bug")
+	vessel.Tier = "med"
+	_, _ = q.Enqueue(vessel)
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{name: "implement", promptContent: "Fix the bug", maxTurns: 10},
+	})
+
+	oldWd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &fallbackCmdRunner{}
+	r := New(cfg, q, &mockWorktree{}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Failed)
+	require.Len(t, cmdRunner.calls, 1)
+	assert.Equal(t, "claude-hard-fail", cmdRunner.calls[0].Command)
+
+	vessels, listErr := q.List()
+	require.NoError(t, listErr)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, queue.StateFailed, vessels[0].State)
+	assert.True(t, strings.Contains(vessels[0].Error, "exit status 1"))
+}

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -258,6 +258,66 @@ func TestProp_SplitRepoSlugRejectsMalformedInput(t *testing.T) {
 	})
 }
 
+func TestProp_ResolvePhaseProviderChainPrefersMostSpecificTier(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		phaseWins := rapid.Bool().Draw(t, "phaseWins")
+		workflowWins := rapid.Bool().Draw(t, "workflowWins")
+		vesselWins := rapid.Bool().Draw(t, "vesselWins")
+		phaseTier := "phase-tier"
+		workflowTier := "workflow-tier"
+		vesselTier := "vessel-tier"
+		defaultTier := "default-tier"
+
+		cfg := &config.Config{
+			LLMRouting: config.LLMRoutingConfig{
+				DefaultTier: defaultTier,
+				Tiers: map[string]config.TierRouting{
+					phaseTier:    {Providers: []string{"phase-provider", "fallback-provider"}},
+					workflowTier: {Providers: []string{"workflow-provider"}},
+					vesselTier:   {Providers: []string{"vessel-provider"}},
+					defaultTier:  {Providers: []string{"default-provider"}},
+				},
+			},
+		}
+
+		vessel := queue.Vessel{Tier: vesselTier}
+		var wf *workflow.Workflow
+		if workflowWins || phaseWins {
+			wf = &workflow.Workflow{Tier: strPtr(workflowTier)}
+		}
+		var p *workflow.Phase
+		if phaseWins {
+			p = &workflow.Phase{Tier: strPtr(phaseTier)}
+		}
+		if !phaseWins && !workflowWins && !vesselWins {
+			vessel.Tier = ""
+		}
+
+		gotTier, gotProviders := resolvePhaseProviderChain(cfg, nil, vessel, wf, p)
+
+		wantTier := defaultTier
+		wantProviders := []string{"default-provider"}
+		switch {
+		case phaseWins:
+			wantTier = phaseTier
+			wantProviders = []string{"phase-provider", "fallback-provider"}
+		case workflowWins:
+			wantTier = workflowTier
+			wantProviders = []string{"workflow-provider"}
+		case vesselWins:
+			wantTier = vesselTier
+			wantProviders = []string{"vessel-provider"}
+		}
+
+		if gotTier != wantTier {
+			t.Fatalf("resolvePhaseProviderChain() tier = %q, want %q", gotTier, wantTier)
+		}
+		if !reflect.DeepEqual(gotProviders, wantProviders) {
+			t.Fatalf("resolvePhaseProviderChain() providers = %#v, want %#v", gotProviders, wantProviders)
+		}
+	})
+}
+
 func TestProp_BudgetExceededIsMonotonic(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		records := rapid.SliceOfN(rapid.Float64Range(0.0, 1.0), 1, 20).Draw(t, "costs")

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -119,6 +119,10 @@ func (m *mockCmdRunner) RunProcess(_ context.Context, _ string, _ string, _ ...s
 }
 
 func (m *mockCmdRunner) RunPhase(_ context.Context, dir string, stdin io.Reader, name string, args ...string) ([]byte, error) {
+	return m.RunPhaseWithEnv(context.Background(), dir, nil, stdin, name, args...)
+}
+
+func (m *mockCmdRunner) RunPhaseWithEnv(_ context.Context, dir string, _ []string, stdin io.Reader, name string, args ...string) ([]byte, error) {
 	prompt, _ := io.ReadAll(stdin)
 	m.mu.Lock()
 	m.phaseCalls = append(m.phaseCalls, phaseCall{
@@ -188,6 +192,10 @@ func (c *countingCmdRunner) RunProcess(_ context.Context, _ string, _ string, _ 
 }
 
 func (c *countingCmdRunner) RunPhase(_ context.Context, _ string, stdin io.Reader, _ string, _ ...string) ([]byte, error) {
+	return c.RunPhaseWithEnv(context.Background(), "", nil, stdin, "")
+}
+
+func (c *countingCmdRunner) RunPhaseWithEnv(_ context.Context, _ string, _ []string, stdin io.Reader, _ string, _ ...string) ([]byte, error) {
 	io.ReadAll(stdin)
 	cur := atomic.AddInt32(&c.concurrent, 1)
 	for {
@@ -224,6 +232,10 @@ func (c *classCountingCmdRunner) RunProcess(_ context.Context, _ string, _ strin
 }
 
 func (c *classCountingCmdRunner) RunPhase(_ context.Context, _ string, stdin io.Reader, _ string, _ ...string) ([]byte, error) {
+	return c.RunPhaseWithEnv(context.Background(), "", nil, stdin, "")
+}
+
+func (c *classCountingCmdRunner) RunPhaseWithEnv(_ context.Context, _ string, _ []string, stdin io.Reader, _ string, _ ...string) ([]byte, error) {
 	prompt, _ := io.ReadAll(stdin)
 	class := "unknown"
 	switch {
@@ -287,6 +299,10 @@ func (b *blockingPhaseCmdRunner) RunProcess(_ context.Context, _ string, _ strin
 }
 
 func (b *blockingPhaseCmdRunner) RunPhase(ctx context.Context, _ string, stdin io.Reader, _ string, _ ...string) ([]byte, error) {
+	return b.RunPhaseWithEnv(ctx, "", nil, stdin, "")
+}
+
+func (b *blockingPhaseCmdRunner) RunPhaseWithEnv(ctx context.Context, _ string, _ []string, stdin io.Reader, _ string, _ ...string) ([]byte, error) {
 	prompt, _ := io.ReadAll(stdin)
 	promptText := string(prompt)
 
@@ -335,6 +351,10 @@ func (b *observedBlockingPhaseCmdRunner) RunPhase(ctx context.Context, dir strin
 	return b.RunPhaseObserved(ctx, dir, stdin, nil, name, args...)
 }
 
+func (b *observedBlockingPhaseCmdRunner) RunPhaseWithEnv(ctx context.Context, dir string, _ []string, stdin io.Reader, name string, args ...string) ([]byte, error) {
+	return b.RunPhaseObserved(ctx, dir, stdin, nil, name, args...)
+}
+
 func (b *observedBlockingPhaseCmdRunner) RunPhaseObserved(ctx context.Context, _ string, stdin io.Reader, observer PhaseProcessObserver, _ string, _ ...string) ([]byte, error) {
 	if _, err := io.ReadAll(stdin); err != nil {
 		return nil, err
@@ -351,6 +371,10 @@ func (b *observedBlockingPhaseCmdRunner) RunPhaseObserved(ctx context.Context, _
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+func (b *observedBlockingPhaseCmdRunner) RunPhaseObservedWithEnv(ctx context.Context, dir string, _ []string, stdin io.Reader, observer PhaseProcessObserver, name string, args ...string) ([]byte, error) {
+	return b.RunPhaseObserved(ctx, dir, stdin, observer, name, args...)
 }
 
 type mockWorktree struct {
@@ -2134,10 +2158,6 @@ func assertCancelledVesselStopsRunningPhaseAndDropsInFlight(t *testing.T) {
 	summary := loadSummary(t, cfg.StateDir, vessel.ID)
 	assert.Equal(t, "cancelled", summary.State)
 	assert.Equal(t, vessel.ID, summary.VesselID)
-}
-
-func TestDrainCancelledVesselStopsRunningPhaseAndDropsInFlight(t *testing.T) {
-	assertCancelledVesselStopsRunningPhaseAndDropsInFlight(t)
 }
 
 func TestSmoke_S38_CancelledVesselStopsRunningPhaseAndDropsInFlight(t *testing.T) {
@@ -4431,7 +4451,7 @@ func TestBuildPhaseArgs(t *testing.T) {
 			Claude: config.ClaudeConfig{Command: "claude"},
 		}
 		p := &workflow.Phase{Name: "analyze", MaxTurns: 5}
-		args := buildPhaseArgs(cfg, nil, nil, p, "")
+		args := buildPhaseArgs(cfg, "claude", mustProviderConfigForTest(t, cfg, "claude"), nil, nil, p, "med", "")
 
 		if args[0] != "-p" {
 			t.Errorf("expected -p, got %s", args[0])
@@ -4446,7 +4466,7 @@ func TestBuildPhaseArgs(t *testing.T) {
 			Claude: config.ClaudeConfig{Command: "claude", Flags: "--bare --dangerously-skip-permissions"},
 		}
 		p := &workflow.Phase{Name: "analyze", MaxTurns: 5}
-		args := buildPhaseArgs(cfg, nil, nil, p, "")
+		args := buildPhaseArgs(cfg, "claude", mustProviderConfigForTest(t, cfg, "claude"), nil, nil, p, "med", "")
 
 		joined := strings.Join(args, " ")
 		if !strings.Contains(joined, "--bare") {
@@ -4463,7 +4483,7 @@ func TestBuildPhaseArgs(t *testing.T) {
 		}
 		allowedTools := "Read,Edit"
 		p := &workflow.Phase{Name: "analyze", MaxTurns: 5, AllowedTools: &allowedTools}
-		args := buildPhaseArgs(cfg, nil, nil, p, "")
+		args := buildPhaseArgs(cfg, "claude", mustProviderConfigForTest(t, cfg, "claude"), nil, nil, p, "med", "")
 
 		// Should have both phase-level and config-level tools
 		toolCount := 0
@@ -4482,7 +4502,7 @@ func TestBuildPhaseArgs(t *testing.T) {
 			Claude: config.ClaudeConfig{Command: "claude"},
 		}
 		p := &workflow.Phase{Name: "analyze", MaxTurns: 5}
-		args := buildPhaseArgs(cfg, nil, nil, p, "harness content")
+		args := buildPhaseArgs(cfg, "claude", mustProviderConfigForTest(t, cfg, "claude"), nil, nil, p, "med", "harness content")
 
 		found := false
 		for i, a := range args {
@@ -4500,91 +4520,74 @@ func strPtr(s string) *string {
 	return &s
 }
 
+func mustProviderConfigForTest(t *testing.T, cfg *config.Config, name string) config.ProviderConfig {
+	t.Helper()
+	provider, ok := providerConfigForName(cfg, name)
+	if !ok {
+		t.Fatalf("provider %q not configured", name)
+	}
+	return provider
+}
+
 func TestBuildPhaseArgsModelResolution(t *testing.T) {
 	tests := []struct {
 		name      string
 		cfg       *config.Config
 		wf        *workflow.Workflow
 		phase     *workflow.Phase
-		wantModel string // expected --model value; empty means no --model flag
+		tier      string
+		wantModel string
 	}{
 		{
-			name: "phase model takes priority",
+			name: "tier model comes from provider tiers",
 			cfg: &config.Config{
-				Claude: config.ClaudeConfig{Command: "claude", DefaultModel: "config-model"},
+				Providers: map[string]config.ProviderConfig{
+					"claude": {Kind: "claude", Command: "claude", Tiers: map[string]string{"med": "claude-med"}},
+				},
 			},
-			wf:        &workflow.Workflow{Model: strPtr("workflow-model")},
-			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5, Model: strPtr("phase-model")},
-			wantModel: "phase-model",
+			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5},
+			tier:      "med",
+			wantModel: "claude-med",
 		},
 		{
-			name: "workflow model when phase has no model",
+			name: "legacy workflow model overrides provider tier when tier unset",
 			cfg: &config.Config{
-				Claude: config.ClaudeConfig{Command: "claude", DefaultModel: "config-model"},
+				Claude: config.ClaudeConfig{Command: "claude", DefaultModel: "claude-default"},
 			},
 			wf:        &workflow.Workflow{Model: strPtr("workflow-model")},
 			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5},
+			tier:      "med",
 			wantModel: "workflow-model",
 		},
 		{
-			name: "config default model when neither phase nor workflow set",
+			name: "phase tier suppresses legacy model override",
 			cfg: &config.Config{
-				Claude: config.ClaudeConfig{Command: "claude", DefaultModel: "config-model"},
+				Providers: map[string]config.ProviderConfig{
+					"claude": {Kind: "claude", Command: "claude", Tiers: map[string]string{"high": "claude-high"}},
+				},
 			},
-			wf:        &workflow.Workflow{},
-			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5},
-			wantModel: "config-model",
-		},
-		{
-			name: "no model when nothing set",
-			cfg: &config.Config{
-				Claude: config.ClaudeConfig{Command: "claude"},
-			},
-			wf:        &workflow.Workflow{},
-			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5},
-			wantModel: "",
-		},
-		{
-			name: "nil workflow still falls back to config",
-			cfg: &config.Config{
-				Claude: config.ClaudeConfig{Command: "claude", DefaultModel: "config-model"},
-			},
-			wf:        nil,
-			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5},
-			wantModel: "config-model",
+			wf:        &workflow.Workflow{Model: strPtr("legacy-workflow-model")},
+			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5, Tier: strPtr("high")},
+			tier:      "high",
+			wantModel: "claude-high",
 		},
 		{
 			name: "flags --model stripped when hierarchy resolves model",
 			cfg: &config.Config{
-				Claude: config.ClaudeConfig{Command: "claude", Flags: "--bare --model old-model --dangerously-skip-permissions"},
+				Providers: map[string]config.ProviderConfig{
+					"claude": {Kind: "claude", Command: "claude", Flags: "--bare --model old-model --dangerously-skip-permissions", Tiers: map[string]string{"med": "workflow-model"}},
+				},
 			},
-			wf:        &workflow.Workflow{Model: strPtr("workflow-model")},
-			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5},
-			wantModel: "workflow-model",
-		},
-		{
-			name: "flags --model preserved when hierarchy does not resolve",
-			cfg: &config.Config{
-				Claude: config.ClaudeConfig{Command: "claude", Flags: "--bare --model flags-model"},
-			},
-			wf:        &workflow.Workflow{},
-			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5},
-			wantModel: "flags-model",
-		},
-		{
-			name: "empty string phase model falls through to workflow",
-			cfg: &config.Config{
-				Claude: config.ClaudeConfig{Command: "claude"},
-			},
-			wf:        &workflow.Workflow{Model: strPtr("workflow-model")},
-			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5, Model: strPtr("")},
+			wf:        &workflow.Workflow{Tier: strPtr("med")},
+			phase:     &workflow.Phase{Name: "analyze", MaxTurns: 5, Tier: strPtr("med")},
+			tier:      "med",
 			wantModel: "workflow-model",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := buildPhaseArgs(tt.cfg, nil, tt.wf, tt.phase, "")
+			args := buildPhaseArgs(tt.cfg, "claude", mustProviderConfigForTest(t, tt.cfg, "claude"), nil, tt.wf, tt.phase, tt.tier, "")
 
 			// Find --model in args
 			foundModel := ""
@@ -4600,7 +4603,8 @@ func TestBuildPhaseArgsModelResolution(t *testing.T) {
 			}
 
 			// When hierarchy resolves a model, --model from flags should be stripped
-			if tt.wantModel != "" && strings.Contains(tt.cfg.Claude.Flags, "--model") {
+			flags := mustProviderConfigForTest(t, tt.cfg, "claude").Flags
+			if tt.wantModel != "" && strings.Contains(flags, "--model") {
 				// Count --model occurrences; should be exactly 1
 				count := 0
 				for _, a := range args {
@@ -4648,164 +4652,88 @@ func TestDrainTimeoutV2Phase(t *testing.T) {
 	}
 }
 
-func TestResolveProvider(t *testing.T) {
-	claude := "claude"
-	copilot := "copilot"
-
+func TestResolveTier(t *testing.T) {
 	tests := []struct {
-		name     string
-		cfgLLM   string
-		wfLLM    *string
-		phaseLLM *string
-		want     string
+		name   string
+		cfg    *config.Config
+		vessel queue.Vessel
+		wf     *workflow.Workflow
+		phase  *workflow.Phase
+		want   string
 	}{
-		{"all nil defaults to claude", "", nil, nil, "claude"},
-		{"config claude", "claude", nil, nil, "claude"},
-		{"config copilot", "copilot", nil, nil, "copilot"},
-		{"workflow overrides config", "claude", &copilot, nil, "copilot"},
-		{"phase overrides workflow", "claude", &claude, &copilot, "copilot"},
-		{"phase overrides config", "claude", nil, &copilot, "copilot"},
-		{"workflow override wins when config empty", "", &copilot, nil, "copilot"},
+		{
+			name:   "phase tier wins",
+			cfg:    &config.Config{LLMRouting: config.LLMRoutingConfig{DefaultTier: "med"}},
+			vessel: queue.Vessel{Tier: "low"},
+			wf:     &workflow.Workflow{Tier: strPtr("high")},
+			phase:  &workflow.Phase{Tier: strPtr("urgent")},
+			want:   "urgent",
+		},
+		{
+			name:   "workflow tier beats vessel",
+			cfg:    &config.Config{LLMRouting: config.LLMRoutingConfig{DefaultTier: "med"}},
+			vessel: queue.Vessel{Tier: "low"},
+			wf:     &workflow.Workflow{Tier: strPtr("high")},
+			want:   "high",
+		},
+		{
+			name:   "vessel tier beats config default",
+			cfg:    &config.Config{LLMRouting: config.LLMRoutingConfig{DefaultTier: "med"}},
+			vessel: queue.Vessel{Tier: "low"},
+			want:   "low",
+		},
+		{
+			name: "config default used when no higher source",
+			cfg:  &config.Config{LLMRouting: config.LLMRoutingConfig{DefaultTier: "high"}},
+			want: "high",
+		},
+		{
+			name: "hard default is med",
+			cfg:  &config.Config{},
+			want: "med",
+		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &config.Config{LLM: tt.cfgLLM}
-			var wf *workflow.Workflow
-			if tt.wfLLM != nil {
-				wf = &workflow.Workflow{LLM: tt.wfLLM}
-			}
-			var p *workflow.Phase
-			if tt.phaseLLM != nil {
-				p = &workflow.Phase{LLM: tt.phaseLLM}
-			}
-			got := resolveProvider(cfg, nil, wf, p)
-			if got != tt.want {
-				t.Errorf("resolveProvider() = %q, want %q", got, tt.want)
-			}
+			got := resolveTier(tt.cfg, tt.vessel, tt.wf, tt.phase)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestResolveModel(t *testing.T) {
+func TestResolveProviderChain(t *testing.T) {
 	cfg := &config.Config{
-		Claude:  config.ClaudeConfig{DefaultModel: "claude-default"},
-		Copilot: config.CopilotConfig{DefaultModel: "copilot-default"},
+		LLMRouting: config.LLMRoutingConfig{
+			DefaultTier: "med",
+			Tiers: map[string]config.TierRouting{
+				"med":  {Providers: []string{"claude", "copilot"}},
+				"high": {Providers: []string{"claude"}},
+			},
+		},
 	}
 
-	phaseModel := "phase-model"
-	wfModel := "wf-model"
+	require.Equal(t, []string{"claude"}, resolveProviderChain(cfg, "high"))
+	require.Equal(t, []string{"claude", "copilot"}, resolveProviderChain(cfg, "missing"))
 
-	tests := []struct {
-		name       string
-		wfModel    *string
-		phaseModel *string
-		provider   string
-		want       string
-	}{
-		{"phase model wins", &wfModel, &phaseModel, "claude", "phase-model"},
-		{"workflow model wins over default", &wfModel, nil, "claude", "wf-model"},
-		{"claude default when no override", nil, nil, "claude", "claude-default"},
-		{"copilot default when provider copilot", nil, nil, "copilot", "copilot-default"},
-		{"workflow model wins for copilot", &wfModel, nil, "copilot", "wf-model"},
-		{"phase model wins for copilot", &wfModel, &phaseModel, "copilot", "phase-model"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var wf *workflow.Workflow
-			if tt.wfModel != nil {
-				wf = &workflow.Workflow{Model: tt.wfModel}
-			}
-			var p *workflow.Phase
-			if tt.phaseModel != nil {
-				p = &workflow.Phase{Model: tt.phaseModel}
-			}
-			got := resolveModel(cfg, nil, wf, p, tt.provider)
-			if got != tt.want {
-				t.Errorf("resolveModel() = %q, want %q", got, tt.want)
-			}
-		})
-	}
+	legacy := &config.Config{LLM: "copilot"}
+	require.Equal(t, []string{"copilot"}, resolveProviderChain(legacy, "med"))
 }
 
-func TestResolveProviderWithSource(t *testing.T) {
-	copilot := "copilot"
-	tests := []struct {
-		name     string
-		cfgLLM   string
-		srcLLM   string
-		wfLLM    *string
-		phaseLLM *string
-		want     string
-	}{
-		{"source overrides config", "claude", "copilot", nil, nil, "copilot"},
-		{"workflow overrides source", "claude", "copilot", strPtrRunner("claude"), nil, "claude"},
-		{"phase overrides source", "claude", "copilot", nil, &copilot, "copilot"},
-		{"empty source falls to config", "copilot", "", nil, nil, "copilot"},
+func TestModelForProvider(t *testing.T) {
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"claude":  {Kind: "claude", Tiers: map[string]string{"high": "claude-opus"}},
+			"copilot": {Kind: "copilot", Tiers: map[string]string{"med": "gpt-5.2-codex"}},
+		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := &config.Config{LLM: tt.cfgLLM}
-			var srcCfg *config.SourceConfig
-			if tt.srcLLM != "" {
-				srcCfg = &config.SourceConfig{LLM: tt.srcLLM}
-			}
-			var wf *workflow.Workflow
-			if tt.wfLLM != nil {
-				wf = &workflow.Workflow{LLM: tt.wfLLM}
-			}
-			var p *workflow.Phase
-			if tt.phaseLLM != nil {
-				p = &workflow.Phase{LLM: tt.phaseLLM}
-			}
-			got := resolveProvider(cfg, srcCfg, wf, p)
-			if got != tt.want {
-				t.Errorf("resolveProvider() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
+	require.Equal(t, "claude-opus", modelForProvider(cfg, "claude", "high"))
+	require.Equal(t, "gpt-5.2-codex", modelForProvider(cfg, "copilot", "med"))
 
-func TestResolveModelWithSourceAndConfigModel(t *testing.T) {
-	tests := []struct {
-		name       string
-		srcModel   string
-		wfModel    *string
-		phaseModel *string
-		provider   string
-		want       string
-	}{
-		{"provider default used when no phase/wf/src for claude", "", nil, nil, "claude", "claude-default"},
-		{"provider default used when no phase/wf/src for copilot", "", nil, nil, "copilot", "copilot-default"},
-		{"source model beats provider default", "src-model", nil, nil, "claude", "src-model"},
-		{"workflow model beats source model", "src-model", strPtrRunner("wf-model"), nil, "claude", "wf-model"},
-		{"phase model beats all", "src-model", strPtrRunner("wf-model"), strPtrRunner("phase-model"), "claude", "phase-model"},
+	legacy := &config.Config{
+		LLMRouting: config.LLMRoutingConfig{DefaultTier: "med"},
+		Claude:     config.ClaudeConfig{DefaultModel: "claude-default"},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := &config.Config{
-				Claude:  config.ClaudeConfig{DefaultModel: "claude-default"},
-				Copilot: config.CopilotConfig{DefaultModel: "copilot-default"},
-			}
-			var srcCfg *config.SourceConfig
-			if tt.srcModel != "" {
-				srcCfg = &config.SourceConfig{Model: tt.srcModel}
-			}
-			var wf *workflow.Workflow
-			if tt.wfModel != nil {
-				wf = &workflow.Workflow{Model: tt.wfModel}
-			}
-			var p *workflow.Phase
-			if tt.phaseModel != nil {
-				p = &workflow.Phase{Model: tt.phaseModel}
-			}
-			got := resolveModel(cfg, srcCfg, wf, p, tt.provider)
-			if got != tt.want {
-				t.Errorf("resolveModel() = %q, want %q", got, tt.want)
-			}
-		})
-	}
+	require.Equal(t, "claude-default", modelForProvider(legacy, "claude", "med"))
 }
 
 func TestBuildCopilotPhaseArgs(t *testing.T) {
@@ -4842,6 +4770,7 @@ func TestBuildCopilotPhaseArgs(t *testing.T) {
 		{
 			name: "copilot with model from phase overrides default",
 			cfg: &config.Config{
+				LLM:     "copilot",
 				Copilot: config.CopilotConfig{Command: "copilot", DefaultModel: "gpt-4o"},
 			},
 			phase:          &workflow.Phase{MaxTurns: maxTurns, Model: strPtrRunner("phase-model")},
@@ -4905,7 +4834,7 @@ func TestBuildCopilotPhaseArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := buildCopilotPhaseArgs(tt.cfg, nil, tt.wf, tt.phase, tt.harness, tt.prompt)
+			args := buildCopilotPhaseArgs(tt.cfg, "copilot", mustProviderConfigForTest(t, tt.cfg, "copilot"), nil, tt.wf, tt.phase, "med", tt.harness, tt.prompt)
 
 			for _, want := range tt.wantContains {
 				found := false
@@ -4967,7 +4896,7 @@ func TestBuildCopilotPhaseArgs(t *testing.T) {
 	t.Run("harness prepended to prompt in -p value", func(t *testing.T) {
 		cfg := &config.Config{Copilot: config.CopilotConfig{Command: "copilot"}}
 		phase := &workflow.Phase{MaxTurns: maxTurns}
-		args := buildCopilotPhaseArgs(cfg, nil, nil, phase, "harness text", "user prompt")
+		args := buildCopilotPhaseArgs(cfg, "copilot", mustProviderConfigForTest(t, cfg, "copilot"), nil, nil, phase, "med", "harness text", "user prompt")
 		if len(args) < 2 {
 			t.Fatalf("expected at least 2 args, got %d: %v", len(args), args)
 		}
@@ -4992,16 +4921,20 @@ func TestBuildProviderPhaseArgsDispatch(t *testing.T) {
 	copilotCmd := "copilot"
 
 	cfg := &config.Config{
-		Claude:  config.ClaudeConfig{Command: claudeCmd},
-		Copilot: config.CopilotConfig{Command: copilotCmd},
+		Providers: map[string]config.ProviderConfig{
+			"claude":  {Kind: "claude", Command: claudeCmd, Tiers: map[string]string{"med": "claude-med"}},
+			"copilot": {Kind: "copilot", Command: copilotCmd, Tiers: map[string]string{"med": "gpt-med"}},
+		},
 	}
 	phase := &workflow.Phase{MaxTurns: 5}
 
 	t.Run("claude provider returns claude command and stdin", func(t *testing.T) {
-		cmd, args, stdin := buildProviderPhaseArgs(cfg, nil, nil, phase, "", "claude", "test prompt", 1)
+		cmd, args, stdin, model, err := buildProviderPhaseArgs(cfg, nil, nil, phase, "", "claude", "med", "test prompt", 1)
+		require.NoError(t, err)
 		if cmd != claudeCmd {
 			t.Errorf("cmd = %q, want %q", cmd, claudeCmd)
 		}
+		require.Equal(t, "claude-med", model)
 		if len(args) == 0 || args[0] != "-p" {
 			t.Errorf("claude args[0] = %q, want -p (args: %v)", args[0], args)
 		}
@@ -5017,10 +4950,12 @@ func TestBuildProviderPhaseArgsDispatch(t *testing.T) {
 	})
 
 	t.Run("copilot provider returns copilot command and nil stdin", func(t *testing.T) {
-		cmd, args, stdin := buildProviderPhaseArgs(cfg, nil, nil, phase, "", "copilot", "test prompt", 1)
+		cmd, args, stdin, model, err := buildProviderPhaseArgs(cfg, nil, nil, phase, "", "copilot", "med", "test prompt", 1)
+		require.NoError(t, err)
 		if cmd != copilotCmd {
 			t.Errorf("cmd = %q, want %q", cmd, copilotCmd)
 		}
+		require.Equal(t, "gpt-med", model)
 		if len(args) == 0 || args[0] != "-p" {
 			t.Errorf("copilot args[0] = %q, want -p (args: %v)", args[0], args)
 		}
@@ -5040,8 +4975,10 @@ func TestBuildProviderPhaseArgsAddsDTUMetadataWhenDTUActive(t *testing.T) {
 	t.Setenv("XYLEM_DTU_STATE_PATH", "/tmp/dtu/state.json")
 
 	cfg := &config.Config{
-		Claude:  config.ClaudeConfig{Command: "claude"},
-		Copilot: config.CopilotConfig{Command: "copilot"},
+		Providers: map[string]config.ProviderConfig{
+			"claude":  {Kind: "claude", Command: "claude", Tiers: map[string]string{"med": "claude-med"}},
+			"copilot": {Kind: "copilot", Command: "copilot", Tiers: map[string]string{"med": "gpt-med"}},
+		},
 	}
 	phase := &workflow.Phase{
 		Name:       "implement",
@@ -5049,7 +4986,8 @@ func TestBuildProviderPhaseArgsAddsDTUMetadataWhenDTUActive(t *testing.T) {
 		MaxTurns:   5,
 	}
 
-	_, claudeArgs, _ := buildProviderPhaseArgs(cfg, nil, nil, phase, "", "claude", "prompt", 2)
+	_, claudeArgs, _, _, err := buildProviderPhaseArgs(cfg, nil, nil, phase, "", "claude", "med", "prompt", 2)
+	require.NoError(t, err)
 	if !containsArgSequence(claudeArgs, "--dtu-phase", "implement") {
 		t.Fatalf("claude args missing DTU phase: %v", claudeArgs)
 	}
@@ -5060,7 +4998,8 @@ func TestBuildProviderPhaseArgsAddsDTUMetadataWhenDTUActive(t *testing.T) {
 		t.Fatalf("claude args missing DTU attempt: %v", claudeArgs)
 	}
 
-	_, copilotArgs, _ := buildProviderPhaseArgs(cfg, nil, nil, phase, "", "copilot", "prompt", 3)
+	_, copilotArgs, _, _, err := buildProviderPhaseArgs(cfg, nil, nil, phase, "", "copilot", "med", "prompt", 3)
+	require.NoError(t, err)
 	if !containsArgSequence(copilotArgs, "--dtu-attempt", "3") {
 		t.Fatalf("copilot args missing DTU attempt: %v", copilotArgs)
 	}
@@ -5186,7 +5125,7 @@ func TestBuildPromptOnlyCmdArgsCopilotFlagStripping(t *testing.T) {
 				Flags:   "--headless --verbose",
 			},
 		}
-		_, args := buildPromptOnlyCmdArgs(cfg, "test prompt")
+		_, args := buildPromptOnlyCmdArgs(cfg, "copilot", "med", "test prompt")
 		// --headless should be fully stripped
 		for _, a := range args {
 			if a == "--headless" {
@@ -5214,7 +5153,7 @@ func TestBuildPromptOnlyCmdArgsCopilotFlagStripping(t *testing.T) {
 				Flags:   "-p old-prompt --verbose",
 			},
 		}
-		_, args := buildPromptOnlyCmdArgs(cfg, "new prompt")
+		_, args := buildPromptOnlyCmdArgs(cfg, "copilot", "med", "new prompt")
 		// -p should appear exactly once with "new prompt" value
 		pCount := 0
 		for _, a := range args {
@@ -5943,6 +5882,10 @@ func (m *perPhaseCmdRunner) RunProcess(_ context.Context, _ string, _ string, _ 
 }
 
 func (m *perPhaseCmdRunner) RunPhase(_ context.Context, dir string, stdin io.Reader, name string, args ...string) ([]byte, error) {
+	return m.RunPhaseWithEnv(context.Background(), dir, nil, stdin, name, args...)
+}
+
+func (m *perPhaseCmdRunner) RunPhaseWithEnv(_ context.Context, dir string, _ []string, stdin io.Reader, name string, args ...string) ([]byte, error) {
 	prompt, _ := io.ReadAll(stdin)
 	m.mu.Lock()
 	m.calls = append(m.calls, phaseCall{dir: dir, prompt: string(prompt), name: name, args: args})
@@ -8824,6 +8767,39 @@ func TestSmoke_S14_PhaseSpanGetsResultAttributesAddedAfterExecution(t *testing.T
 	costParts := strings.Split(attrs["xylem.phase.cost_usd_est"], ".")
 	require.Len(t, costParts, 2)
 	assert.Len(t, costParts[1], 6)
+}
+
+func TestSmoke_PhaseSpanCarriesResolvedLLMProviderAndTier(t *testing.T) {
+	tracer, rec := newTestTracer(t)
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Analyze": []byte("analysis complete"),
+		},
+	}
+	r := newWorkflowRunner(t, "trace-basic", []testPhase{
+		{name: "analyze", promptContent: "Analyze", maxTurns: 5},
+	}, cmdRunner, tracer)
+	r.Config.Providers = map[string]config.ProviderConfig{
+		"claude": {
+			Kind:    "claude",
+			Command: "claude",
+			Tiers:   map[string]string{"med": "claude-sonnet-4"},
+		},
+	}
+	r.Config.LLMRouting = config.LLMRoutingConfig{
+		DefaultTier: "med",
+		Tiers: map[string]config.TierRouting{
+			"med": {Providers: []string{"claude"}},
+		},
+	}
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Completed)
+
+	attrs := spanAttrMap(endedSpanByName(t, rec, "phase:analyze"))
+	assert.Equal(t, "claude", attrs["llm.provider"])
+	assert.Equal(t, "med", attrs["llm.tier"])
 }
 
 func TestSmoke_S15_PhaseSpanRecordsErrorOnPhaseFailure(t *testing.T) {

--- a/cli/internal/runner/runner_tracing_prop_test.go
+++ b/cli/internal/runner/runner_tracing_prop_test.go
@@ -140,6 +140,7 @@ func TestProp_PhaseSpanAttributesNeverEmpty(t *testing.T) {
 				Type:     "prompt",
 				Provider: provider,
 				Model:    model,
+				Tier:     "med",
 			}),
 			observability.PhaseResultAttributes(observability.PhaseResultData{
 				InputTokensEst:  inputTokens,
@@ -153,8 +154,8 @@ func TestProp_PhaseSpanAttributesNeverEmpty(t *testing.T) {
 			t.Fatal("expected non-empty phase attributes")
 		}
 		for _, attr := range attrs {
-			if !strings.HasPrefix(attr.Key, "xylem.phase.") {
-				t.Fatalf("attribute key %q does not use xylem.phase namespace", attr.Key)
+			if !strings.HasPrefix(attr.Key, "xylem.phase.") && !strings.HasPrefix(attr.Key, "llm.") {
+				t.Fatalf("attribute key %q does not use xylem.phase or llm namespace", attr.Key)
 			}
 		}
 	})

--- a/cli/internal/runner/summary.go
+++ b/cli/internal/runner/summary.go
@@ -257,6 +257,10 @@ func (s *vesselRunState) recordPhaseTokens(
 }
 
 func (s *vesselRunState) phaseSummary(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p workflow.Phase, harnessContent string, inputTokensEst, outputTokensEst int, costUSDEst float64, duration time.Duration, status string, gatePassed *bool, errMsg string) PhaseSummary {
+	return s.phaseSummaryWithLLM(cfg, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, duration, status, gatePassed, errMsg, "", "")
+}
+
+func (s *vesselRunState) phaseSummaryWithLLM(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p workflow.Phase, harnessContent string, inputTokensEst, outputTokensEst int, costUSDEst float64, duration time.Duration, status string, gatePassed *bool, errMsg, provider, model string) PhaseSummary {
 	summary := PhaseSummary{
 		Name:       p.Name,
 		Type:       phaseTypeLabel(p),
@@ -275,8 +279,12 @@ func (s *vesselRunState) phaseSummary(cfg *config.Config, srcCfg *config.SourceC
 		return summary
 	}
 
-	provider := resolveProvider(cfg, srcCfg, wf, &p)
-	model := resolveModel(cfg, srcCfg, wf, &p, provider)
+	if provider == "" {
+		provider = resolveLegacyProvider(cfg, srcCfg, wf, &p)
+	}
+	if model == "" {
+		model = resolveLegacyModel(cfg, srcCfg, wf, &p, provider)
+	}
 	summary.Provider = provider
 	summary.Model = model
 	summary.InputTokensEst = inputTokensEst

--- a/docs/design/harness-smoke-scenarios/ws3-observability-cost.md
+++ b/docs/design/harness-smoke-scenarios/ws3-observability-cost.md
@@ -35,17 +35,17 @@ Covers spec sections 5 (observability integration) and 6 (cost estimation and bu
 
 ---
 
-### S3: PhaseSpanAttributes includes name, index, type, provider, and model
+### S3: PhaseSpanAttributes includes resolved phase and LLM routing fields
 
 **Spec ref:** Section 5.3
 
 **Preconditions:** `PhaseSpanAttributes` implemented.
 
-**Action:** Call `PhaseSpanAttributes("analyse", 0, "prompt", "anthropic", "claude-sonnet-4-20250514")`.
+**Action:** Call `PhaseSpanAttributes(PhaseSpanData{Name: "analyse", Index: 0, Type: "prompt", Workflow: "fix-bug", Provider: "anthropic", Model: "claude-sonnet-4-20250514", Tier: "med", RetryAttempt: 2, SandboxMode: "dangerously-skip-permissions"})`.
 
-**Expected outcome:** Returns a slice of five `SpanAttribute` values: `xylem.phase.name = "analyse"`, `xylem.phase.index = "0"`, `xylem.phase.type = "prompt"`, `xylem.phase.provider = "anthropic"`, `xylem.phase.model = "claude-sonnet-4-20250514"`. The index field is stringified, not numeric.
+**Expected outcome:** Returns a slice of ten `SpanAttribute` values: `xylem.phase.name = "analyse"`, `xylem.phase.index = "0"`, `xylem.phase.type = "prompt"`, `xylem.phase.workflow = "fix-bug"`, `xylem.phase.provider = "anthropic"`, `xylem.phase.model = "claude-sonnet-4-20250514"`, `xylem.phase.retry_attempt = "2"`, `xylem.phase.sandbox_mode = "dangerously-skip-permissions"`, `llm.provider = "anthropic"`, and `llm.tier = "med"`. The index field is stringified, not numeric.
 
-**Verification:** Unit test asserting length == 5 and all five key/value pairs are present with correct string values.
+**Verification:** Unit test asserting length == 10 and all ten key/value pairs are present with correct string values.
 
 ---
 


### PR DESCRIPTION
## Summary
Implements [issue #225](https://github.com/nicholls-inc/xylem/issues/225) by replacing the old single-provider runner path with tier-aware routing, provider-specific subprocess environments, and rate-limit fallback across configured providers.

## Smoke scenarios covered
- `WS3 S3` — PhaseSpanAttributes includes resolved phase and LLM routing fields
- `ISS225-SM1` — Tier-aware phase execution falls back from a rate-limited primary provider to the next provider with the correct per-provider env and tier model

## Changes summary
- **Modified** `cli/internal/runner/runner.go`, `cli/internal/runner/summary.go`: added tier/provider resolution helpers (`resolveTier`, `resolveProviderChain`, `resolvePhaseProviderChain`, `resolvePhaseModel`), kind-dispatched provider arg builders, `runPhaseWithProviderFallback`, and provider/model tracking in phase summaries.
- **Added** `cli/internal/runner/runner_fallback_test.go`: regression coverage for fallback-on-rate-limit and non-transient failure handling.
- **Modified** `cli/cmd/xylem/exec.go`: built provider-scoped env maps in `realCmdRunner` and added `RunProcessWithEnv`, `RunPhaseWithEnv`, and `RunPhaseObservedWithEnv` so Claude/Copilot env does not leak across subprocesses.
- **Modified** `cli/internal/observability/vessel.go`: extended `PhaseSpanData` and `PhaseResultData` emission so spans include resolved `llm.provider` and `llm.tier` metadata alongside provider/model fields.
- **Modified tests/docs** `cli/cmd/xylem/exec_test.go`, `cli/internal/dtu/scenario_test.go`, `cli/internal/dtu/scenario_cancel_test.go`, `cli/internal/observability/vessel_prop_test.go`, `cli/internal/observability/vessel_test.go`, `cli/internal/runner/runner_prop_test.go`, `cli/internal/runner/runner_test.go`, `cli/internal/runner/runner_tracing_prop_test.go`, and `docs/design/harness-smoke-scenarios/ws3-observability-cost.md` to cover routing, env isolation, tracing attributes, and updated smoke expectations.

## Test plan
- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #225