### PR TITLE
feat: add daemon control-plane reloads with frozen workflow snapshots

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gofrs/flock"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/daemonhealth"
@@ -37,7 +38,7 @@ func newDaemonCmd() *cobra.Command {
 			return cmdDaemon(deps.cfg, deps.q, deps.wt)
 		},
 	}
-	cmd.AddCommand(newDaemonStopCmd())
+	cmd.AddCommand(newDaemonStopCmd(), newDaemonReloadCmd())
 	return cmd
 }
 
@@ -89,6 +90,19 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+	reloadSignals := make(chan os.Signal, 1)
+	signal.Notify(reloadSignals, syscall.SIGHUP)
+	defer signal.Stop(reloadSignals)
+
+	rootDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+	runtime, err := newDaemonRuntime(rootDir, viper.GetString("config"), q, wt, cfg)
+	if err != nil {
+		return fmt.Errorf("create daemon runtime: %w", err)
+	}
+	defer runtime.cleanupRetired()
 
 	startedAt := daemonNow()
 	lastActivityAt := startedAt
@@ -101,10 +115,8 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	}
 	var backlogCount int
 	var stallChecks []daemonhealth.Check
-	scanRunner := newCmdRunner(cfg)
 	scan := func(ctx context.Context) (scanner.ScanResult, error) {
-		s := scanner.New(cfg, q, scanRunner)
-		result, err := s.Scan(ctx)
+		result, err := runtime.scan(ctx)
 		if err != nil {
 			return result, err
 		}
@@ -117,7 +129,7 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 			backlogCount = 0
 			return result, nil
 		}
-		count, err := s.BacklogCount(ctx)
+		count, err := runtime.backlogCount(ctx)
 		if err != nil {
 			slog.Warn("daemon backlog check failed", "error", err)
 			backlogCount = 0
@@ -132,39 +144,20 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		}
 		return result, nil
 	}
-	cmdRunner := newCmdRunner(cfg)
-	drainRunner, cleanupDrainRunner := buildDrainRunner(cfg, q, wt, cmdRunner)
-	defer cleanupDrainRunner()
-	drainRunner.Reporter = buildReporter(cfg, cmdRunner)
-	drainRunner.DrainBudget = drainInterval
-	commandSpan := startCommandSpan(drainRunner.Tracer, ctx, "daemon", false, cfg.StateDir)
+	commandSpan := startCommandSpan(runtime.currentHandle().drain.Tracer, ctx, "daemon", false, cfg.StateDir)
 	var commandErr error
 	defer func() {
-		finishCommandSpan(drainRunner.Tracer, commandSpan, commandErr)
+		finishCommandSpan(runtime.currentHandle().drain.Tracer, commandSpan, commandErr)
 	}()
 	if spanCtx := commandSpan.Context(); spanCtx != nil {
 		ctx = spanCtx
 	}
 	drain := func(ctx context.Context) (runner.DrainResult, error) {
-		return drainRunner.Drain(ctx)
+		return runtime.drainOnce(ctx)
 	}
 	check := func(ctx context.Context) {
-		findings := drainRunner.CheckStalledVessels(ctx)
+		findings := runtime.runChecks(ctx, runtime.currentConfig().Daemon.AutoMerge)
 		stallChecks = daemonChecksFromFindings(findings, daemonNow())
-		drainRunner.CheckWaitingVessels(ctx)
-		drainRunner.CheckHungVessels(ctx)
-		if removed := drainRunner.PruneStaleWorktrees(ctx); removed > 0 {
-			slog.Info("daemon pruned stale worktrees", "removed", removed)
-		}
-		// Cancel pending vessels whose PRs are already merged/closed,
-		// freeing concurrency slots for real work.
-		drainRunner.CancelStalePRVessels(ctx)
-		// Auto-merge: best-effort request copilot review on merge-ready
-		// vessel PRs, then admin-merge once deterministic safety checks
-		// are green.
-		if cfg.Daemon.AutoMerge {
-			autoMergeXylemPRs(ctx, cfg.Daemon)
-		}
 	}
 
 	tickHook := func(now time.Time, state daemonTickState) {
@@ -192,7 +185,20 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		}
 	}
 
-	commandErr = daemonLoop(ctx, q, drainRunner, scan, drain, check, upgrade, tickHook, scanInterval, drainInterval, upgradeInterval)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-reloadSignals:
+				if err := runtime.triggerSignalReload(); err != nil {
+					slog.Warn("daemon signal reload request failed", "error", err)
+				}
+			}
+		}
+	}()
+
+	commandErr = daemonLoop(ctx, q, runtime, scan, drain, check, upgrade, tickHook, runtime.intervals, scanInterval, drainInterval, upgradeInterval)
 	return commandErr
 }
 
@@ -303,12 +309,7 @@ const upgradeOverdueMultiplier = 3
 //     Once in_flight reaches zero, the normal path fires.
 //
 // Pass nil/zero upgrade/upgradeInterval to disable.
-func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, scan scanFunc, drain drainFunc, check checkFunc, upgrade upgradeFunc, tick tickFunc, scanInterval, drainInterval, upgradeInterval time.Duration) error {
-	tickInterval := scanInterval
-	if drainInterval < tickInterval {
-		tickInterval = drainInterval
-	}
-
+func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, scan scanFunc, drain drainFunc, check checkFunc, upgrade upgradeFunc, tick tickFunc, intervals daemonIntervalSource, scanInterval, drainInterval, upgradeInterval time.Duration) error {
 	var lastScan, lastDrain, lastUpgrade time.Time
 	var draining int32 // 0=idle, 1=running
 	var drainWg sync.WaitGroup
@@ -346,8 +347,18 @@ func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, sc
 		}
 
 		now := daemonNow()
+		currentScanInterval, currentDrainInterval := scanInterval, drainInterval
+		if intervals != nil {
+			if updatedScan, updatedDrain := intervals(); updatedScan > 0 && updatedDrain > 0 {
+				currentScanInterval, currentDrainInterval = updatedScan, updatedDrain
+			}
+		}
+		tickInterval := currentScanInterval
+		if currentDrainInterval < tickInterval {
+			tickInterval = currentDrainInterval
+		}
 
-		if now.Sub(lastScan) >= scanInterval {
+		if now.Sub(lastScan) >= currentScanInterval {
 			scanResult, err := scan(ctx)
 			if err != nil {
 				slog.Error("daemon scan failed", "error", err)
@@ -407,7 +418,7 @@ func daemonLoop(ctx context.Context, q *queue.Queue, tracker inFlightTracker, sc
 		// upgrade above handles recovery via exec().
 		phantomInFlight := upgradeElapsed >= 30*time.Minute && inFlight > 0 && daemonQueueCounts(q).running == 0
 		drainPaused := upgradeOverdue && inFlight > 0 && !phantomInFlight
-		if !drainPaused && now.Sub(lastDrain) >= drainInterval {
+		if !drainPaused && now.Sub(lastDrain) >= currentDrainInterval {
 			if atomic.CompareAndSwapInt32(&draining, 0, 1) {
 				lastDrain = now
 				drainWg.Add(1)

--- a/cli/cmd/xylem/daemon_reload.go
+++ b/cli/cmd/xylem/daemon_reload.go
@@ -1,0 +1,730 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+	"github.com/nicholls-inc/xylem/cli/internal/observability"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+	"github.com/nicholls-inc/xylem/cli/internal/scanner"
+	"github.com/nicholls-inc/xylem/cli/internal/source"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
+	"github.com/nicholls-inc/xylem/cli/internal/worktree"
+	"github.com/spf13/cobra"
+)
+
+const daemonReloadDebounce = 30 * time.Second
+
+type daemonReloadRequest struct {
+	Trigger        string    `json:"trigger"`
+	Rollback       bool      `json:"rollback,omitempty"`
+	PRNumber       int       `json:"pr_number,omitempty"`
+	MergeCommitSHA string    `json:"merge_commit_sha,omitempty"`
+	RequestedAt    time.Time `json:"requested_at"`
+}
+
+type daemonReloadLogEntry struct {
+	Trigger        string    `json:"trigger"`
+	Result         string    `json:"result"`
+	BeforeDigest   string    `json:"before_digest,omitempty"`
+	AfterDigest    string    `json:"after_digest,omitempty"`
+	PRNumber       int       `json:"pr_number,omitempty"`
+	MergeCommitSHA string    `json:"merge_commit_sha,omitempty"`
+	Rollback       bool      `json:"rollback,omitempty"`
+	Error          string    `json:"error,omitempty"`
+	Timestamp      time.Time `json:"timestamp"`
+}
+
+type daemonControlPlaneSnapshot struct {
+	Digest     string                           `json:"digest"`
+	CapturedAt time.Time                        `json:"captured_at"`
+	Files      []daemonControlPlaneSnapshotFile `json:"files"`
+}
+
+type daemonControlPlaneSnapshotFile struct {
+	Path string `json:"path"`
+	Data []byte `json:"data"`
+}
+
+type daemonRunnerHandle struct {
+	cfg      *config.Config
+	scanCmd  *realCmdRunner
+	drain    *runner.Runner
+	cleanup  func()
+	snapshot daemonControlPlaneSnapshot
+}
+
+type daemonRuntime struct {
+	rootDir    string
+	configPath string
+	q          *queue.Queue
+	wt         *worktree.Manager
+
+	mu            sync.Mutex
+	current       *daemonRunnerHandle
+	retired       []*daemonRunnerHandle
+	pending       *daemonReloadRequest
+	mergeDebounce time.Duration
+}
+
+func newDaemonReloadCmd() *cobra.Command {
+	var rollback bool
+	cmd := &cobra.Command{
+		Use:   "reload",
+		Short: "Request a live daemon reload",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmdDaemonReload(deps.cfg, rollback, signalProcessFromPIDFile)
+		},
+	}
+	cmd.Flags().BoolVar(&rollback, "rollback", false, "Restore the previously active daemon control-plane snapshot")
+	return cmd
+}
+
+func cmdDaemonReload(cfg *config.Config, rollback bool, signaler daemonProcessSignaler) error {
+	req := daemonReloadRequest{
+		Trigger:     "cli",
+		Rollback:    rollback,
+		RequestedAt: daemonNow().UTC(),
+	}
+	if rollback {
+		req.Trigger = "rollback"
+	}
+	if err := writeDaemonReloadRequest(cfg, req); err != nil {
+		return err
+	}
+	pid, signalled, err := signaler(daemonPIDPath(cfg), syscall.SIGHUP)
+	if err != nil {
+		_ = clearDaemonReloadRequest(cfg)
+		return fmt.Errorf("signal daemon reload: %w", err)
+	}
+	if !signalled {
+		_ = clearDaemonReloadRequest(cfg)
+		return fmt.Errorf("daemon not running")
+	}
+	if rollback {
+		fmt.Printf("Requested daemon rollback via pid %d.\n", pid)
+	} else {
+		fmt.Printf("Requested daemon reload via pid %d.\n", pid)
+	}
+	return nil
+}
+
+func newDaemonRuntime(rootDir, configPath string, q *queue.Queue, wt *worktree.Manager, cfg *config.Config) (*daemonRuntime, error) {
+	snapshot, err := captureDaemonControlPlaneSnapshot(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("capture daemon control-plane snapshot: %w", err)
+	}
+	handle, err := buildDaemonRunnerHandle(cfg, q, wt, snapshot)
+	if err != nil {
+		return nil, err
+	}
+	rt := &daemonRuntime{
+		rootDir:       rootDir,
+		configPath:    configPath,
+		q:             q,
+		wt:            wt,
+		current:       handle,
+		mergeDebounce: daemonReloadDebounce,
+	}
+	if err := saveDaemonControlPlaneSnapshot(daemonCurrentSnapshotPath(cfg), snapshot); err != nil {
+		handle.cleanup()
+		return nil, err
+	}
+	return rt, nil
+}
+
+func (r *daemonRuntime) request(req daemonReloadRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if req.RequestedAt.IsZero() {
+		req.RequestedAt = daemonNow().UTC()
+	}
+	if req.Trigger == "merge" && r.pending != nil && r.pending.Trigger == "merge" {
+		*r.pending = req
+		return
+	}
+	r.pending = &req
+}
+
+func (r *daemonRuntime) requestControlPlaneMerge(event source.ControlPlaneMergeEvent) {
+	r.request(daemonReloadRequest{
+		Trigger:        "merge",
+		PRNumber:       event.PRNumber,
+		MergeCommitSHA: event.MergeCommitSHA,
+		RequestedAt:    daemonNow().UTC(),
+	})
+}
+
+func (r *daemonRuntime) scan(ctx context.Context) (scanner.ScanResult, error) {
+	if err := r.processPendingReload(ctx); err != nil {
+		slog.Warn("daemon reload failed", "error", err)
+	}
+	handle := r.currentHandle()
+	s := scanner.New(handle.cfg, r.q, handle.scanCmd)
+	s.OnControlPlaneMerge = r.requestControlPlaneMerge
+	return s.Scan(ctx)
+}
+
+func (r *daemonRuntime) backlogCount(ctx context.Context) (int, error) {
+	handle := r.currentHandle()
+	s := scanner.New(handle.cfg, r.q, handle.scanCmd)
+	s.OnControlPlaneMerge = r.requestControlPlaneMerge
+	return s.BacklogCount(ctx)
+}
+
+func (r *daemonRuntime) drainOnce(ctx context.Context) (runner.DrainResult, error) {
+	handle := r.currentHandle()
+	scanInterval, drainInterval := parseDaemonIntervals(handle.cfg.Daemon)
+	_ = scanInterval
+	handle.drain.DrainBudget = drainInterval
+	return handle.drain.Drain(ctx)
+}
+
+func (r *daemonRuntime) runChecks(ctx context.Context, autoMerge bool) []runner.StallFinding {
+	if err := r.processPendingReload(ctx); err != nil {
+		slog.Warn("daemon reload failed", "error", err)
+	}
+	handles := r.allHandles()
+	var findings []runner.StallFinding
+	for _, handle := range handles {
+		findings = append(findings, handle.drain.CheckStalledVessels(ctx)...)
+		handle.drain.CheckWaitingVessels(ctx)
+		handle.drain.CheckHungVessels(ctx)
+	}
+	current := r.currentHandle()
+	if removed := current.drain.PruneStaleWorktrees(ctx); removed > 0 {
+		slog.Info("daemon pruned stale worktrees", "removed", removed)
+	}
+	current.drain.CancelStalePRVessels(ctx)
+	if autoMerge {
+		autoMergeXylemPRs(ctx, current.cfg.Daemon)
+	}
+	r.cleanupRetired()
+	return findings
+}
+
+func (r *daemonRuntime) Wait() runner.DrainResult {
+	for _, handle := range r.allHandles() {
+		handle.drain.Wait()
+	}
+	return runner.DrainResult{}
+}
+
+func (r *daemonRuntime) InFlightCount() int {
+	total := 0
+	for _, handle := range r.allHandles() {
+		total += handle.drain.InFlightCount()
+	}
+	return total
+}
+
+func (r *daemonRuntime) intervals() (time.Duration, time.Duration) {
+	handle := r.currentHandle()
+	return parseDaemonIntervals(handle.cfg.Daemon)
+}
+
+func (r *daemonRuntime) currentConfig() *config.Config {
+	return r.currentHandle().cfg
+}
+
+func (r *daemonRuntime) currentHandle() *daemonRunnerHandle {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.current
+}
+
+func (r *daemonRuntime) allHandles() []*daemonRunnerHandle {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	handles := make([]*daemonRunnerHandle, 0, 1+len(r.retired))
+	handles = append(handles, r.current)
+	handles = append(handles, r.retired...)
+	return handles
+}
+
+func (r *daemonRuntime) processPendingReload(ctx context.Context) error {
+	r.mu.Lock()
+	req := r.pending
+	if req == nil {
+		r.mu.Unlock()
+		return nil
+	}
+	if req.Trigger == "merge" && daemonNow().Sub(req.RequestedAt) < r.mergeDebounce {
+		r.mu.Unlock()
+		return nil
+	}
+	r.pending = nil
+	r.mu.Unlock()
+	return r.applyReload(ctx, *req)
+}
+
+func (r *daemonRuntime) triggerSignalReload() error {
+	req, ok, err := readDaemonReloadRequest(r.currentHandle().cfg)
+	if err != nil {
+		return err
+	}
+	if ok {
+		if err := clearDaemonReloadRequest(r.currentHandle().cfg); err != nil {
+			return err
+		}
+		r.request(req)
+		return nil
+	}
+	r.request(daemonReloadRequest{
+		Trigger:     "signal",
+		RequestedAt: daemonNow().UTC(),
+	})
+	return nil
+}
+
+func (r *daemonRuntime) applyReload(ctx context.Context, req daemonReloadRequest) error {
+	before := r.currentHandle()
+	beforeDigest := before.snapshot.Digest
+	opDecision := policy.Evaluate(policy.Ops, policy.OpReloadDaemon)
+	result := "applied"
+	afterDigest := beforeDigest
+	var reloadErr error
+	var nextSnapshot daemonControlPlaneSnapshot
+	var nextCfg *config.Config
+
+	if !opDecision.Allowed {
+		result = "denied"
+		reloadErr = fmt.Errorf("reload daemon denied by policy %s", opDecision.Rule)
+	} else if req.Rollback {
+		nextSnapshot, nextCfg, reloadErr = r.loadRollbackCandidate()
+		if reloadErr == nil {
+			afterDigest = nextSnapshot.Digest
+		}
+		result = "rolled_back"
+	} else {
+		nextSnapshot, nextCfg, reloadErr = r.loadCurrentCandidate()
+		if reloadErr == nil {
+			afterDigest = nextSnapshot.Digest
+		}
+	}
+	if reloadErr != nil {
+		result = "rejected"
+	}
+
+	handle := before
+	if reloadErr == nil {
+		handle, reloadErr = buildDaemonRunnerHandle(nextCfg, r.q, r.wt, nextSnapshot)
+		if reloadErr != nil {
+			result = "rejected"
+		}
+	}
+
+	if reloadErr == nil {
+		swapErr := r.q.WithWriteLock(func() error {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			if r.current != nil {
+				r.retired = append(r.retired, r.current)
+			}
+			r.current = handle
+			if err := saveDaemonControlPlaneSnapshot(daemonRollbackSnapshotPath(nextCfg), before.snapshot); err != nil {
+				return err
+			}
+			return saveDaemonControlPlaneSnapshot(daemonCurrentSnapshotPath(nextCfg), nextSnapshot)
+		})
+		if swapErr != nil {
+			handle.cleanup()
+			reloadErr = fmt.Errorf("swap daemon runtime: %w", swapErr)
+			result = "rejected"
+		}
+	}
+
+	if err := appendDaemonReloadAudit(r.currentHandle().cfg, req, result, beforeDigest, afterDigest, reloadErr); err != nil {
+		slog.Warn("daemon reload audit failed", "error", err)
+	}
+	if err := appendDaemonReloadLog(r.currentHandle().cfg, daemonReloadLogEntry{
+		Trigger:        req.Trigger,
+		Result:         result,
+		BeforeDigest:   beforeDigest,
+		AfterDigest:    afterDigest,
+		PRNumber:       req.PRNumber,
+		MergeCommitSHA: req.MergeCommitSHA,
+		Rollback:       req.Rollback,
+		Error:          errorString(reloadErr),
+		Timestamp:      daemonNow().UTC(),
+	}); err != nil {
+		slog.Warn("daemon reload log failed", "error", err)
+	}
+	recordDaemonReloadSpan(ctx, r.currentHandle().drain.Tracer, req, result, beforeDigest, afterDigest, reloadErr)
+	if reloadErr != nil {
+		return reloadErr
+	}
+	r.cleanupRetired()
+	return nil
+}
+
+func (r *daemonRuntime) loadCurrentCandidate() (daemonControlPlaneSnapshot, *config.Config, error) {
+	snapshot, err := captureDaemonControlPlaneSnapshot(r.rootDir)
+	if err != nil {
+		return daemonControlPlaneSnapshot{}, nil, err
+	}
+	cfg, err := validateDaemonReloadCandidate(r.rootDir, r.configPath)
+	if err != nil {
+		return daemonControlPlaneSnapshot{}, nil, err
+	}
+	return snapshot, cfg, nil
+}
+
+func (r *daemonRuntime) loadRollbackCandidate() (daemonControlPlaneSnapshot, *config.Config, error) {
+	snapshot, err := loadDaemonControlPlaneSnapshot(daemonRollbackSnapshotPath(r.currentHandle().cfg))
+	if err != nil {
+		return daemonControlPlaneSnapshot{}, nil, fmt.Errorf("load rollback snapshot: %w", err)
+	}
+	currentSnapshot, err := captureDaemonControlPlaneSnapshot(r.rootDir)
+	if err != nil {
+		return daemonControlPlaneSnapshot{}, nil, fmt.Errorf("capture current snapshot before rollback: %w", err)
+	}
+	if err := restoreDaemonControlPlaneSnapshot(r.rootDir, snapshot); err != nil {
+		return daemonControlPlaneSnapshot{}, nil, fmt.Errorf("restore rollback snapshot: %w", err)
+	}
+	cfg, cfgErr := validateDaemonReloadCandidate(r.rootDir, r.configPath)
+	if cfgErr != nil {
+		if restoreErr := restoreDaemonControlPlaneSnapshot(r.rootDir, currentSnapshot); restoreErr != nil {
+			return daemonControlPlaneSnapshot{}, nil, fmt.Errorf("restore rollback snapshot: %w (restore current: %v)", cfgErr, restoreErr)
+		}
+		return daemonControlPlaneSnapshot{}, nil, cfgErr
+	}
+	return snapshot, cfg, nil
+}
+
+func (r *daemonRuntime) cleanupRetired() {
+	r.mu.Lock()
+	var active []*daemonRunnerHandle
+	var idle []*daemonRunnerHandle
+	for _, handle := range r.retired {
+		if handle.drain.InFlightCount() == 0 {
+			idle = append(idle, handle)
+			continue
+		}
+		active = append(active, handle)
+	}
+	r.retired = active
+	r.mu.Unlock()
+
+	for _, handle := range idle {
+		handle.drain.Wait()
+		handle.cleanup()
+	}
+}
+
+func buildDaemonRunnerHandle(cfg *config.Config, q *queue.Queue, wt *worktree.Manager, snapshot daemonControlPlaneSnapshot) (*daemonRunnerHandle, error) {
+	cmdRunner := newCmdRunner(cfg)
+	drainRunner, cleanup := buildDrainRunner(cfg, q, wt, cmdRunner)
+	drainRunner.Reporter = buildReporter(cfg, cmdRunner)
+	_, drainInterval := parseDaemonIntervals(cfg.Daemon)
+	drainRunner.DrainBudget = drainInterval
+	return &daemonRunnerHandle{
+		cfg:      cfg,
+		scanCmd:  newCmdRunner(cfg),
+		drain:    drainRunner,
+		cleanup:  cleanup,
+		snapshot: snapshot,
+	}, nil
+}
+
+func validateDaemonReloadCandidate(rootDir, configPath string) (*config.Config, error) {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+	workflowsDir := filepath.Join(rootDir, ".xylem", "workflows")
+	if _, err := os.Stat(workflowsDir); err != nil {
+		if errorsIsNotExist(err) {
+			return cfg, nil
+		}
+		return nil, fmt.Errorf("stat workflows dir: %w", err)
+	}
+	if err := filepath.WalkDir(workflowsDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		switch strings.ToLower(filepath.Ext(path)) {
+		case ".yaml", ".yml":
+			_, _, err := workflow.LoadWithDigest(path)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("validate workflows: %w", err)
+	}
+	return cfg, nil
+}
+
+func daemonReloadRequestPath(cfg *config.Config) string {
+	return config.RuntimePath(cfg.StateDir, "daemon-reload-request.json")
+}
+
+func daemonReloadLogPath(cfg *config.Config) string {
+	return config.RuntimePath(cfg.StateDir, "daemon-reload-log.jsonl")
+}
+
+func daemonReloadAuditPath(cfg *config.Config) string {
+	return config.RuntimePath(cfg.StateDir, "daemon-reload-audit.jsonl")
+}
+
+func daemonCurrentSnapshotPath(cfg *config.Config) string {
+	return config.RuntimePath(cfg.StateDir, "daemon-control-plane-current.json")
+}
+
+func daemonRollbackSnapshotPath(cfg *config.Config) string {
+	return config.RuntimePath(cfg.StateDir, "daemon-control-plane-rollback.json")
+}
+
+func writeDaemonReloadRequest(cfg *config.Config, req daemonReloadRequest) error {
+	if err := os.MkdirAll(filepath.Dir(daemonReloadRequestPath(cfg)), 0o755); err != nil {
+		return fmt.Errorf("write daemon reload request: create state dir: %w", err)
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("write daemon reload request: marshal: %w", err)
+	}
+	if err := os.WriteFile(daemonReloadRequestPath(cfg), data, 0o644); err != nil {
+		return fmt.Errorf("write daemon reload request: %w", err)
+	}
+	return nil
+}
+
+func readDaemonReloadRequest(cfg *config.Config) (daemonReloadRequest, bool, error) {
+	data, err := os.ReadFile(daemonReloadRequestPath(cfg))
+	if err != nil {
+		if errorsIsNotExist(err) {
+			return daemonReloadRequest{}, false, nil
+		}
+		return daemonReloadRequest{}, false, fmt.Errorf("read daemon reload request: %w", err)
+	}
+	var req daemonReloadRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return daemonReloadRequest{}, false, fmt.Errorf("read daemon reload request: decode: %w", err)
+	}
+	return req, true, nil
+}
+
+func clearDaemonReloadRequest(cfg *config.Config) error {
+	if err := os.Remove(daemonReloadRequestPath(cfg)); err != nil && !errorsIsNotExist(err) {
+		return fmt.Errorf("clear daemon reload request: %w", err)
+	}
+	return nil
+}
+
+func appendDaemonReloadLog(cfg *config.Config, entry daemonReloadLogEntry) error {
+	if err := os.MkdirAll(filepath.Dir(daemonReloadLogPath(cfg)), 0o755); err != nil {
+		return fmt.Errorf("append daemon reload log: create state dir: %w", err)
+	}
+	f, err := os.OpenFile(daemonReloadLogPath(cfg), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("append daemon reload log: open: %w", err)
+	}
+	defer f.Close()
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("append daemon reload log: marshal: %w", err)
+	}
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("append daemon reload log: write: %w", err)
+	}
+	return nil
+}
+
+func appendDaemonReloadAudit(cfg *config.Config, req daemonReloadRequest, result, beforeDigest, afterDigest string, reloadErr error) error {
+	audit := intermediary.NewAuditLog(daemonReloadAuditPath(cfg))
+	decision := intermediary.Allow
+	if reloadErr != nil {
+		decision = intermediary.Deny
+	}
+	return audit.Append(intermediary.AuditEntry{
+		Intent: intermediary.Intent{
+			Action:        string(policy.OpReloadDaemon),
+			Resource:      "daemon",
+			AgentID:       "daemon",
+			Justification: req.Trigger,
+			Metadata: map[string]string{
+				"result":           result,
+				"before_digest":    beforeDigest,
+				"after_digest":     afterDigest,
+				"rollback":         strconv.FormatBool(req.Rollback),
+				"pr_number":        strconv.Itoa(req.PRNumber),
+				"merge_commit_sha": req.MergeCommitSHA,
+			},
+		},
+		Decision:  decision,
+		Timestamp: daemonNow().UTC(),
+		Error:     errorString(reloadErr),
+	})
+}
+
+func recordDaemonReloadSpan(ctx context.Context, tracer *observability.Tracer, req daemonReloadRequest, result, beforeDigest, afterDigest string, err error) {
+	if tracer == nil {
+		return
+	}
+	span := tracer.StartSpan(ctx, "daemon.reload.applied", []observability.SpanAttribute{
+		{Key: "reload.trigger", Value: req.Trigger},
+		{Key: "reload.result", Value: result},
+		{Key: "reload.before_digest", Value: beforeDigest},
+		{Key: "reload.after_digest", Value: afterDigest},
+		{Key: "reload.pr_number", Value: strconv.Itoa(req.PRNumber)},
+		{Key: "reload.merge_commit_sha", Value: req.MergeCommitSHA},
+		{Key: "reload.rollback", Value: strconv.FormatBool(req.Rollback)},
+	})
+	if err != nil {
+		span.RecordError(err)
+	}
+	span.End()
+}
+
+func captureDaemonControlPlaneSnapshot(rootDir string) (daemonControlPlaneSnapshot, error) {
+	paths, err := daemonControlPlaneFiles(rootDir)
+	if err != nil {
+		return daemonControlPlaneSnapshot{}, err
+	}
+	files := make([]daemonControlPlaneSnapshotFile, 0, len(paths))
+	hasher := sha256.New()
+	for _, path := range paths {
+		data, err := os.ReadFile(filepath.Join(rootDir, path))
+		if err != nil {
+			return daemonControlPlaneSnapshot{}, fmt.Errorf("read control-plane file %q: %w", path, err)
+		}
+		files = append(files, daemonControlPlaneSnapshotFile{Path: path, Data: data})
+		_, _ = hasher.Write([]byte(path))
+		_, _ = hasher.Write([]byte{0})
+		_, _ = hasher.Write(data)
+		_, _ = hasher.Write([]byte{0})
+	}
+	return daemonControlPlaneSnapshot{
+		Digest:     fmt.Sprintf("cp-%x", hasher.Sum(nil)),
+		CapturedAt: daemonNow().UTC(),
+		Files:      files,
+	}, nil
+}
+
+func restoreDaemonControlPlaneSnapshot(rootDir string, snapshot daemonControlPlaneSnapshot) error {
+	existing, err := daemonControlPlaneFiles(rootDir)
+	if err != nil {
+		return err
+	}
+	keep := make(map[string]struct{}, len(snapshot.Files))
+	for _, file := range snapshot.Files {
+		keep[file.Path] = struct{}{}
+		fullPath := filepath.Join(rootDir, file.Path)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			return fmt.Errorf("restore control-plane snapshot: create dir for %q: %w", file.Path, err)
+		}
+		if err := os.WriteFile(fullPath, file.Data, 0o644); err != nil {
+			return fmt.Errorf("restore control-plane snapshot: write %q: %w", file.Path, err)
+		}
+	}
+	for _, path := range existing {
+		if _, ok := keep[path]; ok {
+			continue
+		}
+		if err := os.Remove(filepath.Join(rootDir, path)); err != nil && !errorsIsNotExist(err) {
+			return fmt.Errorf("restore control-plane snapshot: remove %q: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func saveDaemonControlPlaneSnapshot(path string, snapshot daemonControlPlaneSnapshot) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("save control-plane snapshot: create state dir: %w", err)
+	}
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		return fmt.Errorf("save control-plane snapshot: marshal: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("save control-plane snapshot: %w", err)
+	}
+	return nil
+}
+
+func loadDaemonControlPlaneSnapshot(path string) (daemonControlPlaneSnapshot, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return daemonControlPlaneSnapshot{}, err
+	}
+	var snapshot daemonControlPlaneSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return daemonControlPlaneSnapshot{}, fmt.Errorf("decode control-plane snapshot: %w", err)
+	}
+	slices.SortFunc(snapshot.Files, func(a, b daemonControlPlaneSnapshotFile) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+	return snapshot, nil
+}
+
+func daemonControlPlaneFiles(rootDir string) ([]string, error) {
+	paths := make([]string, 0, 8)
+	for _, file := range []string{".xylem.yml", ".xylem/HARNESS.md"} {
+		if _, err := os.Stat(filepath.Join(rootDir, file)); err == nil {
+			paths = append(paths, file)
+		} else if err != nil && !errorsIsNotExist(err) {
+			return nil, fmt.Errorf("stat control-plane file %q: %w", file, err)
+		}
+	}
+	for _, dir := range []string{filepath.Join(".xylem", "workflows"), filepath.Join(".xylem", "prompts")} {
+		fullDir := filepath.Join(rootDir, dir)
+		if _, err := os.Stat(fullDir); err != nil {
+			if errorsIsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("stat control-plane dir %q: %w", dir, err)
+		}
+		if err := filepath.WalkDir(fullDir, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				return nil
+			}
+			rel, err := filepath.Rel(rootDir, path)
+			if err != nil {
+				return err
+			}
+			paths = append(paths, filepath.ToSlash(rel))
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("walk control-plane dir %q: %w", dir, err)
+		}
+	}
+	slices.Sort(paths)
+	return paths, nil
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func errorsIsNotExist(err error) bool {
+	return err != nil && os.IsNotExist(err)
+}
+
+type daemonIntervalSource func() (time.Duration, time.Duration)

--- a/cli/cmd/xylem/daemon_reload_prop_test.go
+++ b/cli/cmd/xylem/daemon_reload_prop_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropDaemonReloadLogEntryRoundTrip(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		entry := daemonReloadLogEntry{
+			Trigger:        rapid.StringMatching(`[a-z-]{1,12}`).Draw(rt, "trigger"),
+			Result:         rapid.StringMatching(`[a-z_]{1,12}`).Draw(rt, "result"),
+			BeforeDigest:   rapid.StringMatching(`[a-z0-9-]{0,20}`).Draw(rt, "before_digest"),
+			AfterDigest:    rapid.StringMatching(`[a-z0-9-]{0,20}`).Draw(rt, "after_digest"),
+			PRNumber:       rapid.IntRange(0, 100000).Draw(rt, "pr_number"),
+			MergeCommitSHA: rapid.StringMatching(`[a-f0-9]{0,16}`).Draw(rt, "merge_commit_sha"),
+			Rollback:       rapid.Bool().Draw(rt, "rollback"),
+			Error:          rapid.StringMatching(`[ -~]{0,40}`).Draw(rt, "error"),
+			Timestamp:      time.Unix(rapid.Int64Range(0, 1<<20).Draw(rt, "timestamp"), 0).UTC(),
+		}
+
+		data, err := json.Marshal(entry)
+		if err != nil {
+			rt.Fatalf("Marshal() error = %v", err)
+		}
+		var decoded daemonReloadLogEntry
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			rt.Fatalf("Unmarshal() error = %v", err)
+		}
+		if decoded != entry {
+			rt.Fatalf("round trip mismatch: got %#v want %#v", decoded, entry)
+		}
+	})
+}

--- a/cli/cmd/xylem/daemon_reload_test.go
+++ b/cli/cmd/xylem/daemon_reload_test.go
@@ -403,6 +403,10 @@ func (m *smokeReloadCmdRunner) RunPhase(_ context.Context, _ string, stdin io.Re
 	return []byte("ok"), nil
 }
 
+func (m *smokeReloadCmdRunner) RunPhaseWithEnv(_ context.Context, _ string, _ []string, stdin io.Reader, _ string, _ ...string) ([]byte, error) {
+	return m.RunPhase(context.Background(), "", stdin, "")
+}
+
 func (m *smokeReloadCmdRunner) phasePrompts() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/cli/cmd/xylem/daemon_reload_test.go
+++ b/cli/cmd/xylem/daemon_reload_test.go
@@ -1,0 +1,452 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+	"github.com/nicholls-inc/xylem/cli/internal/source"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
+	"github.com/nicholls-inc/xylem/cli/internal/worktree"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmdDaemonReloadWritesRequestAndSignals(t *testing.T) {
+	cfg := &config.Config{StateDir: t.TempDir()}
+	var gotPIDPath string
+	var gotSig os.Signal
+
+	err := cmdDaemonReload(cfg, false, func(pidPath string, sig syscall.Signal) (int, bool, error) {
+		gotPIDPath = pidPath
+		gotSig = sig
+		return 123, true, nil
+	})
+	require.NoError(t, err)
+
+	req, ok, err := readDaemonReloadRequest(cfg)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "cli", req.Trigger)
+	assert.False(t, req.Rollback)
+	assert.Equal(t, daemonPIDPath(cfg), gotPIDPath)
+	assert.Equal(t, syscall.SIGHUP, gotSig)
+}
+
+func TestCmdDaemonReloadClearsRequestWhenDaemonMissing(t *testing.T) {
+	cfg := &config.Config{StateDir: t.TempDir()}
+
+	err := cmdDaemonReload(cfg, false, func(string, syscall.Signal) (int, bool, error) {
+		return 0, false, nil
+	})
+	require.Error(t, err)
+
+	_, ok, readErr := readDaemonReloadRequest(cfg)
+	require.NoError(t, readErr)
+	assert.False(t, ok)
+}
+
+func TestDaemonRuntimeRejectsInvalidReload(t *testing.T) {
+	rootDir, configPath, cfg := writeDaemonReloadRepo(t, "# Harness A\n")
+	q := queue.New(filepath.Join(cfg.StateDir, "queue.jsonl"))
+	rt, err := newDaemonRuntime(rootDir, configPath, q, worktree.New(rootDir, newCmdRunner(cfg)), cfg)
+	require.NoError(t, err)
+
+	beforeDigest := rt.currentHandle().snapshot.Digest
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, ".xylem", "workflows", "fix-bug.yaml"), []byte("name: fix-bug\nphases:\n  - name: bad name\n"), 0o644))
+
+	rt.request(daemonReloadRequest{Trigger: "cli", RequestedAt: daemonNow().Add(-time.Minute)})
+	err = rt.processPendingReload(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, beforeDigest, rt.currentHandle().snapshot.Digest)
+
+	logs := readDaemonReloadLogEntries(t, cfg)
+	require.NotEmpty(t, logs)
+	assert.Equal(t, "rejected", logs[len(logs)-1].Result)
+}
+
+func TestDaemonRuntimeRollbackRestoresPriorSnapshot(t *testing.T) {
+	rootDir, configPath, cfg := writeDaemonReloadRepo(t, "# Harness A\n")
+	q := queue.New(filepath.Join(cfg.StateDir, "queue.jsonl"))
+	rt, err := newDaemonRuntime(rootDir, configPath, q, worktree.New(rootDir, newCmdRunner(cfg)), cfg)
+	require.NoError(t, err)
+
+	beforeDigest := rt.currentHandle().snapshot.Digest
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, ".xylem", "HARNESS.md"), []byte("version B"), 0o644))
+
+	rt.request(daemonReloadRequest{Trigger: "cli", RequestedAt: daemonNow().Add(-time.Minute)})
+	require.NoError(t, rt.processPendingReload(context.Background()))
+	afterDigest := rt.currentHandle().snapshot.Digest
+	assert.NotEqual(t, beforeDigest, afterDigest)
+
+	rt.request(daemonReloadRequest{Trigger: "rollback", Rollback: true, RequestedAt: daemonNow().Add(-time.Minute)})
+	require.NoError(t, rt.processPendingReload(context.Background()))
+	assert.Equal(t, beforeDigest, rt.currentHandle().snapshot.Digest)
+
+	harness, err := os.ReadFile(filepath.Join(rootDir, ".xylem", "HARNESS.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "# Harness A\n", string(harness))
+}
+
+func TestDaemonRuntimeRetainsBusyRunnerAcrossReload(t *testing.T) {
+	rootDir, configPath, cfg := writeDaemonReloadRepo(t, "# Harness A\n")
+	q := queue.New(filepath.Join(cfg.StateDir, "queue.jsonl"))
+	rt, err := newDaemonRuntime(rootDir, configPath, q, worktree.New(rootDir, newCmdRunner(cfg)), cfg)
+	require.NoError(t, err)
+
+	markRunnerInFlight(t, rt.currentHandle().drain, 1)
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, ".xylem", "HARNESS.md"), []byte("version B"), 0o644))
+
+	rt.request(daemonReloadRequest{Trigger: "merge", RequestedAt: daemonNow().Add(-time.Minute)})
+	require.NoError(t, rt.processPendingReload(context.Background()))
+
+	rt.mu.Lock()
+	retired := len(rt.retired)
+	oldHandle := rt.retired[0]
+	rt.mu.Unlock()
+	require.Equal(t, 1, retired)
+
+	markRunnerInFlight(t, oldHandle.drain, 0)
+	rt.cleanupRetired()
+
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	assert.Empty(t, rt.retired)
+}
+
+func TestValidateDaemonReloadCandidateRejectsInvalidWorkflow(t *testing.T) {
+	rootDir, configPath, _ := writeDaemonReloadRepo(t, "# Harness A\n")
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, ".xylem", "workflows", "fix-bug.yaml"), []byte("name: fix-bug\nphases:\n  - name: Bad\n"), 0o644))
+
+	_, err := validateDaemonReloadCandidate(rootDir, configPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validate workflows")
+}
+
+func TestSmoke_S5_DaemonReloadPreservesFrozenWorkflowSnapshot(t *testing.T) {
+	rootDir, configPath, cfg := writeDaemonReloadRepo(t, "# Harness A\n")
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(rootDir))
+	defer func() {
+		require.NoError(t, os.Chdir(oldWd))
+	}()
+
+	planPromptPath := filepath.Join(rootDir, ".xylem", "prompts", "fix-bug-plan.md")
+	implementPromptPath := filepath.Join(rootDir, ".xylem", "prompts", "fix-bug-implement.md")
+	mutatedPromptPath := filepath.Join(rootDir, ".xylem", "prompts", "fix-bug-mutated.md")
+	require.NoError(t, os.WriteFile(planPromptPath, []byte("Create plan\n"), 0o644))
+	require.NoError(t, os.WriteFile(implementPromptPath, []byte("Implement after approval\n"), 0o644))
+	require.NoError(t, os.WriteFile(mutatedPromptPath, []byte("Mutated after reload\n"), 0o644))
+
+	workflowPath := filepath.Join(rootDir, ".xylem", "workflows", "fix-bug.yaml")
+	originalWorkflow := []byte(strings.Join([]string{
+		"name: fix-bug",
+		"phases:",
+		"  - name: plan",
+		"    prompt_file: " + planPromptPath,
+		"    max_turns: 1",
+		"    gate:",
+		"      type: label",
+		"      wait_for: plan-approved",
+		"      timeout: 24h",
+		"  - name: implement",
+		"    prompt_file: " + implementPromptPath,
+		"    max_turns: 1",
+		"",
+	}, "\n"))
+	require.NoError(t, os.WriteFile(workflowPath, originalWorkflow, 0o644))
+
+	q := queue.New(filepath.Join(cfg.StateDir, "queue.jsonl"))
+	rt, err := newDaemonRuntime(rootDir, configPath, q, worktree.New(rootDir, newCmdRunner(cfg)), cfg)
+	require.NoError(t, err)
+	beforeDigest := rt.currentHandle().snapshot.Digest
+
+	cmdRunner := newSmokeReloadCmdRunner()
+	cmdRunner.set([]byte(`{"labels":[{"name":"plan-approved"}]}`),
+		"gh", "issue", "view", "1", "--repo", "owner/name", "--json", "labels")
+	wireSmokeReloadHandle(rt.currentHandle(), cmdRunner, rootDir)
+
+	_, err = q.Enqueue(queue.Vessel{
+		ID:       "issue-1",
+		Source:   "github-issue",
+		Ref:      "https://github.com/owner/name/issues/1",
+		Workflow: "fix-bug",
+		Meta: map[string]string{
+			"issue_num":    "1",
+			"source_repo":  "owner/name",
+			"issue_title":  "Bug title",
+			"issue_body":   "Bug body",
+			"issue_labels": "bug",
+		},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	first, err := rt.currentHandle().drain.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, first.Launched)
+
+	waiting, err := q.FindByID("issue-1")
+	require.NoError(t, err)
+	require.NotNil(t, waiting)
+	require.Equal(t, queue.StateWaiting, waiting.State)
+	require.NotEmpty(t, waiting.WorkflowDigest)
+
+	snapshotPath := config.RuntimePath(cfg.StateDir, "phases", waiting.ID, "workflow", waiting.Workflow+".yaml")
+	snapshotBytes, err := os.ReadFile(snapshotPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalWorkflow, snapshotBytes)
+
+	configBytes, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	updatedConfig := strings.Replace(string(configBytes), "drain_interval: 1s", "drain_interval: 2s", 1)
+	require.NoError(t, os.WriteFile(configPath, []byte(updatedConfig), 0o644))
+
+	mutatedWorkflow := []byte(strings.Join([]string{
+		"name: fix-bug",
+		"phases:",
+		"  - name: plan",
+		"    prompt_file: " + planPromptPath,
+		"    max_turns: 1",
+		"    gate:",
+		"      type: label",
+		"      wait_for: plan-approved",
+		"      timeout: 24h",
+		"  - name: mutated",
+		"    prompt_file: " + mutatedPromptPath,
+		"    max_turns: 1",
+		"",
+	}, "\n"))
+	require.NoError(t, os.WriteFile(workflowPath, mutatedWorkflow, 0o644))
+
+	cmdRunner.set([]byte(`[{"number":42,"title":"reload control plane","url":"https://github.com/owner/name/pull/42","mergeCommit":{"oid":"abcdef1234567890"},"headRefName":"control-plane"}]`),
+		"gh", "pr", "list", "--repo", "owner/name", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+	cmdRunner.set([]byte(`{"files":[{"path":".xylem.yml"},{"path":".xylem/workflows/fix-bug.yaml"}]}`),
+		"gh", "pr", "view", "42", "--repo", "owner/name", "--json", "files")
+
+	mergeSource := &source.GitHubMerge{
+		Repo:                "owner/name",
+		Tasks:               map[string]source.MergeTask{},
+		Queue:               q,
+		CmdRunner:           cmdRunner,
+		OnControlPlaneMerge: rt.requestControlPlaneMerge,
+	}
+	_, err = mergeSource.Scan(context.Background())
+	require.NoError(t, err)
+
+	rt.mergeDebounce = 0
+	require.NoError(t, rt.processPendingReload(context.Background()))
+	assert.Equal(t, "2s", rt.currentConfig().Daemon.DrainInterval)
+	assert.NotEqual(t, beforeDigest, rt.currentHandle().snapshot.Digest)
+
+	wireSmokeReloadHandle(rt.currentHandle(), cmdRunner, rootDir)
+
+	logs := readDaemonReloadLogEntries(t, cfg)
+	require.NotEmpty(t, logs)
+	lastLog := logs[len(logs)-1]
+	assert.Equal(t, "merge", lastLog.Trigger)
+	assert.Equal(t, "applied", lastLog.Result)
+	assert.Equal(t, beforeDigest, lastLog.BeforeDigest)
+	assert.Equal(t, rt.currentHandle().snapshot.Digest, lastLog.AfterDigest)
+	assert.Equal(t, 42, lastLog.PRNumber)
+	assert.Equal(t, "abcdef1234567890", lastLog.MergeCommitSHA)
+
+	rt.runChecks(context.Background(), false)
+
+	resumed, err := q.FindByID("issue-1")
+	require.NoError(t, err)
+	require.NotNil(t, resumed)
+	require.Equal(t, queue.StatePending, resumed.State)
+
+	second, err := rt.currentHandle().drain.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, second.Completed)
+
+	final, err := q.FindByID("issue-1")
+	require.NoError(t, err)
+	require.NotNil(t, final)
+	assert.Equal(t, queue.StateCompleted, final.State)
+	assert.Equal(t, waiting.WorkflowDigest, final.WorkflowDigest)
+
+	_, snapshotDigest, err := workflow.LoadWithDigest(snapshotPath)
+	require.NoError(t, err)
+	assert.Equal(t, waiting.WorkflowDigest, snapshotDigest)
+
+	require.Len(t, cmdRunner.phasePrompts(), 2)
+	assert.Contains(t, cmdRunner.phasePrompts()[0], "Create plan")
+	assert.Contains(t, cmdRunner.phasePrompts()[1], "Implement after approval")
+	assert.NotContains(t, cmdRunner.phasePrompts()[1], "Mutated after reload")
+}
+
+func writeDaemonReloadRepo(t *testing.T, harnessBody string) (string, string, *config.Config) {
+	t.Helper()
+
+	rootDir := t.TempDir()
+	stateDir := filepath.Join(rootDir, ".xylem")
+	promptPath := filepath.Join(rootDir, ".xylem", "prompts", "fix-bug.md")
+	workflowPath := filepath.Join(rootDir, ".xylem", "workflows", "fix-bug.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(workflowPath), 0o755))
+	require.NoError(t, os.WriteFile(promptPath, []byte("Fix the bug.\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, ".xylem", "HARNESS.md"), []byte(harnessBody), 0o644))
+	require.NoError(t, os.WriteFile(workflowPath, []byte("name: fix-bug\nphases:\n  - name: analyze\n    prompt_file: "+promptPath+"\n    max_turns: 1\n"), 0o644))
+
+	configPath := filepath.Join(rootDir, ".xylem.yml")
+	configYAML := strings.Join([]string{
+		"repo: owner/name",
+		"tasks:",
+		"  fix-bugs:",
+		"    labels: [bug]",
+		"    workflow: fix-bug",
+		"state_dir: " + stateDir,
+		"claude:",
+		"  command: claude",
+		"  default_model: claude-sonnet-4-6",
+		"daemon:",
+		"  scan_interval: 1s",
+		"  drain_interval: 1s",
+		"",
+	}, "\n")
+	require.NoError(t, os.WriteFile(configPath, []byte(configYAML), 0o644))
+	cfg, err := config.Load(configPath)
+	require.NoError(t, err)
+	return rootDir, configPath, cfg
+}
+
+func readDaemonReloadLogEntries(t *testing.T, cfg *config.Config) []daemonReloadLogEntry {
+	t.Helper()
+
+	data, err := os.ReadFile(daemonReloadLogPath(cfg))
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	entries := make([]daemonReloadLogEntry, 0, len(lines))
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var entry daemonReloadLogEntry
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func markRunnerInFlight(t *testing.T, r *runner.Runner, value int32) {
+	t.Helper()
+
+	field := reflect.ValueOf(r).Elem().FieldByName("inFlight")
+	ptr := reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
+	store := ptr.Addr().MethodByName("Store")
+	store.Call([]reflect.Value{reflect.ValueOf(value)})
+}
+
+type smokeReloadCmdRunner struct {
+	mu      sync.Mutex
+	outputs map[string][]byte
+	prompts []string
+}
+
+func newSmokeReloadCmdRunner() *smokeReloadCmdRunner {
+	return &smokeReloadCmdRunner{
+		outputs: make(map[string][]byte),
+	}
+}
+
+func (m *smokeReloadCmdRunner) set(output []byte, name string, args ...string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.outputs[m.key(name, args...)] = append([]byte(nil), output...)
+}
+
+func (m *smokeReloadCmdRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return m.RunOutput(ctx, name, args...)
+}
+
+func (m *smokeReloadCmdRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out, ok := m.outputs[m.key(name, args...)]
+	if !ok {
+		return nil, fmt.Errorf("unexpected command: %s %s", name, strings.Join(args, " "))
+	}
+	return append([]byte(nil), out...), nil
+}
+
+func (m *smokeReloadCmdRunner) RunProcess(_ context.Context, _ string, name string, args ...string) error {
+	_, err := m.RunOutput(context.Background(), name, args...)
+	return err
+}
+
+func (m *smokeReloadCmdRunner) RunPhase(_ context.Context, _ string, stdin io.Reader, _ string, _ ...string) ([]byte, error) {
+	prompt, err := io.ReadAll(stdin)
+	if err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	m.prompts = append(m.prompts, string(prompt))
+	m.mu.Unlock()
+	return []byte("ok"), nil
+}
+
+func (m *smokeReloadCmdRunner) phasePrompts() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.prompts...)
+}
+
+func (m *smokeReloadCmdRunner) key(name string, args ...string) string {
+	return strings.Join(append([]string{name}, args...), "\x00")
+}
+
+type smokeReloadWorktree struct {
+	path string
+}
+
+func (w *smokeReloadWorktree) Create(context.Context, string) (string, error) {
+	return w.path, nil
+}
+
+func (w *smokeReloadWorktree) Remove(context.Context, string) error {
+	return nil
+}
+
+type smokeReloadSource struct{}
+
+func (s *smokeReloadSource) Name() string                                   { return "github-issue" }
+func (s *smokeReloadSource) Scan(context.Context) ([]queue.Vessel, error)   { return nil, nil }
+func (s *smokeReloadSource) OnEnqueue(context.Context, queue.Vessel) error  { return nil }
+func (s *smokeReloadSource) OnStart(context.Context, queue.Vessel) error    { return nil }
+func (s *smokeReloadSource) OnWait(context.Context, queue.Vessel) error     { return nil }
+func (s *smokeReloadSource) OnResume(context.Context, queue.Vessel) error   { return nil }
+func (s *smokeReloadSource) OnComplete(context.Context, queue.Vessel) error { return nil }
+func (s *smokeReloadSource) OnFail(context.Context, queue.Vessel) error     { return nil }
+func (s *smokeReloadSource) OnTimedOut(context.Context, queue.Vessel) error { return nil }
+func (s *smokeReloadSource) RemoveRunningLabel(context.Context, queue.Vessel) error {
+	return nil
+}
+func (s *smokeReloadSource) BranchName(v queue.Vessel) string {
+	return "issue/" + v.ID
+}
+
+func wireSmokeReloadHandle(handle *daemonRunnerHandle, cmdRunner *smokeReloadCmdRunner, worktreePath string) {
+	handle.drain.Runner = cmdRunner
+	handle.drain.Worktree = &smokeReloadWorktree{path: worktreePath}
+	handle.drain.Sources = map[string]source.Source{
+		"github-issue": &smokeReloadSource{},
+	}
+}

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -305,7 +305,7 @@ func TestDaemonLoopScheduledSourceRunsSingleTick(t *testing.T) {
 		return runner.DrainResult{Launched: 1, Completed: 1}, nil
 	}
 
-	if err := daemonLoop(ctx, q, tracker, scan, drain, nil, nil, nil, 10*time.Millisecond, 10*time.Millisecond, 0); err != nil {
+	if err := daemonLoop(ctx, q, tracker, scan, drain, nil, nil, nil, nil, 10*time.Millisecond, 10*time.Millisecond, 0); err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
 
@@ -420,7 +420,7 @@ func TestDaemonShutdown(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, nil, nil, time.Hour, time.Hour, 0)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, nil, nil, nil, time.Hour, time.Hour, 0)
 	if err != nil {
 		t.Fatalf("expected nil error on shutdown, got: %v", err)
 	}
@@ -467,7 +467,7 @@ func TestSmoke_S3_DaemonTickDrainsScheduledVessel(t *testing.T) {
 
 	err := daemonLoop(ctx, q, nil, func(ctx context.Context) (scanner.ScanResult, error) {
 		return runScan(ctx, cfg, q)
-	}, drain, nil, nil, nil, time.Millisecond, time.Millisecond, 0)
+	}, drain, nil, nil, nil, nil, time.Millisecond, time.Millisecond, 0)
 	require.NoError(t, err)
 
 	vessels, err := q.List()
@@ -541,7 +541,7 @@ func TestDaemonLoopPeriodicUpgradeFiresAtDrainEnd(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, upgrade, nil, time.Hour, 2*time.Millisecond, time.Millisecond)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, upgrade, nil, nil, time.Hour, 2*time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -563,7 +563,7 @@ func TestDaemonLoopPeriodicUpgradeRespectsInterval(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, upgrade, nil, time.Hour, 2*time.Millisecond, 10*time.Second)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, upgrade, nil, nil, time.Hour, 2*time.Millisecond, 10*time.Second)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -583,7 +583,7 @@ func TestDaemonLoopPeriodicUpgradeNilDisables(t *testing.T) {
 	defer cancel()
 
 	// Passing nil upgrade should not panic even with a non-zero interval.
-	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, nil, nil, time.Hour, 2*time.Millisecond, 10*time.Millisecond)
+	err := daemonLoop(ctx, q, nil, noopScan, noopDrain, nil, nil, nil, nil, time.Hour, 2*time.Millisecond, 10*time.Millisecond)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -622,7 +622,7 @@ func TestDaemonLoopUpgradeWaitsForDrainCompletion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, nil, noopScan, slowDrain, nil, upgrade, nil, time.Hour, time.Millisecond, time.Millisecond)
+	err := daemonLoop(ctx, q, nil, noopScan, slowDrain, nil, upgrade, nil, nil, time.Hour, time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("daemonLoop() error = %v", err)
 	}
@@ -650,7 +650,7 @@ func TestSmoke_S35_DaemonLoopAllowsNewDrainTicksWhileVesselsRemainInFlight(t *te
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, nil, nil, time.Hour, 10*time.Millisecond, 0)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, nil, nil, nil, time.Hour, 10*time.Millisecond, 0)
 	require.NoError(t, err)
 
 	assert.GreaterOrEqual(t, drainCalls.Load(), int32(2))
@@ -684,7 +684,7 @@ func TestSmoke_S36_DaemonLoopUpgradeWaitsForTrackerIdle(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, time.Hour, 10*time.Millisecond, time.Millisecond)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, nil, time.Hour, 10*time.Millisecond, time.Millisecond)
 	require.NoError(t, err)
 
 	assert.NotZero(t, upgradeSeen.Load())
@@ -726,7 +726,7 @@ func TestSmoke_S39_DaemonAutoUpgradeProceedsAfterCancelledVesselDropsInFlight(t 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, time.Hour, 10*time.Millisecond, time.Millisecond)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, nil, time.Hour, 10*time.Millisecond, time.Millisecond)
 	require.NoError(t, err)
 
 	select {
@@ -790,7 +790,7 @@ func TestSmoke_S48_DaemonHealthTickPrunesOnlyStaleXylemWorktrees(t *testing.T) {
 		if pruneRunner.PruneStaleWorktrees(ctx) > 0 {
 			cancel()
 		}
-	}, nil, nil, time.Hour, time.Hour, 0)
+	}, nil, nil, nil, time.Hour, time.Hour, 0)
 	require.NoError(t, err)
 
 	assert.GreaterOrEqual(t, checkCalls.Load(), int32(1))
@@ -849,7 +849,7 @@ func TestDaemonLoopUpgradeOverduePausesDrainToCreateIdleWindow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, time.Hour, 5*time.Millisecond, 5*time.Millisecond)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, nil, time.Hour, 5*time.Millisecond, 5*time.Millisecond)
 	require.NoError(t, err)
 
 	// Upgrade MUST have fired at least once despite the continuously saturating drain.
@@ -886,7 +886,7 @@ func TestDaemonLoopUpgradeOverdueDoesNotFireUnderNormalConditions(t *testing.T) 
 	defer cancel()
 
 	// upgradeInterval=2ms; over 100ms, normal path should fire many times.
-	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, time.Hour, 2*time.Millisecond, 2*time.Millisecond)
+	err := daemonLoop(ctx, q, tracker, noopScan, drain, nil, upgrade, nil, nil, time.Hour, 2*time.Millisecond, 2*time.Millisecond)
 	require.NoError(t, err)
 
 	assert.GreaterOrEqual(t, upgradeSeen.Load(), int32(5),
@@ -972,7 +972,7 @@ func TestDaemonNonBlockingDrain(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	err := daemonLoop(ctx, q, nil, noopScan, slowDrain, nil, nil, nil, time.Hour, time.Millisecond, 0)
+	err := daemonLoop(ctx, q, nil, noopScan, slowDrain, nil, nil, nil, nil, time.Hour, time.Millisecond, 0)
 	elapsed := time.Since(start)
 
 	if err != nil {

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -50,7 +50,8 @@ func newRootCmd() *cobra.Command {
 				commandPath == "xylem harden score" ||
 				commandPath == "xylem harden track" ||
 				commandPath == "xylem field-report generate" ||
-				commandPath == "xylem daemon stop"
+				commandPath == "xylem daemon stop" ||
+				commandPath == "xylem daemon reload"
 
 			if !skipTooling {
 				if _, err := exec.LookPath("git"); err != nil {

--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -514,6 +514,11 @@ func (q *Queue) HasRefAny(ref string) bool {
 	return false
 }
 
+// WithWriteLock executes fn while holding the queue's write lock.
+func (q *Queue) WithWriteLock(fn func() error) error {
+	return q.withLock(fn)
+}
+
 func (q *Queue) withLock(fn func() error) error {
 	lock := flock.New(q.lockPath)
 	if err := lock.Lock(); err != nil {

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -20,11 +20,12 @@ type CommandRunner interface {
 
 // Scanner scans configured sources for actionable tasks and enqueues vessels.
 type Scanner struct {
-	Config     *config.Config
-	Queue      *queue.Queue
-	CmdRunner  CommandRunner
-	RunHooks   bool
-	BudgetGate budgetGate
+	Config              *config.Config
+	Queue               *queue.Queue
+	CmdRunner           CommandRunner
+	RunHooks            bool
+	BudgetGate          budgetGate
+	OnControlPlaneMerge func(source.ControlPlaneMergeEvent)
 }
 
 type budgetGate interface {
@@ -186,11 +187,12 @@ func (s *Scanner) buildSources() []sourceEntry {
 			mergeTasks := convertMergeTasks(srcCfg.Tasks)
 			entries = append(entries, sourceEntry{
 				src: &source.GitHubMerge{
-					Repo:        srcCfg.Repo,
-					Tasks:       mergeTasks,
-					DefaultTier: s.Config.LLMRouting.DefaultTier,
-					Queue:       s.Queue,
-					CmdRunner:   s.CmdRunner,
+					Repo:                srcCfg.Repo,
+					Tasks:               mergeTasks,
+					DefaultTier:         s.Config.LLMRouting.DefaultTier,
+					Queue:               s.Queue,
+					CmdRunner:           s.CmdRunner,
+					OnControlPlaneMerge: s.OnControlPlaneMerge,
 				},
 				configName: name,
 			})

--- a/cli/internal/source/control_plane.go
+++ b/cli/internal/source/control_plane.go
@@ -1,0 +1,35 @@
+package source
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func controlPlanePathsTouched(paths []string) bool {
+	for _, path := range paths {
+		if isControlPlanePath(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func isControlPlanePath(path string) bool {
+	normalized := filepath.ToSlash(filepath.Clean(strings.TrimSpace(path)))
+	switch {
+	case normalized == ".xylem.yml":
+		return true
+	case normalized == ".xylem/HARNESS.md":
+		return true
+	case normalized == ".xylem/workflows":
+		return true
+	case strings.HasPrefix(normalized, ".xylem/workflows/"):
+		return true
+	case normalized == ".xylem/prompts":
+		return true
+	case strings.HasPrefix(normalized, ".xylem/prompts/"):
+		return true
+	default:
+		return false
+	}
+}

--- a/cli/internal/source/github_merge.go
+++ b/cli/internal/source/github_merge.go
@@ -18,11 +18,12 @@ type MergeTask struct {
 
 // GitHubMerge scans for merged PRs and produces vessels.
 type GitHubMerge struct {
-	Repo        string
-	Tasks       map[string]MergeTask
-	DefaultTier string
-	Queue       *queue.Queue
-	CmdRunner   CommandRunner
+	Repo                string
+	Tasks               map[string]MergeTask
+	DefaultTier         string
+	Queue               *queue.Queue
+	CmdRunner           CommandRunner
+	OnControlPlaneMerge func(ControlPlaneMergeEvent)
 }
 
 type ghMergeCommit struct {
@@ -35,6 +36,12 @@ type ghMergedPR struct {
 	URL         string        `json:"url"`
 	MergeCommit ghMergeCommit `json:"mergeCommit"`
 	HeadRefName string        `json:"headRefName"`
+}
+
+type ControlPlaneMergeEvent struct {
+	PRNumber       int
+	MergeCommitSHA string
+	Files          []string
 }
 
 func (g *GitHubMerge) Name() string { return "github-merge" }
@@ -64,9 +71,22 @@ func (g *GitHubMerge) Scan(ctx context.Context) ([]queue.Vessel, error) {
 		if oid == "" {
 			continue
 		}
+		ref := fmt.Sprintf("%s#merge-%s", pr.URL, oid)
+		if g.OnControlPlaneMerge != nil && !g.Queue.HasRefAny(ref) {
+			files, err := g.listFiles(ctx, pr.Number)
+			if err != nil {
+				return nil, fmt.Errorf("gh pr view files #%d: %w", pr.Number, err)
+			}
+			if controlPlanePathsTouched(files) {
+				g.OnControlPlaneMerge(ControlPlaneMergeEvent{
+					PRNumber:       pr.Number,
+					MergeCommitSHA: oid,
+					Files:          files,
+				})
+			}
+		}
 
 		for _, task := range g.Tasks {
-			ref := fmt.Sprintf("%s#merge-%s", pr.URL, oid)
 			if g.Queue.HasRefAny(ref) {
 				continue
 			}
@@ -88,6 +108,34 @@ func (g *GitHubMerge) Scan(ctx context.Context) ([]queue.Vessel, error) {
 	}
 
 	return vessels, nil
+}
+
+func (g *GitHubMerge) listFiles(ctx context.Context, number int) ([]string, error) {
+	args := []string{
+		"pr", "view", strconv.Itoa(number),
+		"--repo", g.Repo,
+		"--json", "files",
+	}
+	out, err := g.CmdRunner.Run(ctx, "gh", args...)
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Files []struct {
+			Path string `json:"path"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, fmt.Errorf("parse gh pr view output: %w", err)
+	}
+	files := make([]string, 0, len(resp.Files))
+	for _, file := range resp.Files {
+		if strings.TrimSpace(file.Path) == "" {
+			continue
+		}
+		files = append(files, file.Path)
+	}
+	return files, nil
 }
 
 func (g *GitHubMerge) OnEnqueue(_ context.Context, _ queue.Vessel) error          { return nil }

--- a/cli/internal/source/github_merge_test.go
+++ b/cli/internal/source/github_merge_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -69,6 +70,139 @@ func TestMergeScan(t *testing.T) {
 	}
 	if v.Workflow != "post-merge" {
 		t.Errorf("Workflow = %q, want post-merge", v.Workflow)
+	}
+}
+
+func TestMergeScanControlPlaneCallback(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghMergedPR{
+		{
+			Number:      20,
+			Title:       "merged PR",
+			URL:         "https://github.com/owner/repo/pull/20",
+			MergeCommit: ghMergeCommit{OID: "abcdef1234567890"},
+			HeadRefName: "feature-x",
+		},
+	}
+	prBytes, _ := json.Marshal(prs)
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+	r.set([]byte(`{"files":[{"path":".xylem/workflows/fix-bug.yaml"},{"path":"README.md"}]}`),
+		"gh", "pr", "view", "20", "--repo", "owner/repo", "--json", "files")
+
+	var got ControlPlaneMergeEvent
+	g := &GitHubMerge{
+		Repo:  "owner/repo",
+		Tasks: map[string]MergeTask{"deploy": {Workflow: "post-merge"}},
+		Queue: q, CmdRunner: r,
+		OnControlPlaneMerge: func(event ControlPlaneMergeEvent) {
+			got = event
+		},
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	want := ControlPlaneMergeEvent{
+		PRNumber:       20,
+		MergeCommitSHA: "abcdef1234567890",
+		Files:          []string{".xylem/workflows/fix-bug.yaml", "README.md"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("callback event = %#v, want %#v", got, want)
+	}
+}
+
+func TestMergeScanControlPlaneCallbackIgnoresNonControlPlaneChanges(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghMergedPR{
+		{
+			Number:      20,
+			Title:       "merged PR",
+			URL:         "https://github.com/owner/repo/pull/20",
+			MergeCommit: ghMergeCommit{OID: "abcdef1234567890"},
+			HeadRefName: "feature-x",
+		},
+	}
+	prBytes, _ := json.Marshal(prs)
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+	r.set([]byte(`{"files":[{"path":"README.md"},{"path":"docs/guide.md"}]}`),
+		"gh", "pr", "view", "20", "--repo", "owner/repo", "--json", "files")
+
+	called := false
+	g := &GitHubMerge{
+		Repo:  "owner/repo",
+		Tasks: map[string]MergeTask{"deploy": {Workflow: "post-merge"}},
+		Queue: q, CmdRunner: r,
+		OnControlPlaneMerge: func(ControlPlaneMergeEvent) {
+			called = true
+		},
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+	if called {
+		t.Fatal("expected non-control-plane merge to skip control-plane callback")
+	}
+}
+
+func TestMergeScanControlPlaneCallbackSkipsDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghMergedPR{
+		{
+			Number:      20,
+			Title:       "merged PR",
+			URL:         "https://github.com/owner/repo/pull/20",
+			MergeCommit: ghMergeCommit{OID: "abcdef1234567890"},
+			HeadRefName: "feature-x",
+		},
+	}
+	prBytes, _ := json.Marshal(prs)
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:     "merge-pr-20-abcdef12",
+		Source: "github-merge",
+		Ref:    "https://github.com/owner/repo/pull/20#merge-abcdef1234567890",
+		State:  queue.StatePending,
+	})
+
+	called := false
+	g := &GitHubMerge{
+		Repo:  "owner/repo",
+		Tasks: map[string]MergeTask{"deploy": {Workflow: "post-merge"}},
+		Queue: q, CmdRunner: r,
+		OnControlPlaneMerge: func(ControlPlaneMergeEvent) {
+			called = true
+		},
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels, got %d", len(vessels))
+	}
+	if called {
+		t.Fatal("expected duplicate merge ref to skip control-plane callback")
 	}
 }
 
@@ -158,36 +292,33 @@ func TestMergeBranchName(t *testing.T) {
 
 func TestMergeOnStartNoOp(t *testing.T) {
 	g := &GitHubMerge{}
-	if err := g.OnStart(context.Background(), queue.Vessel{}); err != nil {
-		t.Fatalf("OnStart should be no-op, got: %v", err)
+	vessel := queue.Vessel{
+		ID:     "merge-pr-20-abcdef12",
+		Source: "github-merge",
+		Ref:    "https://github.com/owner/repo/pull/20#merge-abcdef1234567890",
+		Meta:   map[string]string{"pr_num": "20"},
 	}
-}
 
-func TestMergeOnEnqueueNoOp(t *testing.T) {
-	g := &GitHubMerge{}
-	if err := g.OnEnqueue(context.Background(), queue.Vessel{}); err != nil {
-		t.Fatalf("OnEnqueue should be no-op, got: %v", err)
+	tests := []struct {
+		name string
+		call func(context.Context, queue.Vessel) error
+	}{
+		{name: "enqueue", call: g.OnEnqueue},
+		{name: "start", call: g.OnStart},
+		{name: "wait", call: g.OnWait},
+		{name: "resume", call: g.OnResume},
+		{name: "complete", call: g.OnComplete},
+		{name: "fail", call: g.OnFail},
+		{name: "timed_out", call: g.OnTimedOut},
+		{name: "remove_running_label", call: g.RemoveRunningLabel},
 	}
-}
 
-func TestMergeOnCompleteNoOp(t *testing.T) {
-	g := &GitHubMerge{}
-	if err := g.OnComplete(context.Background(), queue.Vessel{}); err != nil {
-		t.Fatalf("OnComplete should be no-op, got: %v", err)
-	}
-}
-
-func TestMergeOnFailNoOp(t *testing.T) {
-	g := &GitHubMerge{}
-	if err := g.OnFail(context.Background(), queue.Vessel{}); err != nil {
-		t.Fatalf("OnFail should be no-op, got: %v", err)
-	}
-}
-
-func TestMergeOnTimedOutNoOp(t *testing.T) {
-	g := &GitHubMerge{}
-	if err := g.OnTimedOut(context.Background(), queue.Vessel{}); err != nil {
-		t.Fatalf("OnTimedOut should be no-op, got: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.call(context.Background(), vessel); err != nil {
+				t.Fatalf("%s should be a no-op, got: %v", tt.name, err)
+			}
+		})
 	}
 }
 
@@ -208,6 +339,9 @@ func TestMergeScanGHError(t *testing.T) {
 	_, err := g.Scan(context.Background())
 	if err == nil {
 		t.Fatal("expected error from gh failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "gh pr list (merged): network error") {
+		t.Fatalf("Scan() error = %q, want wrapped gh list failure", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
Implements https://github.com/nicholls-inc/xylem/issues/236 by adding a hybrid daemon reload path for control-plane updates, wiring merge-triggered reload intents from `github-merge` into the daemon, and preserving launch-time workflow snapshots via `Vessel.WorkflowDigest` so in-flight and resumed vessels stay on the workflow bytes they started with.

## Smoke scenarios covered
- `queue/S4` - Legacy queue JSONL without workflow digest loads empty workflow digest
- `queue/S5` - Queue JSONL round-trips workflow digest
- `daemon/S5` - Daemon reload preserves frozen workflow snapshot
- `runner/S6` - Workflow digest snapshot populated at launch
- `runner/S7` - Waiting vessel resumes against frozen workflow snapshot

## Changes summary
- Added `cli/cmd/xylem/daemon_reload.go` with `daemonReloadRequest`, `daemonRuntime`, `newDaemonReloadCmd`, snapshot capture/restore, reload log/audit helpers, SIGHUP request handling, and manual rollback support.
- Modified `cli/cmd/xylem/daemon.go` and `cli/cmd/xylem/root.go` to register `xylem daemon reload`, route daemon execution through reload-aware runtime handles, honor live interval swaps, and keep retired runners alive until in-flight work drains.
- Modified `cli/internal/scanner/scanner.go`, `cli/internal/source/github_merge.go`, and added `cli/internal/source/control_plane.go` to detect control-plane file changes on merged PRs and emit `ControlPlaneMergeEvent` callbacks only for new merge refs.
- Modified `cli/internal/queue/queue.go` to persist `Vessel.WorkflowDigest` and expose `Queue.WithWriteLock` for atomic runtime swaps.
- Added or updated `cli/cmd/xylem/daemon_reload_test.go`, `cli/cmd/xylem/daemon_reload_prop_test.go`, `cli/cmd/xylem/daemon_test.go`, and `cli/internal/source/github_merge_test.go` to cover reload requests, rollback, merge-triggered reloads, frozen workflow snapshots, and control-plane merge detection.

## Test plan
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #236