### PR TITLE
feat: seed doc-garden scheduled workflow in the core profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Use `noop.match` on a phase to let that phase complete the workflow early when i
 
 - **fix-bug** -- Analyze, Plan, Implement (with test gate), PR
 - **implement-feature** -- Analyze, Plan (with label gate for approval), Implement (with test gate), PR
+- **doc-garden** -- Daily documentation drift scan, targeted doc updates, verification, and PR drafting
 - **security-compliance** -- Daily scheduled secrets, static-analysis, dependency-audit, and synthesis pass with issue filing for actionable risk
 
 See the [Workflows Guide](docs/workflows.md) for template variables, custom workflows, and prompt authoring tips.

--- a/cli/cmd/xylem/adapt_repo_seed_test.go
+++ b/cli/cmd/xylem/adapt_repo_seed_test.go
@@ -64,7 +64,7 @@ func TestSmoke_S3_DaemonSeedingCreatesIssueAndMarkerOnFreshRepo(t *testing.T) {
 	assert.Equal(t, 34, marker.IssueNumber)
 	assert.Equal(t, "https://github.com/owner/repo/issues/34", marker.IssueURL)
 	assert.Equal(t, adaptRepoSeededByDaemon, marker.SeededBy)
-	assert.Equal(t, 2, marker.ProfileVersion)
+	assert.Equal(t, 3, marker.ProfileVersion)
 
 	written, err := readAdaptRepoSeedMarker(filepath.Join(cfg.StateDir, "state", "bootstrap", "adapt-repo-seeded.json"))
 	require.NoError(t, err)

--- a/cli/cmd/xylem/field_report.go
+++ b/cli/cmd/xylem/field_report.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/nicholls-inc/xylem/cli/internal/fieldreport"
+	"github.com/nicholls-inc/xylem/cli/internal/profiles"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +33,10 @@ Exit code 0 on success, 2 if there is insufficient data to produce
 a meaningful report (fewer than 5 vessel summaries).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := deps.cfg
+			profileVersion, ok := profiles.Version("core")
+			if !ok {
+				return fmt.Errorf("field report: core profile version is unknown")
+			}
 
 			if !cfg.TelemetryEnabled() {
 				fmt.Fprintln(os.Stderr, "telemetry is disabled; skipping field report generation")
@@ -40,7 +45,7 @@ a meaningful report (fewer than 5 vessel summaries).`,
 
 			opts := fieldreport.Options{
 				XylemVersion:   buildInfo(),
-				ProfileVersion: 2,
+				ProfileVersion: profileVersion,
 				Extended:       cfg.Telemetry.Extended,
 			}
 

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -22,6 +22,7 @@ import (
 var expectedCoreWorkflows = []string{
 	"adapt-repo",
 	"context-weight-audit",
+	"doc-garden",
 	"field-report",
 	"fix-bug",
 	"fix-pr-checks",
@@ -459,7 +460,7 @@ func TestSmoke_S6_InitSeedCreatesAdaptRepoMarkerSynchronously(t *testing.T) {
 	assert.Equal(t, 12, marker.IssueNumber)
 	assert.Equal(t, "https://github.com/owner/name/issues/12", marker.IssueURL)
 	assert.Equal(t, adaptRepoSeededByInit, marker.SeededBy)
-	assert.Equal(t, 2, marker.ProfileVersion)
+	assert.Equal(t, 3, marker.ProfileVersion)
 	assert.Len(t, runner.calls, 3)
 }
 

--- a/cli/internal/fieldreport/fieldreport.go
+++ b/cli/internal/fieldreport/fieldreport.go
@@ -34,7 +34,9 @@ type Options struct {
 	// XylemVersion is the build version string of the running binary.
 	XylemVersion string
 
-	// ProfileVersion is the profile schema version from profile.lock.
+	// ProfileVersion is the seeded profile bundle version associated with
+	// the installation that produced the report (for example, the core
+	// profile version written into adapt-repo bootstrap markers).
 	ProfileVersion int
 
 	// Extended enables the extended telemetry level (hashed repo ID,

--- a/cli/internal/profiles/core/prompts/doc-garden/analyze.md
+++ b/cli/internal/profiles/core/prompts/doc-garden/analyze.md
@@ -1,0 +1,30 @@
+You are running the scheduled `doc-garden` workflow for this repository.
+
+This is a recurring documentation-maintenance vessel, not an issue-driven task.
+
+- Vessel ID: {{.Vessel.ID}}
+- Workflow ref: {{.Vessel.Ref}}
+- Schedule source: {{index .Vessel.Meta "schedule.source_name"}}
+- Fired at: {{index .Vessel.Meta "schedule.fired_at"}}
+
+Inspect the repository for stale, contradictory, or broken documentation. Focus first on cheap heuristics before deeper reasoning:
+
+1. Broken file references, commands, workflow names, or config examples.
+2. Docs that disagree with checked-in defaults, current behavior, or current file layout.
+3. Dead links or references to files, prompts, or workflows that do not exist.
+4. Repeated wording that still describes superseded behavior.
+
+Prioritize `README.md`, `docs/`, prompt/workflow docs under `.xylem/` when present, and other tracked documentation files.
+
+If there is no credible documentation drift to fix right now, output the exact standalone line `XYLEM_NOOP` and explain why no further phases should run.
+
+Otherwise, produce a concise analysis with:
+
+SUMMARY:
+- overall conclusion
+CANDIDATE_FILES:
+- one bullet per file that likely needs an edit
+EVIDENCE:
+- one bullet per stale claim, contradiction, or broken reference
+PLAN:
+- one bullet per documentation fix to apply next

--- a/cli/internal/profiles/core/prompts/doc-garden/implement.md
+++ b/cli/internal/profiles/core/prompts/doc-garden/implement.md
@@ -1,0 +1,16 @@
+Implement the documentation fixes identified by the `doc-garden` analysis.
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+Apply the smallest set of documentation edits that resolves the confirmed drift.
+
+## Rules
+
+1. Prefer documentation-only changes.
+2. Do not change production behavior just to match stale docs.
+3. Keep claims evidence-based and aligned with the checked-in repository state.
+4. Preserve intentional nuance instead of flattening everything into generic wording.
+5. If an analyzed item turns out not to need a fix after inspection, leave it untouched rather than making speculative edits.
+
+When you finish, summarize the files changed and the stale claims you corrected.

--- a/cli/internal/profiles/core/prompts/doc-garden/pr.md
+++ b/cli/internal/profiles/core/prompts/doc-garden/pr.md
@@ -1,0 +1,16 @@
+Create a pull request for the documentation maintenance changes.
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Verification
+{{.PreviousOutputs.verify}}
+
+Open a concise fix-up PR that:
+
+1. Clearly states this was produced by the scheduled `doc-garden` workflow.
+2. Summarizes the stale or broken documentation claims that were corrected.
+3. Notes any remaining documentation gaps that still need human follow-up.
+4. Links the schedule ref `{{.Vessel.Ref}}` in the body for traceability.
+
+Use a title in the form `[xylem] refresh repository documentation`.

--- a/cli/internal/profiles/core/prompts/doc-garden/verify.md
+++ b/cli/internal/profiles/core/prompts/doc-garden/verify.md
@@ -1,0 +1,16 @@
+Verify the `doc-garden` edits against the current repository state.
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Implementation
+{{.PreviousOutputs.implement}}
+
+Re-read the changed documentation and confirm:
+
+1. Referenced files, commands, workflows, and config keys still exist.
+2. The updated docs match current checked-in defaults and behavior.
+3. No obvious stale statements from the analyzed drift remain in the touched files.
+4. The explanation stays specific and useful instead of becoming vague boilerplate.
+
+Write a concise verification note that calls out any residual follow-up risk explicitly.

--- a/cli/internal/profiles/core/workflows/doc-garden.yaml
+++ b/cli/internal/profiles/core/workflows/doc-garden.yaml
@@ -1,0 +1,18 @@
+name: doc-garden
+class: harness-maintenance
+description: "Detect and repair stale documentation drift on a recurring cadence"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/doc-garden/analyze.md
+    max_turns: 30
+    noop:
+      match: XYLEM_NOOP
+  - name: implement
+    prompt_file: .xylem/prompts/doc-garden/implement.md
+    max_turns: 50
+  - name: verify
+    prompt_file: .xylem/prompts/doc-garden/verify.md
+    max_turns: 30
+  - name: pr
+    prompt_file: .xylem/prompts/doc-garden/pr.md
+    max_turns: 20

--- a/cli/internal/profiles/core/xylem.yml.tmpl
+++ b/cli/internal/profiles/core/xylem.yml.tmpl
@@ -82,6 +82,10 @@ sources:
     type: schedule
     cadence: "@daily"
     workflow: lessons
+  doc-gardener:
+    type: schedule
+    cadence: "@daily"
+    workflow: doc-garden
   context-audit:
     type: schedule
     cadence: "@weekly"

--- a/cli/internal/profiles/profiles.go
+++ b/cli/internal/profiles/profiles.go
@@ -15,7 +15,7 @@ import (
 var profileFS embed.FS
 
 var profileVersions = map[string]int{
-	"core":               2,
+	"core":               3,
 	"self-hosting-xylem": 2,
 }
 

--- a/cli/internal/profiles/profiles_prop_test.go
+++ b/cli/internal/profiles/profiles_prop_test.go
@@ -78,6 +78,38 @@ func TestPropComposeCoreKeepsSecurityComplianceBundlePresent(t *testing.T) {
 	})
 }
 
+func TestPropComposeCoreKeepsDocGardenBundlePresent(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		composed, err := Compose("core")
+		if err != nil {
+			t.Fatalf("Compose(core) error = %v", err)
+		}
+
+		checks := docGardenBundle(composed)
+		check := checks[rapid.IntRange(0, len(checks)-1).Draw(t, "checkIndex")]
+		if len(check.data) == 0 {
+			t.Fatalf("%s missing or empty", check.name)
+		}
+		byteIndex := rapid.IntRange(0, len(check.data)-1).Draw(t, "byteIndex")
+		check.data[byteIndex] ^= 0xff
+
+		fresh, err := Compose("core")
+		if err != nil {
+			t.Fatalf("Compose(core) fresh call error = %v", err)
+		}
+
+		for _, want := range docGardenBundle(fresh) {
+			expectedFragment := docGardenExpectedFragments[want.name]
+			if len(want.data) == 0 {
+				t.Fatalf("%s missing or empty", want.name)
+			}
+			if !strings.Contains(string(want.data), expectedFragment) {
+				t.Fatalf("%s = %q, want fragment %q", want.name, string(want.data), expectedFragment)
+			}
+		}
+	})
+}
+
 func TestPropComposeSelfHostingXylemImplementHarnessWorkflowKeepsPRCreateContract(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		composed, err := Compose("core", "self-hosting-xylem")
@@ -120,6 +152,13 @@ var securityComplianceExpectedFragments = map[string]string{
 	"source:security-compliance":              "workflow: security-compliance",
 }
 
+var docGardenExpectedFragments = map[string]string{
+	"workflow:doc-garden":       "name: doc-garden",
+	"prompt:doc-garden/analyze": "cheap heuristics",
+	"prompt:doc-garden/verify":  "current checked-in defaults and behavior",
+	"source:doc-gardener":       "workflow: doc-garden",
+}
+
 var implementHarnessPRCreateContract = []string{
 	`gh pr create`,
 	`--repo nicholls-inc/xylem`,
@@ -138,6 +177,15 @@ func securityComplianceBundle(composed *ComposedProfile) []assetRef {
 		{name: "prompt:security-compliance/scan_secrets", data: composed.Prompts["security-compliance/scan_secrets"]},
 		{name: "prompt:security-compliance/synthesize", data: composed.Prompts["security-compliance/synthesize"]},
 		{name: "source:security-compliance", data: composed.Sources["security-compliance"]},
+	}
+}
+
+func docGardenBundle(composed *ComposedProfile) []assetRef {
+	return []assetRef{
+		{name: "workflow:doc-garden", data: composed.Workflows["doc-garden"]},
+		{name: "prompt:doc-garden/analyze", data: composed.Prompts["doc-garden/analyze"]},
+		{name: "prompt:doc-garden/verify", data: composed.Prompts["doc-garden/verify"]},
+		{name: "source:doc-gardener", data: composed.Sources["doc-gardener"]},
 	}
 }
 

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -23,7 +23,7 @@ func TestSmoke_S1_LoadCoreProfileReturnsEmbeddedAssets(t *testing.T) {
 
 	require.NotNil(t, profile)
 	assert.Equal(t, "core", profile.Name)
-	assert.Equal(t, 2, profile.Version)
+	assert.Equal(t, 3, profile.Version)
 
 	harnessTemplate, err := fs.ReadFile(profile.FS, "HARNESS.md.tmpl")
 	require.NoError(t, err)
@@ -56,11 +56,12 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 	require.NotNil(t, composed)
 	require.Len(t, composed.Profiles, 1)
 	assert.Equal(t, "core", composed.Profiles[0].Name)
-	assert.Equal(t, 2, composed.Profiles[0].Version)
+	assert.Equal(t, 3, composed.Profiles[0].Version)
 
 	assert.Equal(t, []string{
 		"adapt-repo",
 		"context-weight-audit",
+		"doc-garden",
 		"field-report",
 		"fix-bug",
 		"fix-pr-checks",
@@ -77,8 +78,10 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 	}, sortedKeys(composed.Workflows))
 	assert.Contains(t, sortedKeys(composed.Prompts), "adapt-repo/plan")
 	assert.Contains(t, sortedKeys(composed.Prompts), "adapt-repo/pr")
+	assert.Contains(t, sortedKeys(composed.Prompts), "doc-garden/analyze")
 	assert.Contains(t, sortedKeys(composed.Prompts), "security-compliance/synthesize")
 	assert.Contains(t, sortedKeys(composed.Prompts), "workflow-health-report/report")
+	assert.Contains(t, sortedKeys(composed.Sources), "doc-gardener")
 	assert.Contains(t, sortedKeys(composed.Sources), "pr-lifecycle")
 	assert.Contains(t, sortedKeys(composed.Sources), "security-compliance")
 	assert.Contains(t, sortedKeys(composed.Sources), "field-report")
@@ -86,6 +89,7 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 
 	assert.Contains(t, string(composed.Workflows["fix-bug"]), "name: fix-bug")
 	assert.Contains(t, string(composed.Workflows["implement-feature"]), "name: implement-feature")
+	assert.Contains(t, string(composed.Workflows["doc-garden"]), "name: doc-garden")
 	assert.Contains(t, string(composed.Prompts["adapt-repo/pr"]), `--label "ready-to-merge"`)
 	assert.Contains(t, string(composed.Prompts["fix-bug/pr"]), "Create a pull request")
 	assert.Contains(t, string(composed.Prompts["fix-bug/pr"]), `--label "ready-to-merge"`)
@@ -396,6 +400,112 @@ func TestSmoke_S4_SecurityComplianceWorkflowBundleIsSeededInCoreProfile(t *testi
 	assert.Contains(t, string(sourceAsset), "type: schedule")
 	assert.Contains(t, string(sourceAsset), "cadence: '@daily'")
 	assert.Contains(t, string(sourceAsset), "workflow: security-compliance")
+}
+
+func TestSmoke_S4_DocGardenWorkflowBundleIsSeededInCoreProfile(t *testing.T) {
+	t.Parallel()
+
+	composed, err := Compose("core")
+	require.NoError(t, err)
+
+	workflowAsset, ok := composed.Workflows["doc-garden"]
+	require.True(t, ok)
+	assert.Contains(t, string(workflowAsset), "name: doc-garden")
+	assert.Contains(t, string(workflowAsset), "class: harness-maintenance")
+
+	analyzePrompt, ok := composed.Prompts["doc-garden/analyze"]
+	require.True(t, ok)
+	assert.Contains(t, string(analyzePrompt), "XYLEM_NOOP")
+	assert.Contains(t, string(analyzePrompt), "cheap heuristics")
+
+	verifyPrompt, ok := composed.Prompts["doc-garden/verify"]
+	require.True(t, ok)
+	assert.Contains(t, string(verifyPrompt), "current checked-in defaults and behavior")
+
+	sourceAsset, ok := composed.Sources["doc-gardener"]
+	require.True(t, ok)
+	assert.Contains(t, string(sourceAsset), "type: schedule")
+	assert.Contains(t, string(sourceAsset), "cadence: '@daily'")
+	assert.Contains(t, string(sourceAsset), "workflow: doc-garden")
+}
+
+func TestSmoke_S5_DocGardenWorkflowParsesAsFourPhaseMaintenanceWorkflow(t *testing.T) {
+	t.Parallel()
+
+	profile, err := Load("core")
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(oldWd))
+	})
+
+	for _, name := range []string{"analyze.md", "implement.md", "verify.md", "pr.md"} {
+		data, readErr := fs.ReadFile(profile.FS, filepath.Join("prompts", "doc-garden", name))
+		require.NoError(t, readErr)
+		target := filepath.Join(dir, ".xylem", "prompts", "doc-garden", name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
+		require.NoError(t, os.WriteFile(target, data, 0o644))
+	}
+
+	workflowData, err := fs.ReadFile(profile.FS, filepath.Join("workflows", "doc-garden.yaml"))
+	require.NoError(t, err)
+	workflowPath := filepath.Join(dir, "doc-garden.yaml")
+	require.NoError(t, os.WriteFile(workflowPath, workflowData, 0o644))
+
+	wf, err := workflowpkg.Load(workflowPath)
+	require.NoError(t, err)
+	assert.Equal(t, "doc-garden", wf.Name)
+	assert.Equal(t, workflowpkg.ClassHarnessMaintenance, wf.Class)
+	require.Len(t, wf.Phases, 4)
+	assert.Equal(t, "analyze", wf.Phases[0].Name)
+	assert.Equal(t, ".xylem/prompts/doc-garden/analyze.md", wf.Phases[0].PromptFile)
+	require.NotNil(t, wf.Phases[0].NoOp)
+	assert.Equal(t, "XYLEM_NOOP", wf.Phases[0].NoOp.Match)
+	assert.Equal(t, "implement", wf.Phases[1].Name)
+	assert.Equal(t, "verify", wf.Phases[2].Name)
+	assert.Equal(t, "pr", wf.Phases[3].Name)
+	assert.Equal(t, ".xylem/prompts/doc-garden/pr.md", wf.Phases[3].PromptFile)
+}
+
+func TestSmoke_S6_DocGardenPromptsDocumentHeuristicAndPRContract(t *testing.T) {
+	t.Parallel()
+
+	profile, err := Load("core")
+	require.NoError(t, err)
+
+	analyzePrompt, err := fs.ReadFile(profile.FS, filepath.Join("prompts", "doc-garden", "analyze.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(analyzePrompt), "This is a recurring documentation-maintenance vessel")
+	assert.Contains(t, string(analyzePrompt), "cheap heuristics")
+	assert.Contains(t, string(analyzePrompt), "CANDIDATE_FILES:")
+	assert.Contains(t, string(analyzePrompt), "XYLEM_NOOP")
+
+	implementPrompt, err := fs.ReadFile(profile.FS, filepath.Join("prompts", "doc-garden", "implement.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(implementPrompt), "Prefer documentation-only changes.")
+	assert.Contains(t, string(implementPrompt), "Do not change production behavior just to match stale docs.")
+
+	prPrompt, err := fs.ReadFile(profile.FS, filepath.Join("prompts", "doc-garden", "pr.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(prPrompt), "scheduled `doc-garden` workflow")
+	assert.Contains(t, string(prPrompt), "[xylem] refresh repository documentation")
+	assert.Contains(t, string(prPrompt), "{{.Vessel.Ref}}")
+}
+
+func TestSmoke_S7_DocGardenScheduledSourceUsesDailyCadence(t *testing.T) {
+	t.Parallel()
+
+	profile, err := Load("core")
+	require.NoError(t, err)
+
+	configTemplate, err := fs.ReadFile(profile.FS, "xylem.yml.tmpl")
+	require.NoError(t, err)
+
+	assert.Contains(t, string(configTemplate), "doc-gardener:\n    type: schedule\n    cadence: \"@daily\"\n    workflow: doc-garden")
 }
 
 func TestSmoke_S5_SecurityComplianceWorkflowParsesAsFourPhaseAudit(t *testing.T) {

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -377,7 +377,7 @@ func TestScanExistingPR(t *testing.T) {
 	}
 }
 
-func TestScanScheduleSource(t *testing.T) {
+func TestSmoke_S5_ScannerEnqueuesDocGardenerScheduleSource(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{
 		Concurrency: 2,
@@ -397,35 +397,19 @@ func TestScanScheduleSource(t *testing.T) {
 
 	s := New(cfg, q, newMock())
 	result, err := s.Scan(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result.Added != 1 {
-		t.Fatalf("expected 1 added, got %d", result.Added)
-	}
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Added)
 
 	vessels, err := q.List()
-	if err != nil {
-		t.Fatalf("List() error = %v", err)
-	}
-	if len(vessels) != 1 {
-		t.Fatalf("expected 1 vessel, got %d", len(vessels))
-	}
-	if vessels[0].Source != "schedule" {
-		t.Errorf("Source = %q, want schedule", vessels[0].Source)
-	}
-	if vessels[0].Workflow != "doc-garden" {
-		t.Errorf("Workflow = %q, want doc-garden", vessels[0].Workflow)
-	}
-	if vessels[0].Meta["config_source"] != "doc-gardener" {
-		t.Errorf("config_source = %q, want doc-gardener", vessels[0].Meta["config_source"])
-	}
-	if vessels[0].Meta["schedule.cadence"] != "1h" {
-		t.Errorf("schedule.cadence = %q, want 1h", vessels[0].Meta["schedule.cadence"])
-	}
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, "schedule", vessels[0].Source)
+	assert.Equal(t, "doc-garden", vessels[0].Workflow)
+	assert.Equal(t, "doc-gardener", vessels[0].Meta["config_source"])
+	assert.Equal(t, "1h", vessels[0].Meta["schedule.cadence"])
 }
 
-func TestScanMultipleScheduleSourcesKeepConfigNamesDistinct(t *testing.T) {
+func TestSmoke_S6_ScannerKeepsMultipleScheduleSourcesDistinct(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{
 		Concurrency: 2,
@@ -450,53 +434,29 @@ func TestScanMultipleScheduleSourcesKeepConfigNamesDistinct(t *testing.T) {
 
 	s := New(cfg, q, newMock())
 	result, err := s.Scan(context.Background())
-	if err != nil {
-		t.Fatalf("Scan() error = %v", err)
-	}
-	if result.Added != 2 {
-		t.Fatalf("Added = %d, want 2", result.Added)
-	}
+	require.NoError(t, err)
+	require.Equal(t, 2, result.Added)
 
 	vessels, err := q.List()
-	if err != nil {
-		t.Fatalf("List() error = %v", err)
-	}
-	if len(vessels) != 2 {
-		t.Fatalf("len(vessels) = %d, want 2", len(vessels))
-	}
+	require.NoError(t, err)
+	require.Len(t, vessels, 2)
 
 	byConfigSource := make(map[string]queue.Vessel, len(vessels))
 	for _, vessel := range vessels {
 		byConfigSource[vessel.Meta["config_source"]] = vessel
-		if vessel.Source != "schedule" {
-			t.Fatalf("vessel.Source = %q, want schedule", vessel.Source)
-		}
+		assert.Equal(t, "schedule", vessel.Source)
 	}
 
 	docGardener, ok := byConfigSource["doc-gardener"]
-	if !ok {
-		t.Fatal("missing doc-gardener vessel")
-	}
-	if docGardener.Workflow != "doc-garden" {
-		t.Fatalf("doc-gardener workflow = %q, want doc-garden", docGardener.Workflow)
-	}
-	if docGardener.Meta["schedule.cadence"] != "1h" {
-		t.Fatalf("doc-gardener cadence = %q, want 1h", docGardener.Meta["schedule.cadence"])
-	}
+	require.True(t, ok, "missing doc-gardener vessel")
+	assert.Equal(t, "doc-garden", docGardener.Workflow)
+	assert.Equal(t, "1h", docGardener.Meta["schedule.cadence"])
 
 	doctor, ok := byConfigSource["doctor"]
-	if !ok {
-		t.Fatal("missing doctor vessel")
-	}
-	if doctor.Workflow != "doctor" {
-		t.Fatalf("doctor workflow = %q, want doctor", doctor.Workflow)
-	}
-	if doctor.Meta["schedule.cadence"] != "@daily" {
-		t.Fatalf("doctor cadence = %q, want @daily", doctor.Meta["schedule.cadence"])
-	}
-	if doctor.Ref == docGardener.Ref {
-		t.Fatalf("schedule refs collided: %q", doctor.Ref)
-	}
+	require.True(t, ok, "missing doctor vessel")
+	assert.Equal(t, "doctor", doctor.Workflow)
+	assert.Equal(t, "@daily", doctor.Meta["schedule.cadence"])
+	assert.NotEqual(t, docGardener.Ref, doctor.Ref)
 }
 
 func TestScanSkipsUnchangedFailedIssue(t *testing.T) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -231,7 +231,7 @@ Behavior:
 - Later scans enqueue only when the cadence boundary has elapsed since the last successful enqueue.
 - Scheduled sources do not use `tasks`.
 - Vessel metadata includes `schedule.cadence`, `schedule.fired_at`, and the configured source name.
-- Built-in scheduled workflows such as `lessons`, `workflow-health-report`, and `security-compliance` fit this source type directly.
+- Built-in scheduled workflows such as `lessons`, `doc-garden`, `workflow-health-report`, and `security-compliance` fit this source type directly.
 
 ### `scheduled`
 


### PR DESCRIPTION
## Summary
+- Implements [issue #158](https://github.com/nicholls-inc/xylem/issues/158) by turning `doc-garden` into a seeded core-profile workflow with daily schedule wiring, embedded prompts/workflow assets, and docs/test coverage for living-documentation maintenance.
+- Bumps the core profile bundle to v3 so seeded installs and downstream reporting can distinguish the new doc-garden-capable profile.
+
+## Smoke scenarios covered
+- `S1` — `LoadCoreProfileReturnsEmbeddedAssets`
+- `S2` — `ComposeCoreIncludesSeededWorkflowsAndTemplates`
+- `S3` — `DaemonSeedingCreatesIssueAndMarkerOnFreshRepo`
+- `S4` — `DocGardenWorkflowBundleIsSeededInCoreProfile`
+- `S5` — `DocGardenWorkflowParsesAsFourPhaseMaintenanceWorkflow`
+- `S5` — `ScannerEnqueuesDocGardenerScheduleSource`
+- `S6` — `DocGardenPromptsDocumentHeuristicAndPRContract`
+- `S6` — `ScannerKeepsMultipleScheduleSourcesDistinct`
+- `S6` — `InitSeedCreatesAdaptRepoMarkerSynchronously`
+- `S7` — `DocGardenScheduledSourceUsesDailyCadence`
+
+## Changes summary
+- **Added workflow assets**
+  - `cli/internal/profiles/core/workflows/doc-garden.yaml`
+  - `cli/internal/profiles/core/prompts/doc-garden/analyze.md`
+  - `cli/internal/profiles/core/prompts/doc-garden/implement.md`
+  - `cli/internal/profiles/core/prompts/doc-garden/verify.md`
+  - `cli/internal/profiles/core/prompts/doc-garden/pr.md`
+- **Modified seeded profile/config/docs**
+  - `cli/internal/profiles/core/xylem.yml.tmpl` adds the daily `doc-gardener` schedule source.
+  - `cli/internal/profiles/profiles.go` bumps the core profile version to `3` and exposes that bundle version through `Version`.
+  - `README.md` and `docs/configuration.md` document `doc-garden` as a built-in scheduled workflow.
+- **Modified command/runtime surfaces**
+  - `cli/cmd/xylem/field_report.go` now reads the core profile version dynamically via `profiles.Version("core")` instead of hard-coding it.
+  - `cli/internal/fieldreport/fieldreport.go` clarifies `fieldreport.Options.ProfileVersion` as the seeded bundle version carried into reports.
+  - `cli/cmd/xylem/init_test.go` and `cli/cmd/xylem/adapt_repo_seed_test.go` update bootstrap-marker expectations to profile version `3`.
+- **Modified tests**
+  - `cli/internal/profiles/profiles_test.go` adds doc-garden bundle, workflow, prompt-contract, and cadence smoke coverage.
+  - `cli/internal/profiles/profiles_prop_test.go` adds property coverage that `Compose("core")` keeps the doc-garden bundle intact across calls.
+  - `cli/internal/scanner/scanner_test.go` adds/renames schedule-source smoke coverage for the `doc-gardener` source and distinct schedule refs.
+
+## Test plan
+```bash
+cd cli
+goimports -l .
+golangci-lint run
+go vet ./...
+go build ./cmd/xylem
+go test ./...
+```
+
+Post-rebase rerun:
+
+```bash
+cd cli
+go vet ./...
+go build ./cmd/xylem
+go test ./...
+```

Fixes #158