### PR TITLE
fix: resync resolve-conflicts PR branches before merge_main

### DIFF
--- a/.xylem/workflows/resolve-conflicts.yaml
+++ b/.xylem/workflows/resolve-conflicts.yaml
@@ -5,9 +5,12 @@ phases:
     type: command
     run: |
       set -eu
+      head_branch="$(gh pr view {{ .Issue.Number }} --repo {{ .Repo.Slug }} --json headRefName --jq '.headRefName')"
+      git fetch origin "$head_branch" "{{ .Repo.DefaultBranch }}"
+      git branch -D "$head_branch" >/dev/null 2>&1 || true
       gh pr checkout {{ .Issue.Number }} --repo {{ .Repo.Slug }}
-      test "$(git branch --show-current)" = "$(gh pr view {{ .Issue.Number }} --repo {{ .Repo.Slug }} --json headRefName --jq '.headRefName')"
-      git fetch origin {{ .Repo.DefaultBranch }}
+      test "$(git branch --show-current)" = "$head_branch"
+      git reset --hard "origin/$head_branch"
       merge_log=$(mktemp)
       set +e
       git merge origin/{{ .Repo.DefaultBranch }} --no-commit --no-ff >"$merge_log" 2>&1

--- a/cli/cmd/xylem/cleanup_test.go
+++ b/cli/cmd/xylem/cleanup_test.go
@@ -40,8 +40,7 @@ func (m *mockCleanupRunner) Run(_ context.Context, name string, args ...string) 
 		m.removeCalls = append(m.removeCalls, key)
 		return []byte{}, m.removeErr
 	}
-	// branch -d is best-effort
-	if strings.Contains(key, "branch -d") {
+	if strings.Contains(key, "branch -D") {
 		return []byte{}, nil
 	}
 	return []byte{}, nil
@@ -297,7 +296,7 @@ func (m *partialFailRunner) Run(_ context.Context, name string, args ...string) 
 		}
 		return []byte{}, nil
 	}
-	if strings.Contains(key, "branch -d") {
+	if strings.Contains(key, "branch -D") {
 		return []byte{}, nil
 	}
 	return []byte{}, nil

--- a/cli/internal/dtushim/shim.go
+++ b/cli/internal/dtushim/shim.go
@@ -692,7 +692,7 @@ func runGit(_ context.Context, store *dtu.Store, state *dtu.State, args []string
 			return runGitWorktreeRemove(store, args[2:], stderr)
 		}
 	case "branch":
-		if len(args) >= 2 && args[1] == "-d" {
+		if len(args) >= 2 && (args[1] == "-d" || args[1] == "-D") {
 			return runGitBranchDelete(store, args[2:], stderr)
 		}
 	case "ls-remote":
@@ -746,15 +746,17 @@ func runGitRemoteShow(store *dtu.Store, state *dtu.State, args []string, stdout,
 }
 
 func runGitFetch(store *dtu.Store, state *dtu.State, args []string, stderr io.Writer) int {
-	if len(args) != 2 || args[0] != "origin" {
-		return writeError(stderr, 2, fmt.Errorf("git fetch requires origin and a branch name"))
+	if len(args) < 2 || args[0] != "origin" {
+		return writeError(stderr, 2, fmt.Errorf("git fetch requires origin and at least one branch name"))
 	}
 	repo, _, code := loadRepo(store, state, "", stderr)
 	if code != 0 {
 		return code
 	}
-	if !repoHasBranch(repo, args[1]) {
-		return writeError(stderr, 1, fmt.Errorf("branch %q not found", args[1]))
+	for _, branch := range args[1:] {
+		if !repoHasBranch(repo, branch) {
+			return writeError(stderr, 1, fmt.Errorf("branch %q not found", branch))
+		}
 	}
 	return 0
 }
@@ -853,7 +855,7 @@ func runGitWorktreeRemove(store *dtu.Store, args []string, stderr io.Writer) int
 
 func runGitBranchDelete(store *dtu.Store, args []string, stderr io.Writer) int {
 	if len(args) != 1 {
-		return writeError(stderr, 2, fmt.Errorf("git branch -d requires exactly one branch"))
+		return writeError(stderr, 2, fmt.Errorf("git branch -d/-D requires exactly one branch"))
 	}
 	branchName := strings.TrimSpace(args[0])
 	err := store.Update(func(state *dtu.State) error {

--- a/cli/internal/dtushim/shim_test.go
+++ b/cli/internal/dtushim/shim_test.go
@@ -534,6 +534,70 @@ func TestExecuteGitWorktreeCommandsMaterializeDirectories(t *testing.T) {
 	}
 }
 
+func TestExecuteGitBranchForceDeleteRemovesBranch(t *testing.T) {
+	t.Parallel()
+
+	state := sampleState()
+	state.Repositories[0].Branches = []dtu.Branch{{Name: "fix/issue-1-bug-one", SHA: "abc123"}}
+	store, stateDir := testStore(t, state)
+	env := envForStore(store, stateDir, state.UniverseID)
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), "git", []string{"branch", "-D", "fix/issue-1-bug-one"}, nil, &stdout, &stderr, env)
+	if code != 0 {
+		t.Fatalf("git branch -D code = %d, stderr = %q", code, stderr.String())
+	}
+
+	got, err := store.Load()
+	require.NoError(t, err)
+	require.Empty(t, got.Repositories[0].Branches)
+}
+
+func TestExecuteGitFetchSupportsMultipleBranches(t *testing.T) {
+	t.Parallel()
+
+	state := sampleState()
+	state.Repositories[0].Branches = []dtu.Branch{
+		{Name: "main", SHA: "1111111"},
+		{Name: "fix/issue-1-bug-one", SHA: "abc1234"},
+	}
+	store, stateDir := testStore(t, state)
+	env := envForStore(store, stateDir, state.UniverseID)
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), "git", []string{"fetch", "origin", "fix/issue-1-bug-one", "main"}, nil, &stdout, &stderr, env)
+	require.Zero(t, code, "stderr = %q", stderr.String())
+	assert.Empty(t, stdout.String())
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	repo := loaded.RepositoryBySlug("owner/repo")
+	require.NotNil(t, repo)
+	require.NotNil(t, repo.BranchByName("fix/issue-1-bug-one"))
+	require.NotNil(t, repo.BranchByName("main"))
+
+	events, err := store.ReadEvents()
+	require.NoError(t, err)
+	var invocation, result *dtu.Event
+	for i := range events {
+		if events[i].Shim == nil || events[i].Shim.Command != "git" || len(events[i].Shim.Args) == 0 || events[i].Shim.Args[0] != "fetch" {
+			continue
+		}
+		switch events[i].Kind {
+		case dtu.EventKindShimInvocation:
+			invocation = &events[i]
+		case dtu.EventKindShimResult:
+			result = &events[i]
+		}
+	}
+	require.NotNil(t, invocation)
+	require.NotNil(t, result)
+	assert.Equal(t, []string{"fetch", "origin", "fix/issue-1-bug-one", "main"}, invocation.Shim.Args)
+	assert.Equal(t, []string{"fetch", "origin", "fix/issue-1-bug-one", "main"}, result.Shim.Args)
+	require.NotNil(t, result.Shim.ExitCode)
+	assert.Equal(t, 0, *result.Shim.ExitCode)
+}
+
 func TestExecuteGHIssueViewAppliesScheduledMutationAfterObservationThreshold(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/profiles/core/prompts/resolve-conflicts/analyze.md
+++ b/cli/internal/profiles/core/prompts/resolve-conflicts/analyze.md
@@ -5,14 +5,13 @@ URL: {{.Issue.URL}}
 
 {{.Issue.Body}}
 
-Check out the PR branch and attempt a merge from main:
+## Merge Attempt Output
+{{.PreviousOutputs.merge_main}}
 
-1. Run `gh pr checkout {{.Issue.Number}}`
-2. Run `git fetch origin main && git merge origin/main --no-commit`
+The workflow has already checked out the PR branch and attempted `git merge origin/{{ .Repo.DefaultBranch }} --no-commit --no-ff`.
+Do not rerun the merge. Inspect the current conflicted worktree state produced by that command.
 
 Do not modify, stage, or delete anything under `.xylem/`. The xylem control plane is out of scope for conflict resolution.
-
-If the merge completes with no conflicts, include the exact standalone line `XYLEM_NOOP` in your final output and explain that no conflict resolution is needed.
 
 If there are conflicts:
 

--- a/cli/internal/profiles/core/prompts/resolve-conflicts/push.md
+++ b/cli/internal/profiles/core/prompts/resolve-conflicts/push.md
@@ -6,10 +6,9 @@ URL: {{.Issue.URL}}
 ## Resolution
 {{.PreviousOutputs.resolve}}
 
-Commit and push the resolved conflicts:
+Push the already-completed merge resolution:
 
 ```
-git add -A && git commit -m "fix: resolve merge conflicts on #{{.Issue.Number}}"
 git push
 ```
 

--- a/cli/internal/profiles/core/prompts/resolve-conflicts/resolve.md
+++ b/cli/internal/profiles/core/prompts/resolve-conflicts/resolve.md
@@ -6,6 +6,9 @@ URL: {{.Issue.URL}}
 ## Analysis
 {{.PreviousOutputs.analyze}}
 
+## Merge Attempt Output
+{{.PreviousOutputs.merge_main}}
+
 {{if .GateResult}}
 ## Previous Gate Failure
 The following gate check failed after the previous attempt. Fix the issues and try again:
@@ -19,6 +22,8 @@ Resolve each conflict using these strategies:
 - **Overlapping**: both sides modified the same code. Combine the intent of both changes.
 - **Structural**: one side refactored while the other made localized edits. Apply the localized edits to the new structure.
 
+The workflow has already started a merge of `origin/{{ .Repo.DefaultBranch }}` into the PR branch. Resolve the current merge state in place; do not rely on self-reporting that a merge happened.
+
 Do not modify, stage, or delete anything under `.xylem/`. The xylem control plane is out of scope for conflict resolution.
 
 For every conflicting file:
@@ -27,4 +32,6 @@ For every conflicting file:
 2. Apply the appropriate resolution strategy
 3. Verify the file is syntactically valid
 
-After resolving all conflicts, run the repository's validation commands to confirm the branch is healthy.
+After resolving all conflicts, stage the resolved files and complete the in-progress merge before validation. Because the workflow already ran `git merge ... --no-commit --no-ff`, finish that merge in place (for example, `git add <resolved-files> && git commit --no-edit` while `MERGE_HEAD` exists).
+
+Once the merge commit exists, run `cd cli && go vet ./... && go build ./cmd/xylem && go test ./...` to confirm the build and tests pass.

--- a/cli/internal/profiles/core/workflows/resolve-conflicts.yaml
+++ b/cli/internal/profiles/core/workflows/resolve-conflicts.yaml
@@ -1,11 +1,42 @@
 name: resolve-conflicts
 description: "Resolve merge conflicts on a PR branch"
 phases:
+  - name: merge_main
+    type: command
+    run: |
+      set -eu
+      head_branch="$(gh pr view {{ .Issue.Number }} --json headRefName --jq '.headRefName')"
+      git fetch origin "$head_branch" main
+      git branch -D "$head_branch" >/dev/null 2>&1 || true
+      gh pr checkout {{ .Issue.Number }}
+      test "$(git branch --show-current)" = "$head_branch"
+      git reset --hard "origin/$head_branch"
+      merge_log=$(mktemp)
+      set +e
+      git merge origin/main --no-commit --no-ff >"$merge_log" 2>&1
+      merge_status=$?
+      set -e
+      cat "$merge_log"
+      rm -f "$merge_log"
+      if [ "$merge_status" -eq 0 ]; then
+        if git rev-parse -q --verify MERGE_HEAD >/dev/null 2>&1; then
+          git merge --abort
+        fi
+        printf '\nXYLEM_NOOP\n'
+        exit 0
+      fi
+      if git rev-parse -q --verify MERGE_HEAD >/dev/null 2>&1; then
+        if git diff --name-only --diff-filter=U | grep . >/dev/null 2>&1; then
+          exit 0
+        fi
+        git merge --abort
+      fi
+      exit "$merge_status"
+    noop:
+      match: XYLEM_NOOP
   - name: analyze
     prompt_file: .xylem/prompts/resolve-conflicts/analyze.md
     max_turns: 20
-    noop:
-      match: XYLEM_NOOP
   - name: resolve
     prompt_file: .xylem/prompts/resolve-conflicts/resolve.md
     max_turns: 40

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -555,7 +555,47 @@ func TestSmoke_S5_SecurityComplianceWorkflowParsesAsFourPhaseAudit(t *testing.T)
 	assert.Nil(t, wf.Phases[3].Gate)
 }
 
-func TestSmoke_S6_SecurityComplianceScheduledSourceUsesDailyCadence(t *testing.T) {
+func TestSmoke_S6_ResolveConflictsWorkflowResyncsHeadBeforeMerge(t *testing.T) {
+	t.Parallel()
+
+	composed, err := Compose("core")
+	require.NoError(t, err)
+
+	workflowData, ok := composed.Workflows["resolve-conflicts"]
+	require.True(t, ok)
+
+	var wf workflowpkg.Workflow
+	require.NoError(t, yaml.Unmarshal(workflowData, &wf))
+	require.Len(t, wf.Phases, 4)
+
+	mergeMainPhase := wf.Phases[0]
+	assert.Equal(t, "merge_main", mergeMainPhase.Name)
+	assert.Equal(t, "command", mergeMainPhase.Type)
+	assert.Contains(t, mergeMainPhase.Run, "head_branch=\"$(gh pr view {{ .Issue.Number }} --json headRefName --jq '.headRefName')\"")
+	assert.Contains(t, mergeMainPhase.Run, "git fetch origin \"$head_branch\" main")
+	assert.Contains(t, mergeMainPhase.Run, "git branch -D \"$head_branch\" >/dev/null 2>&1 || true")
+	assert.Contains(t, mergeMainPhase.Run, "git reset --hard \"origin/$head_branch\"")
+	assert.Contains(t, mergeMainPhase.Run, "git merge origin/main --no-commit --no-ff")
+	require.NotNil(t, mergeMainPhase.NoOp)
+	assert.Equal(t, "XYLEM_NOOP", mergeMainPhase.NoOp.Match)
+
+	analyzePrompt, ok := composed.Prompts["resolve-conflicts/analyze"]
+	require.True(t, ok)
+	assert.Contains(t, string(analyzePrompt), "{{.PreviousOutputs.merge_main}}")
+	assert.Contains(t, string(analyzePrompt), "Do not rerun the merge.")
+
+	resolvePrompt, ok := composed.Prompts["resolve-conflicts/resolve"]
+	require.True(t, ok)
+	assert.Contains(t, string(resolvePrompt), "{{.PreviousOutputs.merge_main}}")
+	assert.Contains(t, string(resolvePrompt), "complete the in-progress merge before validation")
+
+	pushPrompt, ok := composed.Prompts["resolve-conflicts/push"]
+	require.True(t, ok)
+	assert.Contains(t, string(pushPrompt), "Push the already-completed merge resolution")
+	assert.NotContains(t, string(pushPrompt), "git add -A && git commit")
+}
+
+func TestSmoke_S7_SecurityComplianceScheduledSourceUsesDailyCadence(t *testing.T) {
 	t.Parallel()
 
 	profile, err := Load("core")
@@ -567,7 +607,7 @@ func TestSmoke_S6_SecurityComplianceScheduledSourceUsesDailyCadence(t *testing.T
 	assert.Contains(t, string(configTemplate), "security-compliance:\n    type: schedule\n    cadence: \"@daily\"\n    workflow: security-compliance")
 }
 
-func TestSmoke_S7_SecurityCompliancePromptsDocumentReportingContract(t *testing.T) {
+func TestSmoke_S8_SecurityCompliancePromptsDocumentReportingContract(t *testing.T) {
 	t.Parallel()
 
 	profile, err := Load("core")

--- a/cli/internal/workflow/pr_validation_workflow_test.go
+++ b/cli/internal/workflow/pr_validation_workflow_test.go
@@ -55,13 +55,20 @@ func TestSmoke_S6_ResolveConflictsWorkflowUsesRepoAndValidationTemplates(t *test
 	assert.Equal(t, "command", mergeMainPhase.Type)
 	require.NotNil(t, mergeMainPhase.NoOp, "workflow %q missing merge_main noop", wf.Name)
 	assert.Equal(t, "XYLEM_NOOP", mergeMainPhase.NoOp.Match)
+	assert.Contains(t, mergeMainPhase.Run, "head_branch=\"$(gh pr view {{ .Issue.Number }} --repo {{ .Repo.Slug }} --json headRefName --jq '.headRefName')\"")
+	assert.Contains(t, mergeMainPhase.Run, "git fetch origin \"$head_branch\" \"{{ .Repo.DefaultBranch }}\"")
+	assert.Contains(t, mergeMainPhase.Run, "git branch -D \"$head_branch\" >/dev/null 2>&1 || true")
 	assert.Contains(t, mergeMainPhase.Run, "gh pr checkout {{ .Issue.Number }} --repo {{ .Repo.Slug }}")
+	assert.Contains(t, mergeMainPhase.Run, "git reset --hard \"origin/$head_branch\"")
 	assert.Contains(t, mergeMainPhase.Run, "git merge origin/{{ .Repo.DefaultBranch }} --no-commit --no-ff")
 	assert.Contains(t, mergeMainPhase.Run, "git diff --name-only --diff-filter=U")
 	assert.True(t, commandContainsInOrder(
 		mergeMainPhase.Run,
+		"head_branch=\"$(gh pr view {{ .Issue.Number }} --repo {{ .Repo.Slug }} --json headRefName --jq '.headRefName')\"",
+		"git fetch origin \"$head_branch\" \"{{ .Repo.DefaultBranch }}\"",
+		"git branch -D \"$head_branch\" >/dev/null 2>&1 || true",
 		"gh pr checkout {{ .Issue.Number }} --repo {{ .Repo.Slug }}",
-		"git fetch origin {{ .Repo.DefaultBranch }}",
+		"git reset --hard \"origin/$head_branch\"",
 		"git merge origin/{{ .Repo.DefaultBranch }} --no-commit --no-ff",
 	))
 

--- a/cli/internal/worktree/worktree.go
+++ b/cli/internal/worktree/worktree.go
@@ -366,9 +366,11 @@ func (m *Manager) Remove(ctx context.Context, worktreePath string) error {
 		span.RecordError(err)
 		return fmt.Errorf("git worktree remove: %w", err)
 	}
-	// Best-effort branch deletion using the real branch name
 	if branchName != "" {
-		m.Runner.Run(ctx, "git", "branch", "-d", branchName) //nolint:errcheck
+		if _, err := m.Runner.Run(ctx, "git", "branch", "-D", branchName); err != nil {
+			span.RecordError(err)
+			return fmt.Errorf("git branch -D %s: %w", branchName, err)
+		}
 	}
 	span.AddAttributes(observability.WorktreeSpanAttributes(observability.WorktreeSpanData{
 		Action: "remove",

--- a/cli/internal/worktree/worktree_prop_test.go
+++ b/cli/internal/worktree/worktree_prop_test.go
@@ -1,8 +1,11 @@
 package worktree
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"pgregory.net/rapid"
@@ -32,6 +35,35 @@ func TestPropNormalizePathMatchesAbsoluteEquivalent(t *testing.T) {
 		gotAbsolute := m.NormalizePath(absolutePath)
 		if gotRelative != gotAbsolute {
 			rt.Fatalf("NormalizePath(relative) = %q, NormalizePath(absolute) = %q", gotRelative, gotAbsolute)
+		}
+	})
+}
+
+func TestPropRemoveDeletesExactBranchName(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		repoRoot, err := os.MkdirTemp("", "xylem-worktree-remove-prop-*")
+		if err != nil {
+			rt.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(repoRoot)
+
+		branch := rapid.StringMatching(`[a-z0-9-]{1,8}(?:/[a-z0-9-]{1,8}){1,3}`).Draw(rt, "branch")
+		segments := strings.Split(branch, "/")
+		worktreeRel := filepath.Join(append([]string{".claude", "worktrees"}, segments...)...)
+		worktreeAbs := filepath.Join(append([]string{repoRoot, ".claude", "worktrees"}, segments...)...)
+
+		r := newMock()
+		r.setOutput("git worktree list --porcelain", []byte(fmt.Sprintf("worktree %s\nHEAD abc123\nbranch refs/heads/%s\n\n", worktreeAbs, branch)))
+
+		m := New(repoRoot, r)
+		if err := m.Remove(context.Background(), worktreeRel); err != nil {
+			rt.Fatalf("Remove() error = %v", err)
+		}
+		if !r.called("git", "branch", "-D", branch) {
+			rt.Fatalf("expected branch deletion for %q, calls = %v", branch, r.calls)
+		}
+		if truncated := filepath.Base(branch); truncated != branch && r.called("git", "branch", "-D", truncated) {
+			rt.Fatalf("unexpected truncated branch deletion for %q, calls = %v", truncated, r.calls)
 		}
 	})
 }

--- a/cli/internal/worktree/worktree_test.go
+++ b/cli/internal/worktree/worktree_test.go
@@ -79,6 +79,26 @@ func (m *mockRunner) called(name string, args ...string) bool {
 	return false
 }
 
+func (m *mockRunner) callIndex(name string, args ...string) int {
+	target := append([]string{name}, args...)
+	for idx, call := range m.calls {
+		if len(call) != len(target) {
+			continue
+		}
+		match := true
+		for i := range call {
+			if call[i] != target[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return idx
+		}
+	}
+	return -1
+}
+
 func TestDefaultBranchFromGH(t *testing.T) {
 	r := newMock()
 	r.setOutput("gh repo view --json defaultBranchRef", []byte(`{"defaultBranchRef":{"name":"main"}}`))
@@ -198,11 +218,11 @@ func TestRemoveDeletesCorrectBranchWithSlash(t *testing.T) {
 
 	// The fix: must delete the FULL branch name "fix/issue-42-slug",
 	// NOT the truncated "issue-42-slug" that filepath.Base() would return.
-	if !r.called("git", "branch", "-d", "fix/issue-42-slug") {
-		t.Errorf("expected 'git branch -d fix/issue-42-slug', got calls: %v", r.calls)
+	if !r.called("git", "branch", "-D", "fix/issue-42-slug") {
+		t.Errorf("expected 'git branch -D fix/issue-42-slug', got calls: %v", r.calls)
 	}
-	if r.called("git", "branch", "-d", "issue-42-slug") {
-		t.Error("should NOT call 'git branch -d issue-42-slug' (truncated by filepath.Base)")
+	if r.called("git", "branch", "-D", "issue-42-slug") {
+		t.Error("should NOT call 'git branch -D issue-42-slug' (truncated by filepath.Base)")
 	}
 }
 
@@ -218,8 +238,8 @@ func TestRemoveWithAbsoluteWorktreePath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !r.called("git", "branch", "-d", "feat/add-logging") {
-		t.Errorf("expected 'git branch -d feat/add-logging', got calls: %v", r.calls)
+	if !r.called("git", "branch", "-D", "feat/add-logging") {
+		t.Errorf("expected 'git branch -D feat/add-logging', got calls: %v", r.calls)
 	}
 }
 
@@ -241,6 +261,26 @@ func TestRemoveSkipsBranchDeleteWhenNotFound(t *testing.T) {
 			t.Errorf("should not call git branch when branch name is unknown, got: %v", call)
 		}
 	}
+}
+
+func TestSmoke_S1_RemoveDeletesPersistedBranchRefAfterWorktreeCleanup(t *testing.T) {
+	t.Parallel()
+
+	r := newMock()
+	porcelain := "worktree /repo/.claude/worktrees/feat/issue-235-235\nHEAD abc123\nbranch refs/heads/feat/issue-235-235\n\n"
+	r.setOutput("git worktree list --porcelain", []byte(porcelain))
+
+	m := New("/repo", r)
+	err := m.Remove(context.Background(), ".claude/worktrees/feat/issue-235-235")
+	require.NoError(t, err)
+
+	removeIdx := r.callIndex("git", "worktree", "remove", ".claude/worktrees/feat/issue-235-235", "--force")
+	deleteIdx := r.callIndex("git", "branch", "-D", "feat/issue-235-235")
+	require.NotEqual(t, -1, removeIdx, "expected worktree removal command")
+	require.NotEqual(t, -1, deleteIdx, "expected stale branch ref deletion command")
+
+	assert.Less(t, removeIdx, deleteIdx, "expected stale branch ref deletion after worktree removal")
+	assert.Equal(t, []string{"git", "branch", "-D", "feat/issue-235-235"}, r.calls[deleteIdx])
 }
 
 func TestListParsesPorcelain(t *testing.T) {
@@ -697,8 +737,24 @@ func TestRemoveWorktreeRemoveFails(t *testing.T) {
 		t.Errorf("expected worktree-remove error, got: %v", err)
 	}
 	// Should NOT attempt branch delete if remove failed
-	if r.called("git", "branch", "-d", "fix/issue-1") {
+	if r.called("git", "branch", "-D", "fix/issue-1") {
 		t.Error("should not delete branch when worktree remove fails")
+	}
+}
+
+func TestRemoveBranchDeleteFails(t *testing.T) {
+	r := newMock()
+	porcelain := "worktree /repo/.claude/worktrees/fix/issue-2\nHEAD abc\nbranch refs/heads/fix/issue-2\n\n"
+	r.setOutput("git worktree list --porcelain", []byte(porcelain))
+	r.setErr("git branch -D fix/issue-2", errors.New("branch is checked out elsewhere"))
+
+	m := New("/repo", r)
+	err := m.Remove(context.Background(), ".claude/worktrees/fix/issue-2")
+	if err == nil {
+		t.Fatal("expected error when branch delete fails")
+	}
+	if !strings.Contains(err.Error(), "git branch -D fix/issue-2") {
+		t.Errorf("expected branch-delete error, got: %v", err)
 	}
 }
 
@@ -983,7 +1039,7 @@ func TestRemoveResolvesRelativeRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !r.called("git", "branch", "-d", "fix/issue-42-test") {
+	if !r.called("git", "branch", "-D", "fix/issue-42-test") {
 		t.Errorf("expected branch deletion with relative root, got calls: %v", r.calls)
 	}
 }


### PR DESCRIPTION
## Summary
- Resolves [issue #369](https://github.com/nicholls-inc/xylem/issues/369) by making `resolve-conflicts` resync the PR head branch from `origin/<head>` before `merge_main` runs, so local branch drift cannot make `gh pr checkout` fail with a fast-forward error.
- Hardens worktree cleanup so stale local branch refs are force-deleted after `git worktree remove`, preventing future conflict-resolution runs from inheriting leftover branch state.

## Smoke scenarios covered
- `worktree/S1` — RemoveDeletesPersistedBranchRefAfterWorktreeCleanup
- `workflow/S6` — ResolveConflictsWorkflowUsesRepoAndValidationTemplates
- `workflow/S7` — ResolveConflictsPromptsRelyOnDeterministicMergePhase
- `profiles/S6` — ResolveConflictsWorkflowResyncsHeadBeforeMerge

## Changes summary
- **Modified** `.xylem/workflows/resolve-conflicts.yaml` and `cli/internal/profiles/core/workflows/resolve-conflicts.yaml` to fetch the PR head branch and default branch together, drop any stale local head ref, `gh pr checkout` the PR, hard-reset to `origin/$head_branch`, and treat conflict/no-conflict outcomes deterministically through `merge_main`.
- **Modified** `cli/internal/profiles/core/prompts/resolve-conflicts/analyze.md`, `resolve.md`, and `push.md` so downstream phases consume `{{.PreviousOutputs.merge_main}}`, resolve the in-progress merge in place, and only push after the merge commit exists.
- **Modified** `cli/internal/worktree/worktree.go` so `(*Manager).Remove` force-deletes the exact persisted branch name with `git branch -D` and surfaces branch-delete failures instead of silently leaving drift behind.
- **Modified** `cli/internal/dtushim/shim.go` so the shim accepts `git fetch origin <branch1> <branch2>` and supports `git branch -D`, matching the updated workflow and cleanup paths.
- **Modified tests** in `cli/internal/worktree/worktree_test.go`, `cli/internal/worktree/worktree_prop_test.go`, `cli/internal/workflow/pr_validation_workflow_test.go`, `cli/internal/profiles/profiles_test.go`, `cli/internal/dtushim/shim_test.go`, and `cli/cmd/xylem/cleanup_test.go` to cover branch resync, stale-ref deletion ordering, force-delete behavior, and the updated prompt/workflow contract.

## Test plan
- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #369