### PR TITLE
Wire generator/evaluator loops into runner phases

### DIFF
--- a/cli/internal/phase/phase.go
+++ b/cli/internal/phase/phase.go
@@ -12,6 +12,9 @@ const (
 	MaxGateResultLen     = 8000
 	MaxIssueBodyLen      = 32000
 	MaxReporterOutputLen = 64000
+	MaxEvalFeedbackLen   = 8000
+	MaxEvalOutputLen     = 16000
+	MaxEvalCriteriaLen   = 8000
 	TruncationSuffix     = "\n\n[... output truncated at %d characters]"
 )
 
@@ -22,6 +25,7 @@ type TemplateData struct {
 	Phase           PhaseData
 	PreviousOutputs map[string]string // phase name → output text
 	GateResult      string            // most recent gate command output
+	Evaluation      EvaluationData
 	Vessel          VesselData
 	Repo            RepoData
 	Source          SourceData
@@ -71,6 +75,14 @@ type ValidationData struct {
 	Test   string
 }
 
+// EvaluationData describes evaluator loop context for the current phase.
+type EvaluationData struct {
+	Iteration int
+	Feedback  string
+	Output    string
+	Criteria  string
+}
+
 // TruncateOutput truncates s to maxLen characters, appending a suffix if truncated.
 func TruncateOutput(s string, maxLen int) string {
 	if len(s) <= maxLen {
@@ -101,6 +113,9 @@ func prepareData(data TemplateData) TemplateData {
 
 	out.GateResult = TruncateOutput(data.GateResult, MaxGateResultLen)
 	out.Issue.Body = TruncateOutput(data.Issue.Body, MaxIssueBodyLen)
+	out.Evaluation.Feedback = TruncateOutput(data.Evaluation.Feedback, MaxEvalFeedbackLen)
+	out.Evaluation.Output = TruncateOutput(data.Evaluation.Output, MaxEvalOutputLen)
+	out.Evaluation.Criteria = TruncateOutput(data.Evaluation.Criteria, MaxEvalCriteriaLen)
 
 	return out
 }

--- a/cli/internal/phase/phase_test.go
+++ b/cli/internal/phase/phase_test.go
@@ -124,6 +124,19 @@ func TestRenderPrompt(t *testing.T) {
 			want: "Gate: all checks passed",
 		},
 		{
+			name:     "renders evaluation context",
+			template: "Iteration: {{.Evaluation.Iteration}}\nFeedback: {{.Evaluation.Feedback}}\nOutput: {{.Evaluation.Output}}\nCriteria: {{.Evaluation.Criteria}}",
+			data: TemplateData{
+				Evaluation: EvaluationData{
+					Iteration: 2,
+					Feedback:  "Add tests",
+					Output:    "draft 1",
+					Criteria:  "correctness",
+				},
+			},
+			want: "Iteration: 2\nFeedback: Add tests\nOutput: draft 1\nCriteria: correctness",
+		},
+		{
 			name:     "renders vessel ID and source",
 			template: "Vessel: {{.Vessel.ID}} from {{.Vessel.Source}}",
 			data: TemplateData{
@@ -285,6 +298,29 @@ func TestRenderPromptTruncation(t *testing.T) {
 		suffix := fmt.Sprintf(TruncationSuffix, MaxPreviousOutputLen)
 		if !strings.HasSuffix(got, suffix) {
 			t.Fatalf("expected truncation suffix for large value")
+		}
+	})
+
+	t.Run("Evaluation fields exceeding limits are truncated", func(t *testing.T) {
+		data := TemplateData{
+			Evaluation: EvaluationData{
+				Feedback: longString(MaxEvalFeedbackLen + 100),
+				Output:   longString(MaxEvalOutputLen + 100),
+				Criteria: longString(MaxEvalCriteriaLen + 100),
+			},
+		}
+		got, err := RenderPrompt("{{.Evaluation.Feedback}}\n{{.Evaluation.Output}}\n{{.Evaluation.Criteria}}", data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(got, fmt.Sprintf(TruncationSuffix, MaxEvalFeedbackLen)) {
+			t.Fatalf("expected feedback truncation suffix")
+		}
+		if !strings.Contains(got, fmt.Sprintf(TruncationSuffix, MaxEvalOutputLen)) {
+			t.Fatalf("expected output truncation suffix")
+		}
+		if !strings.Contains(got, fmt.Sprintf(TruncationSuffix, MaxEvalCriteriaLen)) {
+			t.Fatalf("expected criteria truncation suffix")
 		}
 	})
 }

--- a/cli/internal/profiles/core/prompts/fix-bug/implement.md
+++ b/cli/internal/profiles/core/prompts/fix-bug/implement.md
@@ -16,4 +16,11 @@ The following gate check failed after the previous attempt. Fix the issues and t
 {{.GateResult}}
 {{end}}
 
+{{if .Evaluation.Feedback}}
+## Evaluator Feedback
+Address the following evaluator feedback before finalizing the implementation:
+
+{{.Evaluation.Feedback}}
+{{end}}
+
 Implement the changes now. Follow the plan precisely.

--- a/cli/internal/profiles/core/prompts/fix-bug/implement_evaluator.md
+++ b/cli/internal/profiles/core/prompts/fix-bug/implement_evaluator.md
@@ -1,0 +1,28 @@
+Review the current implementation draft for the bug fix before the workflow proceeds.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+## Evaluation Iteration
+{{.Evaluation.Iteration}}
+
+## Criteria
+{{.Evaluation.Criteria}}
+
+## Candidate Output
+{{.Evaluation.Output}}
+
+Return **JSON only** with this shape:
+{"pass":true,"score":{"overall":0.0,"criteria":{"criterion_name":0.0},"issues":[{"severity":0,"description":"","location":"","suggestion":""}]},"feedback":[{"severity":0,"description":"","location":"","suggestion":""}]}
+
+Rules:
+- `severity` must be 0=low, 1=medium, 2=high, or 3=critical.
+- Set `pass` to true only if the implementation meets the configured thresholds.
+- When `pass` is false, include concrete issues and actionable suggestions in both `score.issues` and `feedback`.
+- Do not wrap the JSON in Markdown fences or add extra prose.

--- a/cli/internal/profiles/core/prompts/implement-feature/implement.md
+++ b/cli/internal/profiles/core/prompts/implement-feature/implement.md
@@ -16,4 +16,11 @@ The following gate check failed after the previous attempt. Fix the issues and t
 {{.GateResult}}
 {{end}}
 
+{{if .Evaluation.Feedback}}
+## Evaluator Feedback
+Address the following evaluator feedback before finalizing the implementation:
+
+{{.Evaluation.Feedback}}
+{{end}}
+
 Implement the changes now. Follow the plan precisely.

--- a/cli/internal/profiles/core/prompts/implement-feature/implement_evaluator.md
+++ b/cli/internal/profiles/core/prompts/implement-feature/implement_evaluator.md
@@ -1,0 +1,28 @@
+Review the current implementation draft for the feature before the workflow proceeds.
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Plan
+{{.PreviousOutputs.plan}}
+
+## Evaluation Iteration
+{{.Evaluation.Iteration}}
+
+## Criteria
+{{.Evaluation.Criteria}}
+
+## Candidate Output
+{{.Evaluation.Output}}
+
+Return **JSON only** with this shape:
+{"pass":true,"score":{"overall":0.0,"criteria":{"criterion_name":0.0},"issues":[{"severity":0,"description":"","location":"","suggestion":""}]},"feedback":[{"severity":0,"description":"","location":"","suggestion":""}]}
+
+Rules:
+- `severity` must be 0=low, 1=medium, 2=high, or 3=critical.
+- Set `pass` to true only if the implementation meets the configured thresholds.
+- When `pass` is false, include concrete issues and actionable suggestions in both `score.issues` and `feedback`.
+- Do not wrap the JSON in Markdown fences or add extra prose.

--- a/cli/internal/profiles/core/workflows/fix-bug.yaml
+++ b/cli/internal/profiles/core/workflows/fix-bug.yaml
@@ -12,6 +12,20 @@ phases:
   - name: implement
     prompt_file: .xylem/prompts/fix-bug/implement.md
     max_turns: 60
+    evaluator:
+      prompt_file: .xylem/prompts/fix-bug/implement_evaluator.md
+      max_turns: 20
+      max_iterations: 2
+      pass_threshold: 0.8
+      criteria:
+        - name: correctness
+          description: "The patch addresses the reported bug without obvious regressions."
+          weight: 0.7
+          threshold: 0.8
+        - name: verification
+          description: "The changes include or preserve validation needed to trust the fix."
+          weight: 0.3
+          threshold: 0.7
     gate:
       type: command
       run: "make test"

--- a/cli/internal/profiles/core/workflows/implement-feature.yaml
+++ b/cli/internal/profiles/core/workflows/implement-feature.yaml
@@ -12,6 +12,20 @@ phases:
   - name: implement
     prompt_file: .xylem/prompts/implement-feature/implement.md
     max_turns: 60
+    evaluator:
+      prompt_file: .xylem/prompts/implement-feature/implement_evaluator.md
+      max_turns: 20
+      max_iterations: 2
+      pass_threshold: 0.8
+      criteria:
+        - name: correctness
+          description: "The implementation satisfies the requested feature without contradicting the plan."
+          weight: 0.65
+          threshold: 0.8
+        - name: verification
+          description: "The changes include or preserve validation needed to trust the feature."
+          weight: 0.35
+          threshold: 0.7
     gate:
       type: command
       run: "make test"

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -100,6 +100,8 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 	assert.Contains(t, sortedKeys(composed.Prompts), "adapt-repo/plan")
 	assert.Contains(t, sortedKeys(composed.Prompts), "adapt-repo/pr")
 	assert.Contains(t, sortedKeys(composed.Prompts), "doc-garden/analyze")
+	assert.Contains(t, sortedKeys(composed.Prompts), "fix-bug/implement_evaluator")
+	assert.Contains(t, sortedKeys(composed.Prompts), "implement-feature/implement_evaluator")
 	assert.Contains(t, sortedKeys(composed.Prompts), "security-compliance/synthesize")
 	assert.Contains(t, sortedKeys(composed.Prompts), "workflow-health-report/report")
 	assert.Contains(t, sortedKeys(composed.Sources), "doc-gardener")
@@ -111,11 +113,27 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 	assert.Contains(t, string(composed.Workflows["fix-bug"]), "name: fix-bug")
 	assert.Contains(t, string(composed.Workflows["implement-feature"]), "name: implement-feature")
 	assert.Contains(t, string(composed.Workflows["doc-garden"]), "name: doc-garden")
+	assert.Contains(t, string(composed.Prompts["fix-bug/implement"]), "{{.Evaluation.Feedback}}")
+	assert.Contains(t, string(composed.Prompts["implement-feature/implement"]), "{{.Evaluation.Feedback}}")
 	assert.Contains(t, string(composed.Prompts["adapt-repo/pr"]), `--label "ready-to-merge"`)
 	assert.Contains(t, string(composed.Prompts["fix-bug/pr"]), "Create a pull request")
 	assert.Contains(t, string(composed.Prompts["fix-bug/pr"]), `--label "ready-to-merge"`)
 	assert.Contains(t, string(composed.Prompts["implement-feature/pr"]), `--label "ready-to-merge"`)
 	assert.Contains(t, string(composed.ConfigOverlays[0]), `repo: "{{ .Repo }}"`)
+
+	var fixBug workflowpkg.Workflow
+	require.NoError(t, yaml.Unmarshal(composed.Workflows["fix-bug"], &fixBug))
+	require.Len(t, fixBug.Phases, 5)
+	require.NotNil(t, fixBug.Phases[2].Evaluator)
+	assert.Equal(t, ".xylem/prompts/fix-bug/implement_evaluator.md", fixBug.Phases[2].Evaluator.PromptFile)
+	assert.Equal(t, 2, fixBug.Phases[2].Evaluator.MaxIterations)
+
+	var implementFeature workflowpkg.Workflow
+	require.NoError(t, yaml.Unmarshal(composed.Workflows["implement-feature"], &implementFeature))
+	require.Len(t, implementFeature.Phases, 5)
+	require.NotNil(t, implementFeature.Phases[2].Evaluator)
+	assert.Equal(t, ".xylem/prompts/implement-feature/implement_evaluator.md", implementFeature.Phases[2].Evaluator.PromptFile)
+	assert.Equal(t, 2, implementFeature.Phases[2].Evaluator.MaxIterations)
 }
 
 func TestSmoke_S3_ComposeUnknownProfileReturnsClearError(t *testing.T) {

--- a/cli/internal/runner/evaluator_loop.go
+++ b/cli/internal/runner/evaluator_loop.go
@@ -79,7 +79,7 @@ func (g *phaseLoopGenerator) Generate(ctx context.Context, _ string, feedback []
 	if wErr := os.WriteFile(filepath.Join(g.phasesDir, g.phaseDef.Name+".prompt"), []byte(rendered), 0o644); wErr != nil {
 		log.Printf("warn: write prompt artifact for phase %s: %v", g.phaseDef.Name, wErr)
 	}
-	output, promptForCost, provider, model, err := g.r.runPromptInvocation(ctx, g.vessel, g.worktreePath, g.srcCfg, g.wf, &g.phaseDef, g.harnessContent, rendered, g.retryAttempt)
+	output, promptForCost, provider, model, err := g.r.runPromptInvocation(ctx, g.vessel, g.worktreePath, g.srcCfg, g.wf, &g.phaseDef, g.harnessContent, rendered, evaluatorLoopAttempt(g.retryAttempt, g.iteration))
 	if err != nil {
 		g.appendTrace("generation", false, "")
 		return "", err
@@ -98,7 +98,7 @@ func (g *phaseLoopGenerator) appendTrace(eventType string, success bool, content
 	}
 	*g.traceEvents = append(*g.traceEvents, signal.TraceEvent{
 		Type:       eventType,
-		Timestamp:  time.Now().UTC(),
+		Timestamp:  g.r.runtimeNow().UTC(),
 		Success:    success,
 		TokensUsed: cost.EstimateTokens(content),
 		Content:    content,
@@ -122,6 +122,7 @@ type phaseLoopEvaluator struct {
 	srcCfg          *config.SourceConfig
 	vrs             *vesselRunState
 	traceEvents     *[]signal.TraceEvent
+	retryAttempt    int
 	iteration       int
 }
 
@@ -152,7 +153,7 @@ func (e *phaseLoopEvaluator) Evaluate(ctx context.Context, output string, criter
 	if wErr := os.WriteFile(filepath.Join(e.phasesDir, e.phaseDef.Name+".evaluator.prompt"), []byte(rendered), 0o644); wErr != nil {
 		log.Printf("warn: write evaluator prompt artifact for phase %s: %v", e.phaseDef.Name, wErr)
 	}
-	rawOutput, promptForCost, _, model, err := e.r.runPromptInvocation(ctx, e.vessel, e.worktreePath, e.srcCfg, e.wf, &e.evaluatorDef, e.harnessContent, rendered, e.iteration)
+	rawOutput, promptForCost, _, model, err := e.r.runPromptInvocation(ctx, e.vessel, e.worktreePath, e.srcCfg, e.wf, &e.evaluatorDef, e.harnessContent, rendered, evaluatorLoopAttempt(e.retryAttempt, e.iteration))
 	if err != nil {
 		e.appendTrace(false, "")
 		return nil, err
@@ -161,7 +162,7 @@ func (e *phaseLoopEvaluator) Evaluate(ctx context.Context, output string, criter
 		log.Printf("warn: write evaluator output artifact for phase %s: %v", e.phaseDef.Name, wErr)
 	}
 	if e.vrs != nil {
-		e.vrs.recordEvaluationUsage(model, promptForCost, string(rawOutput), time.Now().UTC())
+		e.vrs.recordEvaluationUsage(model, promptForCost, string(rawOutput), e.r.runtimeNow().UTC())
 	}
 	result, err := parseEvalResultOutput(rawOutput)
 	if err != nil {
@@ -181,7 +182,7 @@ func (e *phaseLoopEvaluator) appendTrace(success bool, content string) {
 	}
 	*e.traceEvents = append(*e.traceEvents, signal.TraceEvent{
 		Type:       "evaluation",
-		Timestamp:  time.Now().UTC(),
+		Timestamp:  e.r.runtimeNow().UTC(),
 		Success:    success,
 		TokensUsed: cost.EstimateTokens(content),
 		Content:    content,
@@ -223,7 +224,7 @@ func (r *Runner) runPhaseEvaluationLoop(ctx context.Context, vessel queue.Vessel
 		return nil, fmt.Errorf("phase %s has no evaluator configuration", p.Name)
 	}
 
-	traceEvents := evaluationSeedEvents(previousOutputs, gateResult)
+	traceEvents := evaluationSeedEvents(previousOutputs, gateResult, r.runtimeNow())
 	seedSignals := signal.Compute(traceEvents, signal.DefaultConfig())
 	intensity := evaluator.SelectIntensity(resolveEvaluationComplexity(p, p.Evaluator), seedSignals.HealthString())
 	srcCfg := r.sourceConfigFromMeta(vessel)
@@ -267,6 +268,7 @@ func (r *Runner) runPhaseEvaluationLoop(ctx context.Context, vessel queue.Vessel
 		srcCfg:          srcCfg,
 		vrs:             vrs,
 		traceEvents:     &traceEvents,
+		retryAttempt:    retryAttempt,
 	}
 	loop, err := evaluator.NewLoop(gen, ev, evaluator.EvalConfig{
 		Criteria:      append([]evaluator.Criterion(nil), p.Evaluator.Criteria...),
@@ -375,13 +377,13 @@ func formatEvaluatorCriteria(criteria []evaluator.Criterion) string {
 	return b.String()
 }
 
-func evaluationSeedEvents(previousOutputs map[string]string, gateResult string) []signal.TraceEvent {
+func evaluationSeedEvents(previousOutputs map[string]string, gateResult string, now time.Time) []signal.TraceEvent {
 	keys := make([]string, 0, len(previousOutputs))
 	for key := range previousOutputs {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	now := time.Now().UTC()
+	now = now.UTC()
 	events := make([]signal.TraceEvent, 0, len(keys)+1)
 	for i, key := range keys {
 		events = append(events, signal.TraceEvent{
@@ -402,6 +404,16 @@ func evaluationSeedEvents(previousOutputs map[string]string, gateResult string) 
 		})
 	}
 	return events
+}
+
+func evaluatorLoopAttempt(retryAttempt, iteration int) int {
+	if retryAttempt < 1 {
+		retryAttempt = 1
+	}
+	if iteration < 1 {
+		iteration = 1
+	}
+	return retryAttempt*1000 + iteration
 }
 
 func resolveEvaluationComplexity(p workflow.Phase, cfg *workflow.PhaseEvaluator) string {

--- a/cli/internal/runner/evaluator_loop.go
+++ b/cli/internal/runner/evaluator_loop.go
@@ -1,0 +1,449 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/cost"
+	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
+	"github.com/nicholls-inc/xylem/cli/internal/phase"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/signal"
+	"github.com/nicholls-inc/xylem/cli/internal/workflow"
+)
+
+type phaseLLMExecution struct {
+	output           []byte
+	promptForCost    string
+	provider         string
+	model            string
+	evaluationReport *PhaseEvaluationReport
+}
+
+type phaseLoopGenerator struct {
+	r                 *Runner
+	vessel            queue.Vessel
+	wf                *workflow.Workflow
+	phaseDef          workflow.Phase
+	promptTemplate    string
+	phaseIdx          int
+	previousOutputs   map[string]string
+	issueData         phase.IssueData
+	gateResult        string
+	harnessContent    string
+	worktreePath      string
+	phasesDir         string
+	srcCfg            *config.SourceConfig
+	retryAttempt      int
+	criteriaText      string
+	traceEvents       *[]signal.TraceEvent
+	iteration         int
+	lastOutput        []byte
+	lastPromptForCost string
+	lastProvider      string
+	lastModel         string
+}
+
+func (g *phaseLoopGenerator) ID() string {
+	return g.phaseDef.Name + "-generator"
+}
+
+func (g *phaseLoopGenerator) Generate(ctx context.Context, _ string, feedback []evaluator.Issue) (string, error) {
+	g.iteration++
+	td := g.r.buildTemplateData(
+		g.vessel,
+		g.issueData,
+		g.phaseDef.Name,
+		g.phaseIdx,
+		g.previousOutputs,
+		g.gateResult,
+		phase.EvaluationData{
+			Iteration: g.iteration,
+			Feedback:  formatEvaluatorFeedback(feedback),
+			Criteria:  g.criteriaText,
+		},
+	)
+	rendered, err := phase.RenderPrompt(g.promptTemplate, td)
+	if err != nil {
+		g.appendTrace("generation", false, "")
+		return "", fmt.Errorf("render prompt for phase %s: %w", g.phaseDef.Name, err)
+	}
+	if wErr := os.WriteFile(filepath.Join(g.phasesDir, g.phaseDef.Name+".prompt"), []byte(rendered), 0o644); wErr != nil {
+		log.Printf("warn: write prompt artifact for phase %s: %v", g.phaseDef.Name, wErr)
+	}
+	output, promptForCost, provider, model, err := g.r.runPromptInvocation(ctx, g.vessel, g.worktreePath, g.srcCfg, g.wf, &g.phaseDef, g.harnessContent, rendered, g.retryAttempt)
+	if err != nil {
+		g.appendTrace("generation", false, "")
+		return "", err
+	}
+	g.lastOutput = output
+	g.lastPromptForCost = promptForCost
+	g.lastProvider = provider
+	g.lastModel = model
+	g.appendTrace("generation", true, string(output))
+	return string(output), nil
+}
+
+func (g *phaseLoopGenerator) appendTrace(eventType string, success bool, content string) {
+	if g.traceEvents == nil {
+		return
+	}
+	*g.traceEvents = append(*g.traceEvents, signal.TraceEvent{
+		Type:       eventType,
+		Timestamp:  time.Now().UTC(),
+		Success:    success,
+		TokensUsed: cost.EstimateTokens(content),
+		Content:    content,
+	})
+}
+
+type phaseLoopEvaluator struct {
+	r               *Runner
+	vessel          queue.Vessel
+	wf              *workflow.Workflow
+	phaseDef        workflow.Phase
+	evaluatorDef    workflow.Phase
+	evalTemplate    string
+	phaseIdx        int
+	previousOutputs map[string]string
+	issueData       phase.IssueData
+	gateResult      string
+	harnessContent  string
+	worktreePath    string
+	phasesDir       string
+	srcCfg          *config.SourceConfig
+	vrs             *vesselRunState
+	traceEvents     *[]signal.TraceEvent
+	iteration       int
+}
+
+func (e *phaseLoopEvaluator) ID() string {
+	return e.phaseDef.Name + "-evaluator"
+}
+
+func (e *phaseLoopEvaluator) Evaluate(ctx context.Context, output string, criteria []evaluator.Criterion) (*evaluator.EvalResult, error) {
+	e.iteration++
+	td := e.r.buildTemplateData(
+		e.vessel,
+		e.issueData,
+		e.phaseDef.Name,
+		e.phaseIdx,
+		e.previousOutputs,
+		e.gateResult,
+		phase.EvaluationData{
+			Iteration: e.iteration,
+			Output:    output,
+			Criteria:  formatEvaluatorCriteria(criteria),
+		},
+	)
+	rendered, err := phase.RenderPrompt(e.evalTemplate, td)
+	if err != nil {
+		e.appendTrace(false, "")
+		return nil, fmt.Errorf("render evaluator prompt for phase %s: %w", e.phaseDef.Name, err)
+	}
+	if wErr := os.WriteFile(filepath.Join(e.phasesDir, e.phaseDef.Name+".evaluator.prompt"), []byte(rendered), 0o644); wErr != nil {
+		log.Printf("warn: write evaluator prompt artifact for phase %s: %v", e.phaseDef.Name, wErr)
+	}
+	rawOutput, promptForCost, _, model, err := e.r.runPromptInvocation(ctx, e.vessel, e.worktreePath, e.srcCfg, e.wf, &e.evaluatorDef, e.harnessContent, rendered, e.iteration)
+	if err != nil {
+		e.appendTrace(false, "")
+		return nil, err
+	}
+	if wErr := os.WriteFile(filepath.Join(e.phasesDir, e.phaseDef.Name+".evaluator.output"), rawOutput, 0o644); wErr != nil {
+		log.Printf("warn: write evaluator output artifact for phase %s: %v", e.phaseDef.Name, wErr)
+	}
+	if e.vrs != nil {
+		e.vrs.recordEvaluationUsage(model, promptForCost, string(rawOutput), time.Now().UTC())
+	}
+	result, err := parseEvalResultOutput(rawOutput)
+	if err != nil {
+		e.appendTrace(false, string(rawOutput))
+		return nil, fmt.Errorf("parse evaluator output for phase %s: %w", e.phaseDef.Name, err)
+	}
+	if len(result.Feedback) == 0 && len(result.Score.Issues) > 0 {
+		result.Feedback = append([]evaluator.Issue(nil), result.Score.Issues...)
+	}
+	e.appendTrace(true, string(rawOutput))
+	return result, nil
+}
+
+func (e *phaseLoopEvaluator) appendTrace(success bool, content string) {
+	if e.traceEvents == nil {
+		return
+	}
+	*e.traceEvents = append(*e.traceEvents, signal.TraceEvent{
+		Type:       "evaluation",
+		Timestamp:  time.Now().UTC(),
+		Success:    success,
+		TokensUsed: cost.EstimateTokens(content),
+		Content:    content,
+	})
+}
+
+func (r *Runner) runPromptInvocation(ctx context.Context, vessel queue.Vessel, worktreePath string, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, harnessContent, rendered string, attempt int) ([]byte, string, string, string, error) {
+	tier, providerChain := resolvePhaseProviderChain(r.Config, srcCfg, vessel, wf, p)
+	provider := ""
+	model := ""
+	output, provider, model, err := r.runPhaseWithProviderFallback(ctx, vessel.ID, p.Name, worktreePath, providerChain, func(provider string) (providerInvocation, error) {
+		cmd, args, phaseStdin, resolvedModel, err := buildProviderPhaseArgs(r.Config, srcCfg, wf, p, harnessContent, provider, tier, rendered, attempt)
+		if err != nil {
+			return providerInvocation{}, err
+		}
+		stdinContent := ""
+		if phaseStdin != nil {
+			stdinContent = rendered
+		}
+		return providerInvocation{
+			Provider:     provider,
+			Model:        resolvedModel,
+			Env:          providerEnvForName(r.Config, provider),
+			Command:      cmd,
+			Args:         args,
+			StdinContent: stdinContent,
+		}, nil
+	})
+	promptForCost := rendered
+	if harnessContent != "" {
+		promptForCost = harnessContent + "\n\n" + rendered
+	}
+	return output, promptForCost, provider, model, err
+}
+
+func (r *Runner) runPhaseEvaluationLoop(ctx context.Context, vessel queue.Vessel, wf *workflow.Workflow, phaseIdx int, previousOutputs map[string]string, issueData phase.IssueData, gateResult, harnessContent, worktreePath, phasesDir, promptTemplate string, vrs *vesselRunState, retryAttempt int) (*phaseLLMExecution, error) {
+	p := wf.Phases[phaseIdx]
+	if p.Evaluator == nil {
+		return nil, fmt.Errorf("phase %s has no evaluator configuration", p.Name)
+	}
+
+	traceEvents := evaluationSeedEvents(previousOutputs, gateResult)
+	seedSignals := signal.Compute(traceEvents, signal.DefaultConfig())
+	intensity := evaluator.SelectIntensity(resolveEvaluationComplexity(p, p.Evaluator), seedSignals.HealthString())
+	srcCfg := r.sourceConfigFromMeta(vessel)
+	gen := &phaseLoopGenerator{
+		r:               r,
+		vessel:          vessel,
+		wf:              wf,
+		phaseDef:        p,
+		promptTemplate:  promptTemplate,
+		phaseIdx:        phaseIdx,
+		previousOutputs: previousOutputs,
+		issueData:       issueData,
+		gateResult:      gateResult,
+		harnessContent:  harnessContent,
+		worktreePath:    worktreePath,
+		phasesDir:       phasesDir,
+		srcCfg:          srcCfg,
+		retryAttempt:    retryAttempt,
+		criteriaText:    formatEvaluatorCriteria(p.Evaluator.Criteria),
+		traceEvents:     &traceEvents,
+	}
+	evalPhase := evaluatorPhaseFromConfig(p, p.Evaluator)
+	evalTemplateBytes, err := os.ReadFile(p.Evaluator.PromptFile)
+	if err != nil {
+		return nil, fmt.Errorf("read evaluator prompt file %s: %w", p.Evaluator.PromptFile, err)
+	}
+	ev := &phaseLoopEvaluator{
+		r:               r,
+		vessel:          vessel,
+		wf:              wf,
+		phaseDef:        p,
+		evaluatorDef:    evalPhase,
+		evalTemplate:    string(evalTemplateBytes),
+		phaseIdx:        phaseIdx,
+		previousOutputs: previousOutputs,
+		issueData:       issueData,
+		gateResult:      gateResult,
+		harnessContent:  harnessContent,
+		worktreePath:    worktreePath,
+		phasesDir:       phasesDir,
+		srcCfg:          srcCfg,
+		vrs:             vrs,
+		traceEvents:     &traceEvents,
+	}
+	loop, err := evaluator.NewLoop(gen, ev, evaluator.EvalConfig{
+		Criteria:      append([]evaluator.Criterion(nil), p.Evaluator.Criteria...),
+		MaxIterations: p.Evaluator.MaxIterations,
+		PassThreshold: p.Evaluator.PassThreshold,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create evaluator loop for phase %s: %w", p.Name, err)
+	}
+	result, err := loop.RunWithIntensity(ctx, promptTemplate, intensity)
+	if err != nil {
+		return nil, fmt.Errorf("run evaluator loop for phase %s: %w", p.Name, err)
+	}
+	if len(gen.lastOutput) == 0 {
+		return nil, fmt.Errorf("run evaluator loop for phase %s: generator did not produce output", p.Name)
+	}
+	signals := signal.Compute(traceEvents, signal.DefaultConfig())
+	report := &PhaseEvaluationReport{
+		Phase:       p.Name,
+		Intensity:   intensity.String(),
+		Signals:     signals,
+		Criteria:    append([]evaluator.Criterion(nil), p.Evaluator.Criteria...),
+		Iterations:  result.Iterations,
+		Converged:   result.Converged,
+		History:     append([]evaluator.EvalResult(nil), result.History...),
+		FinalResult: cloneEvalResult(result.FinalResult),
+	}
+	exec := &phaseLLMExecution{
+		output:           append([]byte(nil), gen.lastOutput...),
+		promptForCost:    gen.lastPromptForCost,
+		provider:         gen.lastProvider,
+		model:            gen.lastModel,
+		evaluationReport: report,
+	}
+	if result.FinalResult == nil {
+		return exec, fmt.Errorf("phase %s evaluator returned no final result", p.Name)
+	}
+	if !result.Converged || !result.FinalResult.Pass {
+		return exec, fmt.Errorf("phase %s evaluator did not pass after %d iterations", p.Name, result.Iterations)
+	}
+	return exec, nil
+}
+
+func cloneEvalResult(result *evaluator.EvalResult) *evaluator.EvalResult {
+	if result == nil {
+		return nil
+	}
+	clone := *result
+	clone.Feedback = append([]evaluator.Issue(nil), result.Feedback...)
+	clone.Score.Issues = append([]evaluator.Issue(nil), result.Score.Issues...)
+	if result.Score.Criteria != nil {
+		clone.Score.Criteria = make(map[string]float64, len(result.Score.Criteria))
+		for key, value := range result.Score.Criteria {
+			clone.Score.Criteria[key] = value
+		}
+	}
+	return &clone
+}
+
+func evaluatorPhaseFromConfig(base workflow.Phase, cfg *workflow.PhaseEvaluator) workflow.Phase {
+	return workflow.Phase{
+		Name:         base.Name + "_evaluator",
+		PromptFile:   cfg.PromptFile,
+		MaxTurns:     cfg.MaxTurns,
+		LLM:          cfg.LLM,
+		Model:        cfg.Model,
+		Tier:         cfg.Tier,
+		AllowedTools: cfg.AllowedTools,
+	}
+}
+
+func formatEvaluatorFeedback(feedback []evaluator.Issue) string {
+	if len(feedback) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, issue := range feedback {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "%d. [%s] %s", i+1, issue.Severity.String(), strings.TrimSpace(issue.Description))
+		if loc := strings.TrimSpace(issue.Location); loc != "" {
+			fmt.Fprintf(&b, " @ %s", loc)
+		}
+		if suggestion := strings.TrimSpace(issue.Suggestion); suggestion != "" {
+			fmt.Fprintf(&b, "\n   Suggestion: %s", suggestion)
+		}
+	}
+	return b.String()
+}
+
+func formatEvaluatorCriteria(criteria []evaluator.Criterion) string {
+	if len(criteria) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, criterion := range criteria {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "%d. %s (weight=%.2f, threshold=%.2f)", i+1, criterion.Name, criterion.Weight, criterion.Threshold)
+		if desc := strings.TrimSpace(criterion.Description); desc != "" {
+			fmt.Fprintf(&b, ": %s", desc)
+		}
+	}
+	return b.String()
+}
+
+func evaluationSeedEvents(previousOutputs map[string]string, gateResult string) []signal.TraceEvent {
+	keys := make([]string, 0, len(previousOutputs))
+	for key := range previousOutputs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	now := time.Now().UTC()
+	events := make([]signal.TraceEvent, 0, len(keys)+1)
+	for i, key := range keys {
+		events = append(events, signal.TraceEvent{
+			Type:       "generation",
+			Timestamp:  now.Add(time.Duration(i) * time.Millisecond),
+			Success:    true,
+			TokensUsed: cost.EstimateTokens(previousOutputs[key]),
+			Content:    previousOutputs[key],
+		})
+	}
+	if strings.TrimSpace(gateResult) != "" {
+		events = append(events, signal.TraceEvent{
+			Type:       "gate_feedback",
+			Timestamp:  now.Add(time.Duration(len(events)) * time.Millisecond),
+			Success:    true,
+			TokensUsed: cost.EstimateTokens(gateResult),
+			Content:    gateResult,
+		})
+	}
+	return events
+}
+
+func resolveEvaluationComplexity(p workflow.Phase, cfg *workflow.PhaseEvaluator) string {
+	raw := ""
+	switch {
+	case cfg != nil && cfg.Tier != nil:
+		raw = strings.ToLower(strings.TrimSpace(*cfg.Tier))
+	case p.Tier != nil:
+		raw = strings.ToLower(strings.TrimSpace(*p.Tier))
+	}
+	switch raw {
+	case "low", "trivial":
+		return "low"
+	case "high", "critical":
+		return "high"
+	default:
+		return "medium"
+	}
+}
+
+func parseEvalResultOutput(raw []byte) (*evaluator.EvalResult, error) {
+	var result evaluator.EvalResult
+	if err := json.Unmarshal(raw, &result); err == nil {
+		return &result, nil
+	}
+	text := strings.TrimSpace(string(raw))
+	start := strings.Index(text, "{")
+	end := strings.LastIndex(text, "}")
+	if start >= 0 && end > start {
+		if err := json.Unmarshal([]byte(text[start:end+1]), &result); err == nil {
+			return &result, nil
+		}
+	}
+	return nil, fmt.Errorf("evaluator output was not valid JSON")
+}
+
+func applyPhaseEvaluationSummary(summary PhaseSummary, report *PhaseEvaluationReport) PhaseSummary {
+	if report == nil {
+		return summary
+	}
+	summary.EvalIterations = report.Iterations
+	summary.EvalConverged = report.Converged
+	summary.EvalIntensity = report.Intensity
+	return summary
+}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -2556,7 +2556,9 @@ func buildGateClaim(p workflow.Phase, passed bool, artifactPath string, recorded
 			}
 			claim.TrustBoundary = "Running system observation"
 		default:
+			claim.Level = evidence.BehaviorallyChecked
 			claim.Checker = p.Gate.Run
+			claim.TrustBoundary = "Command gate output"
 		}
 	}
 	if p.Gate == nil || p.Gate.Evidence == nil {

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -1786,7 +1786,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		if r.vesselCancelled(ctx, vessel.ID) {
 			return singlePhaseResult{status: "cancelled"}
 		}
-		log.Printf("%sphase %q starting (orchestrated)", vesselLabel(vessel), p.Name)
+		log.Printf("%sphase %q starting", vesselLabel(vessel), p.Name)
 		phaseStart := r.runtimeNow()
 
 		td := r.buildTemplateData(vessel, issueData, p.Name, phaseIdx, previousOutputs, gateResult, phase.EvaluationData{})
@@ -2581,8 +2581,12 @@ func buildGateClaim(p workflow.Phase, passed bool, artifactPath string, recorded
 
 func buildEvaluationClaim(vesselID string, p workflow.Phase, report PhaseEvaluationReport, recordedAt time.Time) evidence.Claim {
 	passed := report.Converged && report.FinalResult != nil && report.FinalResult.Pass
+	claimText := fmt.Sprintf("Evaluator review for phase %q did not meet configured quality thresholds", p.Name)
+	if passed {
+		claimText = fmt.Sprintf("Evaluator review for phase %q met configured quality thresholds", p.Name)
+	}
 	return evidence.Claim{
-		Claim:         fmt.Sprintf("Evaluator review for phase %q met configured quality thresholds", p.Name),
+		Claim:         claimText,
 		Level:         evidence.BehaviorallyChecked,
 		Checker:       "generator-evaluator loop",
 		TrustBoundary: "LLM evaluator review of generated output",

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -680,8 +680,6 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 
 	// Rebuild previousOutputs from .xylem/phases/<id>/*.output (for resume)
 	previousOutputs := r.rebuildPreviousOutputs(vessel.ID, sk)
-	srcCfg := r.sourceConfigFromMeta(vessel)
-
 	// Execute phases sequentially (no explicit dependencies)
 	var phaseResults []reporter.PhaseResult
 	for i := vessel.CurrentPhase; i < len(sk.Phases); i++ {
@@ -689,533 +687,51 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			return r.cancelVessel(vessel, worktreePath, vrs, claims)
 		}
 		p := sk.Phases[i]
-		gateResult := ""
-
-		// Initialize gate retries for this phase (once, before retry loop)
-		if p.Gate != nil && (p.Gate.Type == "command" || p.Gate.Type == "live") && p.Gate.Retries > 0 && vessel.GateRetries == 0 {
-			vessel.GateRetries = p.Gate.Retries
+		res := r.runSinglePhase(ctx, vessel, sk, i, previousOutputs, issueData, harnessContent, worktreePath, src, vrs, true)
+		if res.phaseSummary.Name != "" {
+			vrs.addPhase(res.phaseSummary)
+		}
+		if res.evaluationReport != nil {
+			vrs.addEvaluationReport(*res.evaluationReport)
+		}
+		if len(res.evidenceClaims) > 0 {
+			claims = append(claims, res.evidenceClaims...)
 		}
 
-		// Gate retry loop: may re-run the same phase with gate output appended
-		for {
-			if r.vesselCancelled(ctx, vessel.ID) {
-				return r.cancelVessel(vessel, worktreePath, vrs, claims)
-			}
-			log.Printf("%sphase %q starting (%d/%d)", vesselLabel(vessel), p.Name, i+1, len(sk.Phases))
-			phaseStart := r.runtimeNow()
-
-			// Build template data
-			td := r.buildTemplateData(vessel, issueData, p.Name, i, previousOutputs, gateResult)
-
-			var output []byte
-			var runErr error
-			var beforeSnapshot surface.Snapshot
-			var checkProtectedSurfaces bool
-			var promptForCost string
-			tier, providerChain := resolvePhaseProviderChain(r.Config, srcCfg, vessel, sk, &p)
-			provider := ""
-			model := ""
-			if len(providerChain) > 0 {
-				provider = providerChain[0]
-				model = resolvePhaseModel(r.Config, srcCfg, sk, &p, provider, tier)
-			}
-			retryAttempt := 0
-			if p.Gate != nil && (p.Gate.Type == "command" || p.Gate.Type == "live") {
-				retryAttempt = providerAttempt(&p, vessel.GateRetries)
-			}
-			phaseSpan := startPhaseSpan(r.Tracer, ctx, r.Config, sk, p, i, retryAttempt, "", "", tier)
-			phaseSpanEnded := false
-			var phaseDuration time.Duration
-			phaseSpanStatus := "running"
-			phaseOutputArtifactPath := ""
-			finishCurrentPhaseSpan := func(err error) {
-				if phaseSpanEnded {
-					return
-				}
-				if err != nil && phaseSpanStatus == "running" {
-					phaseSpanStatus = "failed"
-				}
-				if phaseDuration == 0 {
-					phaseDuration = r.runtimeSince(phaseStart)
-				}
-				finishPhaseSpan(r.Tracer, phaseSpan, buildPhaseResultData(r.Config, p, promptForCost, string(output), phaseDuration, phaseSpanStatus, phaseOutputArtifactPath, provider, model, tier), err)
-				phaseSpanEnded = true
-			}
-
-			// Create phases dir early
-			phasesDir := config.RuntimePath(r.Config.StateDir, "phases", vessel.ID)
-			if err := os.MkdirAll(phasesDir, 0o755); err != nil {
-				finishCurrentPhaseSpan(err)
-				r.failVessel(vessel.ID, fmt.Sprintf("create phases dir: %v", err))
-				if failErr := src.OnFail(ctx, vessel); failErr != nil {
-					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, failErr)
-				}
-				return "failed"
-			}
-
-			if p.Type == "command" {
-				// Command phase: render and execute shell command
-				rendered, err := renderCommandTemplate(p.Name, "command", p.Run, td)
-				if err != nil {
-					finishCurrentPhaseSpan(err)
-					r.failVessel(vessel.ID, err.Error())
-					if err := src.OnFail(ctx, vessel); err != nil {
-						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-					}
-					return "failed"
-				}
-				if wErr := os.WriteFile(filepath.Join(phasesDir, p.Name+".command"), []byte(rendered), 0o644); wErr != nil {
-					log.Printf("warn: write command file: %v", wErr)
-				}
-				if policyErr := r.enforcePhasePolicy(ctx, vessel, sk, p, worktreePath, rendered, ""); policyErr != nil {
-					finishCurrentPhaseSpan(policyErr)
-					log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
-					vessel.FailedPhase = p.Name
-					r.failUpdatedVessel(&vessel, policyErr.Error())
-					if err := src.OnFail(ctx, vessel); err != nil {
-						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-					}
-					issueNum := r.parseIssueNum(vessel)
-					if issueNum > 0 && r.Reporter != nil {
-						r.logReporterError("post vessel-failed comment", vessel.ID,
-							r.Reporter.VesselFailed(ctx, issueNum, p.Name, policyErr.Error(), ""))
-					}
-					return "failed"
-				}
-				beforeSnapshot, checkProtectedSurfaces, err = r.takeProtectedSurfaceSnapshot(ctx, worktreePath)
-				if err != nil {
-					snapErr := fmt.Errorf("protected surface snapshot failed: %w", err)
-					finishCurrentPhaseSpan(snapErr)
-					r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, snapErr))
-					if err := src.OnFail(ctx, vessel); err != nil {
-						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-					}
-					issueNum := r.parseIssueNum(vessel)
-					if issueNum > 0 && r.Reporter != nil {
-						r.logReporterError("post vessel-failed comment", vessel.ID,
-							r.Reporter.VesselFailed(ctx, issueNum, p.Name, snapErr.Error(), ""))
-					}
-					return "failed"
-				}
-				outputPath := filepath.Join(phasesDir, p.Name+".output")
-				if touchErr := r.touchPhaseActivity(outputPath); touchErr != nil {
-					log.Printf("warn: touch phase activity %s: %v", outputPath, touchErr)
-				}
-				cmdOut, cmdErr := gate.RunCommand(ctx, r.Runner, worktreePath, rendered)
-				output = []byte(cmdOut)
-				runErr = cmdErr
-			} else {
-				// LLM phase: existing code
-				promptContent, err := os.ReadFile(p.PromptFile)
-				if err != nil {
-					finishCurrentPhaseSpan(err)
-					r.failVessel(vessel.ID, fmt.Sprintf("read prompt file %s: %v", p.PromptFile, err))
-					if err := src.OnFail(ctx, vessel); err != nil {
-						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-					}
-					return "failed"
-				}
-				promptTemplate := string(promptContent)
-				rendered, err := phase.RenderPrompt(promptTemplate, td)
-				if err != nil {
-					finishCurrentPhaseSpan(err)
-					r.failVessel(vessel.ID, fmt.Sprintf("render prompt for phase %s: %v", p.Name, err))
-					if err := src.OnFail(ctx, vessel); err != nil {
-						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-					}
-					return "failed"
-				}
-				promptForCost = rendered
-				if harnessContent != "" {
-					promptForCost = harnessContent + "\n\n" + rendered
-				}
-				promptPath := filepath.Join(phasesDir, p.Name+".prompt")
-				if wErr := os.WriteFile(promptPath, []byte(rendered), 0o644); wErr != nil {
-					log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
-				}
-				if policyErr := r.enforcePhasePolicy(ctx, vessel, sk, p, worktreePath, "", promptTemplate); policyErr != nil {
-					finishCurrentPhaseSpan(policyErr)
-					log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
-					vessel.FailedPhase = p.Name
-					r.failUpdatedVessel(&vessel, policyErr.Error())
-					if err := src.OnFail(ctx, vessel); err != nil {
-						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-					}
-					issueNum := r.parseIssueNum(vessel)
-					if issueNum > 0 && r.Reporter != nil {
-						r.logReporterError("post vessel-failed comment", vessel.ID,
-							r.Reporter.VesselFailed(ctx, issueNum, p.Name, policyErr.Error(), ""))
-					}
-					return "failed"
-				}
-				beforeSnapshot, checkProtectedSurfaces, err = r.takeProtectedSurfaceSnapshot(ctx, worktreePath)
-				if err != nil {
-					snapErr := fmt.Errorf("protected surface snapshot failed: %w", err)
-					finishCurrentPhaseSpan(snapErr)
-					r.failVessel(vessel.ID, fmt.Sprintf("phase %s: %v", p.Name, snapErr))
-					if err := src.OnFail(ctx, vessel); err != nil {
-						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-					}
-					issueNum := r.parseIssueNum(vessel)
-					if issueNum > 0 && r.Reporter != nil {
-						r.logReporterError("post vessel-failed comment", vessel.ID,
-							r.Reporter.VesselFailed(ctx, issueNum, p.Name, snapErr.Error(), ""))
-					}
-					return "failed"
-				}
-				attempt := providerAttempt(&p, vessel.GateRetries)
-				outputPath := filepath.Join(phasesDir, p.Name+".output")
-				if touchErr := r.touchPhaseActivity(outputPath); touchErr != nil {
-					log.Printf("warn: touch phase activity %s: %v", outputPath, touchErr)
-				}
-				output, provider, model, runErr = r.runPhaseWithProviderFallback(ctx, vessel.ID, p.Name, worktreePath, providerChain, func(provider string) (providerInvocation, error) {
-					cmd, args, phaseStdin, model, err := buildProviderPhaseArgs(r.Config, srcCfg, sk, &p, harnessContent, provider, tier, rendered, attempt)
-					if err != nil {
-						return providerInvocation{}, err
-					}
-					stdinContent := ""
-					if phaseStdin != nil {
-						stdinContent = rendered
-					}
-					return providerInvocation{
-						Provider:     provider,
-						Model:        model,
-						Env:          providerEnvForName(r.Config, provider),
-						Command:      cmd,
-						Args:         args,
-						StdinContent: stdinContent,
-					}, nil
-				})
-			}
-
-			if r.vesselCancelled(ctx, vessel.ID) {
-				finishCurrentPhaseSpan(context.Canceled)
-				return r.cancelVessel(vessel, worktreePath, vrs, claims)
-			}
-			if r.isVesselTimedOut(vessel.ID) {
-				finishCurrentPhaseSpan(context.DeadlineExceeded)
-				return "timed_out"
-			}
-
-			// Shared: Write phase output
-			outputPath := filepath.Join(phasesDir, p.Name+".output")
-			phaseOutputArtifactPath = phaseArtifactRelativePath(vessel.ID, p.Name)
-			if wErr := os.WriteFile(outputPath, output, 0o644); wErr != nil {
-				log.Printf("warn: write output file %s: %v", outputPath, wErr)
-			}
-			fmt.Printf("Phase %s complete: %s\n", p.Name, outputPath)
-			phaseDuration = r.runtimeSince(phaseStart)
-
-			if runErr != nil {
-				phaseSpanStatus = "failed"
-				finishCurrentPhaseSpan(runErr)
-				log.Printf("%sphase %q failed: %v", vesselLabel(vessel), p.Name, runErr)
-				vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error(), provider, model))
-				vessel.FailedPhase = p.Name
-				r.failUpdatedVessel(&vessel, fmt.Sprintf("phase %s: %v", p.Name, runErr))
-				if err := src.OnFail(ctx, vessel); err != nil {
-					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-				}
-				issueNum := r.parseIssueNum(vessel)
-				if issueNum > 0 && r.Reporter != nil {
-					r.logReporterError("post vessel-failed comment", vessel.ID,
-						r.Reporter.VesselFailed(ctx, issueNum, p.Name, runErr.Error(), ""))
-				}
-				return "failed"
-			}
-
-			if checkProtectedSurfaces {
-				if err := r.verifyProtectedSurfaces(vessel, p, worktreePath, beforeSnapshot); err != nil {
-					phaseSpanStatus = "failed"
-					finishCurrentPhaseSpan(err)
-					log.Printf("%sphase %q violated protected surfaces: %v", vesselLabel(vessel), p.Name, err)
-					vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error(), provider, model))
-					vessel.FailedPhase = p.Name
-					r.failUpdatedVessel(&vessel, err.Error())
-					if err := src.OnFail(ctx, vessel); err != nil {
-						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-					}
-					issueNum := r.parseIssueNum(vessel)
-					if issueNum > 0 && r.Reporter != nil {
-						r.logReporterError("post vessel-failed comment", vessel.ID,
-							r.Reporter.VesselFailed(ctx, issueNum, p.Name, err.Error(), ""))
-					}
-					return "failed"
-				}
-			}
-
-			recordedAt := r.runtimeNow()
-			inputTokensEst, outputTokensEst, costUSDEst := vrs.recordPhaseTokens(p, model, promptForCost, string(output), recordedAt)
-			if vrs.costTracker != nil && vrs.costTracker.BudgetExceeded() {
-				errMsg := fmt.Sprintf("budget exceeded after phase %q: estimated cost $%.4f, estimated tokens %d",
-					p.Name, vrs.costTracker.TotalCost(), vrs.costTracker.TotalTokens())
-				vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg, provider, model))
-				vessel.FailedPhase = p.Name
-				r.failUpdatedVessel(&vessel, errMsg)
-				if err := src.OnFail(ctx, vessel); err != nil {
-					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-				}
-				issueNum := r.parseIssueNum(vessel)
-				if issueNum > 0 && r.Reporter != nil {
-					r.logReporterError("post vessel-failed comment", vessel.ID,
-						r.Reporter.VesselFailed(ctx, issueNum, p.Name, errMsg, ""))
-				}
-				phaseSpanStatus = "failed"
-				finishCurrentPhaseSpan(fmt.Errorf("%s", errMsg))
-				return "failed"
-			}
-
-			if err := r.publishPhaseOutput(ctx, vessel, p, td, string(output)); err != nil {
-				phaseSpanStatus = "failed"
-				finishCurrentPhaseSpan(err)
-				log.Printf("%sphase %q failed while publishing output: %v", vesselLabel(vessel), p.Name, err)
-				vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, err.Error(), provider, model))
-				vessel.FailedPhase = p.Name
-				r.failUpdatedVessel(&vessel, fmt.Sprintf("phase %s: %v", p.Name, err))
-				if err := src.OnFail(ctx, vessel); err != nil {
-					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-				}
-				issueNum := r.parseIssueNum(vessel)
-				if issueNum > 0 && r.Reporter != nil {
-					r.logReporterError("post vessel-failed comment", vessel.ID,
-						r.Reporter.VesselFailed(ctx, issueNum, p.Name, err.Error(), ""))
-				}
-				return "failed"
-			}
-
-			// Store output for subsequent phases
-			previousOutputs[p.Name] = string(output)
-
-			// Update current phase, persist
+		switch res.status {
+		case "failed":
+			return "failed"
+		case "waiting":
+			return "waiting"
+		case "cancelled":
+			return r.cancelVessel(vessel, worktreePath, vrs, claims)
+		case "timed_out":
+			return "timed_out"
+		case "completed", "no-op":
+			previousOutputs[p.Name] = res.output
 			vessel.CurrentPhase = i + 1
 			if vessel.PhaseOutputs == nil {
 				vessel.PhaseOutputs = make(map[string]string)
 			}
-			vessel.PhaseOutputs[p.Name] = outputPath
+			vessel.PhaseOutputs[p.Name] = config.RuntimePath(r.Config.StateDir, "phases", vessel.ID, p.Name+".output")
 			if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
 				if r.cancelledTransition(vessel.ID, updateErr) {
-					finishCurrentPhaseSpan(context.Canceled)
 					return r.cancelVessel(vessel, worktreePath, vrs, claims)
 				}
 				if r.timedOutTransition(vessel.ID, updateErr) {
-					finishCurrentPhaseSpan(context.DeadlineExceeded)
 					return "timed_out"
 				}
 				log.Printf("warn: persist phase progress for %s: %v", vessel.ID, updateErr)
 			}
-
-			log.Printf("%sphase %q completed (%s)", vesselLabel(vessel), p.Name, phaseDuration.Truncate(time.Second))
-
-			issueNum := r.parseIssueNum(vessel)
-
-			phaseStatus := "completed"
-			if phaseMatchedNoOp(&p, string(output)) {
-				phaseStatus = "no-op"
+			if res.phaseReport.Name != "" {
+				phaseResults = append(phaseResults, res.phaseReport)
 			}
-			phaseSpanStatus = phaseStatus
-
-			// Report phase completion (non-fatal)
-			phaseReport := reporter.PhaseResult{
-				Name:                   p.Name,
-				Duration:               phaseDuration,
-				Status:                 phaseStatus,
-				Provider:               provider,
-				Model:                  model,
-				InputTokensEst:         inputTokensEst,
-				OutputTokensEst:        outputTokensEst,
-				CostUSDEst:             costUSDEst,
-				UsageSource:            cost.UsageSourceEstimated,
-				UsageUnavailableReason: "",
-			}
-			if p.Type == "command" {
-				phaseReport.UsageSource = cost.UsageSourceNotApplicable
-				phaseReport.UsageUnavailableReason = "non-llm phase"
-			}
-			if phaseStatus == "no-op" {
-				vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, "", provider, model))
-				phaseResults = append(phaseResults, phaseReport)
-				r.reportPhaseComplete(ctx, vessel, phaseReport, string(output))
+			if res.status == "no-op" {
 				log.Printf("%sphase %q triggered no-op; completing workflow early", vesselLabel(vessel), p.Name)
-				finishCurrentPhaseSpan(nil)
 				if r.vesselCancelled(ctx, vessel.ID) {
 					return r.cancelVessel(vessel, worktreePath, vrs, claims)
 				}
 				return r.completeVessel(ctx, vessel, worktreePath, phaseResults, vrs, claims)
-			}
-
-			// Handle gate
-			if p.Gate == nil {
-				vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, "", provider, model))
-				phaseResults = append(phaseResults, phaseReport)
-				r.reportPhaseComplete(ctx, vessel, phaseReport, string(output))
-				finishCurrentPhaseSpan(nil)
-				break // no gate, proceed to next phase
-			}
-
-			switch p.Gate.Type {
-			case "command", "live":
-				gateResultExec := r.executeVerificationGate(ctx, phaseSpan, vessel, p, td, worktreePath, retryAttempt)
-				if r.vesselCancelled(ctx, vessel.ID) {
-					finishCurrentPhaseSpan(context.Canceled)
-					return r.cancelVessel(vessel, worktreePath, vrs, claims)
-				}
-				if r.isVesselTimedOut(vessel.ID) {
-					finishCurrentPhaseSpan(context.DeadlineExceeded)
-					return "timed_out"
-				}
-				gateOut, passed, gateErr := gateResultExec.output, gateResultExec.passed, gateResultExec.err
-				if gateErr != nil {
-					phaseSpanStatus = "failed"
-					vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error(), provider, model))
-					finishCurrentPhaseSpan(nil)
-					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate error: %v", p.Name, gateErr))
-					if err := src.OnFail(ctx, vessel); err != nil {
-						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-					}
-					return "failed"
-				}
-				if passed {
-					log.Printf("%sgate passed for phase %q", vesselLabel(vessel), p.Name)
-					phaseSpanStatus = phaseStatus
-					vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, gatePassedPointer(true), "", provider, model))
-					if gateResultExec.evidenceClaim != nil {
-						claims = append(claims, *gateResultExec.evidenceClaim)
-					}
-					phaseResults = append(phaseResults, phaseReport)
-					r.reportPhaseComplete(ctx, vessel, phaseReport, string(output))
-					finishCurrentPhaseSpan(nil)
-					break // gate passed, proceed to next phase
-				}
-
-				// Gate failed
-				retryDelay := 10 * time.Second
-				if p.Gate.RetryDelay != "" {
-					if parsed, pErr := time.ParseDuration(p.Gate.RetryDelay); pErr == nil {
-						retryDelay = parsed
-					}
-				}
-
-				if vessel.GateRetries <= 0 {
-					log.Printf("%sgate failed for phase %q, retries exhausted", vesselLabel(vessel), p.Name)
-					phaseSpanStatus = "failed"
-					vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted", provider, model))
-					finishCurrentPhaseSpan(nil)
-					vessel.FailedPhase = p.Name
-					vessel.GateOutput = gateOut
-					r.failUpdatedVessel(&vessel, fmt.Sprintf("phase %s: gate failed, retries exhausted", p.Name))
-					if err := src.OnFail(ctx, vessel); err != nil {
-						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-					}
-					if issueNum > 0 && r.Reporter != nil {
-						r.logReporterError("post vessel-failed comment", vessel.ID,
-							r.Reporter.VesselFailed(ctx, issueNum, p.Name, "gate failed, retries exhausted", gateOut))
-					}
-					return "failed"
-				}
-
-				vessel.GateRetries--
-				log.Printf("%sgate failed for phase %q, retries remaining=%d", vesselLabel(vessel), p.Name, vessel.GateRetries)
-				if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
-					if r.cancelledTransition(vessel.ID, updateErr) {
-						finishCurrentPhaseSpan(context.Canceled)
-						return r.cancelVessel(vessel, worktreePath, vrs, claims)
-					}
-					if r.timedOutTransition(vessel.ID, updateErr) {
-						finishCurrentPhaseSpan(context.DeadlineExceeded)
-						return "timed_out"
-					}
-					log.Printf("warn: persist gate retries for %s: %v", vessel.ID, updateErr)
-				}
-
-				// Re-render prompt with gate output context
-				gateResult = fmt.Sprintf("The following gate check failed after the previous phase. Fix the issues and try again:\n\n%s", gateOut)
-
-				if err := r.runtimeSleep(ctx, retryDelay); err != nil {
-					if r.vesselCancelled(ctx, vessel.ID) {
-						finishCurrentPhaseSpan(context.Canceled)
-						return r.cancelVessel(vessel, worktreePath, vrs, claims)
-					}
-					if r.isVesselTimedOut(vessel.ID) {
-						finishCurrentPhaseSpan(context.DeadlineExceeded)
-						return "timed_out"
-					}
-					vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error(), provider, model))
-					phaseSpanStatus = "failed"
-					finishCurrentPhaseSpan(err)
-					r.failVessel(vessel.ID, fmt.Sprintf("phase %s gate retry interrupted: %v", p.Name, err))
-					if failErr := src.OnFail(ctx, vessel); failErr != nil {
-						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, failErr)
-					}
-					return "failed"
-				}
-				phaseSpanStatus = "retrying"
-				finishCurrentPhaseSpan(nil)
-				continue // re-run same phase
-
-			case "label":
-				gateSpan := startGateSpan(r.Tracer, phaseSpan, ctx, p.Gate.Type)
-				finishGateSpan(r.Tracer, gateSpan, observability.GateSpanData{
-					Type:         p.Gate.Type,
-					Passed:       false,
-					RetryAttempt: retryAttempt,
-				}, nil)
-				log.Printf("%swaiting for label %q after phase %q", vesselLabel(vessel), p.Gate.WaitFor, p.Name)
-				r.reportPhaseComplete(ctx, vessel, phaseReport, string(output))
-				// Set vessel to waiting state
-				vessel.FailedPhase = p.Name
-				vessel.WaitingFor = p.Gate.WaitFor
-				now := r.runtimeNow()
-				vessel.WaitingSince = &now
-				vessel.CurrentPhase = i + 1
-				vessel.State = queue.StateWaiting
-				if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
-					if r.cancelledTransition(vessel.ID, updateErr) {
-						finishCurrentPhaseSpan(context.Canceled)
-						return r.cancelVessel(vessel, worktreePath, vrs, claims)
-					}
-					if r.timedOutTransition(vessel.ID, updateErr) {
-						finishCurrentPhaseSpan(context.DeadlineExceeded)
-						return "timed_out"
-					}
-					log.Printf("warn: persist waiting state for %s: %v", vessel.ID, updateErr)
-					finishCurrentPhaseSpan(updateErr)
-					return "failed"
-				}
-				if err := src.OnWait(ctx, vessel); err != nil {
-					log.Printf("warn: OnWait hook for vessel %s: %v", vessel.ID, err)
-				}
-				waitSpan := r.startWaitTransitionSpan(ctx, vessel, "waiting", 0)
-				r.finishWaitTransitionSpan(waitSpan, nil)
-				phaseSpanStatus = "waiting"
-				finishCurrentPhaseSpan(nil)
-				return "waiting"
-			}
-
-			finishCurrentPhaseSpan(nil)
-			break // gate passed or unknown gate type
-		}
-
-		// Reset gate retries so the next phase's initialization guard fires correctly.
-		// This is only reached after the inner loop exits via break (gate passed or no gate),
-		// never after a retry continue or early return.
-		//
-		// Also persist the reset when needed: the UpdateVessel inside the inner loop may have
-		// written a non-zero GateRetries from this phase (e.g. retries:2 that passed on the
-		// first attempt). Without this write, a daemon restart during the next phase's
-		// RunPhase execution would load the stale non-zero count and give that phase
-		// phantom retries. If GateRetries is already zero, skip the write to avoid an
-		// unnecessary full queue rewrite under lock.
-		prevRetries := vessel.GateRetries
-		vessel.GateRetries = 0
-		if prevRetries != 0 {
-			if updateErr := r.Queue.UpdateVessel(vessel); updateErr != nil {
-				if r.cancelledTransition(vessel.ID, updateErr) {
-					return r.cancelVessel(vessel, worktreePath, vrs, claims)
-				}
-				if r.timedOutTransition(vessel.ID, updateErr) {
-					return "timed_out"
-				}
-				log.Printf("warn: persist gate retry reset for %s: %v", vessel.ID, updateErr)
 			}
 		}
 	}
@@ -1859,7 +1375,14 @@ func (r *Runner) persistRunArtifacts(vessel queue.Vessel, state string, vrs *ves
 	}
 
 	evalPath := config.RuntimePath(r.Config.StateDir, "phases", vessel.ID, evalReportFileName)
-	if info, err := os.Stat(evalPath); err == nil && !info.IsDir() {
+	if artifact := vrs.evaluationArtifact(); artifact != nil {
+		if err := saveJSONArtifact(evalPath, artifact); err != nil {
+			log.Printf("warn: save eval report: %v", err)
+		} else {
+			summary.EvalReportPath = evalReportRelativePath(vessel.ID)
+			reviewArtifacts.EvalReport = summary.EvalReportPath
+		}
+	} else if info, err := os.Stat(evalPath); err == nil && !info.IsDir() {
 		summary.EvalReportPath = evalReportRelativePath(vessel.ID)
 		reviewArtifacts.EvalReport = summary.EvalReportPath
 	}
@@ -2107,8 +1630,11 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 			if result.phaseSummary.Name != "" {
 				vrs.addPhase(result.phaseSummary)
 			}
-			if result.evidenceClaim != nil && claims != nil {
-				*claims = append(*claims, *result.evidenceClaim)
+			if result.evaluationReport != nil {
+				vrs.addEvaluationReport(*result.evaluationReport)
+			}
+			if len(result.evidenceClaims) > 0 && claims != nil {
+				*claims = append(*claims, result.evidenceClaims...)
 			}
 
 			switch result.status {
@@ -2132,11 +1658,15 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 			}
 
 			if result.status == "completed" || result.status == "no-op" {
-				allPhaseResults = append(allPhaseResults, reporter.PhaseResult{
-					Name:     p.Name,
-					Duration: result.duration,
-					Status:   result.status,
-				})
+				if result.phaseReport.Name != "" {
+					allPhaseResults = append(allPhaseResults, result.phaseReport)
+				} else {
+					allPhaseResults = append(allPhaseResults, reporter.PhaseResult{
+						Name:     p.Name,
+						Duration: result.duration,
+						Status:   result.status,
+					})
+				}
 			}
 
 			if result.status == "no-op" {
@@ -2219,12 +1749,14 @@ func (r *Runner) runVesselOrchestrated(ctx context.Context, vessel queue.Vessel,
 
 // singlePhaseResult holds the outcome of executing one phase including its gate.
 type singlePhaseResult struct {
-	output        string
-	status        string // "completed", "no-op", "failed", "waiting", "cancelled", "timed_out"
-	duration      time.Duration
-	gateOut       string
-	phaseSummary  PhaseSummary
-	evidenceClaim *evidence.Claim
+	output           string
+	status           string // "completed", "no-op", "failed", "waiting", "cancelled", "timed_out"
+	duration         time.Duration
+	gateOut          string
+	phaseSummary     PhaseSummary
+	phaseReport      reporter.PhaseResult
+	evaluationReport *PhaseEvaluationReport
+	evidenceClaims   []evidence.Claim
 }
 
 type gateExecutionResult struct {
@@ -2257,13 +1789,15 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		log.Printf("%sphase %q starting (orchestrated)", vesselLabel(vessel), p.Name)
 		phaseStart := r.runtimeNow()
 
-		td := r.buildTemplateData(vessel, issueData, p.Name, phaseIdx, previousOutputs, gateResult)
+		td := r.buildTemplateData(vessel, issueData, p.Name, phaseIdx, previousOutputs, gateResult, phase.EvaluationData{})
 
 		var output []byte
 		var runErr error
 		var beforeSnapshot surface.Snapshot
 		var checkProtectedSurfaces bool
 		var promptForCost string
+		var evaluationReport *PhaseEvaluationReport
+		var evidenceClaims []evidence.Claim
 		tier, providerChain := resolvePhaseProviderChain(r.Config, srcCfg, vessel, wf, &p)
 		provider := ""
 		model := ""
@@ -2365,23 +1899,6 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
 			}
 			promptTemplate := string(promptContent)
-			rendered, err := phase.RenderPrompt(promptTemplate, td)
-			if err != nil {
-				finishCurrentPhaseSpan(err)
-				r.failVessel(vessel.ID, fmt.Sprintf("render prompt for phase %s: %v", p.Name, err))
-				if err := src.OnFail(ctx, vessel); err != nil {
-					log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
-				}
-				return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
-			}
-			promptForCost = rendered
-			if harnessContent != "" {
-				promptForCost = harnessContent + "\n\n" + rendered
-			}
-			promptPath := filepath.Join(phasesDir, p.Name+".prompt")
-			if wErr := os.WriteFile(promptPath, []byte(rendered), 0o644); wErr != nil {
-				log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
-			}
 			if policyErr := r.enforcePhasePolicy(ctx, vessel, wf, p, worktreePath, "", promptTemplate); policyErr != nil {
 				finishCurrentPhaseSpan(policyErr)
 				log.Printf("%sphase %q blocked: %v", vesselLabel(vessel), p.Name, policyErr)
@@ -2417,24 +1934,40 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			if touchErr := r.touchPhaseActivity(outputPath); touchErr != nil {
 				log.Printf("warn: touch phase activity %s: %v", outputPath, touchErr)
 			}
-			output, provider, model, runErr = r.runPhaseWithProviderFallback(ctx, vessel.ID, p.Name, worktreePath, providerChain, func(provider string) (providerInvocation, error) {
-				cmd, args, phaseStdin, model, err := buildProviderPhaseArgs(r.Config, srcCfg, wf, &p, harnessContent, provider, tier, rendered, attempt)
+			if p.Evaluator != nil {
+				exec, err := r.runPhaseEvaluationLoop(ctx, vessel, wf, phaseIdx, previousOutputs, issueData, gateResult, harnessContent, worktreePath, phasesDir, promptTemplate, vrs, attempt)
+				if exec != nil {
+					output = exec.output
+					promptForCost = exec.promptForCost
+					provider = exec.provider
+					model = exec.model
+					evaluationReport = exec.evaluationReport
+					if evaluationReport != nil {
+						evidenceClaims = append(evidenceClaims, buildEvaluationClaim(vessel.ID, p, *evaluationReport, r.runtimeNow()))
+						if r.Tracer != nil {
+							phaseSpan.AddAttributes(phaseEvaluationSpanAttributes(*evaluationReport))
+						}
+					}
+				}
 				if err != nil {
-					return providerInvocation{}, err
+					runErr = err
 				}
-				stdinContent := ""
-				if phaseStdin != nil {
-					stdinContent = rendered
+			} else {
+				rendered, err := phase.RenderPrompt(promptTemplate, td)
+				if err != nil {
+					finishCurrentPhaseSpan(err)
+					r.failVessel(vessel.ID, fmt.Sprintf("render prompt for phase %s: %v", p.Name, err))
+					if err := src.OnFail(ctx, vessel); err != nil {
+						log.Printf("warn: OnFail hook for vessel %s: %v", vessel.ID, err)
+					}
+					return singlePhaseResult{status: "failed", duration: r.runtimeSince(phaseStart)}
 				}
-				return providerInvocation{
-					Provider:     provider,
-					Model:        model,
-					Env:          providerEnvForName(r.Config, provider),
-					Command:      cmd,
-					Args:         args,
-					StdinContent: stdinContent,
-				}, nil
-			})
+				promptPath := filepath.Join(phasesDir, p.Name+".prompt")
+				if wErr := os.WriteFile(promptPath, []byte(rendered), 0o644); wErr != nil {
+					log.Printf("warn: write prompt file %s: %v", promptPath, wErr)
+				}
+				output, promptForCost, provider, model, runErr = r.runPromptInvocation(ctx, vessel, worktreePath, srcCfg, wf, &p, harnessContent, rendered, attempt)
+			}
 		}
 
 		if r.vesselCancelled(ctx, vessel.ID) {
@@ -2470,9 +2003,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					r.Reporter.VesselFailed(ctx, issueNum, p.Name, runErr.Error(), ""))
 			}
 			return singlePhaseResult{
-				status:       "failed",
-				duration:     phaseDuration,
-				phaseSummary: vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error(), provider, model),
+				status:           "failed",
+				duration:         phaseDuration,
+				phaseSummary:     applyPhaseEvaluationSummary(vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, runErr.Error(), provider, model), evaluationReport),
+				evaluationReport: evaluationReport,
+				evidenceClaims:   append([]evidence.Claim(nil), evidenceClaims...),
 			}
 		}
 
@@ -2492,9 +2027,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 						r.Reporter.VesselFailed(ctx, issueNum, p.Name, err.Error(), ""))
 				}
 				return singlePhaseResult{
-					status:       "failed",
-					duration:     phaseDuration,
-					phaseSummary: vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error(), provider, model),
+					status:           "failed",
+					duration:         phaseDuration,
+					phaseSummary:     applyPhaseEvaluationSummary(vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, 0, 0, 0.0, phaseDuration, "failed", nil, err.Error(), provider, model), evaluationReport),
+					evaluationReport: evaluationReport,
+					evidenceClaims:   append([]evidence.Claim(nil), evidenceClaims...),
 				}
 			}
 		}
@@ -2517,9 +2054,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			phaseSpanStatus = "failed"
 			finishCurrentPhaseSpan(fmt.Errorf("%s", errMsg))
 			return singlePhaseResult{
-				status:       "failed",
-				duration:     phaseDuration,
-				phaseSummary: vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg, provider, model),
+				status:           "failed",
+				duration:         phaseDuration,
+				phaseSummary:     applyPhaseEvaluationSummary(vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, errMsg, provider, model), evaluationReport),
+				evaluationReport: evaluationReport,
+				evidenceClaims:   append([]evidence.Claim(nil), evidenceClaims...),
 			}
 		}
 
@@ -2538,9 +2077,11 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					r.Reporter.VesselFailed(ctx, issueNum, p.Name, err.Error(), ""))
 			}
 			return singlePhaseResult{
-				status:       "failed",
-				duration:     phaseDuration,
-				phaseSummary: vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, err.Error(), provider, model),
+				status:           "failed",
+				duration:         phaseDuration,
+				phaseSummary:     applyPhaseEvaluationSummary(vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", nil, err.Error(), provider, model), evaluationReport),
+				evaluationReport: evaluationReport,
+				evidenceClaims:   append([]evidence.Claim(nil), evidenceClaims...),
 			}
 		}
 
@@ -2567,11 +2108,13 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			phaseSpanStatus = "no-op"
 			finishCurrentPhaseSpan(nil)
 			return singlePhaseResult{
-				output:        string(output),
-				status:        "no-op",
-				duration:      phaseDuration,
-				phaseSummary:  vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "no-op", nil, "", provider, model),
-				evidenceClaim: nil,
+				output:           string(output),
+				status:           "no-op",
+				duration:         phaseDuration,
+				phaseSummary:     applyPhaseEvaluationSummary(vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "no-op", nil, "", provider, model), evaluationReport),
+				phaseReport:      phaseReport,
+				evaluationReport: evaluationReport,
+				evidenceClaims:   append([]evidence.Claim(nil), evidenceClaims...),
 			}
 		}
 
@@ -2583,11 +2126,13 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			phaseSpanStatus = "completed"
 			finishCurrentPhaseSpan(nil)
 			return singlePhaseResult{
-				output:        string(output),
-				status:        "completed",
-				duration:      phaseDuration,
-				phaseSummary:  vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, "", provider, model),
-				evidenceClaim: nil,
+				output:           string(output),
+				status:           "completed",
+				duration:         phaseDuration,
+				phaseSummary:     applyPhaseEvaluationSummary(vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, "", provider, model), evaluationReport),
+				phaseReport:      phaseReport,
+				evaluationReport: evaluationReport,
+				evidenceClaims:   append([]evidence.Claim(nil), evidenceClaims...),
 			}
 		}
 
@@ -2611,10 +2156,12 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				phaseSpanStatus = "failed"
 				finishCurrentPhaseSpan(nil)
 				return singlePhaseResult{
-					status:       "failed",
-					duration:     phaseDuration,
-					gateOut:      gateOut,
-					phaseSummary: vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error(), provider, model),
+					status:           "failed",
+					duration:         phaseDuration,
+					gateOut:          gateOut,
+					phaseSummary:     applyPhaseEvaluationSummary(vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), gateErr.Error(), provider, model), evaluationReport),
+					evaluationReport: evaluationReport,
+					evidenceClaims:   append([]evidence.Claim(nil), evidenceClaims...),
 				}
 			}
 			if passed {
@@ -2623,11 +2170,13 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				phaseSpanStatus = "completed"
 				finishCurrentPhaseSpan(nil)
 				return singlePhaseResult{
-					output:        string(output),
-					status:        "completed",
-					duration:      phaseDuration,
-					phaseSummary:  vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", gatePassedPointer(true), "", provider, model),
-					evidenceClaim: gateResultExec.evidenceClaim,
+					output:           string(output),
+					status:           "completed",
+					duration:         phaseDuration,
+					phaseSummary:     applyPhaseEvaluationSummary(vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", gatePassedPointer(true), "", provider, model), evaluationReport),
+					phaseReport:      phaseReport,
+					evaluationReport: evaluationReport,
+					evidenceClaims:   appendEvidenceClaim(evidenceClaims, gateResultExec.evidenceClaim),
 				}
 			}
 
@@ -2653,10 +2202,12 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				phaseSpanStatus = "failed"
 				finishCurrentPhaseSpan(nil)
 				return singlePhaseResult{
-					status:       "failed",
-					duration:     phaseDuration,
-					gateOut:      gateOut,
-					phaseSummary: vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted", provider, model),
+					status:           "failed",
+					duration:         phaseDuration,
+					gateOut:          gateOut,
+					phaseSummary:     applyPhaseEvaluationSummary(vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), "gate failed, retries exhausted", provider, model), evaluationReport),
+					evaluationReport: evaluationReport,
+					evidenceClaims:   append([]evidence.Claim(nil), evidenceClaims...),
 				}
 			}
 			gateRetries--
@@ -2678,10 +2229,12 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				phaseSpanStatus = "failed"
 				finishCurrentPhaseSpan(err)
 				return singlePhaseResult{
-					status:       "failed",
-					duration:     phaseDuration,
-					gateOut:      gateOut,
-					phaseSummary: vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error(), provider, model),
+					status:           "failed",
+					duration:         phaseDuration,
+					gateOut:          gateOut,
+					phaseSummary:     applyPhaseEvaluationSummary(vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "failed", gatePassedPointer(false), err.Error(), provider, model), evaluationReport),
+					evaluationReport: evaluationReport,
+					evidenceClaims:   append([]evidence.Claim(nil), evidenceClaims...),
 				}
 			}
 			phaseSpanStatus = "retrying"
@@ -2723,7 +2276,13 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			r.finishWaitTransitionSpan(waitSpan, nil)
 			phaseSpanStatus = "waiting"
 			finishCurrentPhaseSpan(nil)
-			return singlePhaseResult{output: string(output), status: "waiting", duration: r.runtimeSince(phaseStart)}
+			return singlePhaseResult{
+				output:           string(output),
+				status:           "waiting",
+				duration:         r.runtimeSince(phaseStart),
+				evaluationReport: evaluationReport,
+				evidenceClaims:   append([]evidence.Claim(nil), evidenceClaims...),
+			}
 		}
 
 		// Unknown gate type: treat as passed.
@@ -2731,11 +2290,13 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		phaseSpanStatus = "completed"
 		finishCurrentPhaseSpan(nil)
 		return singlePhaseResult{
-			output:        string(output),
-			status:        "completed",
-			duration:      phaseDuration,
-			phaseSummary:  vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, "", provider, model),
-			evidenceClaim: nil,
+			output:           string(output),
+			status:           "completed",
+			duration:         phaseDuration,
+			phaseSummary:     applyPhaseEvaluationSummary(vrs.phaseSummaryWithLLM(r.Config, srcCfg, wf, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, "completed", nil, "", provider, model), evaluationReport),
+			phaseReport:      phaseReport,
+			evaluationReport: evaluationReport,
+			evidenceClaims:   append([]evidence.Claim(nil), evidenceClaims...),
 		}
 	}
 }
@@ -2768,6 +2329,23 @@ func finishPhaseSpan(tracer *observability.Tracer, span observability.SpanContex
 		span.RecordError(err)
 	}
 	span.End()
+}
+
+func phaseEvaluationSpanAttributes(report PhaseEvaluationReport) []observability.SpanAttribute {
+	attrs := []observability.SpanAttribute{
+		{Key: "xylem.eval.enabled", Value: "true"},
+		{Key: "xylem.eval.iterations", Value: fmt.Sprintf("%d", report.Iterations)},
+		{Key: "xylem.eval.converged", Value: fmt.Sprintf("%t", report.Converged)},
+		{Key: "xylem.eval.intensity", Value: report.Intensity},
+		{Key: "xylem.eval.criteria_count", Value: fmt.Sprintf("%d", len(report.Criteria))},
+	}
+	if report.FinalResult != nil {
+		attrs = append(attrs,
+			observability.SpanAttribute{Key: "xylem.eval.pass", Value: fmt.Sprintf("%t", report.FinalResult.Pass)},
+			observability.SpanAttribute{Key: "xylem.eval.feedback_count", Value: fmt.Sprintf("%d", len(report.FinalResult.Feedback))},
+		)
+	}
+	return append(attrs, observability.SignalSetSpanAttributes(report.Signals)...)
 }
 
 func startGateSpan(tracer *observability.Tracer, phaseSpan observability.SpanContext, ctx context.Context, gateType string) observability.SpanContext {
@@ -2999,6 +2577,28 @@ func buildGateClaim(p workflow.Phase, passed bool, artifactPath string, recorded
 	}
 
 	return claim
+}
+
+func buildEvaluationClaim(vesselID string, p workflow.Phase, report PhaseEvaluationReport, recordedAt time.Time) evidence.Claim {
+	passed := report.Converged && report.FinalResult != nil && report.FinalResult.Pass
+	return evidence.Claim{
+		Claim:         fmt.Sprintf("Evaluator review for phase %q met configured quality thresholds", p.Name),
+		Level:         evidence.BehaviorallyChecked,
+		Checker:       "generator-evaluator loop",
+		TrustBoundary: "LLM evaluator review of generated output",
+		ArtifactPath:  evalReportRelativePath(vesselID),
+		Phase:         p.Name,
+		Passed:        passed,
+		Timestamp:     recordedAt.UTC(),
+	}
+}
+
+func appendEvidenceClaim(claims []evidence.Claim, claim *evidence.Claim) []evidence.Claim {
+	if claim == nil {
+		return append([]evidence.Claim(nil), claims...)
+	}
+	out := append([]evidence.Claim(nil), claims...)
+	return append(out, *claim)
 }
 
 func phaseActionType(p *workflow.Phase) string {
@@ -4431,7 +4031,7 @@ func (r *Runner) resolveDefaultBranch() string {
 	return "main"
 }
 
-func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueData, phaseName string, phaseIndex int, previousOutputs map[string]string, gateResult string) phase.TemplateData {
+func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueData, phaseName string, phaseIndex int, previousOutputs map[string]string, gateResult string, evaluation phase.EvaluationData) phase.TemplateData {
 	sourceName := vessel.Source
 	if configSource := r.sourceConfigNameFromMeta(vessel); configSource != "" {
 		sourceName = configSource
@@ -4455,6 +4055,7 @@ func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueDat
 		},
 		PreviousOutputs: previousOutputs,
 		GateResult:      gateResult,
+		Evaluation:      evaluation,
 		Vessel: phase.VesselData{
 			ID:     vessel.ID,
 			Ref:    vessel.Ref,

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
+	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"github.com/nicholls-inc/xylem/cli/internal/gate"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
@@ -653,7 +655,7 @@ func writeWorkflowFile(t *testing.T, dir, name string, phases []testPhase) {
 func writeWorkflowFileWithOptions(t *testing.T, dir, name string, opts testWorkflowOptions, phases []testPhase) {
 	t.Helper()
 	workflowDir := filepath.Join(dir, ".xylem", "workflows")
-	os.MkdirAll(workflowDir, 0o755)
+	require.NoError(t, os.MkdirAll(workflowDir, 0o755))
 
 	var phaseYAML strings.Builder
 	for _, p := range phases {
@@ -664,11 +666,37 @@ func writeWorkflowFileWithOptions(t *testing.T, dir, name string, opts testWorkf
 			fmt.Fprintf(&phaseYAML, "    run: %q\n", p.run)
 		} else {
 			promptPath := filepath.Join(dir, ".xylem", "prompts", name, p.name+".md")
-			os.MkdirAll(filepath.Dir(promptPath), 0o755)
-			os.WriteFile(promptPath, []byte(p.promptContent), 0o644)
+			require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
+			require.NoError(t, os.WriteFile(promptPath, []byte(p.promptContent), 0o644))
 
 			fmt.Fprintf(&phaseYAML, "    prompt_file: %s\n", promptPath)
 			fmt.Fprintf(&phaseYAML, "    max_turns: %d\n", p.maxTurns)
+			if p.evaluatorPromptContent != "" {
+				evaluatorPromptPath := filepath.Join(dir, ".xylem", "prompts", name, p.name+".evaluator.md")
+				require.NoError(t, os.MkdirAll(filepath.Dir(evaluatorPromptPath), 0o755))
+				require.NoError(t, os.WriteFile(evaluatorPromptPath, []byte(p.evaluatorPromptContent), 0o644))
+
+				phaseYAML.WriteString("    evaluator:\n")
+				fmt.Fprintf(&phaseYAML, "      prompt_file: %s\n", evaluatorPromptPath)
+				fmt.Fprintf(&phaseYAML, "      max_turns: %d\n", p.evaluatorMaxTurns)
+				if p.evaluatorMaxIterations > 0 {
+					fmt.Fprintf(&phaseYAML, "      max_iterations: %d\n", p.evaluatorMaxIterations)
+				}
+				if p.evaluatorPassThreshold > 0 {
+					fmt.Fprintf(&phaseYAML, "      pass_threshold: %.2f\n", p.evaluatorPassThreshold)
+				}
+				if len(p.evaluatorCriteria) > 0 {
+					phaseYAML.WriteString("      criteria:\n")
+					for _, criterion := range p.evaluatorCriteria {
+						fmt.Fprintf(&phaseYAML, "        - name: %q\n", criterion.Name)
+						if criterion.Description != "" {
+							fmt.Fprintf(&phaseYAML, "          description: %q\n", criterion.Description)
+						}
+						fmt.Fprintf(&phaseYAML, "          weight: %.2f\n", criterion.Weight)
+						fmt.Fprintf(&phaseYAML, "          threshold: %.2f\n", criterion.Threshold)
+					}
+				}
+			}
 		}
 		if p.noopMatch != "" {
 			phaseYAML.WriteString("    noop:\n")
@@ -714,7 +742,7 @@ func writeWorkflowFileWithOptions(t *testing.T, dir, name string, opts testWorkf
 		workflowContent += "allow_canonical_protected_writes: true\n"
 	}
 	workflowContent += fmt.Sprintf("phases:\n%s", phaseYAML.String())
-	os.WriteFile(filepath.Join(workflowDir, name+".yaml"), []byte(workflowContent), 0o644)
+	require.NoError(t, os.WriteFile(filepath.Join(workflowDir, name+".yaml"), []byte(workflowContent), 0o644))
 }
 
 func withTestWorkingDir(t *testing.T, dir string) {
@@ -955,6 +983,156 @@ func TestDrainTracingSurfacesVesselHealthAndPatterns(t *testing.T) {
 	}
 }
 
+func TestDrainEvaluatorLoopRetriesGeneratorAndPersistsQualityReport(t *testing.T) {
+	tracer, rec := newTestTracer(t)
+	cmdRunner := &mockCmdRunner{
+		runPhaseHook: func(_ string, prompt, _ string, _ ...string) ([]byte, error, bool) {
+			switch {
+			case strings.Contains(prompt, "Evaluate output") && strings.Contains(prompt, "Output: draft 1"):
+				return []byte(`{"pass":false,"score":{"overall":0.40,"criteria":{"correctness":0.40},"issues":[{"severity":1,"description":"missing tests","suggestion":"add tests"}]},"feedback":[{"severity":1,"description":"missing tests","suggestion":"add tests"}]}`), nil, true
+			case strings.Contains(prompt, "Evaluate output") && strings.Contains(prompt, "Output: draft 2"):
+				return []byte(`{"pass":true,"score":{"overall":0.95,"criteria":{"correctness":0.95}},"feedback":[]}`), nil, true
+			case strings.Contains(prompt, "Implement fix") && strings.Contains(prompt, "Suggestion: add tests"):
+				return []byte("draft 2"), nil, true
+			case strings.Contains(prompt, "Implement fix"):
+				return []byte("draft 1"), nil, true
+			default:
+				return nil, nil, false
+			}
+		},
+	}
+
+	r := newWorkflowRunner(t, "eval-loop", []testPhase{
+		{
+			name:                   "implement",
+			promptContent:          "Implement fix\nFeedback: {{.Evaluation.Feedback}}",
+			maxTurns:               6,
+			evaluatorPromptContent: "Evaluate output\nCriteria: {{.Evaluation.Criteria}}\nOutput: {{.Evaluation.Output}}",
+			evaluatorMaxTurns:      4,
+			evaluatorMaxIterations: 2,
+			evaluatorPassThreshold: 0.70,
+			evaluatorCriteria: []evaluator.Criterion{
+				{Name: "correctness", Description: "Fix is correct", Weight: 1.0, Threshold: 0.70},
+			},
+		},
+	}, cmdRunner, tracer)
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Completed)
+
+	summary := loadSummary(t, r.Config.StateDir, "issue-1")
+	require.Len(t, summary.Phases, 1)
+	assert.Equal(t, evalReportRelativePath("issue-1"), summary.EvalReportPath)
+	assert.Equal(t, evidenceManifestRelativePath("issue-1"), summary.EvidenceManifestPath)
+	assert.Equal(t, 2, summary.Phases[0].EvalIterations)
+	assert.True(t, summary.Phases[0].EvalConverged)
+	assert.NotEmpty(t, summary.Phases[0].EvalIntensity)
+
+	manifest, err := evidence.LoadManifest(r.Config.StateDir, "issue-1")
+	require.NoError(t, err)
+	require.Len(t, manifest.Claims, 1)
+	assert.Equal(t, evidence.BehaviorallyChecked, manifest.Claims[0].Level)
+	assert.Equal(t, evalReportRelativePath("issue-1"), manifest.Claims[0].ArtifactPath)
+	assert.True(t, manifest.Claims[0].Passed)
+
+	outputPath := config.RuntimePath(r.Config.StateDir, "phases", "issue-1", "implement.output")
+	outputData, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Equal(t, "draft 2", string(outputData))
+
+	reportPath := config.RuntimePath(r.Config.StateDir, "phases", "issue-1", evalReportFileName)
+	reportData, err := os.ReadFile(reportPath)
+	require.NoError(t, err)
+
+	var artifact EvaluationArtifact
+	require.NoError(t, json.Unmarshal(reportData, &artifact))
+	require.Len(t, artifact.Phases, 1)
+	assert.Equal(t, "implement", artifact.Phases[0].Phase)
+	assert.Equal(t, 2, artifact.Phases[0].Iterations)
+	assert.True(t, artifact.Phases[0].Converged)
+	if assert.NotNil(t, artifact.Phases[0].FinalResult) {
+		assert.True(t, artifact.Phases[0].FinalResult.Pass)
+	}
+
+	cmdRunner.mu.Lock()
+	require.Len(t, cmdRunner.phaseCalls, 4)
+	assert.Contains(t, cmdRunner.phaseCalls[1].prompt, "Output: draft 1")
+	assert.Contains(t, cmdRunner.phaseCalls[2].prompt, "Suggestion: add tests")
+	assert.Contains(t, cmdRunner.phaseCalls[3].prompt, "Output: draft 2")
+	cmdRunner.mu.Unlock()
+
+	phaseSpan := endedSpanByName(t, rec, "phase:implement")
+	phaseAttrs := spanAttrMap(phaseSpan)
+	assert.Equal(t, "true", phaseAttrs["xylem.eval.enabled"])
+	assert.Equal(t, "2", phaseAttrs["xylem.eval.iterations"])
+	assert.Equal(t, "true", phaseAttrs["xylem.eval.converged"])
+	assert.Equal(t, "true", phaseAttrs["xylem.eval.pass"])
+	assert.NotEmpty(t, phaseAttrs["signals.health"])
+}
+
+func TestDrainEvaluatorLoopAndGatePersistBothEvidenceClaims(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	vessel := makeVessel(2, "eval-and-gate")
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	writeWorkflowFile(t, dir, "eval-and-gate", []testPhase{
+		{
+			name:                   "implement",
+			promptContent:          "Implement fix",
+			maxTurns:               6,
+			evaluatorPromptContent: "Evaluate output\nCriteria: {{.Evaluation.Criteria}}\nOutput: {{.Evaluation.Output}}",
+			evaluatorMaxTurns:      4,
+			evaluatorMaxIterations: 1,
+			evaluatorPassThreshold: 0.70,
+			evaluatorCriteria: []evaluator.Criterion{
+				{Name: "correctness", Description: "Fix is correct", Weight: 1.0, Threshold: 0.70},
+			},
+			gate: `      type: command
+      run: "make test"
+      retries: 0
+      evidence:
+        claim: "Implementation gate passed"
+        level: behaviorally_checked
+        checker: "make test"`,
+		},
+	})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Implement fix": []byte("draft 1"),
+		},
+		runPhaseHook: func(_ string, prompt, _ string, _ ...string) ([]byte, error, bool) {
+			if strings.Contains(prompt, "Evaluate output") {
+				return []byte(`{"pass":true,"score":{"overall":0.95,"criteria":{"correctness":0.95}},"feedback":[]}`), nil, true
+			}
+			return nil, nil, false
+		},
+		gateOutput: []byte("ok"),
+	}
+	r := New(cfg, q, &mockWorktree{}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
+
+	manifest, err := evidence.LoadManifest(cfg.StateDir, vessel.ID)
+	require.NoError(t, err)
+	require.Len(t, manifest.Claims, 2)
+	assert.Equal(t, evidence.BehaviorallyChecked, manifest.Claims[0].Level)
+	assert.Equal(t, evalReportRelativePath(vessel.ID), manifest.Claims[0].ArtifactPath)
+	assert.Equal(t, "implement", manifest.Claims[0].Phase)
+	assert.Equal(t, "Implementation gate passed", manifest.Claims[1].Claim)
+	assert.Equal(t, phaseArtifactRelativePath(vessel.ID, "implement"), manifest.Claims[1].ArtifactPath)
+}
+
 func TestInspectVesselStatusMissingSummaryDoesNotWarn(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)
@@ -1015,6 +1193,11 @@ type testPhase struct {
 	name                          string
 	promptContent                 string
 	maxTurns                      int
+	evaluatorPromptContent        string
+	evaluatorMaxTurns             int
+	evaluatorMaxIterations        int
+	evaluatorPassThreshold        float64
+	evaluatorCriteria             []evaluator.Criterion
 	noopMatch                     string
 	gate                          string
 	allowedTools                  string
@@ -5971,7 +6154,7 @@ func TestSmoke_S4_BuildTemplateDataExposesRepoAndValidation(t *testing.T) {
 			"schedule.source_name": "security-compliance",
 		},
 	}
-	td := r.buildTemplateData(vessel, phase.IssueData{Number: 42}, "merge", 0, nil, "")
+	td := r.buildTemplateData(vessel, phase.IssueData{Number: 42}, "merge", 0, nil, "", phase.EvaluationData{})
 
 	rendered, err := renderCommandTemplate("merge", "command", "gh pr merge {{.Issue.Number}} --repo {{.Repo.Slug}} && echo {{.Source.Name}} {{.Source.Repo}} {{.Repo.DefaultBranch}} {{.Validation.Format}} {{.Validation.Lint}} {{.Validation.Build}} {{.Validation.Test}} {{.Vessel.Ref}} {{index .Vessel.Meta \"schedule.source_name\"}}", td)
 	require.NoError(t, err)
@@ -7781,7 +7964,7 @@ func TestSmoke_S20_SinglePhaseResultIncludesAPhaseSummaryField(t *testing.T) {
 	assert.Greater(t, result.phaseSummary.DurationMS, int64(0))
 }
 
-func TestSmoke_S21_SinglePhaseResultEvidenceClaimIsNilWhenNoGateIsPresent(t *testing.T) {
+func TestSmoke_S21_SinglePhaseResultEvidenceClaimsAreEmptyWhenNoGateIsPresent(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 1)
 	cfg.StateDir = filepath.Join(dir, ".xylem")
@@ -7806,7 +7989,7 @@ func TestSmoke_S21_SinglePhaseResultEvidenceClaimIsNilWhenNoGateIsPresent(t *tes
 	r := New(cfg, queue.New(filepath.Join(dir, "queue.jsonl")), &mockWorktree{path: dir}, cmdRunner)
 
 	result := r.runSinglePhase(context.Background(), vessel, wf, 0, map[string]string{}, phase.IssueData{}, "", dir, &source.Manual{}, vrs, true)
-	assert.Nil(t, result.evidenceClaim)
+	assert.Empty(t, result.evidenceClaims)
 }
 
 func TestSmoke_S22_WaveResultsAreMergedIntoVesselRunStateAfterWgWait(t *testing.T) {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -984,6 +984,8 @@ func TestDrainTracingSurfacesVesselHealthAndPatterns(t *testing.T) {
 }
 
 func TestDrainEvaluatorLoopRetriesGeneratorAndPersistsQualityReport(t *testing.T) {
+	t.Setenv("XYLEM_DTU_STATE_PATH", "/tmp/dtu/state.json")
+
 	tracer, rec := newTestTracer(t)
 	cmdRunner := &mockCmdRunner{
 		runPhaseHook: func(_ string, prompt, _ string, _ ...string) ([]byte, error, bool) {
@@ -1032,6 +1034,7 @@ func TestDrainEvaluatorLoopRetriesGeneratorAndPersistsQualityReport(t *testing.T
 	manifest, err := evidence.LoadManifest(r.Config.StateDir, "issue-1")
 	require.NoError(t, err)
 	require.Len(t, manifest.Claims, 1)
+	assert.Equal(t, `Evaluator review for phase "implement" met configured quality thresholds`, manifest.Claims[0].Claim)
 	assert.Equal(t, evidence.BehaviorallyChecked, manifest.Claims[0].Level)
 	assert.Equal(t, evalReportRelativePath("issue-1"), manifest.Claims[0].ArtifactPath)
 	assert.True(t, manifest.Claims[0].Passed)
@@ -1060,6 +1063,10 @@ func TestDrainEvaluatorLoopRetriesGeneratorAndPersistsQualityReport(t *testing.T
 	assert.Contains(t, cmdRunner.phaseCalls[1].prompt, "Output: draft 1")
 	assert.Contains(t, cmdRunner.phaseCalls[2].prompt, "Suggestion: add tests")
 	assert.Contains(t, cmdRunner.phaseCalls[3].prompt, "Output: draft 2")
+	assert.True(t, containsArgSequence(cmdRunner.phaseCalls[0].args, "--dtu-attempt", "1001"))
+	assert.True(t, containsArgSequence(cmdRunner.phaseCalls[1].args, "--dtu-attempt", "1001"))
+	assert.True(t, containsArgSequence(cmdRunner.phaseCalls[2].args, "--dtu-attempt", "1002"))
+	assert.True(t, containsArgSequence(cmdRunner.phaseCalls[3].args, "--dtu-attempt", "1002"))
 	cmdRunner.mu.Unlock()
 
 	phaseSpan := endedSpanByName(t, rec, "phase:implement")
@@ -1127,10 +1134,21 @@ func TestDrainEvaluatorLoopAndGatePersistBothEvidenceClaims(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, manifest.Claims, 2)
 	assert.Equal(t, evidence.BehaviorallyChecked, manifest.Claims[0].Level)
+	assert.Equal(t, `Evaluator review for phase "implement" met configured quality thresholds`, manifest.Claims[0].Claim)
 	assert.Equal(t, evalReportRelativePath(vessel.ID), manifest.Claims[0].ArtifactPath)
 	assert.Equal(t, "implement", manifest.Claims[0].Phase)
 	assert.Equal(t, "Implementation gate passed", manifest.Claims[1].Claim)
 	assert.Equal(t, phaseArtifactRelativePath(vessel.ID, "implement"), manifest.Claims[1].ArtifactPath)
+}
+
+func TestBuildEvaluationClaimReflectsFailure(t *testing.T) {
+	claim := buildEvaluationClaim("issue-1", workflow.Phase{Name: "implement"}, PhaseEvaluationReport{
+		Converged:   false,
+		FinalResult: &evaluator.EvalResult{Pass: false},
+	}, time.Unix(123, 0))
+
+	assert.Equal(t, `Evaluator review for phase "implement" did not meet configured quality thresholds`, claim.Claim)
+	assert.False(t, claim.Passed)
 }
 
 func TestInspectVesselStatusMissingSummaryDoesNotWarn(t *testing.T) {

--- a/cli/internal/runner/summary.go
+++ b/cli/internal/runner/summary.go
@@ -6,14 +6,17 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
+	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/recovery"
+	"github.com/nicholls-inc/xylem/cli/internal/signal"
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 )
 
@@ -95,6 +98,9 @@ type PhaseSummary struct {
 	Model                  string           `json:"model,omitempty"`
 	DurationMS             int64            `json:"duration_ms"`
 	Status                 string           `json:"status"`
+	EvalIterations         int              `json:"eval_iterations,omitempty"`
+	EvalConverged          bool             `json:"eval_converged,omitempty"`
+	EvalIntensity          string           `json:"eval_intensity,omitempty"`
 	InputTokensEst         int              `json:"input_tokens_est"`
 	OutputTokensEst        int              `json:"output_tokens_est"`
 	CostUSDEst             float64          `json:"cost_usd_est"`
@@ -106,8 +112,9 @@ type PhaseSummary struct {
 }
 
 type vesselRunState struct {
-	startedAt time.Time
-	phases    []PhaseSummary
+	startedAt   time.Time
+	phases      []PhaseSummary
+	evalReports map[string]PhaseEvaluationReport
 
 	costTracker *cost.Tracker
 	vesselID    string
@@ -124,14 +131,30 @@ type vesselRunState struct {
 	trace                *TraceArtifacts
 }
 
+type PhaseEvaluationReport struct {
+	Phase       string                 `json:"phase"`
+	Intensity   string                 `json:"intensity"`
+	Signals     signal.SignalSet       `json:"signals"`
+	Criteria    []evaluator.Criterion  `json:"criteria,omitempty"`
+	Iterations  int                    `json:"iterations"`
+	Converged   bool                   `json:"converged"`
+	History     []evaluator.EvalResult `json:"history,omitempty"`
+	FinalResult *evaluator.EvalResult  `json:"final_result,omitempty"`
+}
+
+type EvaluationArtifact struct {
+	Phases []PhaseEvaluationReport `json:"phases"`
+}
+
 func newVesselRunState(cfg *config.Config, vessel queue.Vessel, startedAt time.Time) *vesselRunState {
 	s := &vesselRunState{
-		startedAt: startedAt.UTC(),
-		phases:    make([]PhaseSummary, 0),
-		vesselID:  vessel.ID,
-		source:    vessel.Source,
-		workflow:  vessel.Workflow,
-		ref:       vessel.Ref,
+		startedAt:   startedAt.UTC(),
+		phases:      make([]PhaseSummary, 0),
+		evalReports: make(map[string]PhaseEvaluationReport),
+		vesselID:    vessel.ID,
+		source:      vessel.Source,
+		workflow:    vessel.Workflow,
+		ref:         vessel.Ref,
 	}
 
 	if cfg == nil {
@@ -165,6 +188,16 @@ func (s *vesselRunState) setTraceContext(data observability.TraceContextData) {
 
 func (s *vesselRunState) addPhase(ps PhaseSummary) {
 	s.phases = append(s.phases, ps)
+}
+
+func (s *vesselRunState) addEvaluationReport(report PhaseEvaluationReport) {
+	if s == nil || strings.TrimSpace(report.Phase) == "" {
+		return
+	}
+	if s.evalReports == nil {
+		s.evalReports = make(map[string]PhaseEvaluationReport)
+	}
+	s.evalReports[report.Phase] = report
 }
 
 func (s *vesselRunState) buildSummary(state string, endedAt time.Time) *VesselSummary {
@@ -238,6 +271,30 @@ func (s *vesselRunState) recordLLMUsage(model, inputText, outputText string, rec
 
 func (s *vesselRunState) recordPromptOnlyUsage(model, prompt, output string, recordedAt time.Time) (int, int, float64) {
 	inputTokens, outputTokens, costUSDEst := s.recordLLMUsage(model, prompt, output, recordedAt)
+	s.extraInputTokensEst += inputTokens
+	s.extraOutputTokensEst += outputTokens
+	s.extraCostUSDEst += costUSDEst
+	return inputTokens, outputTokens, costUSDEst
+}
+
+func (s *vesselRunState) recordEvaluationUsage(model, prompt, output string, recordedAt time.Time) (int, int, float64) {
+	inputTokens := cost.EstimateTokens(prompt)
+	outputTokens := cost.EstimateTokens(output)
+	costUSDEst := cost.EstimateCost(inputTokens, outputTokens, cost.LookupPricing(model))
+
+	if s.costTracker != nil {
+		_ = s.costTracker.Record(cost.UsageRecord{
+			MissionID:    s.vesselID,
+			AgentRole:    cost.RoleEvaluator,
+			Purpose:      cost.PurposeEvaluation,
+			Model:        model,
+			InputTokens:  inputTokens,
+			OutputTokens: outputTokens,
+			CostUSD:      costUSDEst,
+			Timestamp:    recordedAt.UTC(),
+		})
+	}
+
 	s.extraInputTokensEst += inputTokens
 	s.extraOutputTokensEst += outputTokens
 	s.extraCostUSDEst += costUSDEst
@@ -386,6 +443,20 @@ func hasBudgetWarning(alerts []cost.BudgetAlert) bool {
 		}
 	}
 	return false
+}
+
+func (s *vesselRunState) evaluationArtifact() *EvaluationArtifact {
+	if s == nil || len(s.evalReports) == 0 {
+		return nil
+	}
+	phases := make([]PhaseEvaluationReport, 0, len(s.evalReports))
+	for _, report := range s.evalReports {
+		phases = append(phases, report)
+	}
+	sort.Slice(phases, func(i, j int) bool {
+		return phases[i].Phase < phases[j].Phase
+	})
+	return &EvaluationArtifact{Phases: phases}
 }
 
 func evidenceManifestRelativePath(vesselID string) string {

--- a/cli/internal/runner/summary_test.go
+++ b/cli/internal/runner/summary_test.go
@@ -811,7 +811,12 @@ func TestSmoke_S15_BuildGateClaimWithEvidenceMetadataProducesATypedClaim(t *test
 	assert.True(t, claim.Timestamp.Equal(recordedAt))
 }
 
-func TestSmoke_S16_BuildGateClaimWithoutEvidenceMetadataProducesAnUntypedClaim(t *testing.T) {
+func TestSmoke_S16_BuildGateClaimWithoutEvidenceMetadataProducesABehaviorallyCheckedClaim(t *testing.T) {
+	// Command gates run a shell command and assert on its exit status — that is
+	// a behavioral check, not an unclassified assertion. Per P0 #10 in
+	// docs/plans/sota-gap-implementation-2026-04-11.md, command gates default to
+	// evidence.BehaviorallyChecked so evidence manifests never ship with
+	// "untyped" claims into production.
 	recordedAt := time.Date(2026, time.April, 1, 8, 30, 0, 0, time.UTC)
 	artifactPath := phaseArtifactRelativePath("vessel-1", "implement")
 	claim := buildGateClaim(workflow.Phase{
@@ -819,8 +824,8 @@ func TestSmoke_S16_BuildGateClaimWithoutEvidenceMetadataProducesAnUntypedClaim(t
 		Gate: &workflow.Gate{Run: "cd cli && go test ./..."},
 	}, true, artifactPath, recordedAt)
 
-	assert.Equal(t, evidence.Untyped, claim.Level)
-	assert.Equal(t, "No trust boundary declared", claim.TrustBoundary)
+	assert.Equal(t, evidence.BehaviorallyChecked, claim.Level)
+	assert.Equal(t, "Command gate output", claim.TrustBoundary)
 	assert.Contains(t, claim.Claim, "implement")
 	assert.True(t, claim.Passed)
 	assert.Equal(t, artifactPath, claim.ArtifactPath)

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"github.com/nicholls-inc/xylem/cli/internal/policy"
 	"gopkg.in/yaml.v3"
@@ -71,8 +72,23 @@ type Phase struct {
 	Discussion   *DiscussionOutput `yaml:"discussion,omitempty"`
 	NoOp         *NoOp             `yaml:"noop,omitempty"`
 	Gate         *Gate             `yaml:"gate,omitempty"`
+	Evaluator    *PhaseEvaluator   `yaml:"evaluator,omitempty"`
 	AllowedTools *string           `yaml:"allowed_tools,omitempty"`
 	DependsOn    []string          `yaml:"depends_on,omitempty"`
+}
+
+// PhaseEvaluator defines an optional evaluator pass that critiques and can
+// trigger regeneration of a prompt phase before gate execution.
+type PhaseEvaluator struct {
+	PromptFile    string                `yaml:"prompt_file"`
+	MaxTurns      int                   `yaml:"max_turns"`
+	LLM           *string               `yaml:"llm,omitempty"`
+	Model         *string               `yaml:"model,omitempty"`
+	Tier          *string               `yaml:"tier,omitempty"`
+	AllowedTools  *string               `yaml:"allowed_tools,omitempty"`
+	MaxIterations int                   `yaml:"max_iterations,omitempty"`
+	PassThreshold float64               `yaml:"pass_threshold,omitempty"`
+	Criteria      []evaluator.Criterion `yaml:"criteria,omitempty"`
 }
 
 // NoOp defines an early-success completion rule for a phase.
@@ -303,6 +319,12 @@ func (s *Workflow) Validate(workflowFilePath string) error {
 			}
 		}
 
+		if p.Evaluator != nil {
+			if err := validatePhaseEvaluator(p); err != nil {
+				return err
+			}
+		}
+
 		if p.NoOp != nil {
 			if err := validateNoOp(p.Name, p.NoOp); err != nil {
 				return err
@@ -523,6 +545,38 @@ func validateDependencyCycles(phases []Phase) error {
 func validateNoOp(phaseName string, n *NoOp) error {
 	if strings.TrimSpace(n.Match) == "" {
 		return fmt.Errorf("phase %q: noop: match is required", phaseName)
+	}
+	return nil
+}
+
+func validatePhaseEvaluator(p Phase) error {
+	if p.Type == "command" {
+		return fmt.Errorf("phase %q: evaluator is only supported for prompt phases", p.Name)
+	}
+	if p.Evaluator == nil {
+		return nil
+	}
+	if strings.TrimSpace(p.Evaluator.PromptFile) == "" {
+		return fmt.Errorf("phase %q: evaluator.prompt_file is required", p.Name)
+	}
+	if _, err := os.Stat(p.Evaluator.PromptFile); err != nil {
+		return fmt.Errorf("phase %q: evaluator.prompt_file not found: %s", p.Name, p.Evaluator.PromptFile)
+	}
+	if p.Evaluator.MaxTurns <= 0 {
+		return fmt.Errorf("phase %q: evaluator.max_turns must be greater than 0", p.Name)
+	}
+	if p.Evaluator.AllowedTools != nil && *p.Evaluator.AllowedTools == "" {
+		return fmt.Errorf("phase %q: evaluator.allowed_tools must not be empty when specified", p.Name)
+	}
+	if err := validateLLM(p.Evaluator.LLM, fmt.Sprintf("phase %q evaluator", p.Name)); err != nil {
+		return err
+	}
+	if err := evaluator.ValidateConfig(evaluator.EvalConfig{
+		Criteria:      p.Evaluator.Criteria,
+		MaxIterations: p.Evaluator.MaxIterations,
+		PassThreshold: p.Evaluator.PassThreshold,
+	}); err != nil {
+		return fmt.Errorf("phase %q: evaluator: %w", p.Name, err)
 	}
 	return nil
 }

--- a/cli/internal/workflow/workflow.go
+++ b/cli/internal/workflow/workflow.go
@@ -560,7 +560,10 @@ func validatePhaseEvaluator(p Phase) error {
 		return fmt.Errorf("phase %q: evaluator.prompt_file is required", p.Name)
 	}
 	if _, err := os.Stat(p.Evaluator.PromptFile); err != nil {
-		return fmt.Errorf("phase %q: evaluator.prompt_file not found: %s", p.Name, p.Evaluator.PromptFile)
+		if os.IsNotExist(err) {
+			return fmt.Errorf("phase %q: evaluator.prompt_file not found: %s", p.Name, p.Evaluator.PromptFile)
+		}
+		return fmt.Errorf("phase %q: cannot access evaluator.prompt_file %q: %w", p.Name, p.Evaluator.PromptFile, err)
 	}
 	if p.Evaluator.MaxTurns <= 0 {
 		return fmt.Errorf("phase %q: evaluator.max_turns must be greater than 0", p.Name)

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -1283,6 +1283,69 @@ func TestLoadMalformedYAML(t *testing.T) {
 	requireErrorContains(t, err, "did not find expected")
 }
 
+func TestLoadWorkflowParsesPhaseEvaluator(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/implement.md")
+	createPromptFile(t, dir, "prompts/implement-eval.md")
+
+	path := writeWorkflowFile(t, dir, "eval-workflow", `name: eval-workflow
+phases:
+  - name: implement
+    prompt_file: prompts/implement.md
+    max_turns: 10
+    evaluator:
+      prompt_file: prompts/implement-eval.md
+      max_turns: 4
+      max_iterations: 2
+      pass_threshold: 0.75
+      criteria:
+        - name: correctness
+          description: "Fix solves the issue"
+          weight: 1.0
+          threshold: 0.75
+`)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, got.Phases[0].Evaluator)
+	assert.Equal(t, "prompts/implement-eval.md", got.Phases[0].Evaluator.PromptFile)
+	assert.Equal(t, 4, got.Phases[0].Evaluator.MaxTurns)
+	assert.Equal(t, 2, got.Phases[0].Evaluator.MaxIterations)
+	assert.Equal(t, 0.75, got.Phases[0].Evaluator.PassThreshold)
+	require.Len(t, got.Phases[0].Evaluator.Criteria, 1)
+	assert.Equal(t, "correctness", got.Phases[0].Evaluator.Criteria[0].Name)
+}
+
+func TestLoadWorkflowRejectsInvalidPhaseEvaluator(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+	createPromptFile(t, dir, "prompts/implement.md")
+	createPromptFile(t, dir, "prompts/implement-eval.md")
+
+	path := writeWorkflowFile(t, dir, "eval-workflow", `name: eval-workflow
+phases:
+  - name: implement
+    prompt_file: prompts/implement.md
+    max_turns: 10
+    evaluator:
+      prompt_file: prompts/implement-eval.md
+      max_turns: 4
+      criteria:
+        - name: correctness
+          weight: 0.6
+          threshold: 0.75
+        - name: completeness
+          weight: 0.6
+          threshold: 0.75
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `phase "implement": evaluator:`)
+	assert.Contains(t, err.Error(), "criteria weights must sum to ~1.0")
+}
+
 func TestLoadWorkflowWithNoOp(t *testing.T) {
 	dir := t.TempDir()
 	chdirTemp(t, dir)

--- a/cli/internal/workflow/workflow_test.go
+++ b/cli/internal/workflow/workflow_test.go
@@ -1346,6 +1346,19 @@ phases:
 	assert.Contains(t, err.Error(), "criteria weights must sum to ~1.0")
 }
 
+func TestValidatePhaseEvaluatorWrapsAccessErrors(t *testing.T) {
+	err := validatePhaseEvaluator(Phase{
+		Name: "implement",
+		Evaluator: &PhaseEvaluator{
+			PromptFile: "bad\x00path",
+			MaxTurns:   4,
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `phase "implement": cannot access evaluator.prompt_file "bad`)
+}
+
 func TestLoadWorkflowWithNoOp(t *testing.T) {
 	dir := t.TempDir()
 	chdirTemp(t, dir)


### PR DESCRIPTION
## Summary
- add optional per-phase evaluator configuration, evaluator-aware template data, and runner loop execution that retries generators with evaluator feedback
- persist evaluator reports into vessel summaries/evidence, track evaluator cost separately, and cover the new paths with workflow/phase/runner tests
- scaffold core workflow examples and evaluator prompts so seeded implement phases feed evaluator feedback back into the generator

Closes https://github.com/nicholls-inc/xylem/issues/151