### PR TITLE
Reject broken goimports package globs in validation.format

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -198,7 +198,7 @@ observability:
   sample_rate: 1.0
 
 validation:
-  format: "goimports -l ./cli/..."
+  format: "goimports -l ."
   lint: "go vet ./cli/..."
   build: "go build ./cli/cmd/xylem"
   test: "go test ./cli/..."

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -1034,9 +1034,20 @@ func (c *Config) validateTelemetry() error {
 }
 
 func (c *Config) validateWorkflowRequirements() error {
-	if c.ValidationConfigured() {
+	active := c.validationRequiredWorkflows()
+	if len(active) == 0 {
 		return nil
 	}
+	if !c.ValidationConfigured() {
+		return fmt.Errorf("validation: at least one of format, lint, build, or test must be set when workflows are active: %s", strings.Join(active, ", "))
+	}
+	if err := c.validateValidationCommands(); err != nil {
+		return fmt.Errorf("%w (active workflows: %s)", err, strings.Join(active, ", "))
+	}
+	return nil
+}
+
+func (c *Config) validationRequiredWorkflows() []string {
 	required := []string{"fix-pr-checks", "resolve-conflicts"}
 	active := make([]string, 0, len(required))
 	for _, workflowName := range required {
@@ -1044,11 +1055,84 @@ func (c *Config) validateWorkflowRequirements() error {
 			active = append(active, workflowName)
 		}
 	}
-	if len(active) == 0 {
-		return nil
+	if len(active) > 0 {
+		sort.Strings(active)
 	}
-	sort.Strings(active)
-	return fmt.Errorf("validation: at least one of format, lint, build, or test must be set when workflows are active: %s", strings.Join(active, ", "))
+	return active
+}
+
+func (c *Config) validateValidationCommands() error {
+	if target, ok := invalidGoimportsPackagePatternTarget(c.Validation.Format); ok {
+		return fmt.Errorf(`validation.format uses goimports package pattern %q; goimports expects directories or files, use "goimports -l ." or "cd cli && goimports -l ."`, target)
+	}
+	return nil
+}
+
+func invalidGoimportsPackagePatternTarget(command string) (string, bool) {
+	fields := validationCommandFields(command)
+	for i := 0; i < len(fields); i++ {
+		token := trimValidationCommandField(fields[i])
+		if filepath.Base(token) != "goimports" {
+			continue
+		}
+		for j := i + 1; j < len(fields); j++ {
+			rawArg := fields[j]
+			arg := trimValidationCommandField(rawArg)
+			if isValidationCommandSeparator(arg) {
+				break
+			}
+			if arg == "" {
+				continue
+			}
+			if strings.HasPrefix(arg, "-") {
+				if goimportsFlagConsumesValue(arg) {
+					j++
+				}
+				continue
+			}
+			if strings.Contains(arg, "...") {
+				return arg, true
+			}
+		}
+	}
+	return "", false
+}
+
+func goimportsFlagConsumesValue(arg string) bool {
+	flag, _, hasInlineValue := strings.Cut(arg, "=")
+	if hasInlineValue {
+		return false
+	}
+	switch flag {
+	case "-cpuprofile", "-local", "-memprofile", "-memrate", "-srcdir", "-trace":
+		return true
+	default:
+		return false
+	}
+}
+
+func validationCommandFields(command string) []string {
+	replacer := strings.NewReplacer(
+		"&&", " && ",
+		"||", " || ",
+		";", " ; ",
+		"\n", " ; ",
+		"\t", " ",
+	)
+	return strings.Fields(replacer.Replace(command))
+}
+
+func trimValidationCommandField(field string) string {
+	return strings.Trim(field, `"'`)
+}
+
+func isValidationCommandSeparator(field string) bool {
+	switch field {
+	case "", "&&", "||", ";", "|":
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *Config) workflowActive(name string) bool {

--- a/cli/internal/config/config_prop_test.go
+++ b/cli/internal/config/config_prop_test.go
@@ -255,18 +255,11 @@ func TestPropNormalizeLegacyProvidersPreservesDefaultTierModels(t *testing.T) {
 	})
 }
 
-func TestPropValidationRequirementAcceptsAnyNonEmptyValidationCommand(t *testing.T) {
+func TestPropValidationRequirementAcceptsAnyNonEmptyNonGoimportsValidationCommand(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		cfg := validConfig()
-		cfg.Sources = map[string]SourceConfig{
-			"github": {
-				Type: "github",
-				Repo: "owner/name",
-				Tasks: map[string]Task{
-					"fix-checks": {Labels: []string{"ci"}, Workflow: "fix-pr-checks"},
-				},
-			},
-		}
+		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts"}).Draw(t, "workflow")
+		cfg.Sources = validationRequiredSourceConfig(workflow)
 		commands := []*string{
 			&cfg.Validation.Format,
 			&cfg.Validation.Lint,
@@ -274,7 +267,43 @@ func TestPropValidationRequirementAcceptsAnyNonEmptyValidationCommand(t *testing
 			&cfg.Validation.Test,
 		}
 		idx := rapid.IntRange(0, len(commands)-1).Draw(t, "command-index")
-		*commands[idx] = rapid.StringMatching(`[a-z0-9 ./_-]{4,32}`).Draw(t, "command")
+		*commands[idx] = rapid.StringMatching(`(go test|go vet|make|just|npm run) [a-z0-9./:_-]{1,24}`).Draw(t, "command")
+
+		if err := cfg.validateWorkflowRequirements(); err != nil {
+			t.Fatalf("validateWorkflowRequirements() error = %v", err)
+		}
+	})
+}
+
+func TestPropValidationRequirementRejectsGoimportsPackagePatternTargets(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := validConfig()
+		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts"}).Draw(t, "workflow")
+		cfg.Sources = validationRequiredSourceConfig(workflow)
+		target := rapid.SampledFrom([]string{"./...", "./cli/...", "./internal/...", "cli/..."}).Draw(t, "target")
+		cfg.Validation.Format = "goimports -l " + target
+
+		err := cfg.validateWorkflowRequirements()
+		if err == nil {
+			t.Fatalf("validateWorkflowRequirements() unexpectedly accepted %q", cfg.Validation.Format)
+		}
+		if !strings.Contains(err.Error(), target) {
+			t.Fatalf("validateWorkflowRequirements() error = %v, want target %q in error", err, target)
+		}
+	})
+}
+
+func TestPropValidationRequirementAcceptsGoimportsDirectoryTargets(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := validConfig()
+		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts"}).Draw(t, "workflow")
+		cfg.Sources = validationRequiredSourceConfig(workflow)
+		target := rapid.StringMatching(`[./a-z0-9_-]{1,16}`).Draw(t, "target")
+		target = strings.TrimSpace(target)
+		if target == "" || strings.Contains(target, "...") || strings.HasPrefix(target, "-") {
+			target = "."
+		}
+		cfg.Validation.Format = "goimports -l " + target
 
 		if err := cfg.validateWorkflowRequirements(); err != nil {
 			t.Fatalf("validateWorkflowRequirements() error = %v", err)

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -350,6 +351,18 @@ func validConfig() *Config {
 	}
 	cfg.normalize()
 	return cfg
+}
+
+func validationRequiredSourceConfig(workflow string) map[string]SourceConfig {
+	return map[string]SourceConfig{
+		"github": {
+			Type: "github",
+			Repo: "owner/name",
+			Tasks: map[string]Task{
+				"validation": {Labels: []string{"ci"}, Workflow: workflow},
+			},
+		},
+	}
 }
 
 func TestValidateMissingRepoInGitHubSource(t *testing.T) {
@@ -2671,6 +2684,99 @@ claude:
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.Equal(t, "go test ./...", cfg.Validation.Test)
+}
+
+func TestSmoke_S4_RejectsGoimportsPackagePatternForValidationRequiredWorkflows(t *testing.T) {
+	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts"} {
+		t.Run(workflow, func(t *testing.T) {
+			t.Parallel()
+
+			path := writeConfigFile(t, fmt.Sprintf(`sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      validation:
+        labels: [ci]
+        workflow: %s
+validation:
+  format: "goimports -l ./cli/..."
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`, workflow))
+
+			_, err := Load(path)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), `validation.format uses goimports package pattern "./cli/..."`)
+			assert.Contains(t, err.Error(), workflow)
+		})
+	}
+}
+
+func TestSmoke_S5_AllowsGoimportsDirectoryTargetsForValidationRequiredWorkflows(t *testing.T) {
+	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts"} {
+		t.Run(workflow, func(t *testing.T) {
+			t.Parallel()
+
+			path := writeConfigFile(t, fmt.Sprintf(`sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      validation:
+        labels: [ci]
+        workflow: %s
+validation:
+  format: "goimports -l ."
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`, workflow))
+
+			cfg, err := Load(path)
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+			assert.Equal(t, "goimports -l .", cfg.Validation.Format)
+		})
+	}
+}
+
+func TestSmoke_S6_AllowsGoimportsLocalPrefixContainingEllipsisForValidationRequiredWorkflows(t *testing.T) {
+	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts"} {
+		t.Run(workflow, func(t *testing.T) {
+			t.Parallel()
+
+			path := writeConfigFile(t, fmt.Sprintf(`sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      validation:
+        labels: [ci]
+        workflow: %s
+validation:
+  format: "goimports -local example.com/... -l ."
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`, workflow))
+
+			cfg, err := Load(path)
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+			assert.Equal(t, "goimports -local example.com/... -l .", cfg.Validation.Format)
+		})
+	}
 }
 
 func TestValidateRejectsInvalidAutoMergeBranchPattern(t *testing.T) {

--- a/docs/design/productize-xylem-for-external-repos-spec.md
+++ b/docs/design/productize-xylem-for-external-repos-spec.md
@@ -570,7 +570,7 @@ Activation of the overlay MUST be through the `profiles` field in `.xylem.yml`:
 profiles: [core, self-hosting-xylem]
 
 validation:
-  format: "goimports -l ./cli/..."
+  format: "goimports -l ."
   lint:   "go vet ./cli/..."
   build:  "go build ./cli/cmd/xylem"
   test:   "go test ./cli/..."


### PR DESCRIPTION
## Summary
- Implements [issue #373](https://github.com/nicholls-inc/xylem/issues/373) by fixing the self-hosted `.xylem.yml` format command from `goimports -l ./cli/...` to `goimports -l .`.
- Adds config validation that rejects `validation.format` values which invoke `goimports` against Go package-glob targets like `./cli/...` for active `fix-pr-checks` and `resolve-conflicts` workflows.
- Updates the external-repo design spec example so the documented self-hosting validation command matches the runnable config.

## Smoke scenarios covered
- `S4` — RejectsGoimportsPackagePatternForValidationRequiredWorkflows
- `S5` — AllowsGoimportsDirectoryTargetsForValidationRequiredWorkflows
- `S6` — AllowsGoimportsLocalPrefixContainingEllipsisForValidationRequiredWorkflows

## Changes summary
- **Modified** `.xylem.yml` to use `validation.format: "goimports -l ."`.
- **Modified** `cli/internal/config/config.go`.
  - Tightened `(*Config).validateWorkflowRequirements` so active PR-validation workflows require both a configured validation command and a runnable `goimports` target.
  - Added `(*Config).validationRequiredWorkflows`, `(*Config).validateValidationCommands`, `invalidGoimportsPackagePatternTarget`, `goimportsFlagConsumesValue`, `validationCommandFields`, `trimValidationCommandField`, and `isValidationCommandSeparator`.
- **Modified** `cli/internal/config/config_test.go` with smoke coverage for rejected package globs and accepted directory / `-local` forms.
- **Modified** `cli/internal/config/config_prop_test.go` with property coverage that distinguishes invalid `goimports` package patterns from other valid non-empty validation commands.
- **Modified** `docs/design/productize-xylem-for-external-repos-spec.md` so the self-hosting validation example no longer repeats the broken `goimports -l ./cli/...` command.

## Test plan
- `cd cli && goimports -w .`
- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #373