### PR TITLE
fix: reject repo-root cli go targets in validation config

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -199,9 +199,9 @@ observability:
 
 validation:
   format: "goimports -l ."
-  lint: "go vet ./cli/..."
-  build: "go build ./cli/cmd/xylem"
-  test: "go test ./cli/..."
+  lint: "cd cli && go vet ./..."
+  build: "cd cli && go build ./cmd/xylem"
+  test: "cd cli && go test ./..."
 
 daemon:
   auto_upgrade: true

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -1065,6 +1065,19 @@ func (c *Config) validateValidationCommands() error {
 	if target, ok := invalidGoimportsPackagePatternTarget(c.Validation.Format); ok {
 		return fmt.Errorf(`validation.format uses goimports package pattern %q; goimports expects directories or files, use "goimports -l ." or "cd cli && goimports -l ."`, target)
 	}
+	for _, check := range []struct {
+		name    string
+		command string
+		example string
+	}{
+		{name: "lint", command: c.Validation.Lint, example: `cd cli && go vet ./...`},
+		{name: "build", command: c.Validation.Build, example: `cd cli && go build ./cmd/xylem`},
+		{name: "test", command: c.Validation.Test, example: `cd cli && go test ./...`},
+	} {
+		if target, ok := invalidRepoRootGoCLITarget(check.command); ok {
+			return fmt.Errorf(`validation.%s runs go from repo root against %q; xylem executes validation from the worktree root, use %q`, check.name, target, check.example)
+		}
+	}
 	return nil
 }
 
@@ -1091,6 +1104,26 @@ func invalidGoimportsPackagePatternTarget(command string) (string, bool) {
 				continue
 			}
 			if strings.Contains(arg, "...") {
+				return arg, true
+			}
+		}
+	}
+	return "", false
+}
+
+func invalidRepoRootGoCLITarget(command string) (string, bool) {
+	fields := validationCommandFields(command)
+	for i := 0; i < len(fields); i++ {
+		token := trimValidationCommandField(fields[i])
+		if filepath.Base(token) != "go" {
+			continue
+		}
+		for j := i + 1; j < len(fields); j++ {
+			arg := trimValidationCommandField(fields[j])
+			if isValidationCommandSeparator(arg) {
+				break
+			}
+			if strings.HasPrefix(arg, "./cli/") || strings.HasPrefix(arg, "cli/") {
 				return arg, true
 			}
 		}

--- a/cli/internal/config/config_prop_test.go
+++ b/cli/internal/config/config_prop_test.go
@@ -311,6 +311,62 @@ func TestPropValidationRequirementAcceptsGoimportsDirectoryTargets(t *testing.T)
 	})
 }
 
+func TestPropValidationRequirementRejectsRepoRootGoCLITargets(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := validConfig()
+		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts"}).Draw(t, "workflow")
+		cfg.Sources = validationRequiredSourceConfig(workflow)
+		target := rapid.SampledFrom([]string{"./cli/...", "./cli/cmd/xylem", "cli/...", "cli/internal/config"}).Draw(t, "target")
+		field := rapid.SampledFrom([]string{"lint", "build", "test"}).Draw(t, "field")
+
+		switch field {
+		case "lint":
+			cfg.Validation.Lint = "go vet " + target
+		case "build":
+			cfg.Validation.Build = "go build " + target
+		case "test":
+			cfg.Validation.Test = "go test " + target
+		default:
+			t.Fatalf("unexpected field %q", field)
+		}
+
+		err := cfg.validateWorkflowRequirements()
+		if err == nil {
+			t.Fatalf("validateWorkflowRequirements() unexpectedly accepted %s target %q", field, target)
+		}
+		if !strings.Contains(err.Error(), "validation."+field) {
+			t.Fatalf("validateWorkflowRequirements() error = %v, want validation.%s", err, field)
+		}
+		if !strings.Contains(err.Error(), target) {
+			t.Fatalf("validateWorkflowRequirements() error = %v, want target %q in error", err, target)
+		}
+	})
+}
+
+func TestPropValidationRequirementAcceptsCLIWorkingDirGoCommands(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := validConfig()
+		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts"}).Draw(t, "workflow")
+		cfg.Sources = validationRequiredSourceConfig(workflow)
+		field := rapid.SampledFrom([]string{"lint", "build", "test"}).Draw(t, "field")
+
+		switch field {
+		case "lint":
+			cfg.Validation.Lint = "cd cli && go vet ./..."
+		case "build":
+			cfg.Validation.Build = "cd cli && go build ./cmd/xylem"
+		case "test":
+			cfg.Validation.Test = "cd cli && go test ./..."
+		default:
+			t.Fatalf("unexpected field %q", field)
+		}
+
+		if err := cfg.validateWorkflowRequirements(); err != nil {
+			t.Fatalf("validateWorkflowRequirements() error = %v", err)
+		}
+	})
+}
+
 func TestPropEffectiveAutoMergeLabelsNeverReturnsBlank(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		size := rapid.IntRange(0, 6).Draw(t, "size")

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -2779,6 +2779,125 @@ claude:
 	}
 }
 
+func TestSmoke_S7_RejectsRepoRootGoCLIPathsForValidationRequiredWorkflows(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		field      string
+		command    string
+		errMessage string
+	}{
+		{
+			name:       "lint",
+			field:      "lint",
+			command:    "go vet ./cli/...",
+			errMessage: `validation.lint runs go from repo root against "./cli/..."`,
+		},
+		{
+			name:       "build",
+			field:      "build",
+			command:    "go build ./cli/cmd/xylem",
+			errMessage: `validation.build runs go from repo root against "./cli/cmd/xylem"`,
+		},
+		{
+			name:       "test",
+			field:      "test",
+			command:    "go test ./cli/...",
+			errMessage: `validation.test runs go from repo root against "./cli/..."`,
+		},
+	}
+
+	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts"} {
+		workflow := workflow
+		for _, tc := range testCases {
+			tc := tc
+			t.Run(workflow+"/"+tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				path := writeConfigFile(t, fmt.Sprintf(`sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      validation:
+        labels: [ci]
+        workflow: %s
+validation:
+  %s: %q
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`, workflow, tc.field, tc.command))
+
+				_, err := Load(path)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errMessage)
+				assert.Contains(t, err.Error(), workflow)
+			})
+		}
+	}
+}
+
+func TestSmoke_S8_AllowsCLIWorkingDirGoCommandsForValidationRequiredWorkflows(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		field   string
+		command string
+	}{
+		{name: "lint", field: "lint", command: "cd cli && go vet ./..."},
+		{name: "build", field: "build", command: "cd cli && go build ./cmd/xylem"},
+		{name: "test", field: "test", command: "cd cli && go test ./..."},
+	}
+
+	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts"} {
+		workflow := workflow
+		for _, tc := range testCases {
+			tc := tc
+			t.Run(workflow+"/"+tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				path := writeConfigFile(t, fmt.Sprintf(`sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      validation:
+        labels: [ci]
+        workflow: %s
+validation:
+  %s: %q
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`, workflow, tc.field, tc.command))
+
+				cfg, err := Load(path)
+				require.NoError(t, err)
+				require.NotNil(t, cfg)
+				switch tc.field {
+				case "lint":
+					assert.Equal(t, tc.command, cfg.Validation.Lint)
+				case "build":
+					assert.Equal(t, tc.command, cfg.Validation.Build)
+				case "test":
+					assert.Equal(t, tc.command, cfg.Validation.Test)
+				default:
+					t.Fatalf("unexpected field %q", tc.field)
+				}
+			})
+		}
+	}
+}
+
 func TestValidateRejectsInvalidAutoMergeBranchPattern(t *testing.T) {
 	cfg := validConfig()
 	cfg.Daemon.AutoMergeBranchPattern = "("

--- a/docs/design/productize-xylem-for-external-repos-spec.md
+++ b/docs/design/productize-xylem-for-external-repos-spec.md
@@ -504,7 +504,7 @@ type Config struct {
 Semantics:
 
 - Every field is optional; empty means "skip this step".
-- Commands MUST run from the worktree root.
+- Commands are invoked from the worktree root shell and MAY `cd` into a module or subdirectory when the repo layout requires it.
 - `fix-pr-checks`, `resolve-conflicts`, and `adapt-repo verify` MUST template these commands into their gate definitions; they MUST NOT hard-code Go-specific invocations in workflow YAML or prompt Markdown.
 - `adapt-repo` MUST populate this block on first run based on `bootstrap.DetectLanguages` / `DetectBuildTools` output (§8).
 - `xylem config validate` MUST reject a configuration where `fix-pr-checks` / `resolve-conflicts` / `adapt-repo` are active but `validation:` is completely empty.
@@ -571,9 +571,9 @@ profiles: [core, self-hosting-xylem]
 
 validation:
   format: "goimports -l ."
-  lint:   "go vet ./cli/..."
-  build:  "go build ./cli/cmd/xylem"
-  test:   "go test ./cli/..."
+  lint:   "cd cli && go vet ./..."
+  build:  "cd cli && go build ./cmd/xylem"
+  test:   "cd cli && go test ./..."
 
 observability:
   enabled: true


### PR DESCRIPTION
## Summary
- Resolves https://github.com/nicholls-inc/xylem/issues/375 by rejecting `validation.lint`, `validation.build`, and `validation.test` commands that run `go` from the repo root against `cli/...` targets.
- Keeps `fix-pr-checks` and `resolve-conflicts` usable for the xylem worktree layout by allowing `cd cli && go ...` commands and updating the checked-in self-hosting config/spec examples to match.

## Smoke scenarios covered
- `S2` — Rejects empty validation for active PR validation workflows
- `S3` — Allows partial validation for active PR validation workflow
- `S4` — Rejects goimports package pattern for validation-required workflows
- `S5` — Allows goimports directory targets for validation-required workflows
- `S6` — Allows goimports local prefix containing ellipsis for validation-required workflows
- `S7` — Rejects repo-root Go CLI paths for validation-required workflows
- `S8` — Allows CLI working-dir Go commands for validation-required workflows

## Changes summary
- Modified `.xylem.yml` to run validation from `cli/` for `lint`, `build`, and `test`.
- Modified `cli/internal/config/config.go` to extend `validateValidationCommands` with `invalidRepoRootGoCLITarget`, so repo-root `go vet|build|test` commands targeting `cli/...` are rejected with actionable guidance.
- Modified `cli/internal/config/config_test.go` to add smoke coverage for rejecting repo-root `cli/...` targets and accepting `cd cli && go ...` commands for both `fix-pr-checks` and `resolve-conflicts`.
- Modified `cli/internal/config/config_prop_test.go` to add property coverage for the new validation acceptance/rejection rules.
- Modified `docs/design/productize-xylem-for-external-repos-spec.md` so the self-hosting example uses the same module-aware validation commands.

## Test plan
- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #375