### PR TITLE
Delay phase `completed` PR comments until gate success is final

### DIFF
--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -1030,14 +1030,10 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 				phaseReport.UsageSource = cost.UsageSourceNotApplicable
 				phaseReport.UsageUnavailableReason = "non-llm phase"
 			}
-			phaseResults = append(phaseResults, phaseReport)
-			if issueNum > 0 && r.Reporter != nil {
-				r.logReporterError("post phase-complete comment", vessel.ID,
-					r.Reporter.PhaseComplete(ctx, issueNum, phaseReport, string(output)))
-			}
-
 			if phaseStatus == "no-op" {
 				vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, "", provider, model))
+				phaseResults = append(phaseResults, phaseReport)
+				r.reportPhaseComplete(ctx, vessel, phaseReport, string(output))
 				log.Printf("%sphase %q triggered no-op; completing workflow early", vesselLabel(vessel), p.Name)
 				finishCurrentPhaseSpan(nil)
 				if r.vesselCancelled(ctx, vessel.ID) {
@@ -1049,6 +1045,8 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 			// Handle gate
 			if p.Gate == nil {
 				vrs.addPhase(vrs.phaseSummaryWithLLM(r.Config, srcCfg, sk, p, harnessContent, inputTokensEst, outputTokensEst, costUSDEst, phaseDuration, phaseStatus, nil, "", provider, model))
+				phaseResults = append(phaseResults, phaseReport)
+				r.reportPhaseComplete(ctx, vessel, phaseReport, string(output))
 				finishCurrentPhaseSpan(nil)
 				break // no gate, proceed to next phase
 			}
@@ -1082,6 +1080,8 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					if gateResultExec.evidenceClaim != nil {
 						claims = append(claims, *gateResultExec.evidenceClaim)
 					}
+					phaseResults = append(phaseResults, phaseReport)
+					r.reportPhaseComplete(ctx, vessel, phaseReport, string(output))
 					finishCurrentPhaseSpan(nil)
 					break // gate passed, proceed to next phase
 				}
@@ -1159,6 +1159,7 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 					RetryAttempt: retryAttempt,
 				}, nil)
 				log.Printf("%swaiting for label %q after phase %q", vesselLabel(vessel), p.Gate.WaitFor, p.Name)
+				r.reportPhaseComplete(ctx, vessel, phaseReport, string(output))
 				// Set vessel to waiting state
 				vessel.FailedPhase = p.Name
 				vessel.WaitingFor = p.Gate.WaitFor
@@ -1362,8 +1363,7 @@ func (r *Runner) runPromptOnly(ctx context.Context, vessel queue.Vessel, worktre
 	}
 	issueNum := r.parseIssueNum(vessel)
 	if issueNum > 0 && r.Reporter != nil && len(phaseResults) > 0 {
-		r.logReporterError("post phase-complete comment", vessel.ID,
-			r.Reporter.PhaseComplete(ctx, issueNum, phaseResults[0], string(output)))
+		r.reportPhaseComplete(ctx, vessel, phaseResults[0], string(output))
 	}
 
 	if r.vesselCancelled(ctx, vessel.ID) {
@@ -2562,10 +2562,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		}
 		if phaseMatchedNoOp(&p, string(output)) {
 			phaseReport.Status = "no-op"
-			if issueNum > 0 && r.Reporter != nil {
-				r.logReporterError("post phase-complete comment", vessel.ID,
-					r.Reporter.PhaseComplete(ctx, issueNum, phaseReport, string(output)))
-			}
+			r.reportPhaseComplete(ctx, vessel, phaseReport, string(output))
 			phaseSpanStatus = "no-op"
 			finishCurrentPhaseSpan(nil)
 			return singlePhaseResult{
@@ -2578,13 +2575,10 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		}
 
 		phaseReport.Status = "completed"
-		if issueNum > 0 && r.Reporter != nil {
-			r.logReporterError("post phase-complete comment", vessel.ID,
-				r.Reporter.PhaseComplete(ctx, issueNum, phaseReport, string(output)))
-		}
 
 		// Handle gate.
 		if p.Gate == nil {
+			r.reportPhaseComplete(ctx, vessel, phaseReport, string(output))
 			phaseSpanStatus = "completed"
 			finishCurrentPhaseSpan(nil)
 			return singlePhaseResult{
@@ -2624,6 +2618,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 			}
 			if passed {
 				log.Printf("%sgate passed for phase %q", vesselLabel(vessel), p.Name)
+				r.reportPhaseComplete(ctx, vessel, phaseReport, string(output))
 				phaseSpanStatus = "completed"
 				finishCurrentPhaseSpan(nil)
 				return singlePhaseResult{
@@ -2700,6 +2695,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 				RetryAttempt: retryAttempt,
 			}, nil)
 			log.Printf("%swaiting for label %q after phase %q", vesselLabel(vessel), p.Gate.WaitFor, p.Name)
+			r.reportPhaseComplete(ctx, vessel, phaseReport, string(output))
 			vessel.FailedPhase = p.Name
 			vessel.WaitingFor = p.Gate.WaitFor
 			now := r.runtimeNow()
@@ -2730,6 +2726,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		}
 
 		// Unknown gate type: treat as passed.
+		r.reportPhaseComplete(ctx, vessel, phaseReport, string(output))
 		phaseSpanStatus = "completed"
 		finishCurrentPhaseSpan(nil)
 		return singlePhaseResult{
@@ -3774,6 +3771,15 @@ func (r *Runner) logReporterError(action string, vesselID string, err error) {
 	if err != nil {
 		log.Printf("warn: %s for vessel %s: %v", action, vesselID, err)
 	}
+}
+
+func (r *Runner) reportPhaseComplete(ctx context.Context, vessel queue.Vessel, phaseResult reporter.PhaseResult, output string) {
+	issueNum := r.parseIssueNum(vessel)
+	if issueNum <= 0 || r.Reporter == nil {
+		return
+	}
+	r.logReporterError("post phase-complete comment", vessel.ID,
+		r.Reporter.PhaseComplete(ctx, issueNum, phaseResult, output))
 }
 
 // sourceConfigFromMeta returns the SourceConfig for a vessel by looking up

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/reporter"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/surface"
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
@@ -254,6 +256,94 @@ func TestProp_SplitRepoSlugRejectsMalformedInput(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "owner/repo form") {
 			t.Fatalf("splitRepoSlug(%q) error = %q, want owner/repo guidance", malformed, err.Error())
+		}
+	})
+}
+
+func TestProp_CommandGateFailuresNeverEmitCompletedComments(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		retries := rapid.IntRange(0, 4).Draw(t, "retries")
+
+		dir, err := os.MkdirTemp("", "runner-gate-comments-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(dir)
+
+		cfg := makeTestConfig(dir, 1)
+		cfg.StateDir = filepath.Join(dir, ".xylem")
+		q := queue.New(filepath.Join(dir, "queue.jsonl"))
+		if _, err := q.Enqueue(makeVessel(1, "fix-bug")); err != nil {
+			t.Fatalf("Enqueue() error = %v", err)
+		}
+
+		promptPath := filepath.Join(dir, ".xylem", "prompts", "fix-bug", "implement.md")
+		if err := os.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
+			t.Fatalf("MkdirAll(prompt dir) error = %v", err)
+		}
+		if err := os.WriteFile(promptPath, []byte("Implement fix\n{{.GateResult}}"), 0o644); err != nil {
+			t.Fatalf("WriteFile(prompt) error = %v", err)
+		}
+		workflowPath := filepath.Join(dir, ".xylem", "workflows", "fix-bug.yaml")
+		if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+			t.Fatalf("MkdirAll(workflow dir) error = %v", err)
+		}
+		workflowBody := "name: fix-bug\nphases:\n" +
+			"  - name: implement\n" +
+			"    prompt_file: " + promptPath + "\n" +
+			"    max_turns: 5\n" +
+			"    gate:\n" +
+			"      type: command\n" +
+			"      run: \"make test\"\n" +
+			"      retries: " + strconv.Itoa(retries) + "\n" +
+			"      retry_delay: \"0s\"\n"
+		if err := os.WriteFile(workflowPath, []byte(workflowBody), 0o644); err != nil {
+			t.Fatalf("WriteFile(workflow) error = %v", err)
+		}
+
+		oldWd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Getwd() error = %v", err)
+		}
+		if err := os.Chdir(dir); err != nil {
+			t.Fatalf("Chdir(%q) error = %v", dir, err)
+		}
+		defer func() {
+			if err := os.Chdir(oldWd); err != nil {
+				t.Fatalf("restore working directory: %v", err)
+			}
+		}()
+
+		cmdRunner := &mockCmdRunner{
+			gateOutput: []byte("FAIL: TestFoo"),
+			gateErr:    &mockExitError{code: 1},
+		}
+		r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+		r.Sources = map[string]source.Source{
+			"github-issue": makeGitHubSource(),
+		}
+		r.Reporter = &reporter.Reporter{Runner: cmdRunner, Repo: "owner/repo"}
+
+		result, err := r.DrainAndWait(context.Background())
+		if err != nil {
+			t.Fatalf("DrainAndWait() error = %v", err)
+		}
+		if result.Failed != 1 {
+			t.Fatalf("result.Failed = %d, want 1", result.Failed)
+		}
+		if got := len(cmdRunner.phaseCalls); got != retries+1 {
+			t.Fatalf("len(phaseCalls) = %d, want %d", got, retries+1)
+		}
+
+		bodies := issueCommentBodies(cmdRunner)
+		if len(bodies) != 1 {
+			t.Fatalf("len(issueCommentBodies) = %d, want 1", len(bodies))
+		}
+		if strings.Contains(bodies[0], "phase `implement` completed") {
+			t.Fatalf("issue comment = %q, want no completed phase comment", bodies[0])
+		}
+		if !strings.Contains(bodies[0], "failed at phase `implement`") {
+			t.Fatalf("issue comment = %q, want final failure comment", bodies[0])
 		}
 	})
 }

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/recovery"
+	"github.com/nicholls-inc/xylem/cli/internal/reporter"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/surface"
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
@@ -58,9 +59,10 @@ type mockCmdRunner struct {
 	runOutputHook   func(name string, args ...string) ([]byte, error, bool)
 	runPhaseHook    func(dir, prompt, name string, args ...string) ([]byte, error, bool)
 	// Track calls for assertion
-	phaseCalls []phaseCall
-	outputArgs [][]string
-	lastBody   string
+	phaseCalls    []phaseCall
+	outputArgs    [][]string
+	commentBodies []string
+	lastBody      string
 }
 
 type gateCallResult struct {
@@ -78,9 +80,14 @@ type phaseCall struct {
 func (m *mockCmdRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
 	m.mu.Lock()
 	m.outputArgs = append(m.outputArgs, append([]string{name}, args...))
+	isIssueComment := name == "gh" && len(args) >= 3 && args[0] == "issue" && args[1] == "comment"
 	for i, arg := range args {
 		if arg == "--body" && i+1 < len(args) {
-			m.lastBody = args[i+1]
+			body := args[i+1]
+			m.lastBody = body
+			if isIssueComment {
+				m.commentBodies = append(m.commentBodies, body)
+			}
 		}
 	}
 	m.mu.Unlock()
@@ -568,6 +575,13 @@ func hasRunOutputCallContaining(m *mockCmdRunner, fragments ...string) bool {
 		}
 	}
 	return false
+}
+
+func issueCommentBodies(m *mockCmdRunner) []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]string(nil), m.commentBodies...)
 }
 
 func loadSingleVessel(t *testing.T, q *queue.Queue) queue.Vessel {
@@ -3355,6 +3369,88 @@ func TestDrainCommandGateFailsWithRetries(t *testing.T) {
 			t.Errorf("phase call %d args = %v, want --dtu-attempt %s", i, call.args, wantAttempt)
 		}
 	}
+}
+
+func TestSmoke_S39_GateRetryFailurePostsOnlyFinalFailedComment(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fix-bug"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{
+			name:          "implement",
+			promptContent: "Implement fix\n{{.GateResult}}",
+			maxTurns:      10,
+			gate:          "      type: command\n      run: \"make test\"\n      retries: 2\n      retry_delay: \"0s\"",
+		},
+	})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		gateOutput: []byte("FAIL: TestFoo"),
+		gateErr:    &mockExitError{code: 1},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+	r.Reporter = &reporter.Reporter{Runner: cmdRunner, Repo: "owner/repo"}
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Failed)
+	assert.Len(t, cmdRunner.phaseCalls, 3)
+
+	bodies := issueCommentBodies(cmdRunner)
+	require.Len(t, bodies, 1)
+	assert.Contains(t, bodies[0], "failed at phase `implement`")
+	assert.NotContains(t, bodies[0], "phase `implement` completed")
+}
+
+func TestSmoke_S40_GateRetrySuccessPostsCompletedOnceAfterGatePass(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, _ = q.Enqueue(makeVessel(1, "fix-bug"))
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{
+			name:          "implement",
+			promptContent: "Implement fix\n{{.GateResult}}",
+			maxTurns:      10,
+			gate:          "      type: command\n      run: \"make test\"\n      retries: 2\n      retry_delay: \"0s\"",
+		},
+		{name: "pr", promptContent: "Create PR", maxTurns: 3},
+	})
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		gateCallResults: []gateCallResult{
+			{output: []byte("FAIL: TestFoo"), err: &mockExitError{code: 1}},
+			{output: []byte("ok"), err: nil},
+		},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+	r.Reporter = &reporter.Reporter{Runner: cmdRunner, Repo: "owner/repo"}
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
+	assert.Len(t, cmdRunner.phaseCalls, 3)
+
+	bodies := issueCommentBodies(cmdRunner)
+	require.Len(t, bodies, 3)
+	assert.Contains(t, bodies[0], "phase `implement` completed")
+	assert.Contains(t, bodies[1], "phase `pr` completed")
+	assert.Contains(t, bodies[2], "**xylem — all phases completed**")
+	assert.Equal(t, 1, strings.Count(bodies[2], "| implement |"))
+	assert.Equal(t, 1, strings.Count(bodies[2], "| pr |"))
 }
 
 func TestSmoke_S31_ResolveConflictsGateFailsBeforePushWhenOriginMainIsNotAncestor(t *testing.T) {
@@ -8576,6 +8672,57 @@ func TestRunVesselOrchestratedGateTimeoutStopsDependentPhases(t *testing.T) {
 	assert.Contains(t, cmdRunner.phaseCalls[0].prompt, "Root phase")
 	assert.True(t, wt.removeCalled)
 	assert.Equal(t, wt.path, wt.removePath)
+}
+
+func TestSmoke_S41_OrchestratedGateRetryFailurePostsOnlyFinalFailedComment(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+
+	writeWorkflowFile(t, dir, "orchestrated-gate-fail", []testPhase{
+		{
+			name:          "root",
+			promptContent: "Root phase\n{{.GateResult}}",
+			maxTurns:      5,
+			gate:          "      type: command\n      run: \"make test\"\n      retries: 2\n      retry_delay: \"0s\"",
+		},
+		{
+			name:          "child",
+			promptContent: "Child phase {{.PreviousOutputs.root}}",
+			maxTurns:      5,
+			dependsOn:     []string{"root"},
+		},
+	})
+	withTestWorkingDir(t, dir)
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, err := q.Enqueue(makeVessel(1, "orchestrated-gate-fail"))
+	require.NoError(t, err)
+
+	vessel, err := q.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, vessel)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Root phase": []byte("root output"),
+		},
+		gateOutput: []byte("FAIL: TestFoo"),
+		gateErr:    &mockExitError{code: 1},
+	}
+	wt := &mockWorktree{path: filepath.Join(dir, ".claude", "worktrees", vessel.ID)}
+	r := New(cfg, q, wt, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+	r.Reporter = &reporter.Reporter{Runner: cmdRunner, Repo: "owner/repo"}
+
+	outcome := r.runVessel(context.Background(), *vessel)
+	assert.Equal(t, "failed", outcome)
+	assert.Len(t, cmdRunner.phaseCalls, 3)
+	require.Len(t, issueCommentBodies(cmdRunner), 1)
+	assert.Contains(t, issueCommentBodies(cmdRunner)[0], "failed at phase `root`")
+	assert.NotContains(t, issueCommentBodies(cmdRunner)[0], "phase `root` completed")
 }
 
 func TestCheckStalledVesselsDoesNotTimeoutUntrackedRecentPhase(t *testing.T) {


### PR DESCRIPTION
## Summary
- Implements https://github.com/nicholls-inc/xylem/issues/376
- Stops runner phase-complete issue comments from posting before command-gate success is known, so retrying phases no longer emit misleading `completed` comments before a final failure.
- Applies the same comment-timing fix to both the main sequential runner path and the orchestrated single-phase path.

## Smoke scenarios covered
- S39 — Gate retry failure posts only final failed comment
- S40 — Gate retry success posts completed once after gate pass
- S41 — Orchestrated gate retry failure posts only final failed comment

## Changes summary
- Modified `cli/internal/runner/runner.go`
  - Added `(*Runner).reportPhaseComplete` to centralize guarded phase-complete comment posting.
  - Moved `PhaseComplete` reporting in `runVessel` to only fire for no-op, no-gate, label-wait, unknown-gate, and command-gate success terminal outcomes.
  - Moved `PhaseComplete` reporting in `runSinglePhase` to the same post-gate-success timing so orchestrated retries match sequential behavior.
- Modified `cli/internal/runner/runner_test.go`
  - Extended `mockCmdRunner` to retain every posted issue comment body.
  - Added `issueCommentBodies` helper for full comment-sequence assertions.
  - Added regression smoke tests `TestSmoke_S39_GateRetryFailurePostsOnlyFinalFailedComment`, `TestSmoke_S40_GateRetrySuccessPostsCompletedOnceAfterGatePass`, and `TestSmoke_S41_OrchestratedGateRetryFailurePostsOnlyFinalFailedComment`.
- Modified `cli/internal/runner/runner_prop_test.go`
  - Added `TestProp_CommandGateFailuresNeverEmitCompletedComments` to cover retry counts and assert failed command-gate runs never leak a `completed` phase comment.

## Test plan
- `cd cli && goimports -w .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #376