### PR TITLE
Retry only rate-limit errors on the same provider and fall back on auth failures

### DIFF
--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -4346,6 +4346,14 @@ type providerInvocation struct {
 	StdinContent string
 }
 
+type providerErrorDisposition uint8
+
+const (
+	providerErrorFail providerErrorDisposition = iota
+	providerErrorRetrySameProvider
+	providerErrorFallbackNextProvider
+)
+
 // isRateLimitError reports whether the error indicates a transient LLM
 // provider error that should be retried with backoff. This includes HTTP 429
 // rate limits (rate_limit_error), insufficient credit balance, and generic
@@ -4384,6 +4392,58 @@ func isRateLimitError(err error) bool {
 	return false
 }
 
+func classifyProviderError(err error) providerErrorDisposition {
+	if err == nil {
+		return providerErrorFail
+	}
+	if isRateLimitError(err) {
+		return providerErrorRetrySameProvider
+	}
+
+	msg := strings.ToLower(err.Error())
+	fallbackPatterns := []string{
+		"authentication failed",
+		"authentication required",
+		"authentication_error",
+		"invalid api key",
+		"api key is invalid",
+		"missing api key",
+		"invalid x-api-key",
+		"anthropic_api_key",
+		"github token",
+		"github_token",
+		"bad credentials",
+		"invalid token",
+		"token is invalid",
+		"oauth token",
+		"not authorized to access this model",
+		"permission denied for model",
+		"model access denied",
+		"service unavailable",
+		"temporarily unavailable",
+		"provider unavailable",
+		"overloaded_error",
+		"model is overloaded",
+		"currently overloaded",
+		"executable file not found",
+		"command not found",
+	}
+	for _, pattern := range fallbackPatterns {
+		if strings.Contains(msg, pattern) {
+			return providerErrorFallbackNextProvider
+		}
+	}
+	if strings.Contains(msg, "unauthorized") &&
+		(strings.Contains(msg, "api key") || strings.Contains(msg, "token") || strings.Contains(msg, "authentication")) {
+		return providerErrorFallbackNextProvider
+	}
+	if strings.Contains(msg, "forbidden") &&
+		(strings.Contains(msg, "api key") || strings.Contains(msg, "token") || strings.Contains(msg, "model")) {
+		return providerErrorFallbackNextProvider
+	}
+	return providerErrorFail
+}
+
 // runPhaseWithRateLimitRetry wraps RunPhase with retry logic for API rate limit
 // errors (HTTP 429). It retries up to rateLimitMaxRetries times with exponential
 // backoff (30s, 60s, 120s) before returning the final error.
@@ -4410,7 +4470,7 @@ func (r *Runner) runPhaseWithRateLimitRetry(
 		} else {
 			output, err = r.Runner.RunPhaseWithEnv(ctx, dir, extraEnv, stdin, cmd, args...)
 		}
-		if err == nil || !isRateLimitError(err) {
+		if err == nil || classifyProviderError(err) != providerErrorRetrySameProvider {
 			return output, err
 		}
 		if attempt == rateLimitMaxRetries {
@@ -4451,10 +4511,18 @@ func (r *Runner) runPhaseWithProviderFallback(
 		if err == nil {
 			return output, invocation.Provider, invocation.Model, nil
 		}
-		if !isRateLimitError(err) || idx == len(providers)-1 {
+
+		disposition := classifyProviderError(err)
+		if disposition == providerErrorFail || idx == len(providers)-1 {
 			return output, invocation.Provider, invocation.Model, err
 		}
-		log.Printf("provider %s rate-limited, falling back to %s", invocation.Provider, providers[idx+1])
+
+		switch disposition {
+		case providerErrorRetrySameProvider:
+			log.Printf("provider %s exhausted rate-limit retries, falling back to %s", invocation.Provider, providers[idx+1])
+		case providerErrorFallbackNextProvider:
+			log.Printf("provider %s unavailable for phase %s, falling back to %s: %v", invocation.Provider, phaseName, providers[idx+1], err)
+		}
 	}
 	return nil, "", "", nil
 }

--- a/cli/internal/runner/runner_fallback_test.go
+++ b/cli/internal/runner/runner_fallback_test.go
@@ -54,8 +54,12 @@ func (f *fallbackCmdRunner) RunPhaseWithEnv(_ context.Context, _ string, extraEn
 	switch name {
 	case "claude-fallback":
 		return nil, errors.New("Credit balance is too low")
+	case "claude-auth-fail":
+		return nil, errors.New("anthropic: authentication failed: invalid x-api-key")
 	case "claude-hard-fail":
 		return nil, errors.New("exit status 1")
+	case "copilot-auth-fail":
+		return nil, errors.New("copilot: authentication required: github token invalid")
 	default:
 		return []byte("implemented"), nil
 	}
@@ -231,4 +235,175 @@ func TestRunPhaseWithProviderFallbackDoesNotMaskRealFailures(t *testing.T) {
 	require.Len(t, vessels, 1)
 	assert.Equal(t, queue.StateFailed, vessels[0].State)
 	assert.True(t, strings.Contains(vessels[0].Error, "exit status 1"))
+}
+
+func TestRunPhaseWithProviderFallbackFallsBackAfterAuthFailure(t *testing.T) {
+	t.Setenv("XYLEM_DTU_STATE_PATH", setupDTUClock(t))
+	tracer, rec := newTestTracer(t)
+
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 1,
+		MaxTurns:    50,
+		Timeout:     "30s",
+		StateDir:    filepath.Join(dir, ".xylem"),
+		Providers: map[string]config.ProviderConfig{
+			"primary": {
+				Kind:    "claude",
+				Command: "claude-auth-fail",
+				Tiers:   map[string]string{"med": "claude-med"},
+				Env: map[string]string{
+					"ANTHROPIC_API_KEY": "anthropic-secret",
+				},
+			},
+			"secondary": {
+				Kind:    "copilot",
+				Command: "copilot-success",
+				Tiers:   map[string]string{"med": "gpt-med"},
+				Env: map[string]string{
+					"GITHUB_TOKEN": "copilot-secret",
+				},
+			},
+		},
+		LLMRouting: config.LLMRoutingConfig{
+			DefaultTier: "med",
+			Tiers: map[string]config.TierRouting{
+				"med": {Providers: []string{"primary", "secondary"}},
+			},
+		},
+		Harness: config.HarnessConfig{
+			ProtectedSurfaces: config.ProtectedSurfacesConfig{
+				Paths: []string{
+					".xylem/HARNESS.md",
+					".xylem.yml",
+					".xylem/workflows/*.yaml",
+					".xylem/prompts/*/*.md",
+				},
+			},
+		},
+		Sources: map[string]config.SourceConfig{
+			"github": {
+				Type:    "github",
+				Repo:    "owner/repo",
+				Exclude: []string{"wontfix"},
+				Tasks:   map[string]config.Task{"fix-bugs": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	vessel := makeVessel(1, "fix-bug")
+	vessel.Tier = "med"
+	_, _ = q.Enqueue(vessel)
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{name: "implement", promptContent: "Fix the bug", maxTurns: 10},
+	})
+
+	oldWd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &fallbackCmdRunner{}
+	r := New(cfg, q, &mockWorktree{}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.Tracer = tracer
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Completed)
+	require.Len(t, cmdRunner.calls, 2)
+
+	first := cmdRunner.calls[0]
+	assert.Equal(t, "claude-auth-fail", first.Command)
+	assert.True(t, containsArgSequence(first.Args, "--model", "claude-med"))
+	assert.Contains(t, first.Env, "ANTHROPIC_API_KEY=anthropic-secret")
+	assert.NotContains(t, first.Env, "GITHUB_TOKEN=copilot-secret")
+
+	second := cmdRunner.calls[1]
+	assert.Equal(t, "copilot-success", second.Command)
+	assert.True(t, containsArgSequence(second.Args, "--model", "gpt-med"))
+	assert.Contains(t, second.Env, "GITHUB_TOKEN=copilot-secret")
+	assert.NotContains(t, second.Env, "ANTHROPIC_API_KEY=anthropic-secret")
+	assert.True(t, containsArgSequence(second.Args, "-p", "Fix the bug"))
+
+	attrs := spanAttrMap(endedSpanByName(t, rec, "phase:implement"))
+	assert.Equal(t, "secondary", attrs["xylem.phase.provider"])
+	assert.Equal(t, "gpt-med", attrs["xylem.phase.model"])
+	assert.Equal(t, "secondary", attrs["llm.provider"])
+	assert.Equal(t, "med", attrs["llm.tier"])
+}
+
+func TestRunPhaseWithProviderFallbackReturnsAuthFailureOnLastProvider(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 1,
+		MaxTurns:    50,
+		Timeout:     "30s",
+		StateDir:    filepath.Join(dir, ".xylem"),
+		Providers: map[string]config.ProviderConfig{
+			"primary": {
+				Kind:    "claude",
+				Command: "claude-auth-fail",
+				Tiers:   map[string]string{"med": "claude-med"},
+			},
+			"secondary": {
+				Kind:    "copilot",
+				Command: "copilot-auth-fail",
+				Tiers:   map[string]string{"med": "gpt-med"},
+			},
+		},
+		LLMRouting: config.LLMRoutingConfig{
+			DefaultTier: "med",
+			Tiers: map[string]config.TierRouting{
+				"med": {Providers: []string{"primary", "secondary"}},
+			},
+		},
+		Harness: config.HarnessConfig{
+			ProtectedSurfaces: config.ProtectedSurfacesConfig{
+				Paths: []string{
+					".xylem/HARNESS.md",
+					".xylem.yml",
+					".xylem/workflows/*.yaml",
+					".xylem/prompts/*/*.md",
+				},
+			},
+		},
+		Sources: map[string]config.SourceConfig{
+			"github": {
+				Type:    "github",
+				Repo:    "owner/repo",
+				Exclude: []string{"wontfix"},
+				Tasks:   map[string]config.Task{"fix-bugs": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	vessel := makeVessel(1, "fix-bug")
+	vessel.Tier = "med"
+	_, _ = q.Enqueue(vessel)
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{name: "implement", promptContent: "Fix the bug", maxTurns: 10},
+	})
+
+	oldWd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &fallbackCmdRunner{}
+	r := New(cfg, q, &mockWorktree{}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Failed)
+	require.Len(t, cmdRunner.calls, 2)
+	assert.Equal(t, "claude-auth-fail", cmdRunner.calls[0].Command)
+	assert.Equal(t, "copilot-auth-fail", cmdRunner.calls[1].Command)
+
+	vessels, listErr := q.List()
+	require.NoError(t, listErr)
+	require.Len(t, vessels, 1)
+	assert.Equal(t, queue.StateFailed, vessels[0].State)
+	assert.True(t, strings.Contains(vessels[0].Error, "github token invalid"))
 }

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,6 +22,45 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"pgregory.net/rapid"
 )
+
+func TestProp_ClassifyProviderError_RateLimitSentinelsRemainRetryable(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		prefix := rapid.StringMatching(`[A-Za-z0-9 _:/.]{0,32}`).Draw(t, "prefix")
+		suffix := rapid.StringMatching(`[A-Za-z0-9 _:/.]{0,32}`).Draw(t, "suffix")
+		sentinel := rapid.SampledFrom([]string{
+			"rate_limit_error",
+			"credit balance is too low",
+			"insufficient_quota",
+			"too many requests",
+			"api error: 429",
+			"status 429",
+			"429 too many",
+		}).Draw(t, "sentinel")
+
+		if got := classifyProviderError(errors.New(prefix + sentinel + suffix)); got != providerErrorRetrySameProvider {
+			t.Fatalf("classifyProviderError() = %v, want %v", got, providerErrorRetrySameProvider)
+		}
+	})
+}
+
+func TestProp_ClassifyProviderError_AuthSentinelsAreFallbackOnly(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		prefix := rapid.StringMatching(`[A-Za-z0-9 _:/.]{0,32}`).Draw(t, "prefix")
+		suffix := rapid.StringMatching(`[A-Za-z0-9 _:/.]{0,32}`).Draw(t, "suffix")
+		sentinel := rapid.SampledFrom([]string{
+			"authentication failed",
+			"authentication required",
+			"invalid api key",
+			"github token",
+			"not authorized to access this model",
+		}).Draw(t, "sentinel")
+
+		got := classifyProviderError(errors.New(prefix + sentinel + suffix))
+		if got != providerErrorFallbackNextProvider {
+			t.Fatalf("classifyProviderError() = %v, want %v", got, providerErrorFallbackNextProvider)
+		}
+	})
+}
 
 func TestProp_FilterAdditiveProtectedSurfaceViolationsDropsOnlyAdditions(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -9600,6 +9600,8 @@ func TestIsRateLimitError(t *testing.T) {
 		{"api error 429 prefix", errors.New("API Error: 429 retry after 30s"), true},
 		{"unrelated insufficient word", errors.New("insufficient disk space"), false},
 		{"plain rate in unrelated context", errors.New("update rate set to 5"), false},
+		{"auth failure is not rate limit", errors.New("authentication failed: invalid x-api-key"), false},
+		{"provider unavailable is not rate limit", errors.New("service unavailable"), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -9608,6 +9610,60 @@ func TestIsRateLimitError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClassifyProviderError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want providerErrorDisposition
+	}{
+		{name: "nil error", err: nil, want: providerErrorFail},
+		{name: "generic error", err: errors.New("exit status 1"), want: providerErrorFail},
+		{name: "rate limit retry", err: errors.New(`API Error: 429 {"type":"error","error":{"type":"rate_limit_error","message":"rate limited"}}`), want: providerErrorRetrySameProvider},
+		{name: "credit balance retry", err: errors.New("Credit balance is too low"), want: providerErrorRetrySameProvider},
+		{name: "auth failure falls back", err: errors.New("anthropic: authentication failed: invalid x-api-key"), want: providerErrorFallbackNextProvider},
+		{name: "github token failure falls back", err: errors.New("copilot: authentication required: github token missing"), want: providerErrorFallbackNextProvider},
+		{name: "model access failure falls back", err: errors.New("provider: not authorized to access this model"), want: providerErrorFallbackNextProvider},
+		{name: "service unavailable falls back", err: errors.New("provider returned service unavailable"), want: providerErrorFallbackNextProvider},
+		{name: "missing command falls back", err: errors.New("claude: executable file not found in $PATH"), want: providerErrorFallbackNextProvider},
+		{name: "plain unauthorized does not fall back", err: errors.New("unauthorized"), want: providerErrorFail},
+		{name: "plain forbidden does not fall back", err: errors.New("forbidden"), want: providerErrorFail},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyProviderError(tt.err); got != tt.want {
+				t.Fatalf("classifyProviderError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunPhaseWithRateLimitRetryDoesNotRetryAuthFailures(t *testing.T) {
+	authErr := errors.New("anthropic: authentication failed: invalid x-api-key")
+	var callCount int32
+	cmdRunner := &mockCmdRunner{
+		runPhaseHook: func(dir, prompt, name string, args ...string) ([]byte, error, bool) {
+			atomic.AddInt32(&callCount, 1)
+			return nil, authErr, true
+		},
+	}
+	r := New(&config.Config{Concurrency: 1}, nil, &mockWorktree{}, cmdRunner)
+
+	output, err := r.runPhaseWithRateLimitRetry(
+		context.Background(),
+		"issue-1",
+		"implement",
+		t.TempDir(),
+		"Fix the bug",
+		nil,
+		"claude",
+		[]string{"--model", "claude-med"},
+	)
+	require.ErrorIs(t, err, authErr)
+	assert.Nil(t, output)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
 }
 
 // setupDTUClock creates a valid DTU state file so runtimeSleep advances a

--- a/docs/plans/llm-routing-plan.md
+++ b/docs/plans/llm-routing-plan.md
@@ -12,12 +12,12 @@ Today xylem invokes a single LLM per vessel (`claude` or `copilot`), picked via 
 The goal is two-fold:
 
 1. Let users classify vessels by **effort tier** (`high` / `med` / `low`) and map each tier to a specific model per provider.
-2. Let the runner **route** a vessel to the first healthy provider in a per-tier preference list, and **fall back** to the next provider when the current one hits a credit/rate-limit error.
+2. Let the runner **route** a vessel to the first healthy provider in a per-tier preference list, and **fall back** to the next provider when the current one hits a provider-level auth/config/access or availability failure after preserving same-provider retries for credit/rate-limit errors.
 
 Design decisions (per user, 2026-04-09):
 
 - Tier comes from the workflow YAML **and** from `tasks.<name>.tier` in `.xylem.yml` (not GitHub labels).
-- Fallback fires **only** on credit/rate-limit errors — regular failures still fail the phase.
+- Retry the **same provider** on credit/rate-limit errors; fall back to the **next provider** on provider-auth, provider-config/access, or provider-unavailable failures.
 - Provider preference is **per-tier** (`tiers.high.providers: [claude]`, `tiers.low.providers: [copilot, claude]`).
 - Config moves to a **generic `providers:` map** so gemini (and any future CLI) plugs in without new structs.
 
@@ -120,8 +120,9 @@ Replace the current provider/model resolution block (runner.go:3668-3709) with t
 - **New `runPhaseWithProviderFallback`** wraps `runPhaseWithRateLimitRetry` (runner.go:3488-3517):
   - Iterates `resolveProviderChain(cfg, tier)`.
   - For each provider: build args + env, invoke `runPhaseWithRateLimitRetry` as today.
-  - If the final error passes `isRateLimitError` (runner.go:3460) **and** there is a next provider, log the fallback (`log.Printf("provider %s rate-limited, falling back to %s", curr, next)`) and continue.
-  - Any non-rate-limit error returns immediately (preserves today's fail-fast semantics for real bugs).
+  - If the final error is still classified as a same-provider retryable rate-limit/quota error after retries are exhausted **and** there is a next provider, log the fallback and continue.
+  - If the final error is classified as a provider-auth/config/access or provider-unavailable failure **and** there is a next provider, fall through to the next provider immediately without same-provider backoff.
+  - Any other non-provider-routing error returns immediately (preserves today's fail-fast semantics for real bugs).
   - On the last provider, propagate whatever error comes back.
 - Callers of `runPhaseWithRateLimitRetry` inside the phase execution path (around runner.go:735) switch to the new wrapper and pass the resolved tier.
 
@@ -160,8 +161,8 @@ No user-visible doc file changes in this plan (CLAUDE.md already covers config s
 
 ## Reuse / do-not-duplicate
 
-- `isRateLimitError` (`runner.go:3456-3486`) already matches claude 429, copilot quota, and "Credit balance is too low". Reuse verbatim as the fallback trigger.
-- `runPhaseWithRateLimitRetry` (`runner.go:3488-3517`) keeps per-provider retries with its existing exponential backoff; the new fallback wrapper composes it, not replaces it.
+- `isRateLimitError` (`runner.go:3456-3486`) already matches claude 429, copilot quota, and "Credit balance is too low". Keep it as the **same-provider retry** trigger.
+- `runPhaseWithRateLimitRetry` (`runner.go:3488-3517`) keeps per-provider retries with its existing exponential backoff; the new fallback wrapper composes it, not replaces it, and a classifier decides when the next provider should be tried.
 - `resolveProvider` / `resolveModel` (`runner.go:3670-3709`) are deleted — their callers switch to `resolveTier` + `resolveProviderChain` + `modelForProvider`. The `Phase.LLM` / `Phase.Model` / `Workflow.LLM` / `Workflow.Model` fields remain for backward compat: if set and no `Tier` is set, normalize them into a one-off single-provider chain at runtime so we don't need a migration script.
 - `stripModelFlag`, `stripBoolFlag`, `stripPromptFlag` utilities stay as-is and are called from the refactored kind-dispatched arg builders.
 - `RunProcessWithEnv` (`exec.go:155`) is the model for the new `RunPhaseWithEnv` — same merge semantics.
@@ -173,8 +174,8 @@ No user-visible doc file changes in this plan (CLAUDE.md already covers config s
 3. **Format check**: `goimports -l .` clean (CI parity).
 4. **Backward-compat smoke**: take an unmodified `.xylem.yml` from a guest repo (only `claude:` block, no `providers:`) and run `xylem scan --dry-run` + unit tests for the config loader; assert the vessel uses claude with the old `default_model`, no behavior change.
 5. **End-to-end fallback smoke** (manual, against local stub providers):
-   - Write a `.xylem.yml` with two providers where `claude.command` is a shell stub that prints `Error: Credit balance is too low` to stderr and exits non-zero, and `copilot.command` is a stub that echoes a valid phase output to stdout.
+   - Write a `.xylem.yml` with two providers where `claude.command` is a shell stub that prints either `Error: Credit balance is too low` or an auth failure like `authentication failed: invalid x-api-key` to stderr and exits non-zero, and `copilot.command` is a stub that echoes a valid phase output to stdout.
    - Configure `llm_routing.tiers.med.providers: [claude, copilot]`.
    - Run `xylem drain` on a test vessel.
-   - Assert in logs: `rate limit error` retries on claude, then `provider claude rate-limited, falling back to copilot`, then phase success using copilot's env + model.
+   - Assert in logs: rate-limit input retries on claude before falling back, auth-failure input skips same-provider backoff and falls through directly to copilot, and the successful phase uses copilot's env + model.
 6. **Live observability**: with Jaeger running (`docker compose -f dev/docker-compose.yml up -d`), check that the phase span carries the final provider name (extend existing OTel span attributes in `cli/internal/observability` to include `llm.provider` and `llm.tier`).


### PR DESCRIPTION
## Summary

- Implements [issue #404](https://github.com/nicholls-inc/xylem/issues/404).
- Narrows same-provider retry behavior to rate-limit and quota failures only.
- Routes provider-auth, provider-access, provider-unavailable, and missing-command failures to the next configured provider instead of stalling the vessel on tier-1.

## Smoke scenarios covered

- **Unassigned** — Auth failure falls through to the next provider in the tier chain.
- **Unassigned** — Auth failure does not consume same-provider retry attempts or backoff.
- **WS3 S3 — PhaseSpanAttributes includes resolved phase and LLM routing fields** — preserved via fallback span assertions on provider, model, and tier attributes.

## Changes summary

### Files modified

- `cli/internal/runner/runner.go`
- `cli/internal/runner/runner_test.go`
- `cli/internal/runner/runner_fallback_test.go`
- `cli/internal/runner/runner_prop_test.go`
- `docs/plans/llm-routing-plan.md`

### Key types and functions

- Added `providerErrorDisposition` and `classifyProviderError` to separate hard failures, same-provider retries, and next-provider fallback conditions.
- Updated `runPhaseWithRateLimitRetry` so only retryable rate-limit and quota errors stay on the current provider.
- Updated `runPhaseWithProviderFallback` so auth, config/access, unavailable-provider, and missing-command failures advance directly to the next provider.
- Added unit coverage for `TestClassifyProviderError` and `TestRunPhaseWithRateLimitRetryDoesNotRetryAuthFailures`.
- Added fallback coverage for `TestRunPhaseWithProviderFallbackFallsBackAfterAuthFailure` and `TestRunPhaseWithProviderFallbackReturnsAuthFailureOnLastProvider`.
- Added property coverage for retryable rate-limit sentinels and fallback-only auth sentinels.
- Updated `docs/plans/llm-routing-plan.md` so the checked-in routing plan matches the implemented fallback semantics and verification guidance.

## Test plan

- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #404