### PR TITLE
Load .daemon-root/.env before xylem daemon startup and reloads

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -52,6 +52,14 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		return fmt.Errorf("daemon refused to start in main worktree; see log for instructions")
 	}
 
+	rootDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+	if err := loadDaemonStartupEnv(rootDir); err != nil {
+		return err
+	}
+
 	scanInterval, drainInterval := parseDaemonIntervals(cfg.Daemon)
 
 	// P0-3: Acquire singleton lock to prevent multiple daemons.
@@ -93,11 +101,6 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	reloadSignals := make(chan os.Signal, 1)
 	signal.Notify(reloadSignals, syscall.SIGHUP)
 	defer signal.Stop(reloadSignals)
-
-	rootDir, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("resolve working directory: %w", err)
-	}
 	runtime, err := newDaemonRuntime(rootDir, viper.GetString("config"), q, wt, cfg)
 	if err != nil {
 		return fmt.Errorf("create daemon runtime: %w", err)

--- a/cli/cmd/xylem/daemon_env.go
+++ b/cli/cmd/xylem/daemon_env.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func loadDaemonStartupEnv(workingDir string) error {
+	envFile, err := loadDaemonSupervisorEnvFile(daemonSupervisorEnvFilePath(workingDir))
+	if err != nil {
+		return fmt.Errorf("load daemon startup env: %w", err)
+	}
+	if err := applyDaemonEnvEntries(envFile, os.Setenv); err != nil {
+		return fmt.Errorf("apply daemon startup env: %w", err)
+	}
+	return nil
+}
+
+func applyDaemonEnvEntries(env []string, setEnv func(string, string) error) error {
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			return fmt.Errorf("invalid environment entry %q", entry)
+		}
+		if err := setEnv(key, value); err != nil {
+			return fmt.Errorf("set %s: %w", key, err)
+		}
+	}
+	return nil
+}

--- a/cli/cmd/xylem/daemon_env_prop_test.go
+++ b/cli/cmd/xylem/daemon_env_prop_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropApplyDaemonEnvEntriesLastWriteWins(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		key := rapid.StringMatching(`[A-Za-z_][A-Za-z0-9_]{0,15}`).Draw(rt, "key")
+		values := rapid.SliceOfN(rapid.StringMatching(`[A-Za-z0-9_./:= -]{0,24}`), 1, 8).Draw(rt, "values")
+
+		got := map[string]string{}
+		env := make([]string, 0, len(values))
+		for _, value := range values {
+			env = append(env, key+"="+value)
+		}
+
+		err := applyDaemonEnvEntries(env, func(envKey, envValue string) error {
+			got[envKey] = envValue
+			return nil
+		})
+		if err != nil {
+			rt.Fatalf("applyDaemonEnvEntries() error = %v", err)
+		}
+		if got[key] != values[len(values)-1] {
+			rt.Fatalf("value for %q = %q, want %q", key, got[key], values[len(values)-1])
+		}
+	})
+}

--- a/cli/cmd/xylem/daemon_env_test.go
+++ b/cli/cmd/xylem/daemon_env_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadDaemonStartupEnvAppliesDaemonRootEnv(t *testing.T) {
+	repoDir := t.TempDir()
+	envPath := daemonSupervisorEnvFilePath(repoDir)
+	require.NoError(t, os.MkdirAll(filepath.Dir(envPath), 0o755))
+	require.NoError(t, os.WriteFile(envPath, []byte("API_TOKEN=from-file\nEMPTY=\n"), 0o644))
+
+	t.Setenv("API_TOKEN", "from-process")
+	t.Setenv("EMPTY", "non-empty")
+
+	require.NoError(t, loadDaemonStartupEnv(repoDir))
+	assert.Equal(t, "from-file", os.Getenv("API_TOKEN"))
+	assert.Equal(t, "", os.Getenv("EMPTY"))
+}
+
+func TestLoadDaemonStartupEnvMissingFileIsNoop(t *testing.T) {
+	repoDir := t.TempDir()
+	t.Setenv("API_TOKEN", "from-process")
+
+	require.NoError(t, loadDaemonStartupEnv(repoDir))
+	assert.Equal(t, "from-process", os.Getenv("API_TOKEN"))
+}
+
+func TestLoadDaemonStartupEnvReturnsParseError(t *testing.T) {
+	repoDir := t.TempDir()
+	envPath := daemonSupervisorEnvFilePath(repoDir)
+	require.NoError(t, os.MkdirAll(filepath.Dir(envPath), 0o755))
+	require.NoError(t, os.WriteFile(envPath, []byte("not-an-assignment\n"), 0o644))
+
+	err := loadDaemonStartupEnv(repoDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load daemon startup env")
+	assert.Contains(t, err.Error(), ".env")
+}
+
+func TestApplyDaemonEnvEntriesRejectsInvalidEntry(t *testing.T) {
+	err := applyDaemonEnvEntries([]string{"missing-separator"}, func(string, string) error {
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid environment entry")
+}
+
+func TestApplyDaemonEnvEntriesPreservesEmbeddedEquals(t *testing.T) {
+	got := map[string]string{}
+
+	err := applyDaemonEnvEntries([]string{"API_TOKEN=alpha=beta"}, func(key, value string) error {
+		got[key] = value
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "alpha=beta", got["API_TOKEN"])
+}
+
+func TestApplyDaemonEnvEntriesReturnsSetterError(t *testing.T) {
+	err := applyDaemonEnvEntries([]string{"API_TOKEN=value"}, func(string, string) error {
+		return fmt.Errorf("boom")
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "set API_TOKEN")
+	assert.Contains(t, err.Error(), "boom")
+}

--- a/cli/cmd/xylem/daemon_reload.go
+++ b/cli/cmd/xylem/daemon_reload.go
@@ -324,6 +324,12 @@ func (r *daemonRuntime) applyReload(ctx context.Context, req daemonReloadRequest
 
 	handle := before
 	if reloadErr == nil {
+		if err := loadDaemonStartupEnv(r.rootDir); err != nil {
+			reloadErr = fmt.Errorf("reload daemon startup env: %w", err)
+			result = "rejected"
+		}
+	}
+	if reloadErr == nil {
 		handle, reloadErr = buildDaemonRunnerHandle(nextCfg, r.q, r.wt, nextSnapshot)
 		if reloadErr != nil {
 			result = "rejected"

--- a/cli/cmd/xylem/daemon_reload_test.go
+++ b/cli/cmd/xylem/daemon_reload_test.go
@@ -127,6 +127,47 @@ func TestDaemonRuntimeRetainsBusyRunnerAcrossReload(t *testing.T) {
 	assert.Empty(t, rt.retired)
 }
 
+func TestDaemonRuntimeReloadReappliesDaemonRootEnv(t *testing.T) {
+	rootDir, configPath, _ := writeDaemonReloadRepo(t, "# Harness A\n")
+	envPath := daemonSupervisorEnvFilePath(rootDir)
+	require.NoError(t, os.MkdirAll(filepath.Dir(envPath), 0o755))
+	require.NoError(t, os.WriteFile(envPath, []byte("XYLEM_TEST_DAEMON_TOKEN=first\n"), 0o644))
+
+	configYAML := strings.Join([]string{
+		"repo: owner/name",
+		"tasks:",
+		"  fix-bugs:",
+		"    labels: [bug]",
+		"    workflow: fix-bug",
+		"state_dir: " + filepath.Join(rootDir, ".xylem"),
+		"claude:",
+		"  command: claude",
+		"  default_model: claude-sonnet-4-6",
+		"  env:",
+		"    API_TOKEN: ${XYLEM_TEST_DAEMON_TOKEN}",
+		"daemon:",
+		"  scan_interval: 1s",
+		"  drain_interval: 1s",
+		"",
+	}, "\n")
+	require.NoError(t, os.WriteFile(configPath, []byte(configYAML), 0o644))
+
+	cfg, err := config.Load(configPath)
+	require.NoError(t, err)
+	require.NoError(t, loadDaemonStartupEnv(rootDir))
+
+	q := queue.New(filepath.Join(cfg.StateDir, "queue.jsonl"))
+	rt, err := newDaemonRuntime(rootDir, configPath, q, worktree.New(rootDir, newCmdRunner(cfg)), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "first", daemonEnvValue(rt.currentHandle().scanCmd.extraEnv, "API_TOKEN"))
+
+	require.NoError(t, os.WriteFile(envPath, []byte("XYLEM_TEST_DAEMON_TOKEN=second\n"), 0o644))
+
+	rt.request(daemonReloadRequest{Trigger: "signal", RequestedAt: daemonNow().Add(-time.Minute)})
+	require.NoError(t, rt.processPendingReload(context.Background()))
+	assert.Equal(t, "second", daemonEnvValue(rt.currentHandle().scanCmd.extraEnv, "API_TOKEN"))
+}
+
 func TestValidateDaemonReloadCandidateRejectsInvalidWorkflow(t *testing.T) {
 	rootDir, configPath, _ := writeDaemonReloadRepo(t, "# Harness A\n")
 	require.NoError(t, os.WriteFile(filepath.Join(rootDir, ".xylem", "workflows", "fix-bug.yaml"), []byte("name: fix-bug\nphases:\n  - name: Bad\n"), 0o644))

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -1016,13 +1016,11 @@ func TestLogTickSummary(t *testing.T) {
 	}
 }
 
-// TestWS1S28DaemonPathWiresScaffolding verifies that the daemon drain path
-// produces a Runner with Intermediary and AuditLog wired. runDrain delegates
-// directly to buildDrainRunner, so constructing the runner here exercises the
-// same daemon-side wiring.
-//
-// Covers: WS1 S28.
-func TestWS1S28DaemonPathWiresScaffolding(t *testing.T) {
+// TestSmoke_S28_CLIWiringInDaemonGoCreatesIntermediaryFromConfig verifies that
+// the daemon drain path produces a Runner with Intermediary and AuditLog wired.
+// runDrain delegates directly to buildDrainRunner, so constructing the runner
+// here exercises the same daemon-side wiring.
+func TestSmoke_S28_CLIWiringInDaemonGoCreatesIntermediaryFromConfig(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeDrainConfig(dir)
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
@@ -1031,21 +1029,29 @@ func TestWS1S28DaemonPathWiresScaffolding(t *testing.T) {
 	r, cleanup := buildDrainRunner(cfg, q, worktree.New(dir, cmdRunner), cmdRunner)
 	defer cleanup()
 
-	if r.Intermediary == nil {
-		t.Fatal("r.Intermediary = nil: daemon runDrain must wire Intermediary")
-	}
-	if r.AuditLog == nil {
-		t.Fatal("r.AuditLog = nil: daemon runDrain must wire AuditLog")
-	}
+	require.NotNil(t, r)
+	require.NotNil(t, r.Intermediary)
+	require.NotNil(t, r.AuditLog)
 
 	result := r.Intermediary.Evaluate(intermediary.Intent{
 		Action:   "file_write",
 		Resource: ".xylem/HARNESS.md",
 		AgentID:  "issue-1",
 	})
-	if result.Effect != intermediary.Deny {
-		t.Fatalf("default protected-surface effect = %q, want %q", result.Effect, intermediary.Deny)
+	assert.Equal(t, intermediary.Deny, result.Effect)
+
+	entry := intermediary.AuditEntry{
+		Intent: intermediary.Intent{
+			Action:   "phase_execute",
+			Resource: "fix",
+			AgentID:  "issue-1",
+		},
+		Decision:  intermediary.Allow,
+		Timestamp: time.Now().UTC(),
 	}
+	require.NoError(t, r.AuditLog.Append(entry))
+	_, err := os.Stat(filepath.Join(dir, "audit.jsonl"))
+	require.NoError(t, err)
 }
 
 func TestReconcileStaleVessels(t *testing.T) {


### PR DESCRIPTION
## Summary
+- Implements https://github.com/nicholls-inc/xylem/issues/406.
+- Loads `.daemon-root/.env` before plain `xylem daemon` startup so provider env placeholders are resolved before command-runner construction.
+- Reapplies the same env file during daemon control-plane reloads so updated credentials are picked up without needing the supervisor restart path.
+
+## Smoke scenarios covered
+- **S2** — `DaemonSupervisorReloadsEnvOnEachRestart`
+- **S5** — `DaemonReloadPreservesFrozenWorkflowSnapshot`
+
+## Changes summary
+- **Added** `cli/cmd/xylem/daemon_env.go` with `loadDaemonStartupEnv` and `applyDaemonEnvEntries` to reuse the existing `.daemon-root/.env` parsing path and apply entries to the process environment.
+- **Modified** `cli/cmd/xylem/daemon.go` so `cmdDaemon` loads startup env immediately after resolving the working directory and before any `newCmdRunner(cfg)` usage.
+- **Modified** `cli/cmd/xylem/daemon_reload.go` so `(*daemonRuntime).applyReload` reapplies `.daemon-root/.env` before rebuilding the runner handle for a new control-plane snapshot.
+- **Added** `cli/cmd/xylem/daemon_env_test.go` and `cli/cmd/xylem/daemon_env_prop_test.go` covering env application, missing-file no-op behavior, parse failures, setter failures, embedded `=` handling, and last-write-wins behavior.
+- **Modified** `cli/cmd/xylem/daemon_reload_test.go` to cover reload-time env refresh for `${VAR}` expansion in `claude.env`.
+- **Modified** `cli/cmd/xylem/daemon_test.go` to keep the daemon smoke coverage naming aligned with the checked-in scenario catalog while preserving audit/intermediary wiring assertions.
+
+## Test plan
+- `cd cli && goimports -l .`
+- `cd cli && golangci-lint run`
+- `cd cli && go vet ./...`
+- `cd cli && go build ./cmd/xylem`
+- `cd cli && go test ./...`
+

Fixes #406