### PR TITLE
feat: add `xylem workflow validate` CLI subcommand

### DIFF
--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -38,7 +38,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "bootstrap", "continuous-improvement", "continuous-simplicity", "release-cadence", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "recovery", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report"}
+	expected := []string{"init", "bootstrap", "workflow", "continuous-improvement", "continuous-simplicity", "release-cadence", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "recovery", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/daemon_reload.go
+++ b/cli/cmd/xylem/daemon_reload.go
@@ -24,7 +24,6 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
 	"github.com/nicholls-inc/xylem/cli/internal/scanner"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
-	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"github.com/nicholls-inc/xylem/cli/internal/worktree"
 	"github.com/spf13/cobra"
 )
@@ -455,28 +454,7 @@ func validateDaemonReloadCandidate(rootDir, configPath string) (*config.Config, 
 		return nil, fmt.Errorf("load config: %w", err)
 	}
 	workflowsDir := filepath.Join(rootDir, ".xylem", "workflows")
-	if _, err := os.Stat(workflowsDir); err != nil {
-		if errorsIsNotExist(err) {
-			return cfg, nil
-		}
-		return nil, fmt.Errorf("stat workflows dir: %w", err)
-	}
-	if err := filepath.WalkDir(workflowsDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		switch strings.ToLower(filepath.Ext(path)) {
-		case ".yaml", ".yml":
-			_, _, err := workflow.LoadWithDigest(path)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	}); err != nil {
+	if _, err := validateWorkflowDir(workflowsDir, nil); err != nil {
 		return nil, fmt.Errorf("validate workflows: %w", err)
 	}
 	return cfg, nil

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -42,6 +42,8 @@ func newRootCmd() *cobra.Command {
 			// by a command phase. harden inventory/score/track are the same.
 			skipTooling := cmd.Name() == "visualize" ||
 				strings.HasPrefix(commandPath, "xylem visualize") ||
+				commandPath == "xylem workflow validate" ||
+				strings.HasPrefix(commandPath, "xylem workflow ") ||
 				cmd.Name() == "review" ||
 				cmd.Name() == "recovery" ||
 				strings.HasPrefix(commandPath, "xylem recovery") ||
@@ -95,6 +97,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		newInitCmd(),
 		newBootstrapCmd(),
+		newWorkflowCmd(),
 		newContinuousImprovementCmd(),
 		newContinuousSimplicityCmd(),
 		newReleaseCadenceCmd(),

--- a/cli/cmd/xylem/workflow.go
+++ b/cli/cmd/xylem/workflow.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	workflowpkg "github.com/nicholls-inc/xylem/cli/internal/workflow"
+	"github.com/spf13/cobra"
+)
+
+type adaptPlan struct {
+	SchemaVersion  int                `json:"schema_version"`
+	Detected       adaptPlanDetected  `json:"detected"`
+	PlannedChanges []adaptPlanChange  `json:"planned_changes"`
+	Skipped        []adaptPlanSkipped `json:"skipped"`
+}
+
+type adaptPlanDetected struct {
+	Languages   []string `json:"languages"`
+	BuildTools  []string `json:"build_tools"`
+	TestRunners []string `json:"test_runners"`
+	Linters     []string `json:"linters"`
+	HasFrontend bool     `json:"has_frontend"`
+	HasDatabase bool     `json:"has_database"`
+	EntryPoints []string `json:"entry_points"`
+}
+
+type adaptPlanChange struct {
+	Path        string `json:"path"`
+	Op          string `json:"op"`
+	Rationale   string `json:"rationale"`
+	DiffSummary string `json:"diff_summary,omitempty"`
+}
+
+type adaptPlanSkipped struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
+type rawAdaptPlan struct {
+	SchemaVersion  *int                `json:"schema_version"`
+	Detected       *adaptPlanDetected  `json:"detected"`
+	PlannedChanges *[]adaptPlanChange  `json:"planned_changes"`
+	Skipped        *[]adaptPlanSkipped `json:"skipped"`
+}
+
+func newWorkflowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "workflow",
+		Short: "Inspect and validate workflows",
+	}
+
+	cmd.AddCommand(newWorkflowValidateCmd())
+	return cmd
+}
+
+func newWorkflowValidateCmd() *cobra.Command {
+	var proposedPlanPath string
+
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate workflow definitions",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmdWorkflowValidate(cmd.OutOrStdout(), deps.cfg.StateDir, proposedPlanPath)
+		},
+	}
+
+	cmd.Flags().StringVar(&proposedPlanPath, "proposed", "", "Validate workflows after applying an adapt-plan.json in memory")
+	return cmd
+}
+
+func cmdWorkflowValidate(stdout io.Writer, stateDir, proposedPlanPath string) error {
+	var plan *adaptPlan
+	if proposedPlanPath != "" {
+		loadedPlan, err := loadAdaptPlan(proposedPlanPath)
+		if err != nil {
+			return fmt.Errorf("load proposed plan: %w", err)
+		}
+		plan = &loadedPlan
+	}
+
+	workflowsDir := filepath.Join(stateDir, "workflows")
+	count, err := validateWorkflowDir(workflowsDir, plan)
+	if err != nil {
+		return fmt.Errorf("validate workflows: %w", err)
+	}
+	if _, err := fmt.Fprintf(stdout, "Validated %d workflow(s).\n", count); err != nil {
+		return fmt.Errorf("write workflow validation summary: %w", err)
+	}
+	return nil
+}
+
+func validateWorkflowDir(workflowsDir string, plan *adaptPlan) (int, error) {
+	workflowPaths, err := discoverWorkflowPaths(workflowsDir)
+	if err != nil {
+		return 0, err
+	}
+	if plan != nil {
+		workflowPaths, err = applyProposedWorkflowPlan(workflowsDir, workflowPaths, *plan)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	for _, path := range workflowPaths {
+		if _, _, err := workflowpkg.LoadWithDigest(path); err != nil {
+			return 0, err
+		}
+	}
+	return len(workflowPaths), nil
+}
+
+func discoverWorkflowPaths(workflowsDir string) ([]string, error) {
+	info, err := os.Stat(workflowsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat workflows dir: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("workflows path %q is not a directory", workflowsDir)
+	}
+
+	paths := make([]string, 0)
+	if err := filepath.WalkDir(workflowsDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		switch strings.ToLower(filepath.Ext(path)) {
+		case ".yaml", ".yml":
+			paths = append(paths, path)
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("walk workflows dir: %w", err)
+	}
+
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func applyProposedWorkflowPlan(workflowsDir string, workflowPaths []string, plan adaptPlan) ([]string, error) {
+	deleted := make(map[string]struct{})
+	for _, change := range plan.PlannedChanges {
+		if !adaptPlanTargetsWorkflow(change.Path) {
+			continue
+		}
+		switch change.Op {
+		case "delete":
+			deleted[change.Path] = struct{}{}
+		case "patch", "replace", "create":
+			return nil, fmt.Errorf("planned change %q with op %q cannot be validated with --proposed because adapt-plan.json does not include workflow contents", change.Path, change.Op)
+		default:
+			return nil, fmt.Errorf("planned change %q has unsupported op %q", change.Path, change.Op)
+		}
+	}
+
+	filtered := make([]string, 0, len(workflowPaths))
+	for _, path := range workflowPaths {
+		if _, skip := deleted[workflowPlanPathForDiskPath(workflowsDir, path)]; skip {
+			continue
+		}
+		filtered = append(filtered, path)
+	}
+	return filtered, nil
+}
+
+func workflowPlanPathForDiskPath(workflowsDir, path string) string {
+	rel, err := filepath.Rel(workflowsDir, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(filepath.Join(".xylem", "workflows", rel))
+}
+
+func adaptPlanTargetsWorkflow(path string) bool {
+	return strings.HasPrefix(path, ".xylem/workflows/") && isWorkflowFilePath(path)
+}
+
+func isWorkflowFilePath(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".yaml", ".yml":
+		return true
+	default:
+		return false
+	}
+}
+
+func loadAdaptPlan(path string) (adaptPlan, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return adaptPlan{}, fmt.Errorf("read adapt plan %q: %w", path, err)
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+
+	var raw rawAdaptPlan
+	if err := dec.Decode(&raw); err != nil {
+		return adaptPlan{}, fmt.Errorf("decode adapt plan %q: %w", path, err)
+	}
+	if err := ensureSingleJSONObject(dec, path); err != nil {
+		return adaptPlan{}, err
+	}
+
+	plan, err := normalizeAdaptPlan(raw)
+	if err != nil {
+		return adaptPlan{}, fmt.Errorf("validate adapt plan %q: %w", path, err)
+	}
+	return plan, nil
+}
+
+func ensureSingleJSONObject(dec *json.Decoder, path string) error {
+	var extra json.RawMessage
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("decode adapt plan %q: unexpected trailing data", path)
+		}
+		return fmt.Errorf("decode adapt plan %q: %w", path, err)
+	}
+	return nil
+}
+
+func normalizeAdaptPlan(raw rawAdaptPlan) (adaptPlan, error) {
+	switch {
+	case raw.SchemaVersion == nil:
+		return adaptPlan{}, fmt.Errorf(`"schema_version" is required`)
+	case *raw.SchemaVersion != 1:
+		return adaptPlan{}, fmt.Errorf(`"schema_version" must equal 1`)
+	case raw.Detected == nil:
+		return adaptPlan{}, fmt.Errorf(`"detected" is required`)
+	case raw.PlannedChanges == nil:
+		return adaptPlan{}, fmt.Errorf(`"planned_changes" is required`)
+	case raw.Skipped == nil:
+		return adaptPlan{}, fmt.Errorf(`"skipped" is required`)
+	}
+
+	planned := append([]adaptPlanChange(nil), (*raw.PlannedChanges)...)
+	for i := range planned {
+		path, err := normalizeAdaptPlanPath(planned[i].Path)
+		if err != nil {
+			return adaptPlan{}, fmt.Errorf(`"planned_changes[%d].path" %w`, i, err)
+		}
+		if err := validateAdaptPlanChange(path, planned[i]); err != nil {
+			return adaptPlan{}, fmt.Errorf(`"planned_changes[%d]" %w`, i, err)
+		}
+		planned[i].Path = path
+	}
+
+	skipped := append([]adaptPlanSkipped(nil), (*raw.Skipped)...)
+	for i := range skipped {
+		path, err := normalizeAdaptPlanPath(skipped[i].Path)
+		if err != nil {
+			return adaptPlan{}, fmt.Errorf(`"skipped[%d].path" %w`, i, err)
+		}
+		if strings.TrimSpace(skipped[i].Reason) == "" {
+			return adaptPlan{}, fmt.Errorf(`"skipped[%d].reason" must not be empty`, i)
+		}
+		if !isAllowedAdaptPlanPath(path) {
+			return adaptPlan{}, fmt.Errorf(`"skipped[%d].path" %q is outside the adapt-plan allowlist`, i, path)
+		}
+		skipped[i].Path = path
+	}
+
+	return adaptPlan{
+		SchemaVersion:  *raw.SchemaVersion,
+		Detected:       *raw.Detected,
+		PlannedChanges: planned,
+		Skipped:        skipped,
+	}, nil
+}
+
+func normalizeAdaptPlanPath(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("must not be empty")
+	}
+	if filepath.IsAbs(path) {
+		return "", fmt.Errorf("must be relative")
+	}
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("must stay within the repository root")
+	}
+	return cleaned, nil
+}
+
+func validateAdaptPlanChange(path string, change adaptPlanChange) error {
+	switch change.Op {
+	case "patch", "replace", "create", "delete":
+	default:
+		return fmt.Errorf(`has invalid op %q`, change.Op)
+	}
+	if !isAllowedAdaptPlanPath(path) {
+		return fmt.Errorf(`path %q is outside the adapt-plan allowlist`, path)
+	}
+	if strings.TrimSpace(change.Rationale) == "" {
+		return fmt.Errorf(`must include a non-empty rationale`)
+	}
+	if change.Op == "delete" && (!adaptPlanTargetsWorkflow(path) || !strings.HasPrefix(path, ".xylem/workflows/")) {
+		return fmt.Errorf(`delete is only allowed for workflow YAML files under ".xylem/workflows/"`)
+	}
+	return nil
+}
+
+func isAllowedAdaptPlanPath(path string) bool {
+	return path == ".xylem.yml" ||
+		path == "AGENTS.md" ||
+		strings.HasPrefix(path, ".xylem/") ||
+		strings.HasPrefix(path, "docs/")
+}

--- a/cli/cmd/xylem/workflow_prop_test.go
+++ b/cli/cmd/xylem/workflow_prop_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropApplyProposedWorkflowPlanDeleteOnlyRemovesNamedWorkflows(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		rootDir, err := os.MkdirTemp("", "xylem-workflow-prop-*")
+		if err != nil {
+			rt.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(rootDir)
+
+		workflowsDir := filepath.Join(rootDir, ".xylem", "workflows")
+		if err := os.MkdirAll(workflowsDir, 0o755); err != nil {
+			rt.Fatalf("MkdirAll(%q) error = %v", workflowsDir, err)
+		}
+
+		candidates := []string{"alpha", "beta", "gamma", "delta", "epsilon"}
+		workflowPaths := make([]string, 0, len(candidates))
+		deleted := make(map[string]bool, len(candidates))
+		keptCount := 0
+		for _, name := range candidates {
+			ext := rapid.SampledFrom([]string{".yaml", ".yml"}).Draw(rt, "ext-"+name)
+			path := filepath.Join(workflowsDir, name+ext)
+			workflowPaths = append(workflowPaths, path)
+			if rapid.Bool().Draw(rt, "delete-"+name) {
+				deleted[workflowPlanPathForDiskPath(workflowsDir, path)] = true
+				continue
+			}
+			keptCount++
+		}
+
+		changes := make([]adaptPlanChange, 0, len(deleted)+1)
+		for path := range deleted {
+			changes = append(changes, adaptPlanChange{
+				Path:      path,
+				Op:        "delete",
+				Rationale: "remove inapplicable workflow",
+			})
+		}
+		changes = append(changes, adaptPlanChange{
+			Path:      "docs/README.md",
+			Op:        "patch",
+			Rationale: "unrelated doc update",
+		})
+
+		filtered, err := applyProposedWorkflowPlan(workflowsDir, workflowPaths, adaptPlan{
+			SchemaVersion:  1,
+			Detected:       adaptPlanDetected{},
+			PlannedChanges: changes,
+			Skipped:        []adaptPlanSkipped{},
+		})
+		if err != nil {
+			rt.Fatalf("applyProposedWorkflowPlan() error = %v", err)
+		}
+		if len(filtered) != keptCount {
+			rt.Fatalf("len(filtered) = %d, want %d", len(filtered), keptCount)
+		}
+		for _, path := range filtered {
+			if deleted[workflowPlanPathForDiskPath(workflowsDir, path)] {
+				rt.Fatalf("filtered workflows unexpectedly retained deleted path %q", path)
+			}
+		}
+	})
+}

--- a/cli/cmd/xylem/workflow_test.go
+++ b/cli/cmd/xylem/workflow_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSmoke_S1_WorkflowValidateBypassesPersistentPreRunToolingChecks(t *testing.T) {
+	dir := t.TempDir()
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(oldWd))
+	})
+
+	configPath := filepath.Join(dir, ".xylem.yml")
+	require.NoError(t, cmdInit(configPath, false))
+	workflowPaths, err := discoverWorkflowPaths(filepath.Join(dir, defaultStateDir, "workflows"))
+	require.NoError(t, err)
+	require.NotEmpty(t, workflowPaths)
+
+	t.Setenv("PATH", "")
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"--config", configPath, "workflow", "validate"})
+
+	out := captureStdout(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	assert.Equal(t, fmt.Sprintf("Validated %d workflow(s).\n", len(workflowPaths)), out)
+}
+
+func TestSmoke_S2_WorkflowValidateMatchesDaemonReloadValidationError(t *testing.T) {
+	rootDir, configPath, cfg := writeDaemonReloadRepo(t, "# Harness A\n")
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, ".xylem", "workflows", "fix-bug.yaml"), []byte("name: fix-bug\nphases:\n  - name: Bad\n"), 0o644))
+
+	var stdout bytes.Buffer
+	cmdErr := cmdWorkflowValidate(&stdout, cfg.StateDir, "")
+	require.Error(t, cmdErr)
+
+	_, reloadErr := validateDaemonReloadCandidate(rootDir, configPath)
+	require.Error(t, reloadErr)
+
+	assert.Equal(t, reloadErr.Error(), cmdErr.Error())
+	assert.Empty(t, stdout.String())
+}
+
+func TestSmoke_S3_WorkflowValidateWalksDefaultWorkflowDirectoryAndReportsCoverage(t *testing.T) {
+	stateDir := newWorkflowValidationStateDir(t)
+	writeValidWorkflowFile(t, stateDir, "fix-bug")
+	writeValidWorkflowFile(t, stateDir, "review")
+
+	var stdout bytes.Buffer
+	err := cmdWorkflowValidate(&stdout, stateDir, "")
+	require.NoError(t, err)
+	assert.Equal(t, "Validated 2 workflow(s).\n", stdout.String())
+}
+
+func TestSmoke_S4_WorkflowValidateProposedDeleteIgnoresDeletedBrokenWorkflow(t *testing.T) {
+	stateDir := newWorkflowValidationStateDir(t)
+	writeValidWorkflowFile(t, stateDir, "fix-bug")
+	writeWorkflowFile(t, stateDir, "broken", strings.Join([]string{
+		"name: broken",
+		"phases:",
+		"  - name: Bad",
+		"",
+	}, "\n"))
+	planPath := writeAdaptPlanFile(t, filepath.Dir(stateDir), strings.Join([]string{
+		"{",
+		`  "schema_version": 1,`,
+		`  "detected": {"languages": ["go"], "build_tools": ["go"], "test_runners": ["go test"], "linters": ["goimports"], "has_frontend": false, "has_database": false, "entry_points": ["cli/cmd/xylem"]},`,
+		`  "planned_changes": [{"path": ".xylem/workflows/broken.yaml", "op": "delete", "rationale": "remove invalid workflow"}],`,
+		`  "skipped": []`,
+		"}",
+	}, "\n"))
+
+	var stdout bytes.Buffer
+	err := cmdWorkflowValidate(&stdout, stateDir, planPath)
+	require.NoError(t, err)
+	assert.Equal(t, "Validated 1 workflow(s).\n", stdout.String())
+}
+
+func TestSmoke_S5_WorkflowValidateProposedRejectsWorkflowPatchWithoutContents(t *testing.T) {
+	stateDir := newWorkflowValidationStateDir(t)
+	writeValidWorkflowFile(t, stateDir, "fix-bug")
+	planPath := writeAdaptPlanFile(t, filepath.Dir(stateDir), strings.Join([]string{
+		"{",
+		`  "schema_version": 1,`,
+		`  "detected": {"languages": ["go"], "build_tools": ["go"], "test_runners": ["go test"], "linters": ["goimports"], "has_frontend": false, "has_database": false, "entry_points": ["cli/cmd/xylem"]},`,
+		`  "planned_changes": [{"path": ".xylem/workflows/fix-bug.yaml", "op": "patch", "rationale": "update gate"}],`,
+		`  "skipped": []`,
+		"}",
+	}, "\n"))
+
+	err := cmdWorkflowValidate(ioDiscard{}, stateDir, planPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not include workflow contents")
+}
+
+func TestWorkflowValidateProposedRejectsMalformedPlan(t *testing.T) {
+	stateDir := newWorkflowValidationStateDir(t)
+	writeValidWorkflowFile(t, stateDir, "fix-bug")
+	planPath := writeAdaptPlanFile(t, filepath.Dir(stateDir), strings.Join([]string{
+		"{",
+		`  "schema_version": 1,`,
+		`  "detected": {"languages": ["go"], "build_tools": ["go"], "test_runners": ["go test"], "linters": ["goimports"], "has_frontend": false, "has_database": false, "entry_points": ["cli/cmd/xylem"]},`,
+		`  "planned_changes": [],`,
+		`  "unknown": true,`,
+		`  "skipped": []`,
+		"}",
+	}, "\n"))
+
+	err := cmdWorkflowValidate(ioDiscard{}, stateDir, planPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load proposed plan")
+	assert.Contains(t, err.Error(), "unknown field")
+}
+
+type ioDiscard struct{}
+
+func (ioDiscard) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func newWorkflowValidationStateDir(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".xylem")
+	require.NoError(t, os.MkdirAll(filepath.Join(stateDir, "workflows"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(stateDir, "prompts"), 0o755))
+	return stateDir
+}
+
+func writeValidWorkflowFile(t *testing.T, stateDir, name string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "prompts", name+".md"), []byte("Prompt\n"), 0o644))
+	writeWorkflowFile(t, stateDir, name, strings.Join([]string{
+		"name: " + name,
+		"phases:",
+		"  - name: plan",
+		"    prompt_file: .xylem/prompts/" + name + ".md",
+		"    max_turns: 1",
+		"",
+	}, "\n"))
+}
+
+func writeWorkflowFile(t *testing.T, stateDir, name, body string) {
+	t.Helper()
+
+	path := filepath.Join(stateDir, "workflows", name+".yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+}
+
+func writeAdaptPlanFile(t *testing.T, rootDir, body string) string {
+	t.Helper()
+
+	path := filepath.Join(rootDir, "adapt-plan.json")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+	return path
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -73,6 +73,33 @@ xylem init --config my-config.yml
 
 ---
 
+## xylem workflow validate
+
+Validate the checked-in workflow YAML under `<state_dir>/workflows`.
+
+### Usage
+
+```bash
+xylem workflow validate [--proposed /path/to/adapt-plan.json]
+```
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--proposed` | `string` | `""` | Load an `adapt-plan.json` and validate the workflow set after applying any delete-only workflow removals in memory. |
+
+### Behavior
+
+1. Recursively loads every `.yaml` / `.yml` file under `<state_dir>/workflows`.
+2. Validates each workflow through the same `workflow.LoadWithDigest` path used by daemon reload validation.
+3. Prints a summary line with the number of validated workflows.
+4. In `--proposed` mode, rejects workflow `create`, `patch`, and `replace` changes because the current `adapt-plan.json` schema does not include the concrete workflow contents needed to validate those edits in memory.
+
+This command is local-only: it parses config and workflow files but does not require `git` or `gh` on `PATH`.
+
+---
+
 ## xylem dtu
 
 Manage Digital Twin Universe manifests, materialized state, and runtime wiring for offline scenario execution.


### PR DESCRIPTION
## Summary

Adds `xylem workflow validate` for https://github.com/nicholls-inc/xylem/issues/386.

The new subcommand validates all workflow YAML under `<state_dir>/workflows`, reuses the daemon reload validation path, and supports `--proposed` for delete-only workflow removals from `adapt-plan.json` while explicitly rejecting proposed workflow edits whose contents are not present in the plan schema.

## Smoke scenarios covered

- **S1** — Workflow validate bypasses PersistentPreRun tooling checks
- **S2** — Workflow validate matches daemon reload validation error
- **S3** — Workflow validate walks default workflow directory and reports coverage
- **S4** — Workflow validate proposed delete ignores deleted broken workflow
- **S5** — Workflow validate proposed rejects workflow patch without contents

## Changes summary

- **Added** `cli/cmd/xylem/workflow.go`
  - Introduces `newWorkflowCmd`, `newWorkflowValidateCmd`, `cmdWorkflowValidate`, `validateWorkflowDir`, `discoverWorkflowPaths`, `applyProposedWorkflowPlan`, and adapt-plan parsing/validation helpers (`loadAdaptPlan`, `normalizeAdaptPlan`, `validateAdaptPlanChange`, `isAllowedAdaptPlanPath`)
- **Modified** `cli/cmd/xylem/root.go`
  - Registers the new `workflow` command and treats `xylem workflow ...` as local-only for PATH tooling checks
- **Modified** `cli/cmd/xylem/daemon_reload.go`
  - Reuses `validateWorkflowDir` so daemon reload and CLI workflow validation share the same workflow-loading path
- **Modified** `cli/cmd/xylem/cobra_test.go`
  - Covers root command registration for the new subcommand
- **Added** `cli/cmd/xylem/workflow_test.go`
  - Adds smoke coverage for command execution, daemon-reload parity, workflow discovery, and `--proposed` behavior
- **Added** `cli/cmd/xylem/workflow_prop_test.go`
  - Adds property coverage for delete-only proposed workflow filtering
- **Modified** `docs/cli-reference.md`
  - Documents `xylem workflow validate` and its `--proposed` behavior

## Test plan

- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #386