### PR TITLE
feat: add `xylem config validate` for scaffold and ops verification

### DIFF
--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -38,7 +38,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "bootstrap", "workflow", "continuous-improvement", "continuous-simplicity", "release-cadence", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "recovery", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report"}
+	expected := []string{"init", "bootstrap", "config", "workflow", "continuous-improvement", "continuous-simplicity", "release-cadence", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "recovery", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/config.go
+++ b/cli/cmd/xylem/config.go
@@ -322,17 +322,6 @@ func adaptPlanTouchesProfileLock(plan *adaptRepoPlan) bool {
 	return false
 }
 
-func isAllowedAdaptPlanPath(path string) bool {
-	switch {
-	case path == ".xylem.yml", path == "AGENTS.md":
-		return true
-	case strings.HasPrefix(path, ".xylem/"), strings.HasPrefix(path, "docs/"):
-		return true
-	default:
-		return false
-	}
-}
-
 func stringSlicesEqual(left, right []string) bool {
 	if len(left) != len(right) {
 		return false

--- a/cli/cmd/xylem/config.go
+++ b/cli/cmd/xylem/config.go
@@ -1,0 +1,346 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/profiles"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+type adaptRepoPlan struct {
+	SchemaVersion int                     `json:"schema_version"`
+	Detected      adaptRepoPlanDetected   `json:"detected"`
+	Planned       []adaptRepoPlannedAsset `json:"planned_changes"`
+	Skipped       []adaptRepoSkippedAsset `json:"skipped"`
+}
+
+type adaptRepoPlanDetected struct {
+	Languages   []string `json:"languages"`
+	BuildTools  []string `json:"build_tools"`
+	TestRunners []string `json:"test_runners"`
+	Linters     []string `json:"linters"`
+	HasFrontend bool     `json:"has_frontend"`
+	HasDatabase bool     `json:"has_database"`
+	EntryPoints []string `json:"entry_points"`
+}
+
+type adaptRepoPlannedAsset struct {
+	Path        string `json:"path"`
+	Op          string `json:"op"`
+	Rationale   string `json:"rationale"`
+	DiffSummary string `json:"diff_summary,omitempty"`
+}
+
+type adaptRepoSkippedAsset struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
+type profileLock struct {
+	ProfileVersion int                 `yaml:"profile_version"`
+	Profiles       []profileLockRecord `yaml:"profiles"`
+	LockedAt       string              `yaml:"locked_at"`
+}
+
+type profileLockRecord struct {
+	Name    string `yaml:"name"`
+	Version int    `yaml:"version"`
+}
+
+func newConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Inspect and validate xylem config",
+	}
+	cmd.AddCommand(newConfigValidateCmd())
+	return cmd
+}
+
+func newConfigValidateCmd() *cobra.Command {
+	var proposedPath string
+
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate .xylem.yml and related scaffold metadata",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmdConfigValidate(viper.GetString("config"), proposedPath, cmd.OutOrStdout())
+		},
+	}
+	cmd.Flags().StringVar(&proposedPath, "proposed", "", "Apply a proposed adapt-plan.json to config in memory before validation")
+	return cmd
+}
+
+func cmdConfigValidate(configPath, proposedPath string, stdout io.Writer) error {
+	cfg, err := config.LoadUnvalidated(configPath)
+	if err != nil {
+		return fmt.Errorf("load config for validation: %w", err)
+	}
+
+	var plan *adaptRepoPlan
+	if strings.TrimSpace(proposedPath) != "" {
+		plan, err = loadAdaptRepoPlan(proposedPath)
+		if err != nil {
+			return err
+		}
+		if err := applyAdaptRepoPlan(cfg, plan); err != nil {
+			return err
+		}
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("validate config: %w", err)
+	}
+	if err := validateConfiguredProfiles(cfg); err != nil {
+		return err
+	}
+	if err := validateProfileLock(configPath, cfg, plan); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(stdout, "Config valid.")
+	if len(cfg.Profiles) > 0 {
+		fmt.Fprintf(stdout, "Profiles: %s\n", strings.Join(cfg.Profiles, ", "))
+	}
+	fmt.Fprintf(stdout, "Policy mode: %s\n", cfg.HarnessPolicyMode())
+	fmt.Fprintf(stdout, "Protected surfaces: %d\n", len(cfg.EffectiveProtectedSurfaces()))
+	fmt.Fprintf(stdout, "Auto-merge labels: %s\n", strings.Join(cfg.Daemon.EffectiveAutoMergeLabels(), ", "))
+	return nil
+}
+
+func loadAdaptRepoPlan(path string) (*adaptRepoPlan, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read proposed plan %q: %w", path, err)
+	}
+
+	var plan adaptRepoPlan
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&plan); err != nil {
+		return nil, fmt.Errorf("parse proposed plan %q: %w", path, err)
+	}
+	if err := dec.Decode(new(struct{})); err != io.EOF {
+		return nil, fmt.Errorf("parse proposed plan %q: trailing data", path)
+	}
+	if err := plan.Validate(); err != nil {
+		return nil, fmt.Errorf("validate proposed plan %q: %w", path, err)
+	}
+	return &plan, nil
+}
+
+func (p *adaptRepoPlan) Validate() error {
+	if p.SchemaVersion != 1 {
+		return fmt.Errorf("schema_version must equal 1")
+	}
+	if p.Skipped == nil {
+		return fmt.Errorf("skipped must be present")
+	}
+	for i, change := range p.Planned {
+		if strings.TrimSpace(change.Path) == "" {
+			return fmt.Errorf("planned_changes[%d].path must be non-empty", i)
+		}
+		if !isAllowedAdaptPlanPath(change.Path) {
+			return fmt.Errorf("planned_changes[%d].path %q is outside the allowed harness surfaces", i, change.Path)
+		}
+		switch change.Op {
+		case "patch", "replace", "create", "delete":
+		default:
+			return fmt.Errorf("planned_changes[%d].op %q is invalid", i, change.Op)
+		}
+		if change.Op == "delete" && !strings.HasPrefix(change.Path, ".xylem/workflows/") {
+			return fmt.Errorf("planned_changes[%d].op delete is only allowed under .xylem/workflows/", i)
+		}
+		if strings.TrimSpace(change.Rationale) == "" {
+			return fmt.Errorf("planned_changes[%d].rationale must be non-empty", i)
+		}
+	}
+	for i, skipped := range p.Skipped {
+		if strings.TrimSpace(skipped.Path) == "" {
+			return fmt.Errorf("skipped[%d].path must be non-empty", i)
+		}
+		if !isAllowedAdaptPlanPath(skipped.Path) {
+			return fmt.Errorf("skipped[%d].path %q is outside the allowed harness surfaces", i, skipped.Path)
+		}
+		if strings.TrimSpace(skipped.Reason) == "" {
+			return fmt.Errorf("skipped[%d].reason must be non-empty", i)
+		}
+	}
+	return nil
+}
+
+func applyAdaptRepoPlan(cfg *config.Config, plan *adaptRepoPlan) error {
+	if cfg == nil || plan == nil {
+		return nil
+	}
+	for _, change := range plan.Planned {
+		if change.Path != ".xylem.yml" {
+			continue
+		}
+		if change.Op == "delete" {
+			return fmt.Errorf("validate proposed config: .xylem.yml cannot be deleted")
+		}
+		if err := applyConfigDiffSummary(cfg, change.DiffSummary); err != nil {
+			return fmt.Errorf("validate proposed config: %w", err)
+		}
+	}
+	return nil
+}
+
+func applyConfigDiffSummary(cfg *config.Config, summary string) error {
+	summary = strings.TrimSpace(summary)
+	if summary == "" {
+		return nil
+	}
+	for _, raw := range strings.FieldsFunc(summary, func(r rune) bool {
+		return r == ';' || r == '\n'
+	}) {
+		segment := strings.TrimSpace(raw)
+		if segment == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(segment, ":")
+		if !ok {
+			return fmt.Errorf("unsupported .xylem.yml diff_summary segment %q", segment)
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return fmt.Errorf("unsupported .xylem.yml diff_summary key %q with empty value", key)
+		}
+		switch key {
+		case "validation.format":
+			cfg.Validation.Format = value
+		case "validation.lint":
+			cfg.Validation.Lint = value
+		case "validation.build":
+			cfg.Validation.Build = value
+		case "validation.test":
+			cfg.Validation.Test = value
+		case "profiles":
+			profiles, err := parseProposedProfiles(value)
+			if err != nil {
+				return fmt.Errorf("parse profiles override: %w", err)
+			}
+			cfg.Profiles = profiles
+		default:
+			return fmt.Errorf("unsupported .xylem.yml diff_summary key %q", key)
+		}
+	}
+	return nil
+}
+
+func parseProposedProfiles(value string) ([]string, error) {
+	trimmed := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(value), "["), "]"))
+	if trimmed == "" {
+		return nil, fmt.Errorf("profiles override must be non-empty")
+	}
+	parts := strings.Split(trimmed, ",")
+	profiles := make([]string, 0, len(parts))
+	for _, part := range parts {
+		name := strings.Trim(strings.TrimSpace(part), `"'`)
+		if name == "" {
+			continue
+		}
+		profiles = append(profiles, name)
+	}
+	if len(profiles) == 0 {
+		return nil, fmt.Errorf("profiles override must include at least one profile")
+	}
+	return profiles, nil
+}
+
+func validateConfiguredProfiles(cfg *config.Config) error {
+	if cfg == nil || len(cfg.Profiles) == 0 {
+		return nil
+	}
+	if _, err := profiles.Compose(cfg.Profiles...); err != nil {
+		return fmt.Errorf("validate configured profiles: %w", err)
+	}
+	return nil
+}
+
+func validateProfileLock(configPath string, cfg *config.Config, plan *adaptRepoPlan) error {
+	if cfg == nil || len(cfg.Profiles) == 0 || adaptPlanTouchesProfileLock(plan) {
+		return nil
+	}
+	lockPath, err := resolvedStateAssetPath(configPath, cfg.StateDir, "profile.lock")
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return fmt.Errorf("read profile lock %q: %w", lockPath, err)
+	}
+	var lock profileLock
+	if err := yaml.Unmarshal(data, &lock); err != nil {
+		return fmt.Errorf("parse profile lock %q: %w", lockPath, err)
+	}
+	lockedProfiles := make([]string, 0, len(lock.Profiles))
+	for _, profile := range lock.Profiles {
+		if strings.TrimSpace(profile.Name) == "" {
+			continue
+		}
+		lockedProfiles = append(lockedProfiles, profile.Name)
+	}
+	if !stringSlicesEqual(cfg.Profiles, lockedProfiles) {
+		return fmt.Errorf("profile.lock profiles %v do not match .xylem.yml profiles %v", lockedProfiles, cfg.Profiles)
+	}
+	return nil
+}
+
+func resolvedStateAssetPath(configPath, stateDir string, elems ...string) (string, error) {
+	configAbs, err := filepath.Abs(configPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve config path %q: %w", configPath, err)
+	}
+	if strings.TrimSpace(stateDir) == "" {
+		return "", fmt.Errorf("state_dir must be non-empty")
+	}
+	root := filepath.Dir(configAbs)
+	resolvedStateDir := config.ResolveStateDir(root, stateDir)
+	parts := append([]string{resolvedStateDir}, elems...)
+	return filepath.Join(parts...), nil
+}
+
+func adaptPlanTouchesProfileLock(plan *adaptRepoPlan) bool {
+	if plan == nil {
+		return false
+	}
+	for _, change := range plan.Planned {
+		if change.Path == ".xylem/profile.lock" {
+			return true
+		}
+	}
+	return false
+}
+
+func isAllowedAdaptPlanPath(path string) bool {
+	switch {
+	case path == ".xylem.yml", path == "AGENTS.md":
+		return true
+	case strings.HasPrefix(path, ".xylem/"), strings.HasPrefix(path, "docs/"):
+		return true
+	default:
+		return false
+	}
+}
+
+func stringSlicesEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cli/cmd/xylem/config_prop_test.go
+++ b/cli/cmd/xylem/config_prop_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"pgregory.net/rapid"
+)
+
+func TestPropConfigValidateAcceptsProposedValidationAssignments(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		dir, err := os.MkdirTemp("", "xylem-config-validate-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(dir)
+
+		configPath := filepath.Join(dir, ".xylem.yml")
+		configBody := `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      adapt:
+        labels: [bootstrap]
+        workflow: adapt-repo
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`
+		if err := os.WriteFile(configPath, []byte(configBody), 0o644); err != nil {
+			t.Fatalf("WriteFile(%q) error = %v", configPath, err)
+		}
+
+		key := rapid.SampledFrom([]string{
+			"validation.format",
+			"validation.lint",
+			"validation.build",
+			"validation.test",
+		}).Draw(t, "key")
+		value := rapid.SampledFrom([]string{
+			"goimports -l .",
+			"cd cli && go vet ./...",
+			"cd cli && go build ./cmd/xylem",
+			"cd cli && go test ./...",
+		}).Draw(t, "value")
+
+		plan := adaptRepoPlan{
+			SchemaVersion: 1,
+			Detected:      adaptRepoPlanDetected{},
+			Planned: []adaptRepoPlannedAsset{{
+				Path:        ".xylem.yml",
+				Op:          "patch",
+				Rationale:   "apply validation override",
+				DiffSummary: key + ": " + value,
+			}},
+			Skipped: []adaptRepoSkippedAsset{},
+		}
+		data, err := json.Marshal(plan)
+		if err != nil {
+			t.Fatalf("json.Marshal() error = %v", err)
+		}
+		planPath := filepath.Join(dir, "adapt-plan.json")
+		if err := os.WriteFile(planPath, append(data, '\n'), 0o644); err != nil {
+			t.Fatalf("WriteFile(%q) error = %v", planPath, err)
+		}
+
+		if err := cmdConfigValidate(configPath, planPath, io.Discard); err != nil {
+			t.Fatalf("cmdConfigValidate() error = %v", err)
+		}
+	})
+}
+
+func TestPropApplyConfigDiffSummaryRejectsUnknownKeys(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		key := rapid.StringMatching(`[a-z][a-z0-9_.-]{2,16}`).Draw(t, "key")
+		if key == "validation.format" || key == "validation.lint" || key == "validation.build" || key == "validation.test" || key == "profiles" {
+			key = "daemon.scan_interval"
+		}
+
+		err := applyConfigDiffSummary(&config.Config{}, key+": value")
+		if err == nil {
+			t.Fatalf("applyConfigDiffSummary(%q) succeeded, want error", key)
+		}
+		if !strings.Contains(err.Error(), key) {
+			t.Fatalf("applyConfigDiffSummary(%q) error = %v, want key in error", key, err)
+		}
+	})
+}

--- a/cli/cmd/xylem/config_test.go
+++ b/cli/cmd/xylem/config_test.go
@@ -21,7 +21,7 @@ func writeConfigValidateFile(t *testing.T, dir, name, contents string) string {
 	return path
 }
 
-func writeAdaptPlanFile(t *testing.T, dir string, plan adaptRepoPlan) string {
+func writeConfigValidateAdaptPlanFile(t *testing.T, dir string, plan adaptRepoPlan) string {
 	t.Helper()
 
 	data, err := json.Marshal(plan)
@@ -96,7 +96,7 @@ claude:
   command: "claude"
   default_model: "claude-sonnet-4-6"
 `)
-	planPath := writeAdaptPlanFile(t, dir, adaptRepoPlan{
+	planPath := writeConfigValidateAdaptPlanFile(t, dir, adaptRepoPlan{
 		SchemaVersion: 1,
 		Detected:      adaptRepoPlanDetected{},
 		Planned: []adaptRepoPlannedAsset{{

--- a/cli/cmd/xylem/config_test.go
+++ b/cli/cmd/xylem/config_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeConfigValidateFile(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+	return path
+}
+
+func writeAdaptPlanFile(t *testing.T, dir string, plan adaptRepoPlan) string {
+	t.Helper()
+
+	data, err := json.Marshal(plan)
+	require.NoError(t, err)
+	path := filepath.Join(dir, "adapt-plan.json")
+	require.NoError(t, os.WriteFile(path, append(data, '\n'), 0o644))
+	return path
+}
+
+func TestSmoke_S1_ValidateBypassesPersistentPreRun(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".xylem.yml")
+	origWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(origWD))
+	})
+
+	require.NoError(t, cmdInit(configPath, false))
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"--config", configPath, "config", "validate"})
+
+	out := captureStdout(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	assert.Contains(t, out, "Config valid.")
+}
+
+func TestSmoke_S2_RejectsEmptyAdaptRepoValidation(t *testing.T) {
+	dir := t.TempDir()
+	configPath := writeConfigValidateFile(t, dir, ".xylem.yml", `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      adapt:
+        labels: [bootstrap]
+        workflow: adapt-repo
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`)
+
+	err := cmdConfigValidate(configPath, "", io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validation: at least one of format, lint, build, or test must be set")
+	assert.Contains(t, err.Error(), "adapt-repo")
+}
+
+func TestSmoke_S3_ProposedPlanAppliesValidationOverrides(t *testing.T) {
+	dir := t.TempDir()
+	configPath := writeConfigValidateFile(t, dir, ".xylem.yml", `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      adapt:
+        labels: [bootstrap]
+        workflow: adapt-repo
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`)
+	planPath := writeAdaptPlanFile(t, dir, adaptRepoPlan{
+		SchemaVersion: 1,
+		Detected:      adaptRepoPlanDetected{},
+		Planned: []adaptRepoPlannedAsset{{
+			Path:        ".xylem.yml",
+			Op:          "patch",
+			Rationale:   "seed validation",
+			DiffSummary: "validation.test: cd cli && go test ./...",
+		}},
+		Skipped: []adaptRepoSkippedAsset{},
+	})
+
+	require.NoError(t, cmdConfigValidate(configPath, planPath, io.Discard))
+}
+
+func TestSmoke_S4_RejectsUnknownPlanFields(t *testing.T) {
+	dir := t.TempDir()
+	configPath := writeConfigValidateFile(t, dir, ".xylem.yml", `concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`)
+	planPath := writeConfigValidateFile(t, dir, "adapt-plan.json", `{
+  "schema_version": 1,
+  "detected": {},
+  "planned_changes": [],
+  "skipped": [],
+  "unexpected": true
+}`)
+
+	err := cmdConfigValidate(configPath, planPath, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field")
+}
+
+func TestSmoke_S5_RejectsProfileLockDrift(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".xylem.yml")
+	origWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(origWD))
+	})
+
+	require.NoError(t, cmdInitWithProfile(configPath, false, "core"))
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	updated := strings.Replace(string(data), "profiles:\n    - core", "profiles:\n    - core\n    - self-hosting-xylem", 1)
+	require.NoError(t, os.WriteFile(configPath, []byte(updated), 0o644))
+
+	err = cmdConfigValidate(configPath, "", io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "profile.lock profiles")
+}

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -31,7 +31,7 @@ func newRootCmd() *cobra.Command {
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			commandPath := cmd.CommandPath()
-			if cmd.Name() == "init" || cmd.Name() == "shim-dispatch" || cmd.Name() == "version" || commandPath == "xylem dtu" || strings.HasPrefix(commandPath, "xylem dtu ") || commandPath == "xylem bootstrap" || strings.HasPrefix(commandPath, "xylem bootstrap ") || strings.HasPrefix(commandPath, "xylem continuous-simplicity") {
+			if cmd.Name() == "init" || cmd.Name() == "shim-dispatch" || cmd.Name() == "version" || commandPath == "xylem dtu" || strings.HasPrefix(commandPath, "xylem dtu ") || commandPath == "xylem bootstrap" || strings.HasPrefix(commandPath, "xylem bootstrap ") || commandPath == "xylem config" || strings.HasPrefix(commandPath, "xylem config ") || strings.HasPrefix(commandPath, "xylem continuous-simplicity") {
 				return nil
 			}
 
@@ -97,6 +97,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		newInitCmd(),
 		newBootstrapCmd(),
+		newConfigCmd(),
 		newWorkflowCmd(),
 		newContinuousImprovementCmd(),
 		newContinuousSimplicityCmd(),

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -282,6 +282,14 @@ type parsedConcurrency struct {
 }
 
 func Load(path string) (*Config, error) {
+	return load(path, true)
+}
+
+func LoadUnvalidated(path string) (*Config, error) {
+	return load(path, false)
+}
+
+func load(path string, validate bool) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read config file %q: %w", path, err)
@@ -333,8 +341,10 @@ func Load(path string) (*Config, error) {
 
 	cfg.normalize()
 
-	if err := cfg.Validate(); err != nil {
-		return nil, err
+	if validate {
+		if err := cfg.Validate(); err != nil {
+			return nil, err
+		}
 	}
 
 	return cfg, nil
@@ -1061,7 +1071,7 @@ func (c *Config) validateWorkflowRequirements() error {
 }
 
 func (c *Config) validationRequiredWorkflows() []string {
-	required := []string{"fix-pr-checks", "resolve-conflicts"}
+	required := []string{"adapt-repo", "fix-pr-checks", "resolve-conflicts"}
 	active := make([]string, 0, len(required))
 	for _, workflowName := range required {
 		if c.workflowActive(workflowName) {

--- a/cli/internal/config/config_prop_test.go
+++ b/cli/internal/config/config_prop_test.go
@@ -296,7 +296,7 @@ func TestPropNormalizeLegacyProvidersPreservesDefaultTierModels(t *testing.T) {
 func TestPropValidationRequirementAcceptsAnyNonEmptyNonGoimportsValidationCommand(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		cfg := validConfig()
-		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts"}).Draw(t, "workflow")
+		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts", "adapt-repo"}).Draw(t, "workflow")
 		cfg.Sources = validationRequiredSourceConfig(workflow)
 		commands := []*string{
 			&cfg.Validation.Format,
@@ -316,7 +316,7 @@ func TestPropValidationRequirementAcceptsAnyNonEmptyNonGoimportsValidationComman
 func TestPropValidationRequirementRejectsGoimportsPackagePatternTargets(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		cfg := validConfig()
-		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts"}).Draw(t, "workflow")
+		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts", "adapt-repo"}).Draw(t, "workflow")
 		cfg.Sources = validationRequiredSourceConfig(workflow)
 		target := rapid.SampledFrom([]string{"./...", "./cli/...", "./internal/...", "cli/..."}).Draw(t, "target")
 		cfg.Validation.Format = "goimports -l " + target
@@ -334,7 +334,7 @@ func TestPropValidationRequirementRejectsGoimportsPackagePatternTargets(t *testi
 func TestPropValidationRequirementAcceptsGoimportsDirectoryTargets(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		cfg := validConfig()
-		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts"}).Draw(t, "workflow")
+		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts", "adapt-repo"}).Draw(t, "workflow")
 		cfg.Sources = validationRequiredSourceConfig(workflow)
 		target := rapid.StringMatching(`[./a-z0-9_-]{1,16}`).Draw(t, "target")
 		target = strings.TrimSpace(target)
@@ -352,7 +352,7 @@ func TestPropValidationRequirementAcceptsGoimportsDirectoryTargets(t *testing.T)
 func TestPropValidationRequirementRejectsRepoRootGoCLITargets(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		cfg := validConfig()
-		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts"}).Draw(t, "workflow")
+		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts", "adapt-repo"}).Draw(t, "workflow")
 		cfg.Sources = validationRequiredSourceConfig(workflow)
 		target := rapid.SampledFrom([]string{"./cli/...", "./cli/cmd/xylem", "cli/...", "cli/internal/config"}).Draw(t, "target")
 		field := rapid.SampledFrom([]string{"lint", "build", "test"}).Draw(t, "field")
@@ -384,7 +384,7 @@ func TestPropValidationRequirementRejectsRepoRootGoCLITargets(t *testing.T) {
 func TestPropValidationRequirementAcceptsCLIWorkingDirGoCommands(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		cfg := validConfig()
-		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts"}).Draw(t, "workflow")
+		workflow := rapid.SampledFrom([]string{"fix-pr-checks", "resolve-conflicts", "adapt-repo"}).Draw(t, "workflow")
 		cfg.Sources = validationRequiredSourceConfig(workflow)
 		field := rapid.SampledFrom([]string{"lint", "build", "test"}).Draw(t, "field")
 

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -2673,6 +2673,9 @@ func TestSmoke_S2_RejectsEmptyValidationForActivePRValidationWorkflows(t *testin
       resolve-conflicts:
         labels: [merge]
         workflow: resolve-conflicts
+      adapt-repo:
+        labels: [bootstrap]
+        workflow: adapt-repo
 concurrency: 2
 max_turns: 50
 timeout: "30m"
@@ -2684,6 +2687,7 @@ claude:
 	_, err := Load(path)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "validation: at least one of format, lint, build, or test must be set")
+	assert.Contains(t, err.Error(), "adapt-repo")
 	assert.Contains(t, err.Error(), "fix-pr-checks")
 	assert.Contains(t, err.Error(), "resolve-conflicts")
 }
@@ -2698,7 +2702,7 @@ func TestSmoke_S3_AllowsPartialValidationForActivePRValidationWorkflow(t *testin
     tasks:
       fix-checks:
         labels: [ci]
-        workflow: fix-pr-checks
+        workflow: adapt-repo
 validation:
   test: "go test ./..."
 concurrency: 2
@@ -2716,7 +2720,7 @@ claude:
 }
 
 func TestSmoke_S4_RejectsGoimportsPackagePatternForValidationRequiredWorkflows(t *testing.T) {
-	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts"} {
+	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts", "adapt-repo"} {
 		t.Run(workflow, func(t *testing.T) {
 			t.Parallel()
 
@@ -2747,7 +2751,7 @@ claude:
 }
 
 func TestSmoke_S5_AllowsGoimportsDirectoryTargetsForValidationRequiredWorkflows(t *testing.T) {
-	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts"} {
+	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts", "adapt-repo"} {
 		t.Run(workflow, func(t *testing.T) {
 			t.Parallel()
 
@@ -2778,7 +2782,7 @@ claude:
 }
 
 func TestSmoke_S6_AllowsGoimportsLocalPrefixContainingEllipsisForValidationRequiredWorkflows(t *testing.T) {
-	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts"} {
+	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts", "adapt-repo"} {
 		t.Run(workflow, func(t *testing.T) {
 			t.Parallel()
 
@@ -2837,7 +2841,7 @@ func TestSmoke_S7_RejectsRepoRootGoCLIPathsForValidationRequiredWorkflows(t *tes
 		},
 	}
 
-	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts"} {
+	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts", "adapt-repo"} {
 		workflow := workflow
 		for _, tc := range testCases {
 			tc := tc
@@ -2884,7 +2888,7 @@ func TestSmoke_S8_AllowsCLIWorkingDirGoCommandsForValidationRequiredWorkflows(t 
 		{name: "test", field: "test", command: "cd cli && go test ./..."},
 	}
 
-	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts"} {
+	for _, workflow := range []string{"fix-pr-checks", "resolve-conflicts", "adapt-repo"} {
 		workflow := workflow
 		for _, tc := range testCases {
 			tc := tc


### PR DESCRIPTION
## Summary
- Implements [issue #385](https://github.com/nicholls-inc/xylem/issues/385) by adding a `xylem config validate` CLI surface for scaffold-time and operator-facing config verification.
- Lets `adapt-repo` validate proposed `.xylem.yml` changes in memory, while also checking configured profiles and `profile.lock` drift before changes are applied.
- Updates root command wiring so `xylem config validate` can run even when the checked-in config is not yet fully valid, which keeps the scaffold/ops verification path usable.

## Smoke scenarios covered
- **S1** - Validate bypasses persistent pre-run
- **S2** - Rejects empty adapt-repo validation
- **S3** - Proposed plan applies validation overrides
- **S4** - Rejects unknown plan fields
- **S5** - Rejects profile lock drift

## Changes summary
### Files added
- `cli/cmd/xylem/config.go`
- `cli/cmd/xylem/config_test.go`
- `cli/cmd/xylem/config_prop_test.go`

### Files modified
- `cli/cmd/xylem/root.go`
- `cli/cmd/xylem/cobra_test.go`
- `cli/internal/config/config.go`
- `cli/internal/config/config_test.go`
- `cli/internal/config/config_prop_test.go`

### Key types and functions
- Added `newConfigCmd`, `newConfigValidateCmd`, and `cmdConfigValidate` for the new Cobra surface.
- Added adapt-plan parsing and application helpers: `adaptRepoPlan`, `loadAdaptRepoPlan`, `applyAdaptRepoPlan`, and `applyConfigDiffSummary`.
- Added scaffold/profile verification helpers: `validateConfiguredProfiles`, `validateProfileLock`, `resolvedStateAssetPath`, and `adaptPlanTouchesProfileLock`.
- Added `config.LoadUnvalidated` so `xylem config validate` can inspect configs before full validation succeeds.
- Expanded validation-required workflow coverage so `adapt-repo` is governed by the same validation command checks as `fix-pr-checks` and `resolve-conflicts`.

## Test plan
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #385