### PR TITLE
feat: extend CostConfig daily budget policy schema

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -20,6 +20,7 @@ const minTimeout = 30 * time.Second
 const DefaultAuditLogPath = "audit.jsonl"
 const DefaultLLMRoutingTier = "med"
 const DefaultAutoAdminMergeOptOutLabel = "no-auto-admin-merge"
+const DefaultCostOnExceeded = "drain_only"
 const runtimeStateDirName = "state"
 
 // DefaultProtectedSurfaces is the default list of paths that xylem's
@@ -267,7 +268,10 @@ type TelemetryConfig struct {
 }
 
 type CostConfig struct {
-	Budget *BudgetConfig `yaml:"budget,omitempty"`
+	Budget         *BudgetConfig      `yaml:"budget,omitempty"`
+	DailyBudgetUSD float64            `yaml:"daily_budget_usd,omitempty"`
+	PerClassLimit  map[string]float64 `yaml:"per_class_limit,omitempty"`
+	OnExceeded     string             `yaml:"on_exceeded,omitempty"`
 }
 
 type BudgetConfig struct {
@@ -328,6 +332,9 @@ func load(path string, validate bool) (*Config, error) {
 				ScannerIdleThreshold: "5m",
 				OrphanCheckEnabled:   true,
 			},
+		},
+		Cost: CostConfig{
+			OnExceeded: DefaultCostOnExceeded,
 		},
 	}
 
@@ -469,6 +476,7 @@ func (c *Config) normalize() {
 		}
 	}
 	c.ConcurrencyPerClass = normalizeConcurrencyPerClass(c.ConcurrencyPerClass)
+	c.Cost.PerClassLimit = normalizeCostPerClassLimit(c.Cost.PerClassLimit)
 	c.normalizeProviders()
 }
 
@@ -917,6 +925,17 @@ func normalizeConcurrencyPerClass(in map[string]int) map[string]int {
 	return out
 }
 
+func normalizeCostPerClassLimit(in map[string]float64) map[string]float64 {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]float64, len(in))
+	for class, limit := range in {
+		out[strings.TrimSpace(class)] = limit
+	}
+	return out
+}
+
 func (c *Config) VesselBudget() *cost.Budget {
 	if c.Cost.Budget == nil {
 		return nil
@@ -929,6 +948,18 @@ func (c *Config) VesselBudget() *cost.Budget {
 	return &cost.Budget{
 		TokenLimit:   c.Cost.Budget.MaxTokens,
 		CostLimitUSD: c.Cost.Budget.MaxCostUSD,
+	}
+}
+
+func (c *Config) CostOnExceeded() string {
+	mode := strings.ToLower(strings.TrimSpace(c.Cost.OnExceeded))
+	switch mode {
+	case "", DefaultCostOnExceeded:
+		return DefaultCostOnExceeded
+	case "pause", "alert":
+		return mode
+	default:
+		return DefaultCostOnExceeded
 	}
 }
 
@@ -1034,16 +1065,36 @@ func (c *Config) validateObservability() error {
 }
 
 func (c *Config) validateCost() error {
-	if c.Cost.Budget == nil {
+	if c.Cost.Budget != nil {
+		if c.Cost.Budget.MaxCostUSD < 0 {
+			return fmt.Errorf("cost.budget.max_cost_usd must be non-negative")
+		}
+		if c.Cost.Budget.MaxTokens < 0 {
+			return fmt.Errorf("cost.budget.max_tokens must be non-negative")
+		}
+	}
+	if c.Cost.DailyBudgetUSD < 0 {
+		return fmt.Errorf("cost.daily_budget_usd must be non-negative")
+	}
+	totalPerClass := 0.0
+	for class, limit := range c.Cost.PerClassLimit {
+		if strings.TrimSpace(class) == "" {
+			return fmt.Errorf("cost.per_class_limit keys must be non-empty")
+		}
+		if limit < 0 {
+			return fmt.Errorf("cost.per_class_limit[%q] must be non-negative", class)
+		}
+		totalPerClass += limit
+	}
+	if c.Cost.DailyBudgetUSD > 0 && totalPerClass > c.Cost.DailyBudgetUSD {
+		return fmt.Errorf("cost.per_class_limit total must not exceed cost.daily_budget_usd")
+	}
+	switch strings.ToLower(strings.TrimSpace(c.Cost.OnExceeded)) {
+	case "", DefaultCostOnExceeded, "pause", "alert":
 		return nil
+	default:
+		return fmt.Errorf("cost.on_exceeded must be one of drain_only, pause, or alert")
 	}
-	if c.Cost.Budget.MaxCostUSD < 0 {
-		return fmt.Errorf("cost.budget.max_cost_usd must be non-negative")
-	}
-	if c.Cost.Budget.MaxTokens < 0 {
-		return fmt.Errorf("cost.budget.max_tokens must be non-negative")
-	}
-	return nil
 }
 
 func (c *Config) validateTelemetry() error {

--- a/cli/internal/config/config_prop_test.go
+++ b/cli/internal/config/config_prop_test.go
@@ -36,6 +36,24 @@ func outOfRangeSampleRateGen() *rapid.Generator[float64] {
 	})
 }
 
+func variedCaseAndSpacing(t *rapid.T, value string) string {
+	var b strings.Builder
+	b.WriteString(strings.Repeat(" ", rapid.IntRange(0, 3).Draw(t, "leading-spaces")))
+	for i, r := range value {
+		ch := string(r)
+		if ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z') {
+			if rapid.Bool().Draw(t, fmt.Sprintf("upper-%d", i)) {
+				ch = strings.ToUpper(ch)
+			} else {
+				ch = strings.ToLower(ch)
+			}
+		}
+		b.WriteString(ch)
+	}
+	b.WriteString(strings.Repeat(" ", rapid.IntRange(0, 3).Draw(t, "trailing-spaces")))
+	return b.String()
+}
+
 func TestPropEffectiveProtectedSurfacesNeverAliasesInput(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		paths := protectedSurfacePathsGen().Draw(t, "paths")
@@ -127,6 +145,58 @@ func TestPropVesselBudgetNilWhenBothLimitsNonPositive(t *testing.T) {
 
 		if budget := cfg.VesselBudget(); budget != nil {
 			t.Fatalf("VesselBudget() = %#v, want nil", budget)
+		}
+	})
+}
+
+func TestPropValidateCostRejectsOversubscribedPerClassTotals(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		daily := rapid.IntRange(2, 1_000_000).Draw(t, "daily-budget-usd")
+		delivery := rapid.IntRange(1, daily).Draw(t, "delivery-budget-usd")
+		opsMin := daily - delivery + 1
+		ops := rapid.IntRange(opsMin, daily).Draw(t, "ops-budget-usd")
+		cfg := Config{
+			Cost: CostConfig{
+				DailyBudgetUSD: float64(daily),
+				PerClassLimit: map[string]float64{
+					"delivery": float64(delivery),
+					"ops":      float64(ops),
+				},
+			},
+		}
+
+		err := cfg.validateCost()
+		if err == nil {
+			t.Fatal("Validate() error = nil, want oversubscription rejection")
+		}
+		if !strings.Contains(err.Error(), "cost.per_class_limit total") {
+			t.Fatalf("Validate() error = %v, want cost.per_class_limit total", err)
+		}
+	})
+}
+
+func TestPropCostOnExceededDefaultsAndNormalizes(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		base := rapid.SampledFrom([]string{"", "drain_only", "pause", "alert", "stop"}).Draw(t, "mode-base")
+		mode := variedCaseAndSpacing(t, base)
+		cfg := Config{
+			Cost: CostConfig{
+				OnExceeded: mode,
+			},
+		}
+
+		got := cfg.CostOnExceeded()
+		switch base {
+		case "", "drain_only", "stop":
+			if got != DefaultCostOnExceeded {
+				t.Fatalf("CostOnExceeded() = %q, want %q", got, DefaultCostOnExceeded)
+			}
+		case "pause", "alert":
+			if got != base {
+				t.Fatalf("CostOnExceeded() = %q, want %q", got, base)
+			}
+		default:
+			t.Fatalf("unexpected sampled base %q", base)
 		}
 	})
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -195,6 +195,9 @@ claude:
 	if len(cfg.Sources) != 1 {
 		t.Fatalf("expected 1 source after normalization, got %d", len(cfg.Sources))
 	}
+	if got := cfg.CostOnExceeded(); got != DefaultCostOnExceeded {
+		t.Fatalf("CostOnExceeded() = %q, want %q", got, DefaultCostOnExceeded)
+	}
 }
 
 func TestLoadStructuredConcurrency(t *testing.T) {
@@ -740,6 +743,83 @@ func TestValidateCostBudgetNegativeMaxTokens(t *testing.T) {
 
 	err := cfg.Validate()
 	requireErrorContains(t, err, "cost.budget.max_tokens")
+}
+
+func TestValidateCostDailyBudgetNegative(t *testing.T) {
+	cfg := validConfig()
+	cfg.Cost.DailyBudgetUSD = -1
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, "cost.daily_budget_usd")
+}
+
+func TestValidateCostPerClassLimitNegative(t *testing.T) {
+	cfg := validConfig()
+	cfg.Cost.PerClassLimit = map[string]float64{"delivery": -1}
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, `cost.per_class_limit["delivery"]`)
+}
+
+func TestValidateCostPerClassLimitRejectsBlankClassName(t *testing.T) {
+	cfg := validConfig()
+	cfg.Cost.PerClassLimit = map[string]float64{"   ": 1}
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, "cost.per_class_limit keys must be non-empty")
+}
+
+func TestValidateCostPerClassLimitOversubscribed(t *testing.T) {
+	cfg := validConfig()
+	cfg.Cost.DailyBudgetUSD = 10
+	cfg.Cost.PerClassLimit = map[string]float64{
+		"delivery":            8,
+		"harness-maintenance": 3,
+	}
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, "cost.per_class_limit total")
+}
+
+func TestValidateCostPerClassLimitAllowsUnlimitedDailyBudget(t *testing.T) {
+	cfg := validConfig()
+	cfg.Cost.DailyBudgetUSD = 0
+	cfg.Cost.PerClassLimit = map[string]float64{
+		"delivery":            40,
+		"harness-maintenance": 5,
+	}
+
+	require.NoError(t, cfg.Validate())
+}
+
+func TestValidateCostOnExceededRejectsUnknownValue(t *testing.T) {
+	cfg := validConfig()
+	cfg.Cost.OnExceeded = "stop"
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, "cost.on_exceeded")
+}
+
+func TestCostOnExceededDefaultsAndNormalizes(t *testing.T) {
+	tests := []struct {
+		name string
+		mode string
+		want string
+	}{
+		{name: "empty defaults", mode: "", want: DefaultCostOnExceeded},
+		{name: "whitespace defaults", mode: "   ", want: DefaultCostOnExceeded},
+		{name: "drain only trims", mode: " drain_only ", want: DefaultCostOnExceeded},
+		{name: "pause normalizes case", mode: " Pause ", want: "pause"},
+		{name: "alert normalizes case", mode: "ALERT", want: "alert"},
+		{name: "unknown falls back", mode: "stop", want: DefaultCostOnExceeded},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{Cost: CostConfig{OnExceeded: tt.mode}}
+			assert.Equal(t, tt.want, cfg.CostOnExceeded())
+		})
+	}
 }
 
 func TestLoadDefaultModel(t *testing.T) {
@@ -1978,6 +2058,9 @@ func TestSmoke_S2_NoHarnessSectionDefaultsActivate(t *testing.T) {
 	assert.Equal(t, "reviews", cfg.HarnessReviewOutputDir())
 	assert.True(t, cfg.ObservabilityEnabled())
 	assert.Equal(t, 1.0, cfg.ObservabilitySampleRate())
+	assert.Zero(t, cfg.Cost.DailyBudgetUSD)
+	assert.Nil(t, cfg.Cost.PerClassLimit)
+	assert.Equal(t, DefaultCostOnExceeded, cfg.CostOnExceeded())
 	assert.Nil(t, cfg.VesselBudget())
 
 	policies := cfg.BuildIntermediaryPolicies()
@@ -2149,11 +2232,17 @@ func TestSmoke_S29_ObservabilityDefaultsWhenAbsent(t *testing.T) {
 	assert.Equal(t, 1.0, cfg.ObservabilitySampleRate())
 }
 
-func TestSmoke_S30_CostBudgetLoadsCorrectly(t *testing.T) {
+func TestSmoke_S30_CostConfigLoadsBudgetAndDailyBudgetPolicy(t *testing.T) {
 	path := writeSmokeConfigFile(t, `cost:
   budget:
     max_cost_usd: 5.0
     max_tokens: 500000
+  daily_budget_usd: 50
+  per_class_limit:
+    " delivery ": 40
+    " harness-maintenance ": 5
+    ops: 5
+  on_exceeded: " Pause "
 `)
 
 	cfg, err := Load(path)
@@ -2164,6 +2253,37 @@ func TestSmoke_S30_CostBudgetLoadsCorrectly(t *testing.T) {
 	require.NotNil(t, budget)
 	assert.Equal(t, 5.0, budget.CostLimitUSD)
 	assert.Equal(t, 500000, budget.TokenLimit)
+	assert.Equal(t, 50.0, cfg.Cost.DailyBudgetUSD)
+	assert.Equal(t, map[string]float64{
+		"delivery":            40,
+		"harness-maintenance": 5,
+		"ops":                 5,
+	}, cfg.Cost.PerClassLimit)
+	assert.Equal(t, "pause", cfg.CostOnExceeded())
+}
+
+func TestLoadDailyBudgetOversubscriptionRejected(t *testing.T) {
+	path := writeSmokeConfigFile(t, `cost:
+  daily_budget_usd: 10
+  per_class_limit:
+    delivery: 8
+    ops: 4
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cost.per_class_limit total")
+}
+
+func TestLoadDailyBudgetUnknownOnExceededRejected(t *testing.T) {
+	path := writeSmokeConfigFile(t, `cost:
+  daily_budget_usd: 50
+  on_exceeded: stop
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cost.on_exceeded")
 }
 
 func TestSmoke_S31_NegativeSampleRateRejected(t *testing.T) {


### PR DESCRIPTION
## Summary
- Implements [#390](https://github.com/nicholls-inc/xylem/issues/390) by extending the top-level `cost` config surface with `daily_budget_usd`, `per_class_limit`, and `on_exceeded`.
- Preserves the existing per-vessel `cost.budget.*` behavior while adding normalization and validation for the new daily-budget policy fields.
- Keeps the zero-config/default path backward compatible by defaulting `on_exceeded` to `drain_only` and leaving daily budget limits disabled unless configured.

## Smoke scenarios covered
- **S2 — Config Defaults (No Harness Section):** verified default config loading still leaves daily budget unset and `on_exceeded` at `drain_only`.
- **S29 — ObservabilityConfig defaults apply when section is absent:** retained alongside the config-defaults smoke coverage touched by this schema expansion.
- **S30 — CostConfig with budget fields loads correctly:** expanded smoke coverage to load legacy vessel budget settings together with the new daily budget policy fields.

## Changes summary
- **Modified `cli/internal/config/config.go`**
  - Extended `CostConfig` with `DailyBudgetUSD`, `PerClassLimit`, and `OnExceeded`.
  - Added `DefaultCostOnExceeded`, `normalizeCostPerClassLimit`, and `(*Config).CostOnExceeded()`.
  - Wired cost defaults in `Load()`, normalized per-class budget keys in `normalize()`, and expanded `validateCost()` to reject negative values, blank class names, oversubscribed allocations, and unknown `on_exceeded` modes.
- **Modified `cli/internal/config/config_test.go`**
  - Added table-driven/default-path coverage for `CostOnExceeded()`.
  - Added validation tests for negative daily budgets, negative/blank per-class limits, oversubscription rejection, unlimited daily budget acceptance, and unknown `on_exceeded` rejection.
  - Expanded smoke coverage in `TestSmoke_S2_NoHarnessSectionDefaultsActivate` and renamed/extended `TestSmoke_S30_CostConfigLoadsBudgetAndDailyBudgetPolicy`.
  - Added load-time rejection tests for oversubscribed daily budgets and unknown `on_exceeded` values.
- **Modified `cli/internal/config/config_prop_test.go`**
  - Added property coverage for oversubscribed per-class totals.
  - Added property coverage for `CostOnExceeded()` normalization/defaulting across varied casing and whitespace.

## Test plan
- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #390