### PR TITLE
Validate daemon auto-merge against active ops workflows

### DIFF
--- a/.xylem/workflows/merge-pr.yaml
+++ b/.xylem/workflows/merge-pr.yaml
@@ -1,4 +1,5 @@
 name: merge-pr
+class: ops
 description: "Merge a PR after verifying all merge criteria are met"
 phases:
   - name: check

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -12,6 +12,8 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/cadence"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
+	"github.com/nicholls-inc/xylem/cli/internal/profiles"
 	"gopkg.in/yaml.v3"
 )
 
@@ -85,6 +87,7 @@ type Config struct {
 	Observability       ObservabilityConfig       `yaml:"observability,omitempty"`
 	Cost                CostConfig                `yaml:"cost,omitempty"`
 	Telemetry           TelemetryConfig           `yaml:"telemetry,omitempty"`
+	configPath          string
 }
 
 type ProviderConfig struct {
@@ -345,6 +348,7 @@ func load(path string, validate bool) (*Config, error) {
 		cfg.Concurrency = concurrency.Global
 		cfg.ConcurrencyPerClass = concurrency.PerClass
 	}
+	cfg.configPath = path
 
 	cfg.normalize()
 
@@ -1108,6 +1112,9 @@ func (c *Config) validateTelemetry() error {
 }
 
 func (c *Config) validateWorkflowRequirements() error {
+	if err := c.validateAutoMergeWorkflowClass(); err != nil {
+		return err
+	}
 	active := c.validationRequiredWorkflows()
 	if len(active) == 0 {
 		return nil
@@ -1153,6 +1160,109 @@ func (c *Config) validateValidationCommands() error {
 		}
 	}
 	return nil
+}
+
+func (c *Config) validateAutoMergeWorkflowClass() error {
+	if !c.Daemon.AutoMerge {
+		return nil
+	}
+
+	workflows, err := c.activeWorkflowDefinitions()
+	if err != nil {
+		return fmt.Errorf("validate daemon.auto_merge workflows: %w", err)
+	}
+	hasOps, err := workflowMapHasClass(workflows, policy.Ops)
+	if err != nil {
+		return fmt.Errorf("validate daemon.auto_merge workflows: %w", err)
+	}
+	if !hasOps {
+		return fmt.Errorf("daemon.auto_merge requires an active profile with at least one ops-class workflow")
+	}
+	return nil
+}
+
+func (c *Config) activeWorkflowDefinitions() (map[string][]byte, error) {
+	if len(c.Profiles) > 0 {
+		composed, err := profiles.Compose(c.Profiles...)
+		if err != nil {
+			return nil, err
+		}
+		return composed.Workflows, nil
+	}
+	return c.localWorkflowDefinitions()
+}
+
+func (c *Config) localWorkflowDefinitions() (map[string][]byte, error) {
+	if strings.TrimSpace(c.configPath) == "" {
+		return nil, nil
+	}
+
+	workflowsDir := filepath.Join(ResolveStateDir(filepath.Dir(c.configPath), c.StateDir), "workflows")
+	entries, err := os.ReadDir(workflowsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read workflows dir %q: %w", workflowsDir, err)
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	workflows := make(map[string][]byte, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		ext := filepath.Ext(entry.Name())
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+
+		path := filepath.Join(workflowsDir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read workflow %q: %w", path, err)
+		}
+		workflows[strings.TrimSuffix(entry.Name(), ext)] = data
+	}
+
+	return workflows, nil
+}
+
+func composedProfileHasWorkflowClass(composed *profiles.ComposedProfile, want policy.Class) (bool, error) {
+	if composed == nil {
+		return false, fmt.Errorf("composed profile is required")
+	}
+	return workflowMapHasClass(composed.Workflows, want)
+}
+
+func workflowMapHasClass(workflows map[string][]byte, want policy.Class) (bool, error) {
+	for name, data := range workflows {
+		matches, err := workflowBytesHaveClass(name, data, want)
+		if err != nil {
+			return false, err
+		}
+		if matches {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func workflowBytesHaveClass(name string, data []byte, want policy.Class) (bool, error) {
+	var probe struct {
+		Class string `yaml:"class,omitempty"`
+	}
+	if err := yaml.Unmarshal(data, &probe); err != nil {
+		return false, fmt.Errorf("parse workflow %q: %w", name, err)
+	}
+	class, err := policy.ParseClass(probe.Class)
+	if err != nil {
+		return false, fmt.Errorf("workflow %q: %w", name, err)
+	}
+	return class == want, nil
 }
 
 func invalidGoimportsPackagePatternTarget(command string) (string, bool) {

--- a/cli/internal/config/config_prop_test.go
+++ b/cli/internal/config/config_prop_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
+	"github.com/nicholls-inc/xylem/cli/internal/profiles"
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 )
@@ -491,6 +493,31 @@ func TestPropEffectiveAutoMergeLabelsNeverReturnsBlank(t *testing.T) {
 			if strings.TrimSpace(label) == "" {
 				t.Fatalf("EffectiveAutoMergeLabels() returned blank label in %#v", got)
 			}
+		}
+	})
+}
+
+func TestPropComposedProfileOpsCheckTreatsBlankWorkflowClassAsDelivery(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		classValue := rapid.StringMatching(`[ \t]{0,8}`).Draw(t, "class")
+		composed := &profiles.ComposedProfile{
+			Workflows: map[string][]byte{
+				"sample": []byte(fmt.Sprintf(`name: sample
+class: %q
+phases:
+  - name: analyze
+    prompt_file: prompts/sample/analyze.md
+    max_turns: 1
+`, classValue)),
+			},
+		}
+
+		hasOps, err := composedProfileHasWorkflowClass(composed, policy.Ops)
+		if err != nil {
+			t.Fatalf("composedProfileHasWorkflowClass() error = %v", err)
+		}
+		if hasOps {
+			t.Fatalf("composedProfileHasWorkflowClass() = true for blank class %q, want false", classValue)
 		}
 	})
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
 	"github.com/nicholls-inc/xylem/cli/internal/policy"
+	"github.com/nicholls-inc/xylem/cli/internal/profiles"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,6 +24,16 @@ func writeConfigFile(t *testing.T, yaml string) string {
 		t.Fatalf("write config file: %v", err)
 	}
 
+	return path
+}
+
+func writeWorkflowFile(t *testing.T, configPath, name, yaml string) string {
+	t.Helper()
+
+	workflowsDir := filepath.Join(filepath.Dir(configPath), ".xylem", "workflows")
+	path := filepath.Join(workflowsDir, name+".yaml")
+	require.NoError(t, os.MkdirAll(workflowsDir, 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0o644))
 	return path
 }
 
@@ -2740,7 +2751,8 @@ claude:
 func TestSmoke_S1_LoadsValidationAndAutoMergeConfig(t *testing.T) {
 	t.Parallel()
 
-	path := writeConfigFile(t, `sources:
+	path := writeConfigFile(t, `profiles: [core]
+sources:
   github:
     type: github
     repo: owner/name
@@ -3058,6 +3070,193 @@ func TestValidateRejectsInvalidAutoMergeBranchPattern(t *testing.T) {
 	err := cfg.Validate()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "daemon.auto_merge_branch_pattern")
+}
+
+func TestValidateAutoMergeWorkflowClass(t *testing.T) {
+	tests := []struct {
+		name      string
+		profiles  []string
+		autoMerge bool
+		wantErr   string
+	}{
+		{
+			name:      "allows disabled auto merge without ops profile",
+			autoMerge: false,
+		},
+		{
+			name:      "rejects enabled auto merge without ops profile",
+			autoMerge: true,
+			wantErr:   "daemon.auto_merge requires an active profile with at least one ops-class workflow",
+		},
+		{
+			name:      "allows enabled auto merge with ops profile",
+			profiles:  []string{"core"},
+			autoMerge: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.Profiles = tt.profiles
+			cfg.Daemon.AutoMerge = tt.autoMerge
+
+			err := cfg.validateAutoMergeWorkflowClass()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestComposedProfileHasWorkflowClassTreatsUnsetClassAsDelivery(t *testing.T) {
+	composed := &profiles.ComposedProfile{
+		Workflows: map[string][]byte{
+			"merge-pr": []byte(`name: merge-pr
+phases:
+  - name: analyze
+    prompt_file: prompts/merge-pr/analyze.md
+    max_turns: 1
+`),
+		},
+	}
+
+	hasOps, err := composedProfileHasWorkflowClass(composed, policy.Ops)
+	require.NoError(t, err)
+	assert.False(t, hasOps)
+}
+
+func TestSmoke_S9_RejectsAutoMergeWithoutOpsProfile(t *testing.T) {
+	t.Parallel()
+
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix:
+        labels: [bug]
+        workflow: fix-bug
+daemon:
+  auto_merge: true
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daemon.auto_merge requires an active profile with at least one ops-class workflow")
+}
+
+func TestSmoke_S10_AllowsAutoMergeForSelfHostingProfileComposition(t *testing.T) {
+	t.Parallel()
+
+	path := writeConfigFile(t, `profiles: [core, self-hosting-xylem]
+sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix:
+        labels: [bug]
+        workflow: fix-bug
+daemon:
+  auto_merge: true
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	workflows, err := cfg.activeWorkflowDefinitions()
+	require.NoError(t, err)
+	hasOps, err := workflowMapHasClass(workflows, policy.Ops)
+	require.NoError(t, err)
+	assert.True(t, hasOps)
+}
+
+func TestSmoke_S11_AllowsAutoMergeWithCheckedInOpsWorkflowWithoutProfiles(t *testing.T) {
+	t.Parallel()
+
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix:
+        labels: [bug]
+        workflow: fix-bug
+daemon:
+  auto_merge: true
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`)
+	writeWorkflowFile(t, path, "merge-pr", `name: merge-pr
+class: ops
+phases:
+  - name: merge
+    prompt_file: prompts/merge-pr/merge.md
+    max_turns: 1
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	workflows, err := cfg.activeWorkflowDefinitions()
+	require.NoError(t, err)
+	hasOps, err := workflowMapHasClass(workflows, policy.Ops)
+	require.NoError(t, err)
+	assert.True(t, hasOps)
+}
+
+func TestSmoke_S12_RejectsAutoMergeWhenWorkflowClassDefaultsToDelivery(t *testing.T) {
+	t.Parallel()
+
+	path := writeConfigFile(t, `sources:
+  github:
+    type: github
+    repo: owner/name
+    tasks:
+      fix:
+        labels: [bug]
+        workflow: fix-bug
+daemon:
+  auto_merge: true
+concurrency: 2
+max_turns: 50
+timeout: "30m"
+claude:
+  command: "claude"
+  default_model: "claude-sonnet-4-6"
+`)
+	writeWorkflowFile(t, path, "merge-pr", `name: merge-pr
+phases:
+  - name: merge
+    prompt_file: prompts/merge-pr/merge.md
+    max_turns: 1
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daemon.auto_merge requires an active profile with at least one ops-class workflow")
 }
 
 func TestSourceTimeoutValid(t *testing.T) {

--- a/cli/internal/profiles/core/workflows/merge-pr.yaml
+++ b/cli/internal/profiles/core/workflows/merge-pr.yaml
@@ -1,4 +1,5 @@
 name: merge-pr
+class: ops
 description: "Merge a PR after verifying all merge criteria are met"
 phases:
   - name: check

--- a/cli/internal/profiles/profiles_prop_test.go
+++ b/cli/internal/profiles/profiles_prop_test.go
@@ -1,10 +1,11 @@
-package profiles
+package profiles_test
 
 import (
 	"fmt"
 	"strings"
 	"testing"
 
+	. "github.com/nicholls-inc/xylem/cli/internal/profiles"
 	"pgregory.net/rapid"
 )
 

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -1,4 +1,4 @@
-package profiles
+package profiles_test
 
 import (
 	"io/fs"
@@ -8,12 +8,25 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/policy"
+	. "github.com/nicholls-inc/xylem/cli/internal/profiles"
 	workflowpkg "github.com/nicholls-inc/xylem/cli/internal/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
+
+type profileSourceConfig struct {
+	Type     string                       `yaml:"type"`
+	Repo     string                       `yaml:"repo,omitempty"`
+	Schedule string                       `yaml:"schedule,omitempty"`
+	Tasks    map[string]profileTaskConfig `yaml:"tasks,omitempty"`
+}
+
+type profileTaskConfig struct {
+	Workflow string `yaml:"workflow,omitempty"`
+	Ref      string `yaml:"ref,omitempty"`
+}
 
 func stageProfileWorkflowAsset(t *testing.T, profile *Profile, workflowName string, promptNames []string) string {
 	t.Helper()
@@ -126,6 +139,10 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 	require.Len(t, fixBug.Phases, 5)
 	require.NotNil(t, fixBug.Phases[2].Evaluator)
 	assert.Equal(t, ".xylem/prompts/fix-bug/implement_evaluator.md", fixBug.Phases[2].Evaluator.PromptFile)
+
+	var mergePR workflowpkg.Workflow
+	require.NoError(t, yaml.Unmarshal(composed.Workflows["merge-pr"], &mergePR))
+	assert.Equal(t, policy.Ops, mergePR.Class)
 	assert.Equal(t, 2, fixBug.Phases[2].Evaluator.MaxIterations)
 
 	var implementFeature workflowpkg.Workflow
@@ -216,7 +233,7 @@ func TestSmoke_S3_SelfHostingProfileScaffoldsContinuousImprovementScheduledWorkf
 	composed, err := Compose("core", "self-hosting-xylem")
 	require.NoError(t, err)
 
-	var source config.SourceConfig
+	var source profileSourceConfig
 	require.NoError(t, yaml.Unmarshal(composed.Sources["continuous-improvement"], &source))
 	assert.Equal(t, "scheduled", source.Type)
 	assert.Equal(t, "{{ .Repo }}", source.Repo)
@@ -253,7 +270,7 @@ func TestSmoke_S4_SelfHostingProfileScaffoldsMonthlyHardeningAuditWorkflow(t *te
 	composed, err := Compose("core", "self-hosting-xylem")
 	require.NoError(t, err)
 
-	var source config.SourceConfig
+	var source profileSourceConfig
 	require.NoError(t, yaml.Unmarshal(composed.Sources["hardening-audit"], &source))
 	assert.Equal(t, "scheduled", source.Type)
 	assert.Equal(t, "{{ .Repo }}", source.Repo)
@@ -289,7 +306,7 @@ func TestSmoke_S5_SelfHostingProfileScaffoldsDailyBacklogRefinementWorkflow(t *t
 	composed, err := Compose("core", "self-hosting-xylem")
 	require.NoError(t, err)
 
-	var source config.SourceConfig
+	var source profileSourceConfig
 	require.NoError(t, yaml.Unmarshal(composed.Sources["backlog-refinement"], &source))
 	assert.Equal(t, "scheduled", source.Type)
 	assert.Equal(t, "{{ .Repo }}", source.Repo)
@@ -330,7 +347,7 @@ func TestSmoke_S6_SelfHostingProfileScaffoldsReleaseCadenceWorkflow(t *testing.T
 	composed, err := Compose("core", "self-hosting-xylem")
 	require.NoError(t, err)
 
-	var source config.SourceConfig
+	var source profileSourceConfig
 	require.NoError(t, yaml.Unmarshal(composed.Sources["release-cadence"], &source))
 	assert.Equal(t, "scheduled", source.Type)
 	assert.Equal(t, "{{ .Repo }}", source.Repo)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,7 +144,7 @@ daemon:
 | `stall_monitor` | object | see below | No | Deterministic self-monitoring thresholds for phase stalls, idle-with-backlog detection, and orphan repair. |
 | `auto_upgrade` | boolean | `false` | No | Enables periodic self-upgrade checks for the daemon binary. |
 | `upgrade_interval` | string | `"5m"` | No | How often the daemon re-runs auto-upgrade checks while the loop is running. Must be a valid Go duration string. |
-| `auto_merge` | boolean | `false` | No | Enables the merge-ready Copilot review + auto-merge cycle for xylem-authored PRs. |
+| `auto_merge` | boolean | `false` | No | Enables the merge-ready Copilot review + auto-merge cycle for xylem-authored PRs. Requires an active profile or checked-in workflow set that includes at least one `class: ops` workflow. |
 | `auto_merge_repo` | string | current repo remote | No | Optional `owner/name` override for auto-merge GitHub operations. |
 | `auto_merge_labels` | list of strings | `["ready-to-merge"]` | No | Labels a PR must carry before the daemon considers it eligible for auto-merge. Blank entries are ignored. |
 | `auto_merge_branch_pattern` | string | `".*"` | No | Regular expression applied to the PR head branch. Only matching branches participate in daemon auto-merge. |
@@ -295,9 +295,11 @@ To opt out, omit or delete the scheduled `continuous-improvement` source from yo
 1. the scheduled helper checks the release PR age and queued commit count, then adds `ready-to-merge`;
 2. the daemon auto-merge loop performs the usual mergeability, green-CI, and review checks before merging.
 
-The bundled `self-hosting-xylem` profile scaffolds that full contract for you: it installs the `release-cadence` scheduled source and narrows `daemon.auto_merge_branch_pattern` to xylem issue branches plus `release-please`, so unrelated human-authored PRs stay outside the auto-admin-merge path.
+The bundled `self-hosting-xylem` profile scaffolds that full contract for you: it installs the `release-cadence` scheduled source and narrows `daemon.auto_merge_branch_pattern` to xylem issue branches plus `release-please`, so unrelated human-authored PRs stay outside the auto-admin-merge path. With `daemon.auto_merge: true`, xylem now also validates that the active profile composition or checked-in workflow set includes an ops-class workflow such as `merge-pr`.
 
 ```yaml
+profiles: [core, self-hosting-xylem]
+
 sources:
   release-cadence:
     type: scheduled


### PR DESCRIPTION
## Summary
- Implements https://github.com/nicholls-inc/xylem/issues/389.
- Validate `daemon.auto_merge: true` against the active workflow set so config load fails unless the active profile composition or checked-in workflows include at least one `class: ops` workflow.
- Mark the bundled `merge-pr` workflow as ops-class so the seeded core/self-hosting contract satisfies the validator.

## Smoke scenarios covered
- `S2` — Compose core includes seeded workflows and templates.
- `S9` — Rejects auto-merge without ops profile.
- `S10` — Allows auto-merge for self-hosting profile composition.
- `S11` — Allows auto-merge with checked-in ops workflow without profiles.
- `S12` — Rejects auto-merge when workflow class defaults to delivery.

## Changes summary
- Modified `.xylem/workflows/merge-pr.yaml` and `cli/internal/profiles/core/workflows/merge-pr.yaml` to declare `class: ops`.
- Updated `cli/internal/config/config.go` to persist `configPath`, add `validateAutoMergeWorkflowClass`, discover active workflow definitions via `activeWorkflowDefinitions`/`localWorkflowDefinitions`, and inspect workflow class metadata via `workflowMapHasClass` and `workflowBytesHaveClass`.
- Expanded `cli/internal/config/config_test.go` and `cli/internal/config/config_prop_test.go` with auto-merge validation smoke/property coverage.
- Updated `cli/internal/profiles/profiles_test.go` and `cli/internal/profiles/profiles_prop_test.go` to keep profile composition tests package-external and assert the seeded `merge-pr` workflow composes as ops-class.
- Documented the new `daemon.auto_merge` requirement in `docs/configuration.md`.

## Test plan
- `cd cli && goimports -w .`
- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #389