### PR TITLE
Move runtime queue, audit log, and daemon PID under .xylem/state with a compat shim

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -59,6 +59,10 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	if err := loadDaemonStartupEnv(rootDir); err != nil {
 		return err
 	}
+	if err := config.MigrateFlatStateToRuntime(cfg.StateDir); err != nil {
+		return err
+	}
+	q = queue.New(config.RuntimePath(cfg.StateDir, "queue.jsonl"))
 
 	scanInterval, drainInterval := parseDaemonIntervals(cfg.Daemon)
 

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -107,7 +107,7 @@ func newDaemonDTUEnv(t *testing.T, fixtureName string) (string, *dtu.Store, *que
 			dtu.EnvUniverseID + "=" + manifest.Metadata.Name,
 		},
 	}
-	return repoDir, store, queue.New(filepath.Join(stateDir, "queue.jsonl")), cmdRunner
+	return repoDir, store, queue.New(config.RuntimePath(stateDir, "queue.jsonl")), cmdRunner
 }
 
 func loadDaemonDTUState(t *testing.T, store *dtu.Store) *dtu.State {
@@ -196,6 +196,108 @@ type daemonBacklogRunner struct {
 
 func (r daemonBacklogRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
 	return r.output, nil
+}
+
+func TestSmoke_S1_LegacyFlatLayoutMigratesAndDrainKeepsWorking(t *testing.T) {
+	repoDir := t.TempDir()
+	stateDir := filepath.Join(repoDir, ".xylem")
+	require.NoError(t, os.MkdirAll(stateDir, 0o755))
+
+	cfg := makeDrainConfig(stateDir)
+	cmdRunner := &smokeCommandRunner{}
+	stubCommandRunnerFactory(t, func(*config.Config) drainCommandRunner {
+		return cmdRunner
+	})
+
+	legacyQueue := queue.New(filepath.Join(stateDir, "queue.jsonl"))
+	enqueuePromptVessel(t, legacyQueue, "issue-388", filepath.Join(repoDir, "legacy-worktree"))
+
+	legacyAuditPath := filepath.Join(stateDir, config.DefaultAuditLogPath)
+	legacyAudit := intermediary.NewAuditLog(legacyAuditPath)
+	require.NoError(t, legacyAudit.Append(intermediary.AuditEntry{
+		Intent: intermediary.Intent{
+			Action:   "phase_execute",
+			Resource: "prompt",
+			AgentID:  "issue-388",
+		},
+		Decision:  intermediary.Allow,
+		Timestamp: time.Now().UTC(),
+	}))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "daemon.pid"), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644))
+
+	logBuf := withBufferedDefaultLogger(t)
+	require.NoError(t, config.MigrateFlatStateToRuntime(stateDir))
+
+	runtimeQueuePath := config.RuntimePath(stateDir, "queue.jsonl")
+	q := queue.New(runtimeQueuePath)
+	result, err := runDrain(context.Background(), cfg, q, worktree.New(repoDir, cmdRunner), 0)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.Completed)
+	assert.FileExists(t, runtimeQueuePath)
+	assert.FileExists(t, config.RuntimePath(stateDir, config.DefaultAuditLogPath))
+	assert.FileExists(t, filepath.Join(stateDir, "queue.jsonl.migrated"))
+	assert.FileExists(t, filepath.Join(stateDir, config.DefaultAuditLogPath+".migrated"))
+	assert.FileExists(t, filepath.Join(stateDir, "daemon.pid.migrated"))
+	assert.Contains(t, logBuf.String(), "migrated legacy runtime file")
+	assert.Contains(t, logBuf.String(), "prepared daemon pid migration")
+
+	vessel, err := q.FindByID("issue-388")
+	require.NoError(t, err)
+	assert.Equal(t, queue.StateCompleted, vessel.State)
+}
+
+func TestSmoke_S2_NewLayoutStartupDoesNotRenameAndDrainWorks(t *testing.T) {
+	repoDir := t.TempDir()
+	stateDir := filepath.Join(repoDir, ".xylem")
+	require.NoError(t, os.MkdirAll(filepath.Join(stateDir, "state"), 0o755))
+
+	cfg := makeDrainConfig(stateDir)
+	cmdRunner := &smokeCommandRunner{}
+	stubCommandRunnerFactory(t, func(*config.Config) drainCommandRunner {
+		return cmdRunner
+	})
+
+	runtimeQueuePath := config.RuntimePath(stateDir, "queue.jsonl")
+	q := queue.New(runtimeQueuePath)
+	enqueuePromptVessel(t, q, "issue-389", filepath.Join(repoDir, "runtime-worktree"))
+
+	logBuf := withBufferedDefaultLogger(t)
+	require.NoError(t, config.MigrateFlatStateToRuntime(stateDir))
+
+	result, err := runDrain(context.Background(), cfg, q, worktree.New(repoDir, cmdRunner), 0)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.Completed)
+	assert.FileExists(t, runtimeQueuePath)
+	assert.NoFileExists(t, filepath.Join(stateDir, "queue.jsonl"))
+	assert.NoFileExists(t, filepath.Join(stateDir, config.DefaultAuditLogPath+".migrated"))
+	assert.NoFileExists(t, filepath.Join(stateDir, "queue.jsonl.migrated"))
+	assert.NoFileExists(t, filepath.Join(stateDir, "daemon.pid.migrated"))
+	assert.NotContains(t, logBuf.String(), "migrated legacy runtime file")
+	assert.NotContains(t, logBuf.String(), "prepared daemon pid migration")
+
+	vessel, err := q.FindByID("issue-389")
+	require.NoError(t, err)
+	assert.Equal(t, queue.StateCompleted, vessel.State)
+}
+
+func TestSmoke_S3_SplitBrainLayoutErrorsLoudly(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+	require.NoError(t, os.MkdirAll(filepath.Join(stateDir, "state"), 0o755))
+
+	legacyQueue := queue.New(filepath.Join(stateDir, "queue.jsonl"))
+	enqueuePromptVessel(t, legacyQueue, "issue-390", filepath.Join(stateDir, "legacy-worktree"))
+
+	runtimeQueue := queue.New(filepath.Join(stateDir, "state", "queue.jsonl"))
+	enqueuePromptVessel(t, runtimeQueue, "issue-391", filepath.Join(stateDir, "runtime-worktree"))
+
+	logBuf := withBufferedDefaultLogger(t)
+	err := config.MigrateFlatStateToRuntime(stateDir)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "both legacy and runtime queue.jsonl exist")
+	assert.NoFileExists(t, filepath.Join(stateDir, "queue.jsonl.migrated"))
+	assert.NotContains(t, logBuf.String(), "migrated legacy runtime file")
 }
 
 func TestSmoke_S7_DaemonStartupContinuesWhenAdaptRepoSearchFails(t *testing.T) {
@@ -445,7 +547,7 @@ func TestSmoke_S3_DaemonTickDrainsScheduledVessel(t *testing.T) {
 	if err := os.MkdirAll(cfg.StateDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(%q): %v", cfg.StateDir, err)
 	}
-	q := queue.New(filepath.Join(cfg.StateDir, "queue.jsonl"))
+	q := queue.New(config.RuntimePath(cfg.StateDir, "queue.jsonl"))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1066,8 +1168,13 @@ func TestSmoke_S28_CLIWiringInDaemonGoCreatesIntermediaryFromConfig(t *testing.T
 		Timestamp: time.Now().UTC(),
 	}
 	require.NoError(t, r.AuditLog.Append(entry))
-	_, err := os.Stat(filepath.Join(dir, "audit.jsonl"))
+
+	auditLogPath := config.RuntimePath(cfg.StateDir, cfg.EffectiveAuditLogPath())
+	entries, err := intermediary.NewAuditLog(auditLogPath).Entries()
 	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, entry.Intent, entries[0].Intent)
+	assert.Equal(t, entry.Decision, entries[0].Decision)
 }
 
 func TestReconcileStaleVessels(t *testing.T) {

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -441,6 +441,7 @@ func looksLikeControlPlaneDir(stateDir string) bool {
 func hasLegacyRuntimeArtifacts(stateDir string) bool {
 	for _, marker := range []string{
 		"queue.jsonl",
+		"audit.jsonl",
 		"phases",
 		"schedules",
 		"reviews",

--- a/cli/internal/config/config_prop_test.go
+++ b/cli/internal/config/config_prop_test.go
@@ -121,15 +121,74 @@ func TestPropRuntimePathAddsSingleStatePrefixForControlPlane(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte("state/\n"), 0o644))
 
 		segments := []string{
-			rapid.StringMatching(`[A-Za-z0-9._-]{1,8}`).Draw(t, "segment-a"),
-			rapid.StringMatching(`[A-Za-z0-9._-]{1,8}`).Draw(t, "segment-b"),
-			rapid.StringMatching(`[A-Za-z0-9._-]{1,8}`).Draw(t, "segment-c"),
+			rapid.StringMatching(`[A-Za-z0-9][A-Za-z0-9._-]{0,7}`).Draw(t, "segment-a"),
+			rapid.StringMatching(`[A-Za-z0-9][A-Za-z0-9._-]{0,7}`).Draw(t, "segment-b"),
+			rapid.StringMatching(`[A-Za-z0-9][A-Za-z0-9._-]{0,7}`).Draw(t, "segment-c"),
 		}
 
 		got := RuntimePath(root, segments...)
 		want := filepath.Join(append([]string{root, "state"}, segments...)...)
 		if got != want {
 			t.Fatalf("RuntimePath(%q, %#v) = %q, want %q", root, segments, got, want)
+		}
+	})
+}
+
+func TestPropMigrateFlatStateToRuntimePreservesLegacyArtifacts(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		root, err := os.MkdirTemp("", "runtime-migrate-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(root)
+		stateDir := filepath.Join(root, ".xylem")
+		require.NoError(t, os.MkdirAll(stateDir, 0o755))
+
+		queuePayload := rapid.StringMatching(`[A-Za-z0-9._:/# -]{1,48}`).Draw(t, "queue-payload")
+		auditPayload := rapid.StringMatching(`[A-Za-z0-9._:/# -]{1,48}`).Draw(t, "audit-payload")
+
+		require.NoError(t, os.WriteFile(
+			filepath.Join(stateDir, "queue.jsonl"),
+			[]byte(fmt.Sprintf("{\"id\":\"issue-%s\",\"source\":\"manual\",\"state\":\"pending\",\"created_at\":\"2026-04-12T02:00:00Z\",\"prompt\":\"%s\"}\n", queuePayload, queuePayload)),
+			0o644,
+		))
+		require.NoError(t, os.WriteFile(filepath.Join(stateDir, "queue.jsonl.lock"), []byte("legacy queue lock"), 0o644))
+
+		legacyAudit := intermediary.NewAuditLog(filepath.Join(stateDir, DefaultAuditLogPath))
+		require.NoError(t, legacyAudit.Append(intermediary.AuditEntry{
+			Intent: intermediary.Intent{
+				Action:   "phase_execute",
+				Resource: auditPayload,
+				AgentID:  "agent-" + auditPayload,
+			},
+			Decision: intermediary.Allow,
+		}))
+		require.NoError(t, os.WriteFile(filepath.Join(stateDir, "daemon.pid"), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644))
+
+		require.NoError(t, MigrateFlatStateToRuntime(stateDir))
+
+		queueData, err := os.ReadFile(RuntimePath(stateDir, "queue.jsonl"))
+		require.NoError(t, err)
+		if !strings.Contains(string(queueData), `"prompt":"`+queuePayload+`"`) {
+			t.Fatalf("queue payload = %q, want prompt %q", string(queueData), queuePayload)
+		}
+
+		entries, err := intermediary.NewAuditLog(RuntimePath(stateDir, DefaultAuditLogPath)).Entries()
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		if entries[0].Intent.Resource != auditPayload {
+			t.Fatalf("audit resource = %q, want %q", entries[0].Intent.Resource, auditPayload)
+		}
+
+		if !pathExists(filepath.Join(stateDir, "queue.jsonl.migrated")) {
+			t.Fatal("queue migration marker missing")
+		}
+		if !pathExists(filepath.Join(stateDir, DefaultAuditLogPath+".migrated")) {
+			t.Fatal("audit migration marker missing")
+		}
+		if !pathExists(filepath.Join(stateDir, "daemon.pid.migrated")) {
+			t.Fatal("daemon.pid migration marker missing")
+		}
+		if pathExists(RuntimePath(stateDir, "daemon.pid")) {
+			t.Fatal("runtime daemon.pid should be recreated by the lock owner, not migration")
 		}
 	})
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -1,11 +1,13 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
 	"github.com/nicholls-inc/xylem/cli/internal/policy"
@@ -335,6 +337,101 @@ func TestRuntimePathPreservesNonControlPlaneRoots(t *testing.T) {
 	want := filepath.Join(root, "phases", "issue-1", "summary.json")
 	assert.Equal(t, want, got)
 	assert.Equal(t, root, RuntimeRoot(root))
+}
+
+func TestMigrateFlatStateToRuntimeMovesLegacyFiles(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+	require.NoError(t, os.MkdirAll(stateDir, 0o755))
+
+	legacyQueuePath := filepath.Join(stateDir, "queue.jsonl")
+	legacyAuditPath := filepath.Join(stateDir, DefaultAuditLogPath)
+	legacyPIDPath := filepath.Join(stateDir, "daemon.pid")
+
+	queueLine := `{"id":"issue-388","source":"manual","state":"pending","created_at":"2026-04-12T01:00:00Z"}`
+	require.NoError(t, os.WriteFile(legacyQueuePath, []byte(queueLine+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(legacyQueuePath+".lock", []byte("legacy queue lock"), 0o644))
+
+	legacyAudit := intermediary.NewAuditLog(legacyAuditPath)
+	require.NoError(t, legacyAudit.Append(intermediary.AuditEntry{
+		Intent:    intermediary.Intent{Action: "phase_execute", Resource: "implement", AgentID: "issue-388"},
+		Decision:  intermediary.Allow,
+		Timestamp: time.Date(2026, time.April, 12, 1, 1, 0, 0, time.UTC),
+	}))
+	require.NoError(t, os.WriteFile(legacyPIDPath, []byte(fmt.Sprintf("%d", os.Getpid())), 0o644))
+
+	require.NoError(t, MigrateFlatStateToRuntime(stateDir))
+
+	runtimeQueuePath := filepath.Join(stateDir, "state", "queue.jsonl")
+	runtimeAuditPath := filepath.Join(stateDir, "state", DefaultAuditLogPath)
+	runtimePIDPath := filepath.Join(stateDir, "state", "daemon.pid")
+
+	assert.NoFileExists(t, legacyQueuePath)
+	assert.NoFileExists(t, legacyAuditPath)
+	assert.NoFileExists(t, legacyPIDPath)
+	assert.NoFileExists(t, legacyQueuePath+".lock")
+	assert.NoFileExists(t, legacyAuditPath+".lock")
+	assert.FileExists(t, legacyQueuePath+".migrated")
+	assert.FileExists(t, legacyAuditPath+".migrated")
+	assert.FileExists(t, legacyPIDPath+".migrated")
+
+	assert.FileExists(t, runtimeQueuePath)
+	assert.FileExists(t, runtimeAuditPath)
+	assert.NoFileExists(t, runtimePIDPath)
+	assert.FileExists(t, runtimeQueuePath+".lock")
+	assert.FileExists(t, runtimeAuditPath+".lock")
+	assert.Equal(t, runtimeQueuePath, RuntimePath(stateDir, "queue.jsonl"))
+	assert.Equal(t, runtimeAuditPath, RuntimePath(stateDir, DefaultAuditLogPath))
+	assert.Equal(t, runtimePIDPath, RuntimePath(stateDir, "daemon.pid"))
+
+	queueData, err := os.ReadFile(RuntimePath(stateDir, "queue.jsonl"))
+	require.NoError(t, err)
+	var vessel struct {
+		ID string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(string(queueData))), &vessel))
+	assert.Equal(t, "issue-388", vessel.ID)
+
+	runtimeAudit := intermediary.NewAuditLog(RuntimePath(stateDir, DefaultAuditLogPath))
+	entries, err := runtimeAudit.Entries()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, intermediary.Allow, entries[0].Decision)
+
+	_, err = os.Stat(runtimePIDPath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestMigrateFlatStateToRuntimeRejectsSplitBrainQueue(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+	require.NoError(t, os.MkdirAll(filepath.Join(stateDir, "state"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "queue.jsonl"), []byte("{}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "state", "queue.jsonl"), []byte("{}\n"), 0o644))
+
+	err := MigrateFlatStateToRuntime(stateDir)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "both legacy and runtime queue.jsonl exist")
+}
+
+func TestMigrateFlatStateToRuntimeRejectsSplitBrainAuditLog(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+	require.NoError(t, os.MkdirAll(filepath.Join(stateDir, "state"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, DefaultAuditLogPath), []byte("{}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "state", DefaultAuditLogPath), []byte("{}\n"), 0o644))
+
+	err := MigrateFlatStateToRuntime(stateDir)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "both legacy and runtime audit.jsonl exist")
+}
+
+func TestMigrateFlatStateToRuntimeRejectsSplitBrainDaemonPID(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+	require.NoError(t, os.MkdirAll(filepath.Join(stateDir, "state"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "daemon.pid"), []byte("0"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "state", "daemon.pid"), []byte("0"), 0o644))
+
+	err := MigrateFlatStateToRuntime(stateDir)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "both legacy and runtime daemon.pid exist")
 }
 
 func validConfig() *Config {

--- a/cli/internal/config/migrate.go
+++ b/cli/internal/config/migrate.go
@@ -1,0 +1,138 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+type flatRuntimeFileMigration struct {
+	name      string
+	moveLock  bool
+	writeMark bool
+}
+
+// MigrateFlatStateToRuntime moves legacy flat runtime files beneath the
+// profile-ready state/ subtree. It fails loudly on half-migrated conflicts so
+// operators can repair the layout explicitly instead of silently splitting
+// runtime state across both locations.
+func MigrateFlatStateToRuntime(stateDir string) error {
+	stateDir = strings.TrimSpace(stateDir)
+	if stateDir == "" || !looksLikeControlPlaneDir(stateDir) {
+		return nil
+	}
+
+	runtimeRoot := filepath.Join(stateDir, runtimeStateDirName)
+	if err := os.MkdirAll(runtimeRoot, 0o755); err != nil {
+		return fmt.Errorf("migrate flat state to runtime: create runtime dir: %w", err)
+	}
+
+	for _, spec := range []flatRuntimeFileMigration{
+		{name: "queue.jsonl", moveLock: true, writeMark: true},
+		{name: DefaultAuditLogPath, moveLock: true, writeMark: true},
+	} {
+		if err := migrateFlatRuntimeFile(stateDir, runtimeRoot, spec); err != nil {
+			return err
+		}
+	}
+	if err := migrateFlatDaemonPID(stateDir, runtimeRoot); err != nil {
+		return err
+	}
+	return nil
+}
+
+func migrateFlatRuntimeFile(stateDir, runtimeRoot string, spec flatRuntimeFileMigration) error {
+	legacyPath := filepath.Join(stateDir, spec.name)
+	runtimePath := filepath.Join(runtimeRoot, spec.name)
+	legacyLockPath := legacyPath + ".lock"
+	runtimeLockPath := runtimePath + ".lock"
+
+	if pathExists(legacyPath) && pathExists(runtimePath) {
+		return fmt.Errorf("migrate flat state to runtime: both legacy and runtime %s exist", spec.name)
+	}
+	if spec.moveLock && pathExists(legacyLockPath) && pathExists(runtimeLockPath) {
+		return fmt.Errorf("migrate flat state to runtime: both legacy and runtime %s.lock exist", spec.name)
+	}
+	if !pathExists(legacyPath) {
+		return nil
+	}
+
+	if err := os.Rename(legacyPath, runtimePath); err != nil {
+		return fmt.Errorf("migrate flat state to runtime: rename %s: %w", spec.name, err)
+	}
+	if spec.moveLock && pathExists(legacyLockPath) {
+		if err := os.Rename(legacyLockPath, runtimeLockPath); err != nil {
+			return fmt.Errorf("migrate flat state to runtime: rename %s.lock: %w", spec.name, err)
+		}
+	}
+	if spec.writeMark {
+		if err := writeMigrationMarker(legacyPath + ".migrated"); err != nil {
+			return fmt.Errorf("migrate flat state to runtime: write %s marker: %w", spec.name, err)
+		}
+	}
+
+	slog.Info("migrated legacy runtime file", "from", legacyPath, "to", runtimePath)
+	return nil
+}
+
+func migrateFlatDaemonPID(stateDir, runtimeRoot string) error {
+	legacyPath := filepath.Join(stateDir, "daemon.pid")
+	runtimePath := filepath.Join(runtimeRoot, "daemon.pid")
+
+	if pathExists(legacyPath) && pathExists(runtimePath) {
+		return fmt.Errorf("migrate flat state to runtime: both legacy and runtime daemon.pid exist")
+	}
+	if !pathExists(legacyPath) {
+		return nil
+	}
+
+	legacyPID, err := readPIDFile(legacyPath)
+	if err != nil {
+		return fmt.Errorf("migrate flat state to runtime: read daemon.pid: %w", err)
+	}
+	if legacyPID > 0 && legacyPID != os.Getpid() && processAlive(legacyPID) {
+		return fmt.Errorf("migrate flat state to runtime: legacy daemon.pid still references live pid %d", legacyPID)
+	}
+
+	if pathExists(runtimePath) {
+		return fmt.Errorf("migrate flat state to runtime: runtime daemon.pid unexpectedly appeared during migration")
+	}
+	if err := os.Remove(legacyPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("migrate flat state to runtime: remove legacy daemon.pid: %w", err)
+	}
+	if err := writeMigrationMarker(legacyPath + ".migrated"); err != nil {
+		return fmt.Errorf("migrate flat state to runtime: write daemon.pid marker: %w", err)
+	}
+
+	slog.Info("prepared daemon pid migration", "from", legacyPath, "to", runtimePath, "action", "cleared-for-lock-rewrite")
+	return nil
+}
+
+func writeMigrationMarker(path string) error {
+	return os.WriteFile(path, nil, 0o644)
+}
+
+func readPIDFile(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("parse pid: %w", err)
+	}
+	return pid, nil
+}
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, syscall.Signal(0))
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/cli/internal/dtu/scenario_test.go
+++ b/cli/internal/dtu/scenario_test.go
@@ -330,7 +330,7 @@ func newDrainRunner(t *testing.T, cfg *config.Config, q *queue.Queue, cmdRunner 
 	drainer.Sources = map[string]source.Source{
 		src.Name(): src,
 	}
-	drainer.AuditLog = intermediary.NewAuditLog(filepath.Join(cfg.StateDir, cfg.EffectiveAuditLogPath()))
+	drainer.AuditLog = intermediary.NewAuditLog(config.RuntimePath(cfg.StateDir, cfg.EffectiveAuditLogPath()))
 	drainer.Intermediary = intermediary.NewIntermediary(cfg.BuildIntermediaryPolicies(), drainer.AuditLog, nil)
 
 	if cfg.ObservabilityEnabled() && cfg.Observability.Endpoint != "" {

--- a/cli/internal/dtu/scenario_ws1_test.go
+++ b/cli/internal/dtu/scenario_ws1_test.go
@@ -175,7 +175,7 @@ func TestWS1PolicyAllowHappyPathAuditLog(t *testing.T) {
 	cfg := ws1Config(env.stateDir, "fix-bug")
 
 	// When the runner is wired, the audit log should be written to the state dir.
-	auditLogPath := filepath.Join(env.stateDir, "audit.jsonl")
+	auditLogPath := config.RuntimePath(env.stateDir, "audit.jsonl")
 	auditLog := intermediary.NewAuditLog(auditLogPath)
 
 	_, drainResult := ws1Drain(t, env, cfg)
@@ -363,7 +363,7 @@ phases:
 	}
 
 	cfg := ws1Config(env.stateDir, "fix-bug")
-	auditLog := intermediary.NewAuditLog(filepath.Join(env.stateDir, "audit.jsonl"))
+	auditLog := intermediary.NewAuditLog(config.RuntimePath(env.stateDir, "audit.jsonl"))
 	_, drainResult := ws1Drain(t, env, cfg)
 
 	if drainResult.Failed != 1 {
@@ -753,8 +753,20 @@ func TestWS1ConfigDefaultsIntermediaryWiring(t *testing.T) {
 	if err := drainer.AuditLog.Append(entry); err != nil {
 		t.Fatalf("AuditLog.Append() error = %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(env.stateDir, "audit.jsonl")); err != nil {
-		t.Fatalf("Stat(audit.jsonl) error = %v", err)
+	entries, err := intermediary.NewAuditLog(config.RuntimePath(env.stateDir, "audit.jsonl")).Entries()
+	if err != nil {
+		t.Fatalf("AuditLog.Entries() error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(audit entries) = %d, want 1", len(entries))
+	}
+	if entries[0].Decision != entry.Decision {
+		t.Fatalf("audit entry decision = %q, want %q", entries[0].Decision, entry.Decision)
+	}
+	if entries[0].Intent.Action != entry.Intent.Action ||
+		entries[0].Intent.Resource != entry.Intent.Resource ||
+		entries[0].Intent.AgentID != entry.Intent.AgentID {
+		t.Fatalf("audit entry intent = %+v, want %+v", entries[0].Intent, entry.Intent)
 	}
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,7 @@ The following diagram traces work from discovery through execution:
 ```
 Sources                     xylem scan            Queue
 +--------------+            +----------+          +----------------------+
-| github       |--Scan()--> | Scanner  |--Enqueue>| .xylem/queue.jsonl   |
+| github       |--Scan()--> | Scanner  |--Enqueue>| .xylem/state/queue.jsonl |
 | (manual)     |            +----------+          +----------+-----------+
 +--------------+                                             |
                             xylem drain                      | Dequeue
@@ -69,13 +69,13 @@ Sources                     xylem scan            Queue
 
 1. **Scan** -- The scanner queries each configured source (currently GitHub issues by label). The GitHub source calls `gh search issues`, filters out excluded labels, deduplicates against the existing queue and remote branches, and returns candidate vessels.
 
-2. **Enqueue** -- The scanner writes each new vessel to `queue.jsonl` in `pending` state. The queue is a JSONL file protected by file-level locking (`gofrs/flock`). Deduplication uses `HasRef()` to prevent the same issue URL from being enqueued twice.
+2. **Enqueue** -- The scanner writes each new vessel to `state/queue.jsonl` in `pending` state. The queue is a JSONL file protected by file-level locking (`gofrs/flock`). Deduplication uses `HasRef()` to prevent the same issue URL from being enqueued twice.
 
 3. **Dequeue** -- The runner atomically reads the queue, finds the first `pending` vessel that fits both the global and per-workflow concurrency limits, transitions it to `running`, sets `StartedAt`, and returns it. The runner enforces the global limit with a buffered-channel semaphore and tracks optional per-workflow caps in-memory.
 
 4. **Worktree creation** -- The runner asks the source for a branch name (e.g. `fix/issue-42-login-crash`), then creates an isolated git worktree at `.claude/worktrees/<branch>` branched from `origin/<default-branch>`. Provider config files (`.claude/settings.json`, rules) are copied into the worktree.
 
-5. **Phase execution** -- The runner loads the workflow YAML, reads `.xylem/HARNESS.md`, then iterates through phases. Prompt phases render a Go template with issue data and previous phase outputs, then invoke the resolved provider (`claude` or `copilot`). Command phases render and run a shell command directly in the worktree. Phase outputs are persisted to `.xylem/phases/<vessel-id>/<phase>.output`.
+5. **Phase execution** -- The runner loads the workflow YAML, reads `.xylem/HARNESS.md`, then iterates through phases. Prompt phases render a Go template with issue data and previous phase outputs, then invoke the resolved provider (`claude` or `copilot`). Command phases render and run a shell command directly in the worktree. Phase outputs are persisted to `.xylem/state/phases/<vessel-id>/<phase>.output`.
 
 6. **Gate evaluation** -- After each phase, if a gate is defined:
    - **Command gate**: runs a shell command (e.g. `make test`). On failure, the same phase re-runs with gate output appended to the prompt, up to `retries` times.
@@ -171,7 +171,7 @@ type Source interface {
 | `GitHubPR` | `github-pr` | `review/pr-<N>-<slug>` | Adds status label (default: `in-progress`) |
 | `GitHubPREvents` | `github-pr-events` | `event/pr-<N>-<eventType>-<slug>` | None |
 | `GitHubMerge` | `github-merge` | `merge/pr-<N>-<slug>` | None |
-| `Schedule` | `schedule` | `chore/<source-name>-<tick>` | Persists cadence state in `.xylem/schedule-state.json` |
+| `Schedule` | `schedule` | `chore/<source-name>-<tick>` | Persists cadence state in `.xylem/state/schedule-state.json` |
 | `Scheduled` | `scheduled` | `scheduled/<task>-<vessel>` | Persists per-task schedule buckets in `.xylem/schedules/` |
 | `Manual` | `manual` | `task/<id>-<slug>` | None |
 
@@ -296,7 +296,7 @@ scanner.Scan(ctx)
   |     +-- For each candidate vessel:
   |           |
   |           +-- queue.HasRef(ref) -> skip if already enqueued
-  |           +-- queue.Enqueue(vessel) -> append to queue.jsonl
+  |           +-- queue.Enqueue(vessel) -> append to state/queue.jsonl
   |
   +-- Return ScanResult{Added, Skipped, Paused}
 ```
@@ -334,20 +334,20 @@ runner.runVessel(ctx, vessel)
   +-- loadWorkflow(vessel.Workflow) -> parse .xylem/workflows/<name>.yaml
   +-- fetchIssueData(ctx, vessel) -> gh issue view (cached in Meta)
   +-- readHarness() -> read .xylem/HARNESS.md
-  +-- rebuildPreviousOutputs(vesselID, workflow) -> read .xylem/phases/<id>/*.output
+  +-- rebuildPreviousOutputs(vesselID, workflow) -> read .xylem/state/phases/<id>/*.output
   |
   +-- For each phase (starting from vessel.CurrentPhase):
         |
         +-- If prompt phase:
         |     +-- Render prompt template with issue data, previous outputs, gate result
-        |     +-- Write rendered prompt to .xylem/phases/<id>/<phase>.prompt
+        |     +-- Write rendered prompt to .xylem/state/phases/<id>/<phase>.prompt
         |     +-- Resolve provider + model, add harness + allowed_tools
         |     +-- runner.RunPhase(ctx, worktreePath, stdin, <provider-cmd>, args...)
         +-- If command phase:
         |     +-- Render phase.run as a template
-        |     +-- Write rendered command to .xylem/phases/<id>/<phase>.command
+        |     +-- Write rendered command to .xylem/state/phases/<id>/<phase>.command
         |     +-- Run shell command in worktree
-        +-- Write output to .xylem/phases/<id>/<phase>.output
+        +-- Write output to .xylem/state/phases/<id>/<phase>.output
         +-- Persist CurrentPhase + PhaseOutputs to queue
         |
         +-- Gate evaluation:
@@ -453,7 +453,7 @@ For now, treat them as two independent codebases that happen to share a Go modul
 
 ## Queue persistence
 
-The queue is a single JSONL file (`<state_dir>/queue.jsonl`). Each line is a JSON-encoded `Vessel`. Reads and writes are protected by a file lock (`gofrs/flock`) stored at `<state_dir>/queue.jsonl.lock`.
+The queue is a single JSONL file (`<state_dir>/state/queue.jsonl` in the standard `.xylem` layout). Each line is a JSON-encoded `Vessel`. Reads and writes are protected by a file lock (`gofrs/flock`) stored at `<state_dir>/state/queue.jsonl.lock`.
 
 - **Read operations** (`List`, `FindByID`, `ListByState`, `HasRef`) acquire a read lock.
 - **Write operations** (`Enqueue`, `Dequeue`, `Update`, `UpdateVessel`, `Cancel`) acquire an exclusive write lock.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -15,7 +15,7 @@ Before any command runs (except `init`), xylem performs the following checks:
 1. Verifies that `git` is on PATH.
 2. Loads and validates the config file at the `--config` path.
 3. If any configured source has `type: github`, verifies that `gh` is on PATH.
-4. Initializes the JSONL queue at `<state_dir>/queue.jsonl` and the worktree manager.
+4. Initializes the JSONL queue at the resolved runtime path (`<state_dir>/state/queue.jsonl` in the standard `.xylem` layout) and the worktree manager.
 
 ## Exit Codes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,12 +9,14 @@ xylem looks for `.xylem.yml` in the root of your repository. Run `xylem init` to
 ```
 your-repo/
   .xylem.yml          <-- configuration file
-  .xylem/              <-- state directory (queue, workflows, prompts, phase outputs)
-    queue.jsonl
+  .xylem/              <-- xylem control plane + runtime root
     HARNESS.md
     workflows/
     prompts/
-    phases/
+    state/
+      queue.jsonl
+      audit.jsonl
+      phases/
 ```
 
 ## Minimal config
@@ -78,7 +80,7 @@ timeout: "30m"          # per-session timeout (Go duration string)
 # ---------------------------------------------------------------------------
 # State and branch management
 # ---------------------------------------------------------------------------
-state_dir: ".xylem"     # directory for queue, workflows, prompts, phase outputs
+state_dir: ".xylem"     # control-plane directory; runtime files live under state/
 default_branch: "main"  # branch to create worktrees from (auto-detected if omitted)
 cleanup_after: "168h"   # remove worktrees older than this (default: 7 days)
 
@@ -123,7 +125,7 @@ daemon:
 | `concurrency` | integer | `2` | No | Maximum number of simultaneous sessions. Must be greater than 0. |
 | `max_turns` | integer | `50` | No | Maximum turns per prompt phase or prompt-only run. Must be greater than 0. |
 | `timeout` | string | `"30m"` | No | Per-session timeout. Must be a valid Go duration string and at least `30s`. |
-| `state_dir` | string | `".xylem"` | No | Directory for queue file, workflows, prompts, and phase outputs. |
+| `state_dir` | string | `".xylem"` | No | Control-plane directory. In the standard repo layout, runtime files are resolved under `<state_dir>/state/`. |
 | `default_branch` | string | auto-detected | No | Git branch to create worktrees from. If omitted, xylem detects it from the repository. |
 | `cleanup_after` | string | `"168h"` | No | Age threshold for worktree cleanup. Must be a valid Go duration string. |
 | `llm` | string | `"claude"` | No | Default LLM provider. Valid values: `claude`, `copilot`. |
@@ -249,7 +251,7 @@ sources:
         ref: sota-gap-analysis
 ```
 
-The built-in `context-weight-audit` workflow is another `scheduled` use case: it reads persisted run summaries from `<state_dir>/phases/`, writes `context-weight-audit.{json,md}` under `<state_dir>/<harness.review.output_dir>/`, and opens de-duplicated GitHub hygiene issues for repeated high-footprint findings.
+The built-in `context-weight-audit` workflow is another `scheduled` use case: it reads persisted run summaries from `<state_dir>/state/phases/`, writes `context-weight-audit.{json,md}` under `<state_dir>/<harness.review.output_dir>/`, and opens de-duplicated GitHub hygiene issues for repeated high-footprint findings.
 
 `harness-gap-analysis` is a sibling built-in scheduled workflow for xylem self-hosting. It reads existing daemon telemetry (for example `<state_dir>/daemon.log`), current GitHub state, and git drift, then writes `harness-gap-analysis.{json,md}` plus a durable issue-dedup state file under `<state_dir>/<harness.review.output_dir>/`.
 
@@ -488,7 +490,7 @@ When `harness.policy.rules` is empty, xylem installs a default policy that denie
 |-------|------|---------|----------|-------------|
 | `harness.protected_surfaces.paths` | list of strings | `[".xylem/HARNESS.md", ".xylem.yml", ".xylem/workflows/*.yaml", ".xylem/prompts/*/*.md"]` | No | Glob patterns for files agents cannot modify. Set to `["none"]` to disable all surface protections. |
 | `harness.policy.rules` | list of objects | `[]` | No | Policy rules for action authorization. Each rule has `action`, `resource`, and `effect`. |
-| `harness.audit_log` | string | `"audit.jsonl"` | No | Path to the audit log file for policy decisions, relative to the state directory. |
+| `harness.audit_log` | string | `"audit.jsonl"` | No | Path to the audit log file for policy decisions, relative to the runtime state root (`<state_dir>/state/` in the standard layout). |
 | `harness.review.enabled` | bool | `false` | No | Enables recurring harness review generation after drain runs. Manual `xylem review` works regardless. |
 | `harness.review.cadence` | string | `"manual"` | No | Automatic review cadence. Valid values: `manual`, `every_drain`, `every_n_runs`. |
 | `harness.review.every_n_runs` | integer | `10` | No | When cadence is `every_n_runs`, regenerate after this many new reviewed runs. |
@@ -535,7 +537,7 @@ harness:
     output_dir: "reviews"
 ```
 
-`xylem review` writes `harness-review.json` and `harness-review.md` under `<state_dir>/<output_dir>/`. Automatic reviews are best-effort: failed review generation never fails `drain` or `daemon`. Built-in context-weight audits also write `context-weight-audit.json`, `context-weight-audit.md`, and a durable issue-dedup state file in the same directory when a scheduled `context-weight-audit` vessel runs. Built-in `harness-gap-analysis` runs do the same for `harness-gap-analysis.{json,md}` while surfacing recurring daemon-operation gaps such as drift, idle backlog episodes, stale conflict labels, and parked failed backlog. When failed or timed-out runs also have `<state_dir>/phases/<vessel-id>/failure-review.json`, the review loader reconstructs those recovery decisions alongside the existing evidence/cost/eval artifacts.
+`xylem review` writes `harness-review.json` and `harness-review.md` under `<state_dir>/<output_dir>/`. Automatic reviews are best-effort: failed review generation never fails `drain` or `daemon`. Built-in context-weight audits also write `context-weight-audit.json`, `context-weight-audit.md`, and a durable issue-dedup state file in the same directory when a scheduled `context-weight-audit` vessel runs. Built-in `harness-gap-analysis` runs do the same for `harness-gap-analysis.{json,md}` while surfacing recurring daemon-operation gaps such as drift, idle backlog episodes, stale conflict labels, and parked failed backlog. When failed or timed-out runs also have `<state_dir>/state/phases/<vessel-id>/failure-review.json`, the review loader reconstructs those recovery decisions alongside the existing evidence/cost/eval artifacts.
 
 ### Observability settings
 

--- a/docs/decisions/001-jsonl-queue.md
+++ b/docs/decisions/001-jsonl-queue.md
@@ -13,7 +13,7 @@ The workload is low-throughput: tens to low hundreds of vessels, infrequent writ
 
 ## Decision
 
-Vessels are persisted in a single JSONL file at `<state_dir>/queue.jsonl`. File-level locking uses `gofrs/flock` with a `.lock` sidecar file. Two lock helpers provide appropriate access levels:
+Vessels are persisted in a single JSONL file at `<state_dir>/state/queue.jsonl` in the standard `.xylem` layout. File-level locking uses `gofrs/flock` with a `.lock` sidecar file. Two lock helpers provide appropriate access levels:
 
 - `withLock` — exclusive write lock for all mutation operations
 - `withRLock` — shared read lock for read-only operations (e.g., `List`)

--- a/docs/decisions/004-runtime-state-under-state-subdir.md
+++ b/docs/decisions/004-runtime-state-under-state-subdir.md
@@ -1,0 +1,44 @@
+# ADR-004: Place runtime files under `.xylem/state/`
+
+**Status:** Accepted
+
+## Context
+
+`xylem` now distinguishes between:
+
+- **Control plane** — tracked repo assets such as `.xylem.yml`, workflow YAML, prompt templates, and `HARNESS.md`
+- **Runtime state** — mutable operational files such as the queue, audit log, PID files, phase outputs, and other daemon artifacts
+
+Earlier versions still kept some mutable files at the flat `.xylem/` root, especially:
+
+- `queue.jsonl`
+- `audit.jsonl`
+- `daemon.pid`
+
+That mixed tracked config and live daemon state in the same directory and made the productize spec's control-plane/runtime split incomplete.
+
+## Decision
+
+Canonical runtime locations live under `.xylem/state/`.
+
+For the queue, audit log, and daemon PID file:
+
+- `queue.jsonl` lives at `.xylem/state/queue.jsonl`
+- `audit.jsonl` lives at `.xylem/state/audit.jsonl`
+- `daemon.pid` lives at `.xylem/state/daemon.pid`
+
+Daemon startup performs a one-release compatibility migration:
+
+1. If only the legacy flat file exists, migrate it into `.xylem/state/`
+2. Leave a zero-byte `<name>.migrated` breadcrumb at the old location
+3. If both legacy and runtime locations exist, fail loudly instead of guessing
+
+Queue and audit files move with `os.Rename`; their `.lock` sidecars move with them.
+`daemon.pid` is rewritten at the new path and the legacy file is removed because PID files are process-owned lock files, not regular data blobs.
+
+## Consequences
+
+- Runtime files are grouped under a single rebuildable subtree
+- The `.xylem/` root better reflects tracked control-plane assets
+- Existing checkouts upgrade in place during daemon startup without silently forking queue or audit state
+- Operators get a visible breadcrumb when a migration has occurred

--- a/docs/design/harness-smoke-scenarios/running-manual-smoke-tests.md
+++ b/docs/design/harness-smoke-scenarios/running-manual-smoke-tests.md
@@ -300,7 +300,7 @@ DTU environments are ephemeral and isolated. To start fresh:
 # The shim directory is shared; the state is per-universe
 rm -rf "/Users/harry.nicholls/repos/xylem/cli/.xylem/dtu/ws1-policy-allow-happy-path/"
 rm -rf "$XYLEM_DTU_WORKDIR/.xylem/phases" "$XYLEM_DTU_WORKDIR/.xylem/worktrees"
-rm -f "$XYLEM_DTU_WORKDIR/.xylem/queue.jsonl" "$XYLEM_DTU_WORKDIR/.xylem/queue.jsonl.lock"
+rm -f "$XYLEM_DTU_WORKDIR/.xylem/state/queue.jsonl" "$XYLEM_DTU_WORKDIR/.xylem/state/queue.jsonl.lock"
 
 # Re-materialize the environment
 eval "$("$XYLEM_BIN" dtu env \

--- a/docs/design/harness-smoke-scenarios/ws1-config-surface-policy.md
+++ b/docs/design/harness-smoke-scenarios/ws1-config-surface-policy.md
@@ -507,7 +507,7 @@ violations := []surface.Violation{
 
 **Action:** Inspect the `Runner` struct after `cmdDrain` constructs it, before `r.Drain()` is called.
 
-**Expected outcome:** `r.Intermediary` is non-nil. `r.AuditLog` is non-nil. The audit log path is `filepath.Join(cfg.StateDir, "audit.jsonl")` (the default). The intermediary's policies include the default policy with at least the `file_write` deny rule for `.xylem/HARNESS.md`.
+**Expected outcome:** `r.Intermediary` is non-nil. `r.AuditLog` is non-nil. The audit log path is `config.RuntimePath(cfg.StateDir, "audit.jsonl")` (which resolves to `filepath.Join(cfg.StateDir, "state", "audit.jsonl")` in the standard layout). The intermediary's policies include the default policy with at least the `file_write` deny rule for `.xylem/HARNESS.md`.
 
 **Verification:** In a unit test that stubs the queue and CommandRunner, assert `r.Intermediary != nil` and `r.AuditLog != nil` after construction.
 


### PR DESCRIPTION
## Summary
- Implements [issue #388](https://github.com/nicholls-inc/xylem/issues/388) by making `.xylem/state/` the canonical runtime home for `queue.jsonl`, `audit.jsonl`, and `daemon.pid`.
- Adds a one-release compatibility shim that migrates legacy flat runtime files on daemon startup, moves queue/audit lock sidecars, leaves `.migrated` breadcrumbs, and fails loudly on split-brain layouts.

## Smoke scenarios covered
- `S1` — Legacy flat layout migrates and drain keeps working
- `S2` — New layout startup does not rename and drain works
- `S3` — Split-brain layout errors loudly
- `S22` — Audit log records policy decisions

## Changes summary
- **Added:** `cli/internal/config/migrate.go`, `docs/decisions/004-runtime-state-under-state-subdir.md`
- **Modified:** `cli/cmd/xylem/daemon.go`, `cli/cmd/xylem/daemon_test.go`, `cli/internal/config/config.go`, `cli/internal/config/config_test.go`, `cli/internal/config/config_prop_test.go`, `cli/internal/dtu/scenario_test.go`, `cli/internal/dtu/scenario_ws1_test.go`, `docs/architecture.md`, `docs/cli-reference.md`, `docs/configuration.md`, `docs/decisions/001-jsonl-queue.md`, `docs/design/harness-smoke-scenarios/running-manual-smoke-tests.md`, `docs/design/harness-smoke-scenarios/ws1-config-surface-policy.md`
- **Key types and functions:** `config.RuntimeRoot`, `config.RuntimePath`, `config.MigrateFlatStateToRuntime`, `cmdDaemon`, and the migration/smoke coverage in `TestMigrateFlatStateToRuntime*`, `TestPropMigrateFlatStateToRuntimePreservesLegacyArtifacts`, `TestSmoke_S1_LegacyFlatLayoutMigratesAndDrainKeepsWorking`, `TestSmoke_S2_NewLayoutStartupDoesNotRenameAndDrainWorks`, and `TestSmoke_S3_SplitBrainLayoutErrorsLoudly`.

## Test plan
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #388