### PR TITLE
feat: enforce phase-level tool permission scopes through the harness catalog

### DIFF
--- a/cli/internal/catalog/catalog.go
+++ b/cli/internal/catalog/catalog.go
@@ -72,6 +72,12 @@ type RolePermissions struct {
 	AllowedTools []string
 }
 
+const (
+	RoleDiagnostic   = "diagnostic"
+	RoleDelivery     = "delivery"
+	RoleHousekeeping = "housekeeping"
+)
+
 // Catalog is a centralised registry of tools, metrics, and role permissions.
 type Catalog struct {
 	mu      sync.RWMutex
@@ -87,6 +93,24 @@ func NewCatalog() *Catalog {
 		metrics: make(map[string]*ToolMetrics),
 		roles:   make(map[string]*RolePermissions),
 	}
+}
+
+// NewDefaultPhaseCatalog returns a catalog preloaded with the common prompt tools
+// xylem exposes to provider CLIs plus the default phase-role permissions used by
+// runner prompt phases.
+func NewDefaultPhaseCatalog() (*Catalog, error) {
+	c := NewCatalog()
+	for _, tool := range defaultPhaseTools() {
+		if err := c.Register(tool); err != nil {
+			return nil, fmt.Errorf("register default tool %q: %w", tool.Name, err)
+		}
+	}
+	for _, rp := range defaultPhaseRolePermissions() {
+		if err := c.SetRolePermissions(rp); err != nil {
+			return nil, fmt.Errorf("set default role permissions %q: %w", rp.Role, err)
+		}
+	}
+	return c, nil
 }
 
 // ValidateTool checks that a tool's required fields are populated and its
@@ -240,6 +264,19 @@ func (c *Catalog) SetRolePermissions(rp RolePermissions) error {
 	return nil
 }
 
+// GetRolePermissions returns a copy of the permissions for the named role.
+func (c *Catalog) GetRolePermissions(role string) (*RolePermissions, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	rp, ok := c.roles[role]
+	if !ok {
+		return nil, fmt.Errorf("get role permissions: role %q not found", role)
+	}
+	cpy := *rp
+	cpy.AllowedTools = append([]string(nil), rp.AllowedTools...)
+	return &cpy, nil
+}
+
 // Authorize checks whether the given role is allowed to invoke the named tool.
 // It verifies both that the tool appears in the role's allowed list and that the
 // tool's scope does not exceed the role's maximum scope.
@@ -263,6 +300,43 @@ func (c *Catalog) Authorize(agentRole, toolName string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// AllowedToolsForRole returns the configured tool list for a role after
+// validating that every listed tool exists in the catalog.
+func (c *Catalog) AllowedToolsForRole(role string) ([]string, error) {
+	rp, err := c.GetRolePermissions(role)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(rp.AllowedTools))
+	for _, toolName := range rp.AllowedTools {
+		if _, err := c.Get(toolName); err != nil {
+			return nil, fmt.Errorf("allowed tools for role %q: %w", role, err)
+		}
+		out = append(out, toolName)
+	}
+	return out, nil
+}
+
+// ResolveRoleTools validates an explicit requested tool list against the named
+// role. When requested is empty, it derives the role's full allowed set.
+func (c *Catalog) ResolveRoleTools(role string, requested []string) ([]string, error) {
+	if len(requested) == 0 {
+		return c.AllowedToolsForRole(role)
+	}
+	out := make([]string, 0, len(requested))
+	for _, toolName := range requested {
+		allowed, err := c.Authorize(role, toolName)
+		if err != nil {
+			return nil, fmt.Errorf("resolve role tools: %w", err)
+		}
+		if !allowed {
+			return nil, fmt.Errorf("resolve role tools: role %q is not allowed to use tool %q", role, toolName)
+		}
+		out = append(out, toolName)
+	}
+	return out, nil
 }
 
 // RecordUsage records a single invocation of the named tool.
@@ -395,4 +469,42 @@ func jaccardStrings(a, b []string) float64 {
 		return 0
 	}
 	return math.Round(float64(intersection)/float64(union)*1000) / 1000
+}
+
+func defaultPhaseTools() []Tool {
+	return []Tool{
+		{Name: "Bash", Description: "Run shell commands in the repository worktree", Scope: ScopeFullAutonomy, Tags: []string{"shell", "command"}},
+		{Name: "Edit", Description: "Modify an existing file", Scope: ScopeWriteWithApproval, Tags: []string{"file", "write"}},
+		{Name: "Glob", Description: "Find files by glob pattern", Scope: ScopeReadOnly, Tags: []string{"file", "search"}},
+		{Name: "Grep", Description: "Search file contents by pattern", Scope: ScopeReadOnly, Tags: []string{"file", "search"}},
+		{Name: "LS", Description: "List files and directories", Scope: ScopeReadOnly, Tags: []string{"file", "read"}},
+		{Name: "MultiEdit", Description: "Apply multiple edits to an existing file", Scope: ScopeWriteWithApproval, Tags: []string{"file", "write"}},
+		{Name: "Read", Description: "Read file contents", Scope: ScopeReadOnly, Tags: []string{"file", "read"}},
+		{Name: "Task", Description: "Delegate work to a sub-agent", Scope: ScopeFullAutonomy, Tags: []string{"agent", "orchestration"}},
+		{Name: "WebFetch", Description: "Fetch content from the web", Scope: ScopeReadOnly, Tags: []string{"web", "read"}},
+		{Name: "WebSearch", Description: "Search the web for current information", Scope: ScopeReadOnly, Tags: []string{"web", "search"}},
+		{Name: "Write", Description: "Create or replace a file", Scope: ScopeWriteWithApproval, Tags: []string{"file", "write"}},
+	}
+}
+
+func defaultPhaseRolePermissions() []RolePermissions {
+	diagnosticTools := []string{"Bash", "Glob", "Grep", "LS", "Read", "WebFetch", "WebSearch"}
+	return []RolePermissions{
+		{
+			Role:         RoleDiagnostic,
+			MaxScope:     ScopeFullAutonomy,
+			AllowedTools: append([]string(nil), diagnosticTools...),
+		},
+		{
+			Role:     RoleDelivery,
+			MaxScope: ScopeFullAutonomy,
+			AllowedTools: append(append([]string(nil), diagnosticTools...),
+				"Edit", "MultiEdit", "Write"),
+		},
+		{
+			Role:         RoleHousekeeping,
+			MaxScope:     ScopeFullAutonomy,
+			AllowedTools: append(append([]string(nil), diagnosticTools...), "Write"),
+		},
+	}
 }

--- a/cli/internal/catalog/catalog_prop_test.go
+++ b/cli/internal/catalog/catalog_prop_test.go
@@ -241,6 +241,42 @@ func TestPropAuthorizationHierarchy(t *testing.T) {
 	})
 }
 
+func TestPropResolveRoleToolsPreservesAuthorizedRequests(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		c, err := NewDefaultPhaseCatalog()
+		if err != nil {
+			t.Fatalf("NewDefaultPhaseCatalog(): %v", err)
+		}
+		role := rapid.SampledFrom([]string{RoleDiagnostic, RoleDelivery, RoleHousekeeping}).Draw(t, "role")
+		allowed, err := c.AllowedToolsForRole(role)
+		if err != nil {
+			t.Fatalf("AllowedToolsForRole(%q): %v", role, err)
+		}
+		subset := make([]string, 0, len(allowed))
+		for _, tool := range allowed {
+			if rapid.Bool().Draw(t, "keep-"+tool) {
+				subset = append(subset, tool)
+			}
+		}
+		if len(subset) == 0 {
+			subset = append(subset, allowed[0])
+		}
+
+		resolved, err := c.ResolveRoleTools(role, subset)
+		if err != nil {
+			t.Fatalf("ResolveRoleTools(%q): %v", role, err)
+		}
+		if len(resolved) != len(subset) {
+			t.Fatalf("ResolveRoleTools(%q) len = %d, want %d", role, len(resolved), len(subset))
+		}
+		for i := range subset {
+			if resolved[i] != subset[i] {
+				t.Fatalf("ResolveRoleTools(%q)[%d] = %q, want %q", role, i, resolved[i], subset[i])
+			}
+		}
+	})
+}
+
 // --- Property: unregistered tool operations return error ---
 
 func TestPropUnregisteredToolErrors(t *testing.T) {

--- a/cli/internal/catalog/catalog_test.go
+++ b/cli/internal/catalog/catalog_test.go
@@ -3,6 +3,9 @@ package catalog
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- helper ---
@@ -347,6 +350,134 @@ func TestSetRolePermissionsValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewDefaultPhaseCatalog(t *testing.T) {
+	c, err := NewDefaultPhaseCatalog()
+	if err != nil {
+		t.Fatalf("NewDefaultPhaseCatalog() error = %v", err)
+	}
+
+	tests := []struct {
+		role string
+		want []string
+	}{
+		{
+			role: RoleDiagnostic,
+			want: []string{"Bash", "Glob", "Grep", "LS", "Read", "WebFetch", "WebSearch"},
+		},
+		{
+			role: RoleDelivery,
+			want: []string{"Bash", "Glob", "Grep", "LS", "Read", "WebFetch", "WebSearch", "Edit", "MultiEdit", "Write"},
+		},
+		{
+			role: RoleHousekeeping,
+			want: []string{"Bash", "Glob", "Grep", "LS", "Read", "WebFetch", "WebSearch", "Write"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.role, func(t *testing.T) {
+			got, err := c.AllowedToolsForRole(tt.role)
+			if err != nil {
+				t.Fatalf("AllowedToolsForRole(%q) error = %v", tt.role, err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("AllowedToolsForRole(%q) len = %d, want %d (%v)", tt.role, len(got), len(tt.want), got)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("AllowedToolsForRole(%q)[%d] = %q, want %q", tt.role, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+	if _, err := c.Get("Read"); err != nil {
+		t.Fatalf("default catalog missing Read: %v", err)
+	}
+	if _, err := c.Get("Edit"); err != nil {
+		t.Fatalf("default catalog missing Edit: %v", err)
+	}
+	if _, err := c.Get("Write"); err != nil {
+		t.Fatalf("default catalog missing Write: %v", err)
+	}
+}
+
+func TestResolveRoleTools(t *testing.T) {
+	c, err := NewDefaultPhaseCatalog()
+	if err != nil {
+		t.Fatalf("NewDefaultPhaseCatalog() error = %v", err)
+	}
+
+	t.Run("derives role defaults", func(t *testing.T) {
+		got, err := c.ResolveRoleTools(RoleDiagnostic, nil)
+		if err != nil {
+			t.Fatalf("ResolveRoleTools() error = %v", err)
+		}
+		want := []string{"Bash", "Glob", "Grep", "LS", "Read", "WebFetch", "WebSearch"}
+		if len(got) != len(want) {
+			t.Fatalf("ResolveRoleTools() len = %d, want %d (%v)", len(got), len(want), got)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("ResolveRoleTools()[%d] = %q, want %q", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("rejects unauthorized tool", func(t *testing.T) {
+		_, err := c.ResolveRoleTools(RoleDiagnostic, []string{"Edit"})
+		if err == nil {
+			t.Fatal("ResolveRoleTools() error = nil, want unauthorized tool rejection")
+		}
+	})
+}
+
+func TestSmoke_S1_DefaultPhaseCatalogMapsRolesToExpectedToolSets(t *testing.T) {
+	c, err := NewDefaultPhaseCatalog()
+	require.NoError(t, err)
+
+	tests := []struct {
+		role      string
+		wantScope PermissionScope
+		wantTools []string
+	}{
+		{
+			role:      RoleDiagnostic,
+			wantScope: ScopeFullAutonomy,
+			wantTools: []string{"Bash", "Glob", "Grep", "LS", "Read", "WebFetch", "WebSearch"},
+		},
+		{
+			role:      RoleDelivery,
+			wantScope: ScopeFullAutonomy,
+			wantTools: []string{"Bash", "Glob", "Grep", "LS", "Read", "WebFetch", "WebSearch", "Edit", "MultiEdit", "Write"},
+		},
+		{
+			role:      RoleHousekeeping,
+			wantScope: ScopeFullAutonomy,
+			wantTools: []string{"Bash", "Glob", "Grep", "LS", "Read", "WebFetch", "WebSearch", "Write"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.role, func(t *testing.T) {
+			rp, err := c.GetRolePermissions(tt.role)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantScope, rp.MaxScope)
+			assert.Equal(t, tt.wantTools, rp.AllowedTools)
+
+			got, err := c.ResolveRoleTools(tt.role, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTools, got)
+		})
+	}
+
+	allowed, err := c.Authorize(RoleDelivery, "Edit")
+	require.NoError(t, err)
+	assert.True(t, allowed)
+
+	allowed, err = c.Authorize(RoleDiagnostic, "Edit")
+	require.NoError(t, err)
+	assert.False(t, allowed)
 }
 
 // --- Metrics tests ---

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/cadence"
+	"github.com/nicholls-inc/xylem/cli/internal/catalog"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
 	"github.com/nicholls-inc/xylem/cli/internal/policy"
@@ -229,8 +230,19 @@ type StallMonitorConfig struct {
 type HarnessConfig struct {
 	ProtectedSurfaces ProtectedSurfacesConfig `yaml:"protected_surfaces,omitempty"`
 	Policy            PolicyConfig            `yaml:"policy,omitempty"`
+	ToolPermissions   ToolPermissionsConfig   `yaml:"tool_permissions,omitempty"`
 	AuditLog          string                  `yaml:"audit_log,omitempty"`
 	Review            HarnessReviewConfig     `yaml:"review,omitempty"`
+}
+
+type ToolPermissionsConfig struct {
+	PhaseRoles map[string]string         `yaml:"phase_roles,omitempty"`
+	Roles      map[string]ToolRoleConfig `yaml:"roles,omitempty"`
+}
+
+type ToolRoleConfig struct {
+	MaxScope     string   `yaml:"max_scope,omitempty"`
+	AllowedTools []string `yaml:"allowed_tools,omitempty"`
 }
 
 type HarnessReviewConfig struct {
@@ -988,6 +1000,67 @@ func (c *Config) BuildIntermediaryPolicies() []intermediary.Policy {
 	}}
 }
 
+func (c *Config) BuildPhaseToolCatalog() (*catalog.Catalog, error) {
+	toolCatalog, err := catalog.NewDefaultPhaseCatalog()
+	if err != nil {
+		return nil, fmt.Errorf("build phase tool catalog: %w", err)
+	}
+	if c == nil {
+		return toolCatalog, nil
+	}
+
+	roleNames := make([]string, 0, len(c.Harness.ToolPermissions.Roles))
+	for role := range c.Harness.ToolPermissions.Roles {
+		roleNames = append(roleNames, role)
+	}
+	sort.Strings(roleNames)
+	for _, role := range roleNames {
+		override := c.Harness.ToolPermissions.Roles[role]
+		existing, existingErr := toolCatalog.GetRolePermissions(role)
+		maxScope := catalog.ScopeFullAutonomy
+		var allowedTools []string
+		if existingErr == nil {
+			maxScope = existing.MaxScope
+			allowedTools = append([]string(nil), existing.AllowedTools...)
+		}
+		if strings.TrimSpace(override.MaxScope) != "" {
+			parsedScope, err := parseToolPermissionScope(override.MaxScope)
+			if err != nil {
+				return nil, fmt.Errorf("build phase tool catalog: role %q: %w", role, err)
+			}
+			maxScope = parsedScope
+		} else if existingErr != nil {
+			return nil, fmt.Errorf("build phase tool catalog: role %q: max_scope is required for custom roles", role)
+		}
+
+		if len(override.AllowedTools) > 0 {
+			allowedTools = normalizeToolPermissionTools(override.AllowedTools)
+		}
+		for _, toolName := range allowedTools {
+			if _, err := toolCatalog.Get(toolName); err != nil {
+				return nil, fmt.Errorf("build phase tool catalog: role %q: %w", role, err)
+			}
+		}
+		if err := toolCatalog.SetRolePermissions(catalog.RolePermissions{
+			Role:         role,
+			MaxScope:     maxScope,
+			AllowedTools: allowedTools,
+		}); err != nil {
+			return nil, fmt.Errorf("build phase tool catalog: role %q: %w", role, err)
+		}
+	}
+	return toolCatalog, nil
+}
+
+func (c *Config) PhaseToolRole(class policy.Class, phaseName, phaseType string) string {
+	if c != nil {
+		if role := strings.TrimSpace(c.Harness.ToolPermissions.PhaseRoles[strings.TrimSpace(phaseName)]); role != "" {
+			return role
+		}
+	}
+	return defaultPhaseToolRole(class, phaseName, phaseType)
+}
+
 // DefaultPolicy returns the default user policy layer. Workflow-class matrix
 // decisions are enforced separately inside the intermediary; this default layer
 // simply keeps autonomous execution unblocked unless operators opt into tighter
@@ -1028,6 +1101,33 @@ func (c *Config) validateHarness() error {
 
 	if _, err := intermediary.ParsePolicyMode(c.Harness.Policy.Mode); err != nil {
 		return fmt.Errorf("harness.policy.mode: %w", err)
+	}
+
+	for phaseName, role := range c.Harness.ToolPermissions.PhaseRoles {
+		if strings.TrimSpace(phaseName) == "" {
+			return fmt.Errorf("harness.tool_permissions.phase_roles keys must be non-empty")
+		}
+		if strings.TrimSpace(role) == "" {
+			return fmt.Errorf("harness.tool_permissions.phase_roles[%q] must be non-empty", phaseName)
+		}
+	}
+	for role, cfg := range c.Harness.ToolPermissions.Roles {
+		if strings.TrimSpace(role) == "" {
+			return fmt.Errorf("harness.tool_permissions.roles keys must be non-empty")
+		}
+		if strings.TrimSpace(cfg.MaxScope) != "" {
+			if _, err := parseToolPermissionScope(cfg.MaxScope); err != nil {
+				return fmt.Errorf("harness.tool_permissions.roles[%q].max_scope: %w", role, err)
+			}
+		}
+		for i, tool := range cfg.AllowedTools {
+			if strings.TrimSpace(tool) == "" {
+				return fmt.Errorf("harness.tool_permissions.roles[%q].allowed_tools[%d] must be non-empty", role, i)
+			}
+		}
+	}
+	if _, err := c.BuildPhaseToolCatalog(); err != nil {
+		return err
 	}
 
 	if cadence := c.Harness.Review.Cadence; cadence != "" {
@@ -1110,6 +1210,83 @@ func (c *Config) validateTelemetry() error {
 		}
 	}
 	return nil
+}
+
+func defaultPhaseToolRole(class policy.Class, phaseName, phaseType string) string {
+	switch class {
+	case policy.Delivery:
+		return catalog.RoleDelivery
+	case policy.HarnessMaintenance, policy.Ops:
+		return catalog.RoleHousekeeping
+	}
+
+	if strings.EqualFold(strings.TrimSpace(phaseType), "command") {
+		return catalog.RoleHousekeeping
+	}
+
+	name := strings.ToLower(strings.TrimSpace(phaseName))
+	switch {
+	case strings.HasPrefix(name, "pr"),
+		strings.Contains(name, "review"),
+		strings.Contains(name, "release"),
+		strings.Contains(name, "merge"),
+		strings.Contains(name, "report"),
+		strings.Contains(name, "lessons"),
+		strings.Contains(name, "audit"),
+		strings.Contains(name, "backlog"):
+		return catalog.RoleHousekeeping
+	case strings.Contains(name, "implement"),
+		strings.Contains(name, "fix"),
+		strings.Contains(name, "resolve"),
+		strings.Contains(name, "refactor"),
+		strings.Contains(name, "patch"),
+		strings.Contains(name, "write"):
+		return catalog.RoleDelivery
+	default:
+		return catalog.RoleDiagnostic
+	}
+}
+
+func parseToolPermissionScope(raw string) (catalog.PermissionScope, error) {
+	switch normalizeToolPermissionToken(raw) {
+	case "readonly", "read_only", "read-only":
+		return catalog.ScopeReadOnly, nil
+	case "writewithapproval", "write_with_approval", "write-with-approval":
+		return catalog.ScopeWriteWithApproval, nil
+	case "fullautonomy", "full_autonomy", "full-autonomy":
+		return catalog.ScopeFullAutonomy, nil
+	default:
+		return 0, fmt.Errorf("invalid value %q (must be read_only, write_with_approval, or full_autonomy)", raw)
+	}
+}
+
+func normalizeToolPermissionTools(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func normalizeToolPermissionToken(value string) string {
+	trimmed := strings.TrimSpace(strings.ToLower(value))
+	trimmed = strings.ReplaceAll(trimmed, "-", "_")
+	return strings.ReplaceAll(trimmed, " ", "")
 }
 
 func (c *Config) validateWorkflowRequirements() error {

--- a/cli/internal/config/config_prop_test.go
+++ b/cli/internal/config/config_prop_test.go
@@ -308,6 +308,26 @@ func TestPropHarnessReviewOutputDirRejectsTraversal(t *testing.T) {
 	})
 }
 
+func TestPropPhaseToolRoleOverrideWins(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		phaseName := rapid.StringMatching(`[a-z][a-z0-9_]{2,12}`).Draw(t, "phase-name")
+		role := rapid.SampledFrom([]string{"diagnostic", "delivery", "housekeeping"}).Draw(t, "role")
+		cfg := Config{
+			Harness: HarnessConfig{
+				ToolPermissions: ToolPermissionsConfig{
+					PhaseRoles: map[string]string{
+						phaseName: role,
+					},
+				},
+			},
+		}
+
+		if got := cfg.PhaseToolRole(policy.Delivery, phaseName, "prompt"); got != role {
+			t.Fatalf("PhaseToolRole(%q) = %q, want %q", phaseName, got, role)
+		}
+	})
+}
+
 func TestPropHarnessPolicyModeDefaultsToWarn(t *testing.T) {
 	// Contract:
 	//   - Empty / whitespace-only / invalid modes resolve to warn (the zero-

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -845,6 +845,94 @@ claude:
 	requireErrorContains(t, err, "claude.allowed_tools is no longer supported")
 }
 
+func TestValidateHarnessToolPermissionsRejectsUnknownTool(t *testing.T) {
+	cfg := validConfig()
+	cfg.Harness.ToolPermissions.Roles = map[string]ToolRoleConfig{
+		"diagnostic": {
+			AllowedTools: []string{"Read", "NotARealTool"},
+		},
+	}
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, `role "diagnostic"`)
+	requireErrorContains(t, err, `tool "NotARealTool" not found`)
+}
+
+func TestValidateHarnessToolPermissionsRejectsCustomRoleWithoutScope(t *testing.T) {
+	cfg := validConfig()
+	cfg.Harness.ToolPermissions.Roles = map[string]ToolRoleConfig{
+		"custom": {
+			AllowedTools: []string{"Read"},
+		},
+	}
+
+	err := cfg.Validate()
+	requireErrorContains(t, err, `role "custom": max_scope is required for custom roles`)
+}
+
+func TestBuildPhaseToolCatalogAppliesOverrides(t *testing.T) {
+	cfg := validConfig()
+	cfg.Harness.ToolPermissions.PhaseRoles = map[string]string{
+		"implement": "diagnostic",
+	}
+	cfg.Harness.ToolPermissions.Roles = map[string]ToolRoleConfig{
+		"diagnostic": {
+			AllowedTools: []string{"Read", "Edit"},
+			MaxScope:     "full_autonomy",
+		},
+	}
+
+	role := cfg.PhaseToolRole(policy.Delivery, "implement", "prompt")
+	require.Equal(t, "diagnostic", role)
+
+	toolCatalog, err := cfg.BuildPhaseToolCatalog()
+	require.NoError(t, err)
+
+	allowed, err := toolCatalog.ResolveRoleTools(role, []string{"Read", "Edit"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"Read", "Edit"}, allowed)
+}
+
+func TestSmoke_S2_ConfigToolOverridesTakePrecedenceOverWorkflowClass(t *testing.T) {
+	cfg := validConfig()
+	cfg.Harness.ToolPermissions.PhaseRoles = map[string]string{
+		"implement": "diagnostic",
+	}
+	cfg.Harness.ToolPermissions.Roles = map[string]ToolRoleConfig{
+		"diagnostic": {
+			AllowedTools: []string{"Read", "Edit"},
+			MaxScope:     "full_autonomy",
+		},
+	}
+
+	role := cfg.PhaseToolRole(policy.Ops, "implement", "prompt")
+	require.Equal(t, "diagnostic", role)
+
+	toolCatalog, err := cfg.BuildPhaseToolCatalog()
+	require.NoError(t, err)
+
+	allowed, err := toolCatalog.ResolveRoleTools(role, []string{"Read", "Edit"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Read", "Edit"}, allowed)
+
+	_, err = toolCatalog.ResolveRoleTools("housekeeping", []string{"Read", "Edit"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `role "housekeeping" is not allowed to use tool "Edit"`)
+}
+
+func TestPhaseToolRoleDefaults(t *testing.T) {
+	cfg := validConfig()
+
+	assert.Equal(t, "delivery", cfg.PhaseToolRole(policy.Delivery, "analyze", "prompt"))
+	assert.Equal(t, "housekeeping", cfg.PhaseToolRole(policy.HarnessMaintenance, "analyze", "prompt"))
+	assert.Equal(t, "housekeeping", cfg.PhaseToolRole(policy.Ops, "merge_pr", "prompt"))
+	assert.Equal(t, "diagnostic", cfg.PhaseToolRole("", "analyze", "prompt"))
+	assert.Equal(t, "delivery", cfg.PhaseToolRole("", "implement", "prompt"))
+	assert.Equal(t, "housekeeping", cfg.PhaseToolRole("", "review", "prompt"))
+	assert.Equal(t, "housekeeping", cfg.PhaseToolRole("", "pr_draft", "prompt"))
+	assert.Equal(t, "housekeeping", cfg.PhaseToolRole("", "smoke", "command"))
+}
+
 func TestValidateCostBudgetNegativeMaxTokens(t *testing.T) {
 	cfg := validConfig()
 	cfg.Cost.Budget = &BudgetConfig{MaxTokens: -1}

--- a/cli/internal/runner/evaluator_loop.go
+++ b/cli/internal/runner/evaluator_loop.go
@@ -194,7 +194,22 @@ func (r *Runner) runPromptInvocation(ctx context.Context, vessel queue.Vessel, w
 	provider := ""
 	model := ""
 	output, provider, model, err := r.runPhaseWithProviderFallback(ctx, vessel.ID, p.Name, worktreePath, providerChain, func(provider string) (providerInvocation, error) {
-		cmd, args, phaseStdin, resolvedModel, err := buildProviderPhaseArgs(r.Config, srcCfg, wf, p, harnessContent, provider, tier, rendered, attempt)
+		providerCfg, ok := providerConfigForName(r.Config, provider)
+		if !ok {
+			return providerInvocation{}, fmt.Errorf("provider %q is not configured", provider)
+		}
+		resolvedAllowedTools, err := r.resolvePhaseAllowedTools(wf, p, providerCfg)
+		if err != nil {
+			return providerInvocation{}, err
+		}
+		phaseDef := *p
+		if resolvedAllowedTools == "" {
+			phaseDef.AllowedTools = nil
+		} else {
+			phaseDef.AllowedTools = &resolvedAllowedTools
+		}
+		providerCfg.AllowedTools = nil
+		cmd, args, phaseStdin, resolvedModel, err := buildProviderPhaseArgs(r.Config, providerCfg, srcCfg, wf, &phaseDef, harnessContent, provider, tier, rendered, attempt)
 		if err != nil {
 			return providerInvocation{}, err
 		}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -19,6 +19,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/nicholls-inc/xylem/cli/internal/catalog"
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
 	"github.com/nicholls-inc/xylem/cli/internal/dtu"
@@ -92,6 +93,7 @@ type Runner struct {
 	Runner   CommandRunner
 	LiveGate gate.LiveGateRunner
 	Sources  map[string]source.Source
+	Catalog  *catalog.Catalog
 	// BuiltinWorkflows handles workflow names that execute internal logic
 	// instead of loading .xylem/workflows/<name>.yaml.
 	BuiltinWorkflows map[string]BuiltinWorkflowHandler
@@ -948,6 +950,44 @@ func (r *Runner) runBuiltinWorkflow(ctx context.Context, vessel queue.Vessel, sr
 		log.Printf("warn: OnComplete hook for vessel %s: %v", vessel.ID, err)
 	}
 	return r.completeVessel(ctx, vessel, "", nil, vrs, nil)
+}
+
+func (r *Runner) phaseToolCatalog() (*catalog.Catalog, error) {
+	if r.Catalog != nil {
+		return r.Catalog, nil
+	}
+	if r.Config == nil {
+		return catalog.NewDefaultPhaseCatalog()
+	}
+	return r.Config.BuildPhaseToolCatalog()
+}
+
+func (r *Runner) resolvePhaseAllowedTools(wf *workflow.Workflow, p *workflow.Phase, provider config.ProviderConfig) (string, error) {
+	if p == nil {
+		return "", nil
+	}
+	toolCatalog, err := r.phaseToolCatalog()
+	if err != nil {
+		return "", fmt.Errorf("resolve phase allowed tools: %w", err)
+	}
+
+	requested := mergeAllowedToolLists(parseAllowedToolsString(pointerStringValue(p.AllowedTools)), provider.AllowedTools)
+	role := catalog.RoleDiagnostic
+	if r.Config != nil {
+		class := policy.Class("")
+		if wf != nil {
+			class = wf.Class
+		}
+		role = r.Config.PhaseToolRole(class, p.Name, p.Type)
+	}
+	resolved, err := toolCatalog.ResolveRoleTools(role, requested)
+	if err != nil {
+		return "", fmt.Errorf("resolve phase %q allowed tools for role %q: %w", p.Name, role, err)
+	}
+	if len(resolved) == 0 {
+		return "", nil
+	}
+	return strings.Join(resolved, ","), nil
 }
 
 func (r *Runner) ensureWorktree(ctx context.Context, vessel *queue.Vessel, src source.Source) (string, bool) {
@@ -4595,6 +4635,49 @@ func providerEnvForName(cfg *config.Config, providerName string) []string {
 	return expandedProviderEnv(provider.Env)
 }
 
+func parseAllowedToolsString(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n' || r == '\r'
+	})
+	return mergeAllowedToolLists(parts, nil)
+}
+
+func mergeAllowedToolLists(first, second []string) []string {
+	total := len(first) + len(second)
+	if total == 0 {
+		return nil
+	}
+	out := make([]string, 0, total)
+	seen := make(map[string]struct{}, total)
+	for _, list := range [][]string{first, second} {
+		for _, item := range list {
+			trimmed := strings.TrimSpace(item)
+			if trimmed == "" {
+				continue
+			}
+			if _, ok := seen[trimmed]; ok {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			out = append(out, trimmed)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func pointerStringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
 // buildPhaseArgs constructs the claude-style CLI arguments for a phase invocation.
 func buildPhaseArgs(cfg *config.Config, providerName string, provider config.ProviderConfig, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, tier, harnessContent string) []string {
 	args := []string{"-p"}
@@ -4676,11 +4759,7 @@ func buildCopilotPhaseArgs(cfg *config.Config, providerName string, provider con
 // and returns the command binary, argument slice, and stdin reader for the phase invocation.
 // For providers that embed the prompt in CLI args (copilot -p <text>), stdin is nil.
 // For providers that read the prompt from stdin (claude -p), stdin carries the prompt.
-func buildProviderPhaseArgs(cfg *config.Config, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, harnessContent, provider, tier, renderedPrompt string, attempt int) (string, []string, io.Reader, string, error) {
-	providerCfg, ok := providerConfigForName(cfg, provider)
-	if !ok {
-		return "", nil, nil, "", fmt.Errorf("provider %q is not configured", provider)
-	}
+func buildProviderPhaseArgs(cfg *config.Config, providerCfg config.ProviderConfig, srcCfg *config.SourceConfig, wf *workflow.Workflow, p *workflow.Phase, harnessContent, provider, tier, renderedPrompt string, attempt int) (string, []string, io.Reader, string, error) {
 	model := resolvePhaseModel(cfg, srcCfg, wf, p, provider, tier)
 	switch providerCfg.Kind {
 	case "copilot":

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -5042,16 +5042,13 @@ func TestBuildPhaseArgs(t *testing.T) {
 		p := &workflow.Phase{Name: "analyze", MaxTurns: 5, AllowedTools: &allowedTools}
 		args := buildPhaseArgs(cfg, "claude", mustProviderConfigForTest(t, cfg, "claude"), nil, nil, p, "med", "")
 
-		// Should have both phase-level and config-level tools
-		toolCount := 0
-		for _, a := range args {
-			if a == "--allowedTools" {
-				toolCount++
+		var got []string
+		for i := 0; i < len(args); i++ {
+			if args[i] == "--allowedTools" && i+1 < len(args) {
+				got = append(got, args[i+1])
 			}
 		}
-		if toolCount != 2 {
-			t.Errorf("expected 2 --allowedTools flags, got %d in %v", toolCount, args)
-		}
+		require.Equal(t, []string{"Read,Edit", "WebFetch"}, got)
 	})
 
 	t.Run("with harness", func(t *testing.T) {
@@ -5084,6 +5081,91 @@ func mustProviderConfigForTest(t *testing.T, cfg *config.Config, name string) co
 		t.Fatalf("provider %q not configured", name)
 	}
 	return provider
+}
+
+func TestResolvePhaseAllowedTools(t *testing.T) {
+	t.Run("derives defaults from diagnostic role", func(t *testing.T) {
+		cfg := &config.Config{
+			Claude: config.ClaudeConfig{Command: "claude"},
+		}
+		r := New(cfg, nil, nil, nil)
+		p := &workflow.Phase{Name: "analyze", MaxTurns: 5}
+
+		got, err := r.resolvePhaseAllowedTools(nil, p, mustProviderConfigForTest(t, cfg, "claude"))
+		require.NoError(t, err)
+		require.Equal(t, "Bash,Glob,Grep,LS,Read,WebFetch,WebSearch", got)
+	})
+
+	t.Run("uses workflow class before phase-name heuristic", func(t *testing.T) {
+		cfg := &config.Config{
+			Claude: config.ClaudeConfig{Command: "claude"},
+		}
+		r := New(cfg, nil, nil, nil)
+		wf := &workflow.Workflow{Class: policy.Delivery}
+		p := &workflow.Phase{Name: "analyze", MaxTurns: 5}
+
+		got, err := r.resolvePhaseAllowedTools(wf, p, mustProviderConfigForTest(t, cfg, "claude"))
+		require.NoError(t, err)
+		require.Equal(t, "Bash,Glob,Grep,LS,Read,WebFetch,WebSearch,Edit,MultiEdit,Write", got)
+	})
+
+	t.Run("rejects unauthorized tool for default role", func(t *testing.T) {
+		cfg := &config.Config{
+			Claude: config.ClaudeConfig{Command: "claude"},
+		}
+		r := New(cfg, nil, nil, nil)
+		p := &workflow.Phase{Name: "analyze", MaxTurns: 5, AllowedTools: strPtrRunner("Edit")}
+
+		_, err := r.resolvePhaseAllowedTools(nil, p, mustProviderConfigForTest(t, cfg, "claude"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `role "diagnostic"`)
+		require.Contains(t, err.Error(), `tool "Edit"`)
+	})
+
+	t.Run("phase role override wins over workflow class", func(t *testing.T) {
+		baseCfg := &config.Config{
+			Claude: config.ClaudeConfig{Command: "claude"},
+		}
+		baseRunner := New(baseCfg, nil, nil, nil)
+		wf := &workflow.Workflow{Class: policy.Ops}
+		p := &workflow.Phase{Name: "analyze", MaxTurns: 5, AllowedTools: strPtrRunner("Edit")}
+
+		_, err := baseRunner.resolvePhaseAllowedTools(wf, p, mustProviderConfigForTest(t, baseCfg, "claude"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `role "housekeeping"`)
+
+		cfg := &config.Config{
+			Claude: config.ClaudeConfig{Command: "claude"},
+			Harness: config.HarnessConfig{
+				ToolPermissions: config.ToolPermissionsConfig{
+					PhaseRoles: map[string]string{"analyze": "delivery"},
+				},
+			},
+		}
+		r := New(cfg, nil, nil, nil)
+
+		got, err := r.resolvePhaseAllowedTools(wf, p, mustProviderConfigForTest(t, cfg, "claude"))
+		require.NoError(t, err)
+		require.Equal(t, "Edit", got)
+	})
+
+	t.Run("merges provider defaults with phase request", func(t *testing.T) {
+		cfg := &config.Config{
+			Providers: map[string]config.ProviderConfig{
+				"claude": {
+					Kind:         "claude",
+					Command:      "claude",
+					AllowedTools: []string{"WebFetch"},
+				},
+			},
+		}
+		r := New(cfg, nil, nil, nil)
+		p := &workflow.Phase{Name: "analyze", MaxTurns: 5, AllowedTools: strPtrRunner("Read")}
+
+		got, err := r.resolvePhaseAllowedTools(&workflow.Workflow{Class: policy.Delivery}, p, mustProviderConfigForTest(t, cfg, "claude"))
+		require.NoError(t, err)
+		require.Equal(t, "Read,WebFetch", got)
+	})
 }
 
 func TestBuildPhaseArgsModelResolution(t *testing.T) {
@@ -5486,7 +5568,7 @@ func TestBuildProviderPhaseArgsDispatch(t *testing.T) {
 	phase := &workflow.Phase{MaxTurns: 5}
 
 	t.Run("claude provider returns claude command and stdin", func(t *testing.T) {
-		cmd, args, stdin, model, err := buildProviderPhaseArgs(cfg, nil, nil, phase, "", "claude", "med", "test prompt", 1)
+		cmd, args, stdin, model, err := buildProviderPhaseArgs(cfg, mustProviderConfigForTest(t, cfg, "claude"), nil, nil, phase, "", "claude", "med", "test prompt", 1)
 		require.NoError(t, err)
 		if cmd != claudeCmd {
 			t.Errorf("cmd = %q, want %q", cmd, claudeCmd)
@@ -5507,7 +5589,7 @@ func TestBuildProviderPhaseArgsDispatch(t *testing.T) {
 	})
 
 	t.Run("copilot provider returns copilot command and nil stdin", func(t *testing.T) {
-		cmd, args, stdin, model, err := buildProviderPhaseArgs(cfg, nil, nil, phase, "", "copilot", "med", "test prompt", 1)
+		cmd, args, stdin, model, err := buildProviderPhaseArgs(cfg, mustProviderConfigForTest(t, cfg, "copilot"), nil, nil, phase, "", "copilot", "med", "test prompt", 1)
 		require.NoError(t, err)
 		if cmd != copilotCmd {
 			t.Errorf("cmd = %q, want %q", cmd, copilotCmd)
@@ -5543,7 +5625,7 @@ func TestBuildProviderPhaseArgsAddsDTUMetadataWhenDTUActive(t *testing.T) {
 		MaxTurns:   5,
 	}
 
-	_, claudeArgs, _, _, err := buildProviderPhaseArgs(cfg, nil, nil, phase, "", "claude", "med", "prompt", 2)
+	_, claudeArgs, _, _, err := buildProviderPhaseArgs(cfg, mustProviderConfigForTest(t, cfg, "claude"), nil, nil, phase, "", "claude", "med", "prompt", 2)
 	require.NoError(t, err)
 	if !containsArgSequence(claudeArgs, "--dtu-phase", "implement") {
 		t.Fatalf("claude args missing DTU phase: %v", claudeArgs)
@@ -5555,11 +5637,68 @@ func TestBuildProviderPhaseArgsAddsDTUMetadataWhenDTUActive(t *testing.T) {
 		t.Fatalf("claude args missing DTU attempt: %v", claudeArgs)
 	}
 
-	_, copilotArgs, _, _, err := buildProviderPhaseArgs(cfg, nil, nil, phase, "", "copilot", "med", "prompt", 3)
+	_, copilotArgs, _, _, err := buildProviderPhaseArgs(cfg, mustProviderConfigForTest(t, cfg, "copilot"), nil, nil, phase, "", "copilot", "med", "prompt", 3)
 	require.NoError(t, err)
 	if !containsArgSequence(copilotArgs, "--dtu-attempt", "3") {
 		t.Fatalf("copilot args missing DTU attempt: %v", copilotArgs)
 	}
+}
+
+func TestRunPromptInvocationToolPermissions(t *testing.T) {
+	t.Run("derived tools are passed to provider", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := &config.Config{
+			Claude: config.ClaudeConfig{Command: "claude"},
+		}
+		cmdRunner := &mockCmdRunner{}
+		r := New(cfg, nil, nil, cmdRunner)
+
+		_, _, _, _, err := r.runPromptInvocation(context.Background(), queue.Vessel{ID: "v1"}, dir, nil, &workflow.Workflow{Class: policy.Delivery}, &workflow.Phase{Name: "analyze", MaxTurns: 5}, "", "prompt body", 1)
+		require.NoError(t, err)
+		require.Len(t, cmdRunner.phaseCalls, 1)
+		assert.Contains(t, cmdRunner.phaseCalls[0].args, "--allowedTools")
+		assert.Contains(t, cmdRunner.phaseCalls[0].args, "Bash,Glob,Grep,LS,Read,WebFetch,WebSearch,Edit,MultiEdit,Write")
+	})
+
+	t.Run("unauthorized tool fails before subprocess", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := &config.Config{
+			Claude: config.ClaudeConfig{Command: "claude"},
+		}
+		cmdRunner := &mockCmdRunner{}
+		r := New(cfg, nil, nil, cmdRunner)
+
+		_, _, _, _, err := r.runPromptInvocation(context.Background(), queue.Vessel{ID: "v1"}, dir, nil, nil, &workflow.Phase{Name: "analyze", MaxTurns: 5, AllowedTools: strPtrRunner("Edit")}, "", "prompt body", 1)
+		require.Error(t, err)
+		require.Empty(t, cmdRunner.phaseCalls)
+	})
+}
+
+func TestSmoke_S3_DeliveryPhaseLaunchPassesResolvedAllowedTools(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Claude: config.ClaudeConfig{Command: "claude"},
+	}
+	cmdRunner := &mockCmdRunner{}
+	r := New(cfg, nil, nil, cmdRunner)
+	wf := &workflow.Workflow{Class: policy.Delivery}
+	phase := &workflow.Phase{Name: "analyze", MaxTurns: 5}
+
+	output, promptForCost, provider, model, err := r.runPromptInvocation(context.Background(), queue.Vessel{ID: "v1"}, dir, nil, wf, phase, "", "prompt body", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte("mock output"), output)
+	assert.Equal(t, "prompt body", promptForCost)
+	assert.Equal(t, "claude", provider)
+	assert.Equal(t, "", model)
+	require.Len(t, cmdRunner.phaseCalls, 1)
+
+	call := cmdRunner.phaseCalls[0]
+	assert.Equal(t, dir, call.dir)
+	assert.Equal(t, "claude", call.name)
+	assert.Contains(t, call.args, "--allowedTools")
+	assert.Contains(t, call.args, "Bash,Glob,Grep,LS,Read,WebFetch,WebSearch,Edit,MultiEdit,Write")
+	assert.Equal(t, "prompt body", call.prompt)
 }
 
 func TestBuildCommandCopilotDirect(t *testing.T) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -207,7 +207,7 @@ phases:
 
 The workflow name must match the YAML filename. Phase names must be unique within a workflow. Prompt files are Go templates rendered with issue data, previous phase outputs, and gate results.
 
-Prompt phases can also override the LLM provider and model at the workflow or phase level, and can set per-phase `allowed_tools` restrictions that the runner forwards to the selected provider CLI. Provider resolution is `phase.llm` -> `workflow.llm` -> `.xylem.yml llm`, with support for both `claude` and `copilot`. `xylem init` also scaffolds `.xylem/HARNESS.md`; the runner reads that file and passes it as a system prompt for prompt phases.
+Prompt phases can also override the LLM provider and model at the workflow or phase level, and can set per-phase `allowed_tools` restrictions. The runner resolves those tool requests through the harness catalog's role permissions first, then forwards the effective list to the selected provider CLI. Provider resolution is `phase.llm` -> `workflow.llm` -> `.xylem.yml llm`, with support for both `claude` and `copilot`. `xylem init` also scaffolds `.xylem/HARNESS.md`; the runner reads that file and passes it as a system prompt for prompt phases.
 
 **Built-in workflows:**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -446,6 +446,7 @@ The `claude` section controls how xylem invokes the Claude CLI for each session.
 - If `claude.flags` contains `--bare`, then `claude.env` must include a non-empty `ANTHROPIC_API_KEY`. The `--bare` flag disables Claude's built-in authentication, so you must provide your own API key.
 - `claude.template` is no longer supported and produces a hard error if present. Migrate to phase-based workflows in `<state_dir>/workflows/`.
 - `claude.allowed_tools` is no longer supported and produces a hard error if present. Define allowed tools in workflow phase definitions instead.
+- Phase `allowed_tools` are resolved against the harness tool catalog before xylem invokes the provider CLI. When a prompt phase omits `allowed_tools`, xylem derives the role's default tool set instead of leaving the provider unrestricted.
 
 ### Copilot session settings
 
@@ -473,7 +474,7 @@ When `daemon.auto_upgrade` is enabled, start the daemon from the **root of a ded
 
 ### Harness settings
 
-The `harness` section configures agent safety guardrails: protected file surfaces, policy rules, and audit logging.
+The `harness` section configures agent safety guardrails: protected file surfaces, policy rules, phase tool-permission roles, and audit logging.
 
 When `harness.policy.rules` is empty, xylem installs a default policy that denies writes to protected control surfaces and otherwise allows the actions the runner currently classifies, so autonomous drains can finish without a built-in approval pause. Today that boundary is narrow: every phase is classified as `phase_execute` or `external_command`, and the runner may additionally emit `git_commit`, `git_push`, and `pr_create` when it detects those publication steps in rendered prompts or commands. The same `harness.protected_surfaces.paths` list also drives the worktree's read-only hardening and the runner's post-phase surface verification.
 
@@ -490,6 +491,8 @@ When `harness.policy.rules` is empty, xylem installs a default policy that denie
 |-------|------|---------|----------|-------------|
 | `harness.protected_surfaces.paths` | list of strings | `[".xylem/HARNESS.md", ".xylem.yml", ".xylem/workflows/*.yaml", ".xylem/prompts/*/*.md"]` | No | Glob patterns for files agents cannot modify. Set to `["none"]` to disable all surface protections. |
 | `harness.policy.rules` | list of objects | `[]` | No | Policy rules for action authorization. Each rule has `action`, `resource`, and `effect`. |
+| `harness.tool_permissions.phase_roles` | map of string to string | `{}` | No | Exact phase-name to role override for prompt-phase tool resolution. If unset, xylem derives the default role from the workflow class (`delivery` -> `delivery`; `harness-maintenance`/`ops` -> `housekeeping`) and only falls back to phase-name heuristics when no workflow class is available. |
+| `harness.tool_permissions.roles` | map of objects | `{}` | No | Role permission overrides for the phase tool catalog. Each role object may set `max_scope` (`read_only`, `write_with_approval`, `full_autonomy`) and `allowed_tools`. Custom roles must set `max_scope`. |
 | `harness.audit_log` | string | `"audit.jsonl"` | No | Path to the audit log file for policy decisions, relative to the runtime state root (`<state_dir>/state/` in the standard layout). |
 | `harness.review.enabled` | bool | `false` | No | Enables recurring harness review generation after drain runs. Manual `xylem review` works regardless. |
 | `harness.review.cadence` | string | `"manual"` | No | Automatic review cadence. Valid values: `manual`, `every_drain`, `every_n_runs`. |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -123,7 +123,7 @@ Protected-surface write allowances are intentionally narrow. `allow_additive_pro
 | `noop` | No | Early-success completion rule checked against the phase output before any gate runs. |
 | `output` | No | Optional post-phase output target. Supported values: `discussion`. |
 | `discussion` | No | GitHub Discussions publishing config. Requires `output: discussion`. |
-| `allowed_tools` | No | Tool restriction string for prompt phases. Passed through to the provider CLI. Use this instead of top-level `claude.allowed_tools`, which is rejected by config validation. |
+| `allowed_tools` | No | Tool restriction string for prompt phases. The runner resolves it through the harness tool catalog for the phase role, rejecting unauthorized tools and deriving the role default list when this field is omitted. That role comes from `harness.tool_permissions.phase_roles` when configured, otherwise from the workflow class (with a phase-name fallback only when no class is available). The resulting list is then passed to the provider CLI. |
 | `gate` | No | Quality gate that must pass after this phase completes. |
 | `depends_on` | No | List of phase names this phase depends on. Enables parallel execution -- phases without dependency relationships can execute concurrently. Validated for duplicate entries, self-references, references to unknown phase names, and dependency cycles. |
 
@@ -1154,7 +1154,7 @@ If a prompt phase should only read code (no edits), use the `allowed_tools` fiel
 
 This prevents an analysis phase from accidentally making code changes.
 
-The value is passed directly to the selected provider CLI (`--allowedTools` for Claude, `--allowed-tools` for Copilot), so use the syntax your provider expects.
+The runner first resolves the phase's effective tool list through the harness tool catalog and role permissions, then passes that list to the selected provider CLI (`--allowedTools` for Claude, `--available-tools` for Copilot).
 
 ### Test your prompts manually
 


### PR DESCRIPTION
## Summary
- Implements https://github.com/nicholls-inc/xylem/issues/393
- Wires prompt-phase `allowed_tools` through `cli/internal/catalog` role permissions before provider CLI invocation.
- Adds config-driven phase role overrides and role permission overrides so workflow classes, phase names, and operator policy resolve to a single effective tool list.

## Smoke scenarios covered
- `S1` — `DefaultPhaseCatalogMapsRolesToExpectedToolSets`
- `S2` — `ConfigToolOverridesTakePrecedenceOverWorkflowClass`
- `S3` — `DeliveryPhaseLaunchPassesResolvedAllowedTools`

## Changes summary
- **Modified files:** `cli/internal/catalog/catalog.go`, `cli/internal/catalog/catalog_test.go`, `cli/internal/catalog/catalog_prop_test.go`, `cli/internal/config/config.go`, `cli/internal/config/config_test.go`, `cli/internal/config/config_prop_test.go`, `cli/internal/runner/runner.go`, `cli/internal/runner/evaluator_loop.go`, `cli/internal/runner/runner_test.go`, `docs/architecture.md`, `docs/configuration.md`, `docs/workflows.md`
- **Key catalog additions:** `RoleDiagnostic`, `RoleDelivery`, `RoleHousekeeping`, `NewDefaultPhaseCatalog`, `GetRolePermissions`, `AllowedToolsForRole`, `ResolveRoleTools`
- **Key config additions:** `ToolPermissionsConfig`, `ToolRoleConfig`, `BuildPhaseToolCatalog`, `PhaseToolRole`, default role derivation, tool-scope parsing and validation
- **Key runner changes:** `Runner.Catalog`, `phaseToolCatalog`, `resolvePhaseAllowedTools`, provider-arg building updated to pass resolved phase-scoped tool lists instead of raw per-phase strings

## Test plan
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`

Fixes #393