### PR TITLE
feat: wire ctxmgr compaction into phase prompt rendering

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -24,6 +24,7 @@ const DefaultAuditLogPath = "audit.jsonl"
 const DefaultLLMRoutingTier = "med"
 const DefaultAutoAdminMergeOptOutLabel = "no-auto-admin-merge"
 const DefaultCostOnExceeded = "drain_only"
+const DefaultPhaseContextBudget = 100_000
 const runtimeStateDirName = "state"
 
 // DefaultProtectedSurfaces is the default list of paths that xylem's
@@ -84,6 +85,7 @@ type Config struct {
 	Copilot             CopilotConfig             `yaml:"copilot,omitempty"`
 	Validation          ValidationConfig          `yaml:"validation,omitempty"`
 	Daemon              DaemonConfig              `yaml:"daemon,omitempty"`
+	Phase               PhaseConfig               `yaml:"phase,omitempty"`
 	Harness             HarnessConfig             `yaml:"harness,omitempty"`
 	Observability       ObservabilityConfig       `yaml:"observability,omitempty"`
 	Cost                CostConfig                `yaml:"cost,omitempty"`
@@ -221,6 +223,10 @@ type DaemonConfig struct {
 	AutoMergeReviewer string `yaml:"auto_merge_reviewer,omitempty"`
 }
 
+type PhaseConfig struct {
+	ContextBudget int `yaml:"context_budget,omitempty"`
+}
+
 type StallMonitorConfig struct {
 	PhaseStallThreshold  string `yaml:"phase_stall_threshold,omitempty"`
 	ScannerIdleThreshold string `yaml:"scanner_idle_threshold,omitempty"`
@@ -325,6 +331,15 @@ func load(path string, validate bool) (*Config, error) {
 	}
 	removeYAMLField(&root, "concurrency")
 
+	var phaseProbe struct {
+		Phase struct {
+			ContextBudget *int `yaml:"context_budget"`
+		} `yaml:"phase"`
+	}
+	if err := root.Decode(&phaseProbe); err != nil {
+		return nil, fmt.Errorf("decode phase config probe: %w", err)
+	}
+
 	cfg := &Config{
 		Concurrency:         2,
 		ConcurrencyPerClass: nil,
@@ -348,6 +363,9 @@ func load(path string, validate bool) (*Config, error) {
 				OrphanCheckEnabled:   true,
 			},
 		},
+		Phase: PhaseConfig{
+			ContextBudget: DefaultPhaseContextBudget,
+		},
 		Cost: CostConfig{
 			OnExceeded: DefaultCostOnExceeded,
 		},
@@ -355,6 +373,9 @@ func load(path string, validate bool) (*Config, error) {
 
 	if err := root.Decode(cfg); err != nil {
 		return nil, fmt.Errorf("decode config yaml: %w", err)
+	}
+	if phaseProbe.Phase.ContextBudget != nil && *phaseProbe.Phase.ContextBudget <= 0 {
+		return nil, fmt.Errorf("phase.context_budget must be greater than 0")
 	}
 	if concurrency.Set {
 		cfg.Concurrency = concurrency.Global
@@ -575,6 +596,9 @@ func (c *Config) Validate() error {
 		if _, err := time.ParseDuration(c.Daemon.StallMonitor.ScannerIdleThreshold); err != nil {
 			return fmt.Errorf("daemon.stall_monitor.scanner_idle_threshold must be a valid duration: %w", err)
 		}
+	}
+	if c.Phase.ContextBudget < 0 {
+		return fmt.Errorf("phase.context_budget must be greater than 0")
 	}
 	if strings.TrimSpace(c.Daemon.AutoMergeBranchPattern) != "" {
 		if _, err := regexp.Compile(strings.TrimSpace(c.Daemon.AutoMergeBranchPattern)); err != nil {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -68,6 +68,8 @@ claude:
   flags: "--bare"
   env:
     ANTHROPIC_API_KEY: "test-key"
+phase:
+  context_budget: 120000
 `)
 
 	cfg, err := Load(path)
@@ -122,6 +124,9 @@ claude:
 
 	if cfg.Claude.Env["ANTHROPIC_API_KEY"] != "test-key" {
 		t.Fatalf("Claude.Env[ANTHROPIC_API_KEY] = %q, want test-key", cfg.Claude.Env["ANTHROPIC_API_KEY"])
+	}
+	if cfg.Phase.ContextBudget != 120000 {
+		t.Fatalf("Phase.ContextBudget = %d, want 120000", cfg.Phase.ContextBudget)
 	}
 
 	// Legacy config should be normalized into Sources
@@ -203,6 +208,9 @@ claude:
 	if !cfg.Daemon.StallMonitor.OrphanCheckEnabled {
 		t.Fatal("Daemon.StallMonitor.OrphanCheckEnabled = false, want true")
 	}
+	if cfg.Phase.ContextBudget != DefaultPhaseContextBudget {
+		t.Fatalf("Phase.ContextBudget = %d, want %d", cfg.Phase.ContextBudget, DefaultPhaseContextBudget)
+	}
 
 	// Legacy config should be normalized into Sources
 	if len(cfg.Sources) != 1 {
@@ -259,6 +267,29 @@ claude:
 
 	_, err := Load(path)
 	requireErrorContains(t, err, "concurrency.global is required when concurrency is a map")
+}
+
+func TestLoadRejectsNonPositivePhaseContextBudget(t *testing.T) {
+	path := writeConfigFile(t, `repo: owner/name
+tasks:
+  fix-bugs:
+    labels: [bug]
+    workflow: fix-bug
+claude:
+  default_model: "claude-sonnet-4-6"
+phase:
+  context_budget: 0
+`)
+
+	_, err := Load(path)
+	requireErrorContains(t, err, "phase.context_budget must be greater than 0")
+}
+
+func TestValidateRejectsNegativePhaseContextBudget(t *testing.T) {
+	cfg := validConfig()
+	cfg.Phase.ContextBudget = -1
+
+	requireErrorContains(t, cfg.Validate(), "phase.context_budget must be greater than 0")
 }
 
 func TestResolveStateDir(t *testing.T) {

--- a/cli/internal/ctxmgr/ctxmgr.go
+++ b/cli/internal/ctxmgr/ctxmgr.go
@@ -127,6 +127,11 @@ type CompactionConfig struct {
 	PreserveDurable bool    `json:"preserve_durable"`
 }
 
+type indexedSegment struct {
+	Segment
+	index int
+}
+
 // NewPipeline creates a pipeline from the given processors, sorted by
 // priority (ascending).
 // INV: Pipeline output is deterministic for same input and same processors.
@@ -198,6 +203,64 @@ func Compact(window *Window, config CompactionConfig) *Window {
 		Segments:  kept,
 		MaxTokens: window.MaxTokens,
 	}
+}
+
+// CompactToFit removes the lowest-priority working segments until the window
+// fits within MaxTokens, preserving original order for the segments that
+// remain.
+func CompactToFit(window *Window, config CompactionConfig) *Window {
+	if window == nil {
+		return nil
+	}
+	if window.UsedTokens() <= window.MaxTokens && window.Utilization() <= config.Threshold {
+		copied := *window
+		copied.Segments = make([]Segment, len(window.Segments))
+		copy(copied.Segments, window.Segments)
+		return &copied
+	}
+
+	preserved := make(map[int]bool, len(window.Segments))
+	total := 0
+	working := make([]indexedSegment, 0, len(window.Segments))
+	for idx, seg := range window.Segments {
+		tokens := seg.Tokens
+		if tokens < 0 {
+			tokens = 0
+		}
+		if config.PreserveDurable && seg.Durable {
+			preserved[idx] = true
+			total += tokens
+			continue
+		}
+		working = append(working, indexedSegment{Segment: seg, index: idx})
+	}
+
+	sort.SliceStable(working, func(i, j int) bool {
+		if working[i].Priority == working[j].Priority {
+			return working[i].index < working[j].index
+		}
+		return working[i].Priority > working[j].Priority
+	})
+
+	for _, seg := range working {
+		tokens := seg.Tokens
+		if tokens < 0 {
+			tokens = 0
+		}
+		if total+tokens > window.MaxTokens {
+			continue
+		}
+		preserved[seg.index] = true
+		total += tokens
+	}
+
+	result := &Window{MaxTokens: window.MaxTokens}
+	for idx, seg := range window.Segments {
+		if preserved[idx] {
+			result.Segments = append(result.Segments, seg)
+		}
+	}
+	return result
 }
 
 // SelectStrategy picks a context management strategy based on current

--- a/cli/internal/ctxmgr/ctxmgr_prop_test.go
+++ b/cli/internal/ctxmgr/ctxmgr_prop_test.go
@@ -170,6 +170,39 @@ func TestProp_EstimateTokensNonNegative(t *testing.T) {
 	})
 }
 
+func TestProp_CompactToFitRespectsBudgetWhenDurableFits(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		w := genWindow().Draw(t, "window")
+		durableTokens := 0
+		for _, seg := range w.Segments {
+			if seg.Durable && seg.Tokens > 0 {
+				durableTokens += seg.Tokens
+			}
+		}
+
+		maxTokens := rapid.IntRange(1, 100000).Draw(t, "maxTokens")
+		if durableTokens > maxTokens {
+			maxTokens = durableTokens
+		}
+		w.MaxTokens = maxTokens
+
+		result := CompactToFit(&w, CompactionConfig{
+			Threshold:       rapid.Float64Range(0.0, 1.0).Draw(t, "threshold"),
+			PreserveDurable: true,
+		})
+		if result == nil {
+			t.Fatal("CompactToFit() = nil")
+			return
+		}
+		if result.UsedTokens() > result.MaxTokens {
+			t.Fatalf("CompactToFit() used=%d, max=%d", result.UsedTokens(), result.MaxTokens)
+		}
+		if result.UsedTokens() > w.UsedTokens() {
+			t.Fatalf("CompactToFit() increased tokens: %d > %d", result.UsedTokens(), w.UsedTokens())
+		}
+	})
+}
+
 func TestProp_AssembleDeterministic(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		n := rapid.IntRange(0, 5).Draw(t, "n")

--- a/cli/internal/ctxmgr/ctxmgr_test.go
+++ b/cli/internal/ctxmgr/ctxmgr_test.go
@@ -373,6 +373,64 @@ func TestCompact(t *testing.T) {
 	}
 }
 
+func TestCompactToFit(t *testing.T) {
+	tests := []struct {
+		name      string
+		window    Window
+		config    CompactionConfig
+		wantNames []string
+		wantUsed  int
+	}{
+		{
+			name: "keeps highest priority working segments that fit",
+			window: Window{
+				Segments: []Segment{
+					{Name: "old", Tokens: 400, Priority: 10},
+					{Name: "recent", Tokens: 400, Priority: 30},
+					{Name: "gate", Tokens: 100, Priority: 20},
+				},
+				MaxTokens: 500,
+			},
+			config:    CompactionConfig{Threshold: 0.95, PreserveDurable: true},
+			wantNames: []string{"recent", "gate"},
+			wantUsed:  500,
+		},
+		{
+			name: "preserves durable segments when they alone exceed budget",
+			window: Window{
+				Segments: []Segment{
+					{Name: "harness", Tokens: 600, Durable: true},
+					{Name: "history", Tokens: 300, Priority: 5},
+				},
+				MaxTokens: 500,
+			},
+			config:    CompactionConfig{Threshold: 0.95, PreserveDurable: true},
+			wantNames: []string{"harness"},
+			wantUsed:  600,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CompactToFit(&tt.window, tt.config)
+			if got == nil {
+				t.Fatal("CompactToFit() = nil")
+			}
+			if got.UsedTokens() != tt.wantUsed {
+				t.Fatalf("UsedTokens() = %d, want %d", got.UsedTokens(), tt.wantUsed)
+			}
+			if len(got.Segments) != len(tt.wantNames) {
+				t.Fatalf("len(Segments) = %d, want %d", len(got.Segments), len(tt.wantNames))
+			}
+			for i, want := range tt.wantNames {
+				if got.Segments[i].Name != want {
+					t.Fatalf("Segments[%d].Name = %q, want %q", i, got.Segments[i].Name, want)
+				}
+			}
+		})
+	}
+}
+
 func TestSelectStrategy(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/cli/internal/phase/phase.go
+++ b/cli/internal/phase/phase.go
@@ -3,7 +3,11 @@ package phase
 import (
 	"bytes"
 	"fmt"
+	"sort"
+	"strings"
 	"text/template"
+
+	"github.com/nicholls-inc/xylem/cli/internal/ctxmgr"
 )
 
 // Truncation limits (constants, not configurable).
@@ -16,20 +20,30 @@ const (
 	MaxEvalOutputLen     = 16000
 	MaxEvalCriteriaLen   = 8000
 	TruncationSuffix     = "\n\n[... output truncated at %d characters]"
+	minSummaryTokens     = 8
 )
 
 // TemplateData holds all data available to phase prompt templates.
 type TemplateData struct {
-	Date            string
-	Issue           IssueData
-	Phase           PhaseData
-	PreviousOutputs map[string]string // phase name → output text
-	GateResult      string            // most recent gate command output
-	Evaluation      EvaluationData
-	Vessel          VesselData
-	Repo            RepoData
-	Source          SourceData
-	Validation      ValidationData
+	Date  string
+	Issue IssueData
+	Phase PhaseData
+	// PreviousOutputs maps phase name to output text.
+	PreviousOutputs map[string]string
+	// PreviousOutputOrder is the compaction order to apply to previous phase
+	// outputs. When empty, lexical key order is used.
+	PreviousOutputOrder []string
+	GateResult          string // most recent gate command output
+	Evaluation          EvaluationData
+	Vessel              VesselData
+	Repo                RepoData
+	Source              SourceData
+	Validation          ValidationData
+}
+
+type RenderOptions struct {
+	ContextBudget int
+	Preamble      string
 }
 
 // IssueData describes the issue being worked on.
@@ -94,20 +108,11 @@ func TruncateOutput(s string, maxLen int) string {
 // prepareData returns a copy of data with all fields truncated to their limits.
 // It does not mutate the caller's data.
 func prepareData(data TemplateData) TemplateData {
-	out := data
+	out := cloneTemplateData(data)
 
-	// Deep copy and truncate PreviousOutputs.
-	if data.PreviousOutputs != nil {
-		out.PreviousOutputs = make(map[string]string, len(data.PreviousOutputs))
-		for k, v := range data.PreviousOutputs {
+	if out.PreviousOutputs != nil {
+		for k, v := range out.PreviousOutputs {
 			out.PreviousOutputs[k] = TruncateOutput(v, MaxPreviousOutputLen)
-		}
-	}
-
-	if data.Vessel.Meta != nil {
-		out.Vessel.Meta = make(map[string]string, len(data.Vessel.Meta))
-		for k, v := range data.Vessel.Meta {
-			out.Vessel.Meta[k] = v
 		}
 	}
 
@@ -124,17 +129,350 @@ func prepareData(data TemplateData) TemplateData {
 // with the provided data. Fields are truncated to their respective limits
 // before rendering.
 func RenderPrompt(templateContent string, data TemplateData) (string, error) {
+	return renderPrompt(templateContent, data, RenderOptions{})
+}
+
+// RenderPromptWithOptions renders a phase prompt with optional context-budget
+// compaction.
+func RenderPromptWithOptions(templateContent string, data TemplateData, opts RenderOptions) (string, error) {
+	return renderPrompt(templateContent, data, opts)
+}
+
+func renderPrompt(templateContent string, data TemplateData, opts RenderOptions) (string, error) {
 	tmpl, err := template.New("phase").Option("missingkey=zero").Parse(templateContent)
 	if err != nil {
 		return "", fmt.Errorf("parse template: %w", err)
 	}
 
 	prepared := prepareData(data)
-
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, prepared); err != nil {
+	rendered, err := executeTemplate(tmpl, prepared)
+	if err != nil {
 		return "", fmt.Errorf("execute template: %w", err)
 	}
+	if opts.ContextBudget <= 0 {
+		return rendered, nil
+	}
+	if renderedFitsBudget(rendered, opts) {
+		return rendered, nil
+	}
+	compacted, err := compactRenderedPrompt(tmpl, prepared, opts)
+	if err != nil {
+		return "", err
+	}
+	return compacted, nil
+}
 
+func executeTemplate(tmpl *template.Template, data TemplateData) (string, error) {
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
 	return buf.String(), nil
+}
+
+type mutableField struct {
+	name     string
+	priority int
+	get      func(*TemplateData) string
+	set      func(*TemplateData, string)
+}
+
+func compactRenderedPrompt(tmpl *template.Template, data TemplateData, opts RenderOptions) (string, error) {
+	available := availableBodyBudget(opts)
+	compacted := cloneTemplateData(data)
+	fields := mutableFields(compacted)
+
+	base := cloneTemplateData(compacted)
+	clearMutableFields(&base, fields)
+	baseRendered, err := executeTemplate(tmpl, base)
+	if err != nil {
+		return "", fmt.Errorf("execute template: %w", err)
+	}
+	fieldBudget := max(0, available-ctxmgr.EstimateTokens(baseRendered))
+	if fieldBudget > 0 {
+		window := &ctxmgr.Window{
+			MaxTokens: fieldBudget,
+			Segments:  make([]ctxmgr.Segment, 0, len(fields)),
+		}
+		for _, field := range fields {
+			content := field.get(&compacted)
+			if content == "" {
+				continue
+			}
+			window.Segments = append(window.Segments, ctxmgr.Segment{
+				Name:     field.name,
+				Content:  content,
+				Tokens:   ctxmgr.EstimateTokens(content),
+				Priority: field.priority,
+			})
+		}
+
+		kept := make(map[string]struct{}, len(window.Segments))
+		for _, seg := range ctxmgr.CompactToFit(window, ctxmgr.CompactionConfig{
+			Threshold:       ctxmgr.DefaultCompactionThreshold,
+			PreserveDurable: true,
+		}).Segments {
+			kept[seg.Name] = struct{}{}
+		}
+		for _, field := range fields {
+			if _, ok := kept[field.name]; !ok {
+				field.set(&compacted, "")
+			}
+		}
+	}
+
+	rendered, err := executeTemplate(tmpl, compacted)
+	if err != nil {
+		return "", fmt.Errorf("execute template: %w", err)
+	}
+	for i := 0; i < len(fields)*4 && !renderedFitsBudget(rendered, opts); i++ {
+		field := largestMutableField(compacted, fields)
+		if field == nil {
+			break
+		}
+		current := field.get(&compacted)
+		target := ctxmgr.EstimateTokens(current) / 2
+		if target >= ctxmgr.EstimateTokens(current) {
+			target = ctxmgr.EstimateTokens(current) - 1
+		}
+		next := summarizeText(current, target)
+		if next == current {
+			next = ""
+		}
+		field.set(&compacted, next)
+		rendered, err = executeTemplate(tmpl, compacted)
+		if err != nil {
+			return "", fmt.Errorf("execute template: %w", err)
+		}
+	}
+	if renderedFitsBudget(rendered, opts) {
+		return rendered, nil
+	}
+	return compactBodyToFit(rendered, opts.ContextBudget, preambleBudgetPrefix(opts.Preamble)), nil
+}
+
+// ApplyContextBudget compacts a fully assembled prompt to fit within the
+// configured token budget, preserving opts.Preamble verbatim when present.
+func ApplyContextBudget(prompt string, opts RenderOptions) string {
+	if opts.ContextBudget <= 0 {
+		return prompt
+	}
+	prefix := preservedPrefix(prompt, opts.Preamble)
+	body := prompt[len(prefix):]
+	return prefix + compactBodyToFit(body, opts.ContextBudget, prefix)
+}
+
+func availableBodyBudget(opts RenderOptions) int {
+	return max(0, opts.ContextBudget-ctxmgr.EstimateTokens(preambleBudgetPrefix(opts.Preamble)))
+}
+
+func renderedFitsBudget(rendered string, opts RenderOptions) bool {
+	return ctxmgr.EstimateTokens(preambleBudgetPrefix(opts.Preamble)+rendered) <= opts.ContextBudget
+}
+
+func preambleBudgetPrefix(preamble string) string {
+	if preamble == "" {
+		return ""
+	}
+	return preamble + "\n\n"
+}
+
+func preservedPrefix(prompt, preamble string) string {
+	if preamble == "" {
+		return ""
+	}
+	if strings.HasPrefix(prompt, preamble+"\n\n") {
+		return preamble + "\n\n"
+	}
+	if strings.HasPrefix(prompt, preamble) {
+		return preamble
+	}
+	return ""
+}
+
+func mutableFields(data TemplateData) []mutableField {
+	fields := make([]mutableField, 0, 5+len(data.PreviousOutputs))
+	order := orderedPreviousOutputKeys(data)
+	for idx, key := range order {
+		key := key
+		fields = append(fields, mutableField{
+			name:     "previous:" + key,
+			priority: idx + 1,
+			get: func(td *TemplateData) string {
+				if td.PreviousOutputs == nil {
+					return ""
+				}
+				return td.PreviousOutputs[key]
+			},
+			set: func(td *TemplateData, value string) {
+				if td.PreviousOutputs == nil {
+					if value == "" {
+						return
+					}
+					td.PreviousOutputs = map[string]string{}
+				}
+				td.PreviousOutputs[key] = value
+			},
+		})
+	}
+	fields = append(fields,
+		mutableField{
+			name:     "issue-body",
+			priority: 1000,
+			get:      func(td *TemplateData) string { return td.Issue.Body },
+			set:      func(td *TemplateData, value string) { td.Issue.Body = value },
+		},
+		mutableField{
+			name:     "gate-result",
+			priority: 900,
+			get:      func(td *TemplateData) string { return td.GateResult },
+			set:      func(td *TemplateData, value string) { td.GateResult = value },
+		},
+		mutableField{
+			name:     "eval-feedback",
+			priority: 850,
+			get:      func(td *TemplateData) string { return td.Evaluation.Feedback },
+			set:      func(td *TemplateData, value string) { td.Evaluation.Feedback = value },
+		},
+		mutableField{
+			name:     "eval-output",
+			priority: 840,
+			get:      func(td *TemplateData) string { return td.Evaluation.Output },
+			set:      func(td *TemplateData, value string) { td.Evaluation.Output = value },
+		},
+		mutableField{
+			name:     "eval-criteria",
+			priority: 830,
+			get:      func(td *TemplateData) string { return td.Evaluation.Criteria },
+			set:      func(td *TemplateData, value string) { td.Evaluation.Criteria = value },
+		},
+	)
+	return fields
+}
+
+func orderedPreviousOutputKeys(data TemplateData) []string {
+	if len(data.PreviousOutputs) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(data.PreviousOutputs))
+	seen := make(map[string]struct{}, len(data.PreviousOutputs))
+	for _, key := range data.PreviousOutputOrder {
+		if _, ok := data.PreviousOutputs[key]; !ok {
+			continue
+		}
+		keys = append(keys, key)
+		seen[key] = struct{}{}
+	}
+	extras := make([]string, 0, len(data.PreviousOutputs)-len(keys))
+	for key := range data.PreviousOutputs {
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		extras = append(extras, key)
+	}
+	sort.Strings(extras)
+	return append(keys, extras...)
+}
+
+func clearMutableFields(data *TemplateData, fields []mutableField) {
+	for _, field := range fields {
+		field.set(data, "")
+	}
+}
+
+func largestMutableField(data TemplateData, fields []mutableField) *mutableField {
+	var selected *mutableField
+	maxTokens := 0
+	for i := range fields {
+		tokens := ctxmgr.EstimateTokens(fields[i].get(&data))
+		if tokens > maxTokens {
+			maxTokens = tokens
+			selected = &fields[i]
+		}
+	}
+	return selected
+}
+
+func summarizeText(content string, maxTokens int) string {
+	if maxTokens <= 0 {
+		return ""
+	}
+	if ctxmgr.EstimateTokens(content) <= maxTokens {
+		return content
+	}
+	maxChars := maxTokens * 4
+	if maxChars <= 0 {
+		return ""
+	}
+	notice := fmt.Sprintf("[context compacted to fit %d tokens]\n", maxTokens)
+	if len(notice) >= maxChars {
+		return notice[:maxChars]
+	}
+	remaining := maxChars - len(notice)
+	if remaining <= 0 {
+		return notice
+	}
+	if remaining <= 5 {
+		return notice + content[:remaining]
+	}
+
+	ellipsis := "\n...\n"
+	payload := remaining - len(ellipsis)
+	if payload <= 0 {
+		return notice + content[:remaining]
+	}
+	if ctxmgr.EstimateTokens(content) <= minSummaryTokens {
+		if len(content) > payload {
+			return notice + content[:payload]
+		}
+		return notice + content
+	}
+	head := payload * 3 / 4
+	tail := payload - head
+	if head > len(content) {
+		head = len(content)
+	}
+	if tail > len(content)-head {
+		tail = len(content) - head
+	}
+	return notice + content[:head] + ellipsis + content[len(content)-tail:]
+}
+
+func compactBodyToFit(body string, budget int, fixedPrefix string) string {
+	if ctxmgr.EstimateTokens(fixedPrefix+body) <= budget {
+		return body
+	}
+	for bodyBudget := max(0, budget-ctxmgr.EstimateTokens(fixedPrefix)); bodyBudget >= 0; bodyBudget-- {
+		candidate := summarizeText(body, bodyBudget)
+		for len(candidate) > 0 && ctxmgr.EstimateTokens(fixedPrefix+candidate) > budget {
+			candidate = candidate[:len(candidate)-1]
+		}
+		if ctxmgr.EstimateTokens(fixedPrefix+candidate) <= budget {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func cloneTemplateData(data TemplateData) TemplateData {
+	out := data
+	if data.PreviousOutputs != nil {
+		out.PreviousOutputs = make(map[string]string, len(data.PreviousOutputs))
+		for key, value := range data.PreviousOutputs {
+			out.PreviousOutputs[key] = value
+		}
+	}
+	if data.Vessel.Meta != nil {
+		out.Vessel.Meta = make(map[string]string, len(data.Vessel.Meta))
+		for key, value := range data.Vessel.Meta {
+			out.Vessel.Meta[key] = value
+		}
+	}
+	if data.Issue.Labels != nil {
+		out.Issue.Labels = append([]string(nil), data.Issue.Labels...)
+	}
+	if data.PreviousOutputOrder != nil {
+		out.PreviousOutputOrder = append([]string(nil), data.PreviousOutputOrder...)
+	}
+	return out
 }

--- a/cli/internal/phase/phase_prop_test.go
+++ b/cli/internal/phase/phase_prop_test.go
@@ -3,6 +3,7 @@ package phase
 import (
 	"testing"
 
+	"github.com/nicholls-inc/xylem/cli/internal/ctxmgr"
 	"pgregory.net/rapid"
 )
 
@@ -20,6 +21,27 @@ func TestPropRenderPromptInterpolatesMergeMainPreviousOutput(t *testing.T) {
 		}
 		if got != mergeOutput {
 			t.Fatalf("RenderPrompt() = %q, want %q", got, mergeOutput)
+		}
+	})
+}
+
+func TestPropApplyContextBudgetPreservesConfiguredPreamble(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		preamble := rapid.StringMatching(`[\t\n\r -~]{1,64}`).Draw(t, "preamble")
+		body := rapid.StringN(0, 4096, 4096).Draw(t, "body")
+		prefix := preamble + "\n\n"
+		minBudget := max(1, ctxmgr.EstimateTokens(prefix))
+		budget := rapid.IntRange(minBudget, minBudget+2048).Draw(t, "budget")
+
+		got := ApplyContextBudget(prefix+body, RenderOptions{
+			ContextBudget: budget,
+			Preamble:      preamble,
+		})
+		if len(got) < len(prefix) || got[:len(prefix)] != prefix {
+			t.Fatalf("ApplyContextBudget() did not preserve prefix %q in %q", prefix, got)
+		}
+		if ctxmgr.EstimateTokens(got) > budget {
+			t.Fatalf("EstimateTokens() = %d, want <= %d", ctxmgr.EstimateTokens(got), budget)
 		}
 	})
 }

--- a/cli/internal/phase/phase_test.go
+++ b/cli/internal/phase/phase_test.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/ctxmgr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTruncateOutput(t *testing.T) {
@@ -402,4 +406,193 @@ func TestRenderPromptNilPreviousOutputs(t *testing.T) {
 	if got != "done" {
 		t.Fatalf("got %q, want %q", got, "done")
 	}
+}
+
+func TestRenderPromptWithOptions(t *testing.T) {
+	t.Run("small prompt is unchanged", func(t *testing.T) {
+		got, err := RenderPromptWithOptions("Title: {{.Issue.Title}}", TemplateData{
+			Issue: IssueData{Title: "compact me not"},
+		}, RenderOptions{ContextBudget: 100})
+		if err != nil {
+			t.Fatalf("RenderPromptWithOptions() error = %v", err)
+		}
+		if got != "Title: compact me not" {
+			t.Fatalf("RenderPromptWithOptions() = %q, want %q", got, "Title: compact me not")
+		}
+	})
+
+	t.Run("oversize prompt drops oldest previous outputs first", func(t *testing.T) {
+		data := TemplateData{
+			PreviousOutputs: map[string]string{
+				"analyze": strings.Repeat("a", 1200),
+				"plan":    strings.Repeat("b", 1200),
+				"recent":  strings.Repeat("c", 1200),
+			},
+			PreviousOutputOrder: []string{"analyze", "plan", "recent"},
+		}
+		got, err := RenderPromptWithOptions(
+			`{{.PreviousOutputs.analyze}}|{{.PreviousOutputs.plan}}|{{.PreviousOutputs.recent}}`,
+			data,
+			RenderOptions{ContextBudget: 500},
+		)
+		if err != nil {
+			t.Fatalf("RenderPromptWithOptions() error = %v", err)
+		}
+		if ctxmgr.EstimateTokens(got) > 500 {
+			t.Fatalf("EstimateTokens() = %d, want <= 500", ctxmgr.EstimateTokens(got))
+		}
+		if strings.Contains(got, strings.Repeat("a", 32)) {
+			t.Fatal("expected oldest previous output to be compacted out first")
+		}
+		if !strings.Contains(got, strings.Repeat("c", 32)) {
+			t.Fatal("expected most recent previous output to survive initial compaction")
+		}
+	})
+
+	t.Run("accounts for preamble rounding in final budget", func(t *testing.T) {
+		got, err := RenderPromptWithOptions("AAAAA", TemplateData{}, RenderOptions{
+			ContextBudget: 1,
+			Preamble:      "\t",
+		})
+		if err != nil {
+			t.Fatalf("RenderPromptWithOptions() error = %v", err)
+		}
+		if ctxmgr.EstimateTokens("\t\n\n"+got) > 1 {
+			t.Fatalf("EstimateTokens() = %d, want <= 1", ctxmgr.EstimateTokens("\t\n\n"+got))
+		}
+		if got != "AAAA" {
+			t.Fatalf("RenderPromptWithOptions() = %q, want %q", got, "AAAA")
+		}
+	})
+}
+
+func TestSmoke_S1_SmallPromptUnchanged(t *testing.T) {
+	got, err := RenderPromptWithOptions("Title: {{.Issue.Title}}", TemplateData{
+		Issue: IssueData{Title: "compact me not"},
+	}, RenderOptions{ContextBudget: 100})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Title: compact me not", got)
+}
+
+func TestSmoke_S2_OversizePromptCompactedToBudget(t *testing.T) {
+	data := TemplateData{
+		PreviousOutputs: map[string]string{
+			"analyze": strings.Repeat("a", 1200),
+			"plan":    strings.Repeat("b", 1200),
+			"recent":  strings.Repeat("c", 1200),
+		},
+		PreviousOutputOrder: []string{"analyze", "plan", "recent"},
+	}
+
+	got, err := RenderPromptWithOptions(
+		`{{.PreviousOutputs.analyze}}|{{.PreviousOutputs.plan}}|{{.PreviousOutputs.recent}}`,
+		data,
+		RenderOptions{ContextBudget: 500},
+	)
+
+	require.NoError(t, err)
+	assert.LessOrEqual(t, ctxmgr.EstimateTokens(got), 500)
+	assert.NotContains(t, got, strings.Repeat("a", 32))
+	assert.Contains(t, got, strings.Repeat("c", 32))
+}
+
+func TestSmoke_S3_HarnessPreamblePreservedVerbatim(t *testing.T) {
+	preamble := "HARNESS RULES\n- keep this exact"
+	body := strings.Repeat("body paragraph\n", 400)
+
+	got := ApplyContextBudget(preamble+"\n\n"+body, RenderOptions{
+		ContextBudget: 500,
+		Preamble:      preamble,
+	})
+
+	require.NotEmpty(t, got)
+	assert.True(t, strings.HasPrefix(got, preamble+"\n\n"))
+	assert.LessOrEqual(t, ctxmgr.EstimateTokens(got), 500)
+}
+
+func TestApplyContextBudgetPreservesPreamble(t *testing.T) {
+	preamble := "HARNESS RULES\n- keep this exact"
+	body := strings.Repeat("body paragraph\n", 400)
+	got := ApplyContextBudget(preamble+"\n\n"+body, RenderOptions{
+		ContextBudget: 500,
+		Preamble:      preamble,
+	})
+	if !strings.HasPrefix(got, preamble+"\n\n") {
+		t.Fatalf("ApplyContextBudget() did not preserve preamble verbatim: %q", got[:len(preamble)+2])
+	}
+	if ctxmgr.EstimateTokens(got) > 500 {
+		t.Fatalf("EstimateTokens() = %d, want <= 500", ctxmgr.EstimateTokens(got))
+	}
+}
+
+func TestSummarizeText(t *testing.T) {
+	findBudget := func(t *testing.T, predicate func(maxTokens, remaining int, notice string) bool) (int, int, string) {
+		t.Helper()
+		for maxTokens := 1; maxTokens <= 100; maxTokens++ {
+			notice := fmt.Sprintf("[context compacted to fit %d tokens]\n", maxTokens)
+			remaining := maxTokens*4 - len(notice)
+			if predicate(maxTokens, remaining, notice) {
+				return maxTokens, remaining, notice
+			}
+		}
+		t.Fatal("failed to find matching maxTokens")
+		return 0, 0, ""
+	}
+
+	t.Run("returns original content when already within budget", func(t *testing.T) {
+		content := "hi"
+		got := summarizeText(content, 2)
+		if got != content {
+			t.Fatalf("summarizeText(%q, 2) = %q, want %q", content, got, content)
+		}
+	})
+
+	t.Run("returns empty string for non-positive budgets", func(t *testing.T) {
+		got := summarizeText("will be dropped", 0)
+		if got != "" {
+			t.Fatalf("summarizeText() = %q, want empty string", got)
+		}
+	})
+
+	t.Run("truncates compaction notice when the notice alone exceeds the budget", func(t *testing.T) {
+		content := strings.Repeat("x", 8)
+		const maxTokens = 1
+		notice := fmt.Sprintf("[context compacted to fit %d tokens]\n", maxTokens)
+
+		got := summarizeText(content, maxTokens)
+		want := notice[:maxTokens*4]
+		if got != want {
+			t.Fatalf("summarizeText() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("appends only the available prefix when a few characters remain", func(t *testing.T) {
+		maxTokens, remaining, notice := findBudget(t, func(_ int, remaining int, _ string) bool {
+			return remaining > 0 && remaining <= 5
+		})
+		content := strings.Repeat("abcdef", maxTokens)
+
+		got := summarizeText(content, maxTokens)
+		want := notice + content[:remaining]
+		if got != want {
+			t.Fatalf("summarizeText() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("keeps both head and tail with ellipsis when there is room for a summary", func(t *testing.T) {
+		maxTokens, remaining, notice := findBudget(t, func(maxTokens, remaining int, _ string) bool {
+			return remaining > len("\n...\n") && maxTokens > minSummaryTokens
+		})
+		content := strings.Repeat("0123456789", maxTokens*2)
+		payload := remaining - len("\n...\n")
+		headLen := payload * 3 / 4
+		tailLen := payload - headLen
+
+		got := summarizeText(content, maxTokens)
+		want := notice + content[:headLen] + "\n...\n" + content[len(content)-tailLen:]
+		if got != want {
+			t.Fatalf("summarizeText() = %q, want %q", got, want)
+		}
+	})
 }

--- a/cli/internal/runner/evaluator_loop.go
+++ b/cli/internal/runner/evaluator_loop.go
@@ -60,6 +60,7 @@ func (g *phaseLoopGenerator) Generate(ctx context.Context, _ string, feedback []
 	g.iteration++
 	td := g.r.buildTemplateData(
 		g.vessel,
+		g.wf,
 		g.issueData,
 		g.phaseDef.Name,
 		g.phaseIdx,
@@ -71,7 +72,10 @@ func (g *phaseLoopGenerator) Generate(ctx context.Context, _ string, feedback []
 			Criteria:  g.criteriaText,
 		},
 	)
-	rendered, err := phase.RenderPrompt(g.promptTemplate, td)
+	rendered, err := phase.RenderPromptWithOptions(g.promptTemplate, td, phase.RenderOptions{
+		ContextBudget: phaseContextBudget(g.r.Config),
+		Preamble:      g.harnessContent,
+	})
 	if err != nil {
 		g.appendTrace("generation", false, "")
 		return "", fmt.Errorf("render prompt for phase %s: %w", g.phaseDef.Name, err)
@@ -134,6 +138,7 @@ func (e *phaseLoopEvaluator) Evaluate(ctx context.Context, output string, criter
 	e.iteration++
 	td := e.r.buildTemplateData(
 		e.vessel,
+		e.wf,
 		e.issueData,
 		e.phaseDef.Name,
 		e.phaseIdx,
@@ -145,7 +150,10 @@ func (e *phaseLoopEvaluator) Evaluate(ctx context.Context, output string, criter
 			Criteria:  formatEvaluatorCriteria(criteria),
 		},
 	)
-	rendered, err := phase.RenderPrompt(e.evalTemplate, td)
+	rendered, err := phase.RenderPromptWithOptions(e.evalTemplate, td, phase.RenderOptions{
+		ContextBudget: phaseContextBudget(e.r.Config),
+		Preamble:      e.harnessContent,
+	})
 	if err != nil {
 		e.appendTrace(false, "")
 		return nil, fmt.Errorf("render evaluator prompt for phase %s: %w", e.phaseDef.Name, err)

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -1829,7 +1829,7 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 		log.Printf("%sphase %q starting", vesselLabel(vessel), p.Name)
 		phaseStart := r.runtimeNow()
 
-		td := r.buildTemplateData(vessel, issueData, p.Name, phaseIdx, previousOutputs, gateResult, phase.EvaluationData{})
+		td := r.buildTemplateData(vessel, wf, issueData, p.Name, phaseIdx, previousOutputs, gateResult, phase.EvaluationData{})
 
 		var output []byte
 		var runErr error
@@ -1993,7 +1993,10 @@ func (r *Runner) runSinglePhase(ctx context.Context, vessel queue.Vessel, wf *wo
 					runErr = err
 				}
 			} else {
-				rendered, err := phase.RenderPrompt(promptTemplate, td)
+				rendered, err := phase.RenderPromptWithOptions(promptTemplate, td, phase.RenderOptions{
+					ContextBudget: phaseContextBudget(r.Config),
+					Preamble:      harnessContent,
+				})
 				if err != nil {
 					finishCurrentPhaseSpan(err)
 					r.failVessel(vessel.ID, fmt.Sprintf("render prompt for phase %s: %v", p.Name, err))
@@ -4077,7 +4080,7 @@ func (r *Runner) resolveDefaultBranch() string {
 	return "main"
 }
 
-func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueData, phaseName string, phaseIndex int, previousOutputs map[string]string, gateResult string, evaluation phase.EvaluationData) phase.TemplateData {
+func (r *Runner) buildTemplateData(vessel queue.Vessel, wf *workflow.Workflow, issueData phase.IssueData, phaseName string, phaseIndex int, previousOutputs map[string]string, gateResult string, evaluation phase.EvaluationData) phase.TemplateData {
 	sourceName := vessel.Source
 	if configSource := r.sourceConfigNameFromMeta(vessel); configSource != "" {
 		sourceName = configSource
@@ -4099,9 +4102,10 @@ func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueDat
 			Name:  phaseName,
 			Index: phaseIndex,
 		},
-		PreviousOutputs: previousOutputs,
-		GateResult:      gateResult,
-		Evaluation:      evaluation,
+		PreviousOutputs:     previousOutputs,
+		PreviousOutputOrder: orderedPreviousOutputNames(wf, phaseIndex, previousOutputs),
+		GateResult:          gateResult,
+		Evaluation:          evaluation,
 		Vessel: phase.VesselData{
 			ID:     vessel.ID,
 			Ref:    vessel.Ref,
@@ -4118,6 +4122,44 @@ func (r *Runner) buildTemplateData(vessel queue.Vessel, issueData phase.IssueDat
 		},
 		Validation: validation,
 	}
+}
+
+func orderedPreviousOutputNames(wf *workflow.Workflow, phaseIndex int, previousOutputs map[string]string) []string {
+	if len(previousOutputs) == 0 {
+		return nil
+	}
+	ordered := make([]string, 0, len(previousOutputs))
+	seen := make(map[string]struct{}, len(previousOutputs))
+	if wf != nil {
+		limit := phaseIndex
+		if limit > len(wf.Phases) {
+			limit = len(wf.Phases)
+		}
+		for i := 0; i < limit; i++ {
+			name := wf.Phases[i].Name
+			if _, ok := previousOutputs[name]; !ok {
+				continue
+			}
+			ordered = append(ordered, name)
+			seen[name] = struct{}{}
+		}
+	}
+	extras := make([]string, 0, len(previousOutputs)-len(ordered))
+	for name := range previousOutputs {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		extras = append(extras, name)
+	}
+	sort.Strings(extras)
+	return append(ordered, extras...)
+}
+
+func phaseContextBudget(cfg *config.Config) int {
+	if cfg == nil || cfg.Phase.ContextBudget <= 0 {
+		return config.DefaultPhaseContextBudget
+	}
+	return cfg.Phase.ContextBudget
 }
 
 func vesselLabel(v queue.Vessel) string {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/cost"
+	"github.com/nicholls-inc/xylem/cli/internal/ctxmgr"
 	"github.com/nicholls-inc/xylem/cli/internal/evaluator"
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"github.com/nicholls-inc/xylem/cli/internal/gate"
@@ -3632,6 +3633,55 @@ func TestSmoke_WS6_S17_PromptOnlyVesselSummaryArtifact(t *testing.T) {
 	assert.Equal(t, summary.TotalCostUSDEst, report.Phases[0].CostUSD)
 }
 
+func TestSmoke_S4_CompactedPromptArtifactWrittenWithinContextBudget(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Phase.ContextBudget = config.DefaultPhaseContextBudget
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	_, err := q.Enqueue(makeVessel(1, "context-compaction"))
+	require.NoError(t, err)
+
+	writeWorkflowFile(t, dir, "context-compaction", []testPhase{
+		{
+			name:          "analyze",
+			promptContent: "Analyze the oversized prompt inputs",
+			maxTurns:      5,
+		},
+		{
+			name:          "implement",
+			promptContent: strings.Repeat("{{.PreviousOutputs.analyze}}\n", 40),
+			maxTurns:      5,
+		},
+	})
+
+	withTestWorkingDir(t, dir)
+
+	cmdRunner := &mockCmdRunner{
+		phaseOutputs: map[string][]byte{
+			"Analyze the oversized prompt inputs": []byte(strings.Repeat("analysis context block ", 1200)),
+			"[context compacted":                  []byte("implementation completed"),
+		},
+	}
+	r := New(cfg, q, &mockWorktree{path: dir}, cmdRunner)
+	r.Sources = map[string]source.Source{
+		"github-issue": makeGitHubSource(),
+	}
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Completed)
+
+	promptPath := config.RuntimePath(cfg.StateDir, "phases", "issue-1", "implement.prompt")
+	assert.FileExists(t, promptPath)
+
+	prompt, err := os.ReadFile(promptPath)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, ctxmgr.EstimateTokens(string(prompt)), config.DefaultPhaseContextBudget)
+	assert.Contains(t, string(prompt), "[context compacted")
+}
+
 func TestDrainCommandGatePasses(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(dir, 2)
@@ -6311,7 +6361,7 @@ func TestSmoke_S4_BuildTemplateDataExposesRepoAndValidation(t *testing.T) {
 			"schedule.source_name": "security-compliance",
 		},
 	}
-	td := r.buildTemplateData(vessel, phase.IssueData{Number: 42}, "merge", 0, nil, "", phase.EvaluationData{})
+	td := r.buildTemplateData(vessel, nil, phase.IssueData{Number: 42}, "merge", 0, nil, "", phase.EvaluationData{})
 
 	rendered, err := renderCommandTemplate("merge", "command", "gh pr merge {{.Issue.Number}} --repo {{.Repo.Slug}} && echo {{.Source.Name}} {{.Source.Repo}} {{.Repo.DefaultBranch}} {{.Validation.Format}} {{.Validation.Lint}} {{.Validation.Build}} {{.Validation.Test}} {{.Vessel.Ref}} {{index .Vessel.Meta \"schedule.source_name\"}}", td)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
Implements [issue #391](https://github.com/nicholls-inc/xylem/issues/391) by wiring `cli/internal/ctxmgr` into phase prompt rendering so oversized prompts compact against a configurable phase context budget while preserving harness preambles and dependency-aware phase ordering.

## Smoke scenarios covered
- `S1` — Small prompt unchanged
- `S2` — Oversize prompt compacted to budget
- `S3` — Harness preamble preserved verbatim
- `S4` — Compacted prompt artifact written within context budget

## Changes summary
### Files modified
- `cli/internal/config/config.go`
- `cli/internal/config/config_test.go`
- `cli/internal/ctxmgr/ctxmgr.go`
- `cli/internal/ctxmgr/ctxmgr_prop_test.go`
- `cli/internal/ctxmgr/ctxmgr_test.go`
- `cli/internal/phase/phase.go`
- `cli/internal/phase/phase_prop_test.go`
- `cli/internal/phase/phase_test.go`
- `cli/internal/runner/evaluator_loop.go`
- `cli/internal/runner/runner.go`
- `cli/internal/runner/runner_test.go`

### Key types and functions
- Added `config.PhaseConfig` and `DefaultPhaseContextBudget` to load and validate `phase.context_budget`.
- Added `ctxmgr.CompactToFit` for deterministic token-budget compaction that preserves durable segments and prompt order.
- Added `phase.RenderOptions`, `phase.RenderPromptWithOptions`, and `phase.ApplyContextBudget` to compact rendered prompts while preserving a configured preamble.
- Updated `phase.TemplateData` with `PreviousOutputOrder` so compaction can prefer newer dependency outputs.
- Updated `runner.buildTemplateData`, `orderedPreviousOutputNames`, and `phaseContextBudget` so runner and evaluator loops pass workflow-aware ordering and the configured context budget into prompt rendering.

## Test plan
- `cd cli && go vet ./...`
- `cd cli && go build ./cmd/xylem`
- `cd cli && go test ./...`
- `cd cli && goimports -l .`
- `cd cli && golangci-lint run`

Fixes #391