### PR TITLE
chore: switch default LLM from copilot to claude

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -220,7 +220,7 @@ timeout: "45m"
 state_dir: ".xylem"
 
 # llm selects the global default LLM provider: "claude" (default) or "copilot"
-llm: copilot
+llm: claude
 model: gpt-5.4
 
 claude:


### PR DESCRIPTION
## Summary
- Switches `llm: copilot` → `llm: claude` in `.xylem.yml`
- Copilot quota exhausted — all vessels dying on `402 You have no quota` since ~02:54 UTC
- Issue #417 tracks the provider-fallback classification bug that prevented automatic failover

## Impact
- **16+ issues** stuck with `xylem-failed` label due to quota exhaustion
- Daemon queue halted with 0 pending, 0 running vessels
- Switching to Claude (Anthropic API) unblocks all vessel processing

## Test plan
- [ ] CI passes (config-only change, no code changes)
- [ ] After merge + auto-upgrade, vessels should process using Claude provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)