### PR TITLE
fix: raise pr_draft and test_critic max_turns from 30 to 50 in implement-harness workflow

### DIFF
--- a/.xylem/workflows/implement-harness.yaml
+++ b/.xylem/workflows/implement-harness.yaml
@@ -25,7 +25,7 @@ phases:
       retries: 2
   - name: test_critic
     prompt_file: .xylem/prompts/implement-harness/test_critic.md
-    max_turns: 30
+    max_turns: 50
     gate:
       type: command
       run: "cd cli && go test ./..."
@@ -39,7 +39,7 @@ phases:
       retries: 2
   - name: pr_draft
     prompt_file: .xylem/prompts/implement-harness/pr_draft.md
-    max_turns: 30
+    max_turns: 50
     gate:
       type: command
       run: |


### PR DESCRIPTION
## Summary

Fixes https://github.com/nicholls-inc/xylem/issues/420

The `pr_draft` phase in `implement-harness.yaml` was consistently hitting the 30-turn cap before completing its work sequence (read diffs → stage → rebase → commit → push → write `pr_draft.json`). Every vessel was dying at PR creation. This PR raises the limit to 50, matching the budget needed for this multi-step phase.

`test_critic` was also at 30 turns despite needing to read full test output across multiple files — raised to 50 for the same reason (issue suggestion #3).

## Changes

**`.xylem/workflows/implement-harness.yaml`**
- `test_critic.max_turns`: 30 → 50
- `pr_draft.max_turns`: 30 → 50

No Go code changes. No new tests required — `max_turns` is a per-phase cap read at phase-start; excess budget is unused if the phase completes earlier.

## Smoke scenarios covered

No smoke scenario IDs are assigned to this issue. This is a pure configuration bug fix with no spec workstream step.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./cmd/xylem` — clean
- [x] `go test ./...` — all 38 packages pass
- [ ] Runtime validation: next vessel running the `implement-harness` workflow should complete `pr_draft` without hitting the turn cap

Fixes #420