### PR TITLE
chore: xylem repo housekeeping — DefaultProtectedSurfaces comment refresh + restart-survival test + dedup test

### DIFF
--- a/cli/cmd/xylem/adapt_repo_seed_test.go
+++ b/cli/cmd/xylem/adapt_repo_seed_test.go
@@ -151,6 +151,41 @@ func TestEnsureAdaptRepoSeededSkipsConfigsWithoutGitHubRepo(t *testing.T) {
 	assert.Empty(t, runner.calls)
 }
 
+func TestEnsureAdaptRepoSeededDedupesClosedIssues(t *testing.T) {
+	// Acceptance-criteria name for the scenario covered by S4.
+	// Asserts: closed-issue match → marker reflects existing issue, no gh issue create call, marker written to disk.
+	cfg := &config.Config{
+		StateDir: t.TempDir(),
+		Sources: map[string]config.SourceConfig{
+			"adapt-repo": {Type: "github", Repo: "owner/repo"},
+		},
+	}
+	runner := &seedRunnerStub{
+		outputs: map[string][]byte{
+			adaptRepoSearchCallForState("owner/repo", "open"):   []byte("[]"),
+			adaptRepoSearchCallForState("owner/repo", "closed"): []byte(`[{"number":21,"title":"[xylem] adapt harness to this repository","url":"https://github.com/owner/repo/issues/21"}]`),
+		},
+	}
+
+	marker, err := ensureAdaptRepoSeeded(context.Background(), cfg, runner, adaptRepoSeededByDaemon)
+	require.NoError(t, err)
+	require.NotNil(t, marker)
+	assert.Equal(t, 21, marker.IssueNumber)
+	assert.Equal(t, "https://github.com/owner/repo/issues/21", marker.IssueURL)
+	assert.Equal(t, adaptRepoSeededByDaemon, marker.SeededBy)
+
+	written, err := readAdaptRepoSeedMarker(filepath.Join(cfg.StateDir, "state", "bootstrap", "adapt-repo-seeded.json"))
+	require.NoError(t, err)
+	assert.Equal(t, marker, written)
+
+	// Exactly 2 calls (open search + closed search): no gh issue create.
+	assert.Len(t, runner.calls, 2)
+	for _, call := range runner.calls {
+		assert.NotContains(t, strings.Join(call, " "), "issue create",
+			"must not call gh issue create when closed issue exists")
+	}
+}
+
 func TestFindExistingAdaptRepoIssueStopsAfterOpenMatch(t *testing.T) {
 	runner := &seedRunnerStub{
 		outputs: map[string][]byte{

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -62,6 +62,10 @@ const runtimeStateDirName = "state"
 // suspenders in place.
 //
 // See issue #194 for the design discussion.
+//
+// Post-PR #366, the policy matrix in cli/internal/policy/ became the
+// authoritative enforcement layer for protected-surface class routing.
+// See issue #366 for the class matrix design and migration notes.
 var DefaultProtectedSurfaces = []string{}
 
 type Config struct {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -2305,6 +2305,15 @@ func TestSmoke_S3_PathsNoneDisablesProtection(t *testing.T) {
 	assert.Nil(t, cfg.EffectiveProtectedSurfaces())
 }
 
+func TestDefaultProtectedSurfacesComment(t *testing.T) {
+	// Read config.go source to assert the comment stays up-to-date.
+	src, err := os.ReadFile("config.go")
+	require.NoError(t, err)
+	content := string(src)
+	assert.Contains(t, content, "#366", "DefaultProtectedSurfaces comment must reference PR #366")
+	assert.Contains(t, content, "class matrix", "DefaultProtectedSurfaces comment must reference the class matrix")
+}
+
 func TestSmoke_S4_InvalidGlobRejected(t *testing.T) {
 	path := writeSmokeConfigFile(t, `harness:
   protected_surfaces:

--- a/cli/internal/source/github_pr_events_test.go
+++ b/cli/internal/source/github_pr_events_test.go
@@ -489,6 +489,57 @@ func TestPREventsScanPROpenedDedupByPR(t *testing.T) {
 	}
 }
 
+func TestPROpenedDedupSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	queuePath := filepath.Join(dir, "queue.jsonl")
+
+	prs := []ghPR{
+		{Number: 11, Title: "PR 11", URL: "https://github.com/owner/repo/pull/11", HeadRefName: "branch-11"},
+	}
+	listCall := []string{"gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50"}
+
+	// --- First "daemon boot" ---
+	q1 := queue.New(queuePath)
+	r1 := newMock()
+	r1.set(prEventsListJSON(prs), listCall...)
+
+	g1 := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review": {Workflow: "review-pr", PROpened: true},
+		},
+		StateDir:  dir,
+		Queue:     q1,
+		CmdRunner: r1,
+	}
+
+	vessels, err := g1.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, vessels, 1)
+	_, err = q1.Enqueue(vessels[0])
+	require.NoError(t, err)
+	require.NoError(t, g1.OnEnqueue(context.Background(), vessels[0]))
+
+	// --- Simulate restart: new queue instance, same backing file ---
+	q2 := queue.New(queuePath)
+	r2 := newMock()
+	r2.set(prEventsListJSON(prs), listCall...)
+
+	g2 := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review": {Workflow: "review-pr", PROpened: true},
+		},
+		StateDir:  dir,
+		Queue:     q2,
+		CmdRunner: r2,
+	}
+
+	vessels2, err := g2.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, vessels2, "queue-backed dedup must survive daemon restart")
+}
+
 func TestPREventsScanPRHeadUpdatedDedupsPerHead(t *testing.T) {
 	dir := t.TempDir()
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))


### PR DESCRIPTION
## Summary

Implements sub-items B, C, and D from https://github.com/nicholls-inc/xylem/issues/401.

Sub-items A and E (AGENTS.md at repo root and HARNESS.md reference) are blocked by issue #G-1 (AGENTS.md template not yet landed) and are intentionally excluded from this PR.

## Smoke scenarios covered

| ID | Title | Result |
|---|---|---|
| B1 | `TestDefaultProtectedSurfacesComment` — comment references `#366` and `class matrix` | ✅ passes |
| C1 | `TestPROpenedDedupSurvivesRestart` — queue-backed pr_opened dedup survives daemon restart | ✅ passes |
| D1 | `TestEnsureAdaptRepoSeededDedupesClosedIssues` — closed-issue match suppresses `gh issue create` | ✅ passes |

## Changes summary

### `cli/internal/config/config.go`
- Extended the `DefaultProtectedSurfaces` block comment (lines 66–68) to reference PR `#366` and the `class matrix` in `cli/internal/policy/` as the authoritative enforcement layer post-#366.

### `cli/internal/config/config_test.go`
- Added `TestDefaultProtectedSurfacesComment`: reads `config.go` source via `os.ReadFile` and asserts the comment contains both `"#366"` and `"class matrix"`.

### `cli/internal/source/github_pr_events_test.go`
- Added `TestPROpenedDedupSurvivesRestart`: creates `queue₁`, scans and enqueues a pr_opened vessel, then constructs `queue₂` backed by the same JSONL file (simulating a daemon restart) and asserts a second scan produces 0 vessels — confirming queue-backed dedup survives in-memory state loss.

### `cli/cmd/xylem/adapt_repo_seed_test.go`
- Added `TestEnsureAdaptRepoSeededDedupesClosedIssues`: acceptance-criteria name for the scenario covered by `TestSmoke_S4`. Asserts closed-issue match returns the existing issue marker, writes it to disk, and makes no `gh issue create` call (verified by inspecting `runner.calls`).

## Test plan

```bash
cd cli
go test ./internal/config -run TestDefaultProtectedSurfacesComment
go test ./internal/source -run TestPROpenedDedupSurvivesRestart
go test ./cmd/xylem -run TestEnsureAdaptRepoSeededDedupesClosedIssues
go test ./...
```

All tests pass. `go vet ./...`, `go build ./cmd/xylem`, and `golangci-lint run` clean.

Fixes #401