### PR TITLE
fix: classifyProviderError: add 'no quota' pattern so copilot quota exhaustion triggers provider fallback

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
 
       - id: golangci-lint
         name: golangci-lint
-        entry: bash -c 'cd cli && golangci-lint run --path-mode=abs'
+        entry: bash -c 'cd cli && GOCACHE=${TMPDIR:-/tmp}/golangci-lint-cache golangci-lint run ./...'
         language: system
         pass_filenames: false
         files: ^(cli/.*\.go|cli/go\.(mod|sum)|\.golangci\.yml)$

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -4509,6 +4509,7 @@ func classifyProviderError(err error) providerErrorDisposition {
 		"currently overloaded",
 		"executable file not found",
 		"command not found",
+		"no quota", // copilot: "402 You have no quota (Request ID: ...)"
 	}
 	for _, pattern := range fallbackPatterns {
 		if strings.Contains(msg, pattern) {

--- a/cli/internal/runner/runner_fallback_test.go
+++ b/cli/internal/runner/runner_fallback_test.go
@@ -60,6 +60,8 @@ func (f *fallbackCmdRunner) RunPhaseWithEnv(_ context.Context, _ string, extraEn
 		return nil, errors.New("exit status 1")
 	case "copilot-auth-fail":
 		return nil, errors.New("copilot: authentication required: github token invalid")
+	case "copilot-quota-fail":
+		return nil, errors.New("402 You have no quota")
 	default:
 		return []byte("implemented"), nil
 	}
@@ -329,6 +331,102 @@ func TestRunPhaseWithProviderFallbackFallsBackAfterAuthFailure(t *testing.T) {
 	attrs := spanAttrMap(endedSpanByName(t, rec, "phase:implement"))
 	assert.Equal(t, "secondary", attrs["xylem.phase.provider"])
 	assert.Equal(t, "gpt-med", attrs["xylem.phase.model"])
+	assert.Equal(t, "secondary", attrs["llm.provider"])
+	assert.Equal(t, "med", attrs["llm.tier"])
+}
+
+func TestRunPhaseWithProviderFallbackFallsBackAfterQuotaExhaustion(t *testing.T) {
+	t.Setenv("XYLEM_DTU_STATE_PATH", setupDTUClock(t))
+	tracer, rec := newTestTracer(t)
+
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Concurrency: 1,
+		MaxTurns:    50,
+		Timeout:     "30s",
+		StateDir:    filepath.Join(dir, ".xylem"),
+		Providers: map[string]config.ProviderConfig{
+			"primary": {
+				Kind:    "copilot",
+				Command: "copilot-quota-fail",
+				Tiers:   map[string]string{"med": "gpt-med"},
+				Env: map[string]string{
+					"GITHUB_TOKEN": "copilot-secret",
+				},
+			},
+			"secondary": {
+				Kind:    "claude",
+				Command: "claude-success",
+				Tiers:   map[string]string{"med": "claude-med"},
+				Env: map[string]string{
+					"ANTHROPIC_API_KEY": "anthropic-secret",
+				},
+			},
+		},
+		LLMRouting: config.LLMRoutingConfig{
+			DefaultTier: "med",
+			Tiers: map[string]config.TierRouting{
+				"med": {Providers: []string{"primary", "secondary"}},
+			},
+		},
+		Harness: config.HarnessConfig{
+			ProtectedSurfaces: config.ProtectedSurfacesConfig{
+				Paths: []string{
+					".xylem/HARNESS.md",
+					".xylem.yml",
+					".xylem/workflows/*.yaml",
+					".xylem/prompts/*/*.md",
+				},
+			},
+		},
+		Sources: map[string]config.SourceConfig{
+			"github": {
+				Type:    "github",
+				Repo:    "owner/repo",
+				Exclude: []string{"wontfix"},
+				Tasks:   map[string]config.Task{"fix-bugs": {Labels: []string{"bug"}, Workflow: "fix-bug"}},
+			},
+		},
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	vessel := makeVessel(1, "fix-bug")
+	vessel.Tier = "med"
+	_, _ = q.Enqueue(vessel)
+
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{name: "implement", promptContent: "Fix the bug", maxTurns: 10},
+	})
+
+	oldWd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldWd)
+
+	cmdRunner := &fallbackCmdRunner{}
+	r := New(cfg, q, &mockWorktree{}, cmdRunner)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+	r.Tracer = tracer
+
+	result, err := r.DrainAndWait(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Completed)
+	require.Len(t, cmdRunner.calls, 2)
+
+	first := cmdRunner.calls[0]
+	assert.Equal(t, "copilot-quota-fail", first.Command)
+	assert.True(t, containsArgSequence(first.Args, "--model", "gpt-med"))
+	assert.Contains(t, first.Env, "GITHUB_TOKEN=copilot-secret")
+	assert.NotContains(t, first.Env, "ANTHROPIC_API_KEY=anthropic-secret")
+
+	second := cmdRunner.calls[1]
+	assert.Equal(t, "claude-success", second.Command)
+	assert.True(t, containsArgSequence(second.Args, "--model", "claude-med"))
+	assert.Contains(t, second.Env, "ANTHROPIC_API_KEY=anthropic-secret")
+	assert.NotContains(t, second.Env, "GITHUB_TOKEN=copilot-secret")
+	assert.Equal(t, "Fix the bug", second.Prompt)
+
+	attrs := spanAttrMap(endedSpanByName(t, rec, "phase:implement"))
+	assert.Equal(t, "secondary", attrs["xylem.phase.provider"])
+	assert.Equal(t, "claude-med", attrs["xylem.phase.model"])
 	assert.Equal(t, "secondary", attrs["llm.provider"])
 	assert.Equal(t, "med", attrs["llm.tier"])
 }

--- a/cli/internal/runner/runner_prop_test.go
+++ b/cli/internal/runner/runner_prop_test.go
@@ -62,6 +62,21 @@ func TestProp_ClassifyProviderError_AuthSentinelsAreFallbackOnly(t *testing.T) {
 	})
 }
 
+func TestProp_ClassifyProviderError_QuotaSentinelsAreFallback(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		prefix := rapid.StringMatching(`[A-Za-z0-9 _:/.]{0,32}`).Draw(t, "prefix")
+		suffix := rapid.StringMatching(`[A-Za-z0-9 _:/.]{0,32}`).Draw(t, "suffix")
+		sentinel := rapid.SampledFrom([]string{
+			"no quota",
+		}).Draw(t, "sentinel")
+
+		got := classifyProviderError(errors.New(prefix + sentinel + suffix))
+		if got != providerErrorFallbackNextProvider {
+			t.Fatalf("classifyProviderError() = %v, want %v", got, providerErrorFallbackNextProvider)
+		}
+	})
+}
+
 func TestProp_FilterAdditiveProtectedSurfaceViolationsDropsOnlyAdditions(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		allowAdditive := rapid.Bool().Draw(t, "allowAdditive")

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -9816,6 +9816,8 @@ func TestClassifyProviderError(t *testing.T) {
 		{name: "model access failure falls back", err: errors.New("provider: not authorized to access this model"), want: providerErrorFallbackNextProvider},
 		{name: "service unavailable falls back", err: errors.New("provider returned service unavailable"), want: providerErrorFallbackNextProvider},
 		{name: "missing command falls back", err: errors.New("claude: executable file not found in $PATH"), want: providerErrorFallbackNextProvider},
+		{name: "quota exhaustion falls back to next provider", err: errors.New("402 You have no quota (Request ID: EBB5:1DBFAF)"), want: providerErrorFallbackNextProvider},
+		{name: "quota exceeded without sentinel does not fall back", err: errors.New("quota exceeded"), want: providerErrorFail},
 		{name: "plain unauthorized does not fall back", err: errors.New("unauthorized"), want: providerErrorFail},
 		{name: "plain forbidden does not fall back", err: errors.New("forbidden"), want: providerErrorFail},
 	}


### PR DESCRIPTION
## Summary

Fixes https://github.com/nicholls-inc/xylem/issues/417 — cascade step 6 of the provider error-classification chain.

When Copilot exhausts its quota it returns `"402 You have no quota (Request ID: ...)"`. This string matched neither `transientPatterns` (which drive retry-same-provider) nor `fallbackPatterns` (which drive fallback-next-provider), so `classifyProviderError` fell through to `providerErrorFail` and the vessel was marked failed without ever trying the Claude fallback.

The fix adds `"no quota"` to `fallbackPatterns` in `classifyProviderError`. Quota exhaustion is permanent for the billing period — retrying the same provider wastes turns — so `providerErrorFallbackNextProvider` is the correct disposition.

Also fixes the `golangci-lint` pre-commit hook entry to use `GOCACHE=${TMPDIR:-/tmp}/golangci-lint-cache golangci-lint run ./...` instead of the broken `--path-mode=abs` invocation (which fails with exit code 5 in this environment).

## Smoke scenarios covered

No Harbor scenario IDs are assigned to this issue. The fix is covered by unit, property-based, and integration tests:

- **Unit** — `TestClassifyProviderError/quota_exhaustion_falls_back_to_next_provider`: verifies `"402 You have no quota (Request ID: EBB5:1DBFAF)"` → `providerErrorFallbackNextProvider`
- **Property** — `TestProp_ClassifyProviderError_QuotaSentinelsAreFallback`: 100 rapid checks asserting any string containing `"no quota"` returns `providerErrorFallbackNextProvider`
- **Integration** — `TestRunPhaseWithProviderFallbackFallsBackAfterQuotaExhaustion`: end-to-end runner test with a `copilot-quota-fail` stub confirming the vessel completes via the secondary provider

## Changes summary

### Files modified

| File | Change |
|---|---|
| `cli/internal/runner/runner.go` | Add `"no quota"` to `fallbackPatterns` in `classifyProviderError` |
| `cli/internal/runner/runner_test.go` | Add `quota_exhaustion_falls_back_to_next_provider` table case to `TestClassifyProviderError` |
| `cli/internal/runner/runner_prop_test.go` | Add `TestProp_ClassifyProviderError_QuotaSentinelsAreFallback` property test |
| `cli/internal/runner/runner_fallback_test.go` | Add `copilot-quota-fail` stub to `fallbackCmdRunner` and `TestRunPhaseWithProviderFallbackFallsBackAfterQuotaExhaustion` integration test |
| `.pre-commit-config.yaml` | Fix `golangci-lint` hook to use `GOCACHE=${TMPDIR:-/tmp}/golangci-lint-cache golangci-lint run ./...` |

### Key functions

- `classifyProviderError` (`runner.go`) — three-way dispatch: retry-same, fallback-next, fail. The `fallbackPatterns` slice now includes `"no quota"`.
- `fallbackCmdRunner.RunPhaseWithEnv` (`runner_fallback_test.go`) — stub switch extended with `"copilot-quota-fail"` case returning `errors.New("402 You have no quota")`.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./cmd/xylem` — clean
- [x] `go test ./...` — all packages pass
- [x] `go test ./internal/runner -run TestClassifyProviderError` — 13 cases pass including new quota case
- [x] `go test ./internal/runner -run TestProp_ClassifyProviderError_QuotaSentinelsAreFallback` — 100 rapid iterations pass
- [x] `go test ./internal/runner -run TestRunPhaseWithProviderFallbackFallsBackAfterQuotaExhaustion` — passes, confirms fallback fires and vessel completes

Fixes #417