### PR TITLE
feat: remote monitoring via GitHub Discussions + Telegram escalation

### DIFF
--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -38,7 +38,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "bootstrap", "config", "workflow", "continuous-improvement", "continuous-simplicity", "release-cadence", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "recovery", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report"}
+	expected := []string{"init", "bootstrap", "config", "workflow", "continuous-improvement", "continuous-simplicity", "release-cadence", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "recovery", "report", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -167,6 +167,9 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		stallChecks = daemonChecksFromFindings(findings, daemonNow())
 	}
 
+	// Notification system: periodic status reports + escalation alerts.
+	dn := newDaemonNotifier(cfg, q)
+
 	tickHook := func(now time.Time, state daemonTickState) {
 		if !state.LastUpgrade.IsZero() {
 			lastUpgradeAt = state.LastUpgrade
@@ -189,6 +192,14 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 		}
 		if err := daemonhealth.Save(cfg.StateDir, snapshot); err != nil {
 			slog.Warn("daemon save health failed", "error", err)
+		}
+
+		// Dispatch notifications (status reports + escalation alerts).
+		if dn != nil {
+			upgradeOverdue := upgrade != nil && upgradeInterval > 0 &&
+				now.Sub(lastUpgradeAt) >= upgradeInterval*3
+			upgradeOverdueBy := now.Sub(lastUpgradeAt) - upgradeInterval
+			dn.tick(ctx, now, checks, upgradeOverdue, upgradeOverdueBy)
 		}
 	}
 

--- a/cli/cmd/xylem/daemon_notify.go
+++ b/cli/cmd/xylem/daemon_notify.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/daemonhealth"
+	"github.com/nicholls-inc/xylem/cli/internal/discussion"
+	"github.com/nicholls-inc/xylem/cli/internal/notify"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/reporter"
+)
+
+// daemonNotifier holds the state for periodic status reporting and escalation
+// alerting within the daemon loop.
+type daemonNotifier struct {
+	multi    *notify.Multi
+	rules    []notify.EscalationRule
+	cfg      *config.Config
+	q        *queue.Queue
+	interval time.Duration
+
+	lastReportAt time.Time
+}
+
+// newDaemonNotifier constructs the notifier from config. Returns nil if no
+// notifications are configured.
+func newDaemonNotifier(cfg *config.Config, q *queue.Queue) *daemonNotifier {
+	ncfg := cfg.Notifications
+	if !ncfg.GitHubDiscussion.Enabled && !ncfg.Telegram.Enabled {
+		return nil
+	}
+
+	var notifiers []notify.Notifier
+
+	if ncfg.GitHubDiscussion.Enabled {
+		repoSlug := ncfg.GitHubDiscussion.Repo
+		if repoSlug == "" {
+			repoSlug = resolveDefaultRepo(cfg)
+		}
+		if repoSlug != "" {
+			cmdRunner := newCmdRunner(cfg)
+			pub := &discussion.Publisher{Runner: cmdRunner}
+			disc, err := notify.NewDiscussion(pub, repoSlug,
+				ncfg.GitHubDiscussion.Category,
+				ncfg.GitHubDiscussion.Title)
+			if err != nil {
+				slog.Warn("daemon: failed to create discussion notifier", "error", err)
+			} else {
+				notifiers = append(notifiers, disc)
+			}
+		} else {
+			slog.Warn("daemon: discussion notifications enabled but no repo configured")
+		}
+	}
+
+	if ncfg.Telegram.Enabled {
+		token := os.Getenv(ncfg.Telegram.TokenEnv)
+		chatID := os.Getenv(ncfg.Telegram.ChatIDEnv)
+		if token != "" && chatID != "" {
+			tg := notify.NewTelegram(token, chatID, ncfg.Telegram.Levels)
+			notifiers = append(notifiers, tg)
+		} else {
+			slog.Warn("daemon: telegram notifications enabled but token/chat_id env vars empty",
+				"token_env", ncfg.Telegram.TokenEnv,
+				"chat_id_env", ncfg.Telegram.ChatIDEnv)
+		}
+	}
+
+	if len(notifiers) == 0 {
+		return nil
+	}
+
+	interval := time.Hour
+	if ncfg.GitHubDiscussion.Interval != "" {
+		if d, err := time.ParseDuration(ncfg.GitHubDiscussion.Interval); err == nil && d > 0 {
+			interval = d
+		}
+	}
+
+	return &daemonNotifier{
+		multi:    &notify.Multi{Notifiers: notifiers},
+		rules:    notify.DefaultRules(),
+		cfg:      cfg,
+		q:        q,
+		interval: interval,
+	}
+}
+
+// tick is called from the daemon's tickHook on every loop iteration. It
+// handles both periodic status reports and real-time escalation checks.
+func (dn *daemonNotifier) tick(ctx context.Context, now time.Time, checks []daemonhealth.Check, upgradeOverdue bool, upgradeOverdueBy time.Duration) {
+	// Escalation check: runs every tick (~30s).
+	dn.checkEscalations(ctx, now, checks, upgradeOverdue, upgradeOverdueBy)
+
+	// Status report: runs at configured interval (default 1h).
+	if now.Sub(dn.lastReportAt) >= dn.interval {
+		dn.postReport(ctx, now)
+		dn.lastReportAt = now
+	}
+}
+
+func (dn *daemonNotifier) checkEscalations(ctx context.Context, now time.Time, checks []daemonhealth.Check, upgradeOverdue bool, upgradeOverdueBy time.Duration) {
+	vessels, err := dn.q.List()
+	if err != nil {
+		return
+	}
+
+	state := buildFleetState(vessels, checks, now, upgradeOverdue, upgradeOverdueBy)
+	alerts := notify.Evaluate(dn.rules, state)
+	for _, alert := range alerts {
+		if err := dn.multi.SendAlert(ctx, alert); err != nil {
+			slog.Warn("daemon: escalation alert failed", "code", alert.Code, "error", err)
+		}
+	}
+}
+
+func (dn *daemonNotifier) postReport(ctx context.Context, now time.Time) {
+	report := reporter.CollectStatus(ctx, reporter.StatusDeps{
+		StateDir:      dn.cfg.StateDir,
+		Queue:         dn.q,
+		FleetAnalyzer: fleetAnalyzerFromRunner,
+	}, now)
+
+	md := reporter.FormatMarkdown(report)
+	if err := dn.multi.PostStatus(ctx, notify.StatusReport{Markdown: md}); err != nil {
+		slog.Warn("daemon: status report post failed", "error", err)
+	} else {
+		slog.Info("daemon: status report posted")
+	}
+}
+
+// buildFleetState constructs the notify.FleetState from current queue state.
+func buildFleetState(vessels []queue.Vessel, checks []daemonhealth.Check, now time.Time, upgradeOverdue bool, upgradeOverdueBy time.Duration) notify.FleetState {
+	state := notify.FleetState{
+		UpgradeOverdue:   upgradeOverdue,
+		UpgradeOverdueBy: upgradeOverdueBy,
+	}
+
+	cutoff := now.Add(-time.Hour)
+	var oldestPendingCreated time.Time
+
+	for _, v := range vessels {
+		switch v.State {
+		case queue.StatePending:
+			state.Pending++
+			if oldestPendingCreated.IsZero() || v.CreatedAt.Before(oldestPendingCreated) {
+				oldestPendingCreated = v.CreatedAt
+			}
+		case queue.StateRunning:
+			state.Running++
+		case queue.StateCompleted:
+			state.Completed++
+			if v.EndedAt != nil && v.EndedAt.After(cutoff) {
+				state.RecentCompletions++
+			}
+		case queue.StateFailed:
+			state.Failed++
+			if v.EndedAt != nil && v.EndedAt.After(cutoff) {
+				state.RecentFailures = append(state.RecentFailures, notify.VesselFailure{
+					VesselID:  v.ID,
+					Error:     v.Error,
+					Timestamp: *v.EndedAt,
+				})
+			}
+		case queue.StateTimedOut:
+			state.TimedOut++
+			if v.EndedAt != nil && v.EndedAt.After(cutoff) {
+				state.RecentFailures = append(state.RecentFailures, notify.VesselFailure{
+					VesselID:  v.ID,
+					Error:     v.Error,
+					Timestamp: *v.EndedAt,
+				})
+			}
+		case queue.StateWaiting:
+			state.Waiting++
+		case queue.StateCancelled:
+			state.Cancelled++
+		}
+	}
+
+	if !oldestPendingCreated.IsZero() {
+		state.OldestPendingAge = now.Sub(oldestPendingCreated)
+	}
+
+	for _, c := range checks {
+		state.HealthChecks = append(state.HealthChecks, notify.HealthCheck{
+			Code:    c.Code,
+			Level:   string(c.Level),
+			Message: c.Message,
+		})
+	}
+
+	return state
+}

--- a/cli/cmd/xylem/report.go
+++ b/cli/cmd/xylem/report.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/discussion"
+	"github.com/nicholls-inc/xylem/cli/internal/notify"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/nicholls-inc/xylem/cli/internal/reporter"
+	"github.com/nicholls-inc/xylem/cli/internal/runner"
+)
+
+func newReportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "report",
+		Short: "Collect and display daemon status report",
+		Long: `Collect vessel metrics, daemon health, and fleet status into a report.
+
+By default, prints to stdout. Use --post to also post to the configured
+GitHub Discussion. Use --json for machine-readable output.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			post, _ := cmd.Flags().GetBool("post")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			root, _ := cmd.Flags().GetString("root")
+
+			scopedDeps, err := doctorDepsForRoot(deps, root)
+			if err != nil {
+				return err
+			}
+			return cmdReport(scopedDeps.cfg, scopedDeps.q, post, jsonMode)
+		},
+	}
+	cmd.Flags().Bool("post", false, "Post report to configured GitHub Discussion")
+	cmd.Flags().Bool("json", false, "Output as JSON")
+	cmd.Flags().String("root", "", "Collect status from the xylem state rooted at this directory")
+	return cmd
+}
+
+func cmdReport(cfg *config.Config, q *queue.Queue, post, jsonMode bool) error {
+	now := time.Now()
+	report := reporter.CollectStatus(context.Background(), reporter.StatusDeps{
+		StateDir:      cfg.StateDir,
+		Queue:         q,
+		FleetAnalyzer: fleetAnalyzerFromRunner,
+	}, now)
+
+	if jsonMode {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+
+	if !post {
+		fmt.Print(reporter.FormatPlainText(report))
+		return nil
+	}
+
+	// Post to GitHub Discussion.
+	fmt.Print(reporter.FormatPlainText(report))
+
+	dcfg := cfg.Notifications.GitHubDiscussion
+	if !dcfg.Enabled {
+		return fmt.Errorf("notifications.github_discussion.enabled is false; enable it in .xylem.yml to post")
+	}
+	repoSlug := dcfg.Repo
+	if repoSlug == "" {
+		repoSlug = resolveDefaultRepo(cfg)
+	}
+	if repoSlug == "" {
+		return fmt.Errorf("notifications.github_discussion.repo not set and no source repo found")
+	}
+
+	cmdRunner := newCmdRunner(cfg)
+	pub := &discussion.Publisher{Runner: cmdRunner}
+	disc, err := notify.NewDiscussion(pub, repoSlug, dcfg.Category, dcfg.Title)
+	if err != nil {
+		return fmt.Errorf("create discussion notifier: %w", err)
+	}
+
+	md := reporter.FormatMarkdown(report)
+	if err := disc.PostStatus(context.Background(), notify.StatusReport{Markdown: md}); err != nil {
+		return fmt.Errorf("post to discussion: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Posted status to GitHub Discussion\n")
+	return nil
+}
+
+// fleetAnalyzerFromRunner bridges the reporter's FleetAnalyzer callback to the
+// runner package, resolving the import cycle.
+func fleetAnalyzerFromRunner(stateDir string, vessels []queue.Vessel) reporter.FleetHealth {
+	ids := make([]string, len(vessels))
+	for i, v := range vessels {
+		ids[i] = v.ID
+	}
+	summaries, _ := runner.LoadVesselSummaries(stateDir, ids)
+	fleet := runner.AnalyzeFleetStatus(vessels, summaries)
+	patterns := make([]reporter.FleetPattern, len(fleet.Patterns))
+	for i, p := range fleet.Patterns {
+		patterns[i] = reporter.FleetPattern{Code: p.Code, Count: p.Count}
+	}
+	return reporter.FleetHealth{
+		Healthy:   fleet.Healthy,
+		Degraded:  fleet.Degraded,
+		Unhealthy: fleet.Unhealthy,
+		Patterns:  patterns,
+	}
+}
+
+// resolveDefaultRepo finds the first GitHub source's repo slug from config.
+func resolveDefaultRepo(cfg *config.Config) string {
+	if cfg.Repo != "" {
+		return cfg.Repo
+	}
+	for _, src := range cfg.Sources {
+		if src.Repo != "" {
+			return src.Repo
+		}
+	}
+	return ""
+}

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -118,6 +118,7 @@ func newRootCmd() *cobra.Command {
 		newCancelCmd(),
 		newCleanupCmd(),
 		newDoctorCmd(),
+		newReportCmd(),
 		newDaemonCmd(),
 		newDaemonSupervisorCmd(),
 		newRetryCmd(),

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -94,6 +94,7 @@ type Config struct {
 	Observability       ObservabilityConfig       `yaml:"observability,omitempty"`
 	Cost                CostConfig                `yaml:"cost,omitempty"`
 	Telemetry           TelemetryConfig           `yaml:"telemetry,omitempty"`
+	Notifications       NotificationsConfig       `yaml:"notifications,omitempty"`
 	configPath          string
 }
 
@@ -304,6 +305,26 @@ type BudgetConfig struct {
 	MaxTokens  int     `yaml:"max_tokens,omitempty"`
 }
 
+type NotificationsConfig struct {
+	GitHubDiscussion DiscussionNotifyConfig `yaml:"github_discussion,omitempty"`
+	Telegram         TelegramNotifyConfig   `yaml:"telegram,omitempty"`
+}
+
+type DiscussionNotifyConfig struct {
+	Enabled  bool   `yaml:"enabled,omitempty"`
+	Repo     string `yaml:"repo,omitempty"`
+	Category string `yaml:"category,omitempty"`
+	Interval string `yaml:"interval,omitempty"`
+	Title    string `yaml:"title,omitempty"`
+}
+
+type TelegramNotifyConfig struct {
+	Enabled   bool     `yaml:"enabled,omitempty"`
+	TokenEnv  string   `yaml:"token_env,omitempty"`
+	ChatIDEnv string   `yaml:"chat_id_env,omitempty"`
+	Levels    []string `yaml:"levels,omitempty"`
+}
+
 type parsedConcurrency struct {
 	Global   int
 	PerClass map[string]int
@@ -372,6 +393,18 @@ func load(path string, validate bool) (*Config, error) {
 		},
 		Cost: CostConfig{
 			OnExceeded: DefaultCostOnExceeded,
+		},
+		Notifications: NotificationsConfig{
+			GitHubDiscussion: DiscussionNotifyConfig{
+				Category: "Reports",
+				Interval: "1h",
+				Title:    "Xylem Daemon Status Log",
+			},
+			Telegram: TelegramNotifyConfig{
+				TokenEnv:  "XYLEM_TELEGRAM_TOKEN",
+				ChatIDEnv: "XYLEM_TELEGRAM_CHAT_ID",
+				Levels:    []string{"critical", "warning"},
+			},
 		},
 	}
 

--- a/cli/internal/discussion/discussion.go
+++ b/cli/internal/discussion/discussion.go
@@ -1,0 +1,220 @@
+package discussion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	resolveQuery = `query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    id
+    discussionCategories(first: 25) { nodes { id, name } }
+  }
+}`
+	searchQuery = `query($repoId: ID!, $catId: ID!) {
+  node(id: $repoId) {
+    ... on Repository {
+      discussions(first: 20, categoryId: $catId, orderBy: {field: CREATED_AT, direction: DESC}) {
+        nodes { id, title, url }
+      }
+    }
+  }
+}`
+	createMutation = `mutation($repoId: ID!, $catId: ID!, $title: String!, $body: String!) {
+  createDiscussion(input: {repositoryId: $repoId, title: $title, body: $body, categoryId: $catId}) {
+    discussion { id, title, url }
+  }
+}`
+	commentMutation = `mutation($discussionId: ID!, $body: String!) {
+  addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+    comment { url }
+  }
+}`
+)
+
+// CommandRunner abstracts subprocess execution for the discussion publisher.
+type CommandRunner interface {
+	RunOutput(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// Ref identifies an existing GitHub discussion.
+type Ref struct {
+	ID    string
+	Title string
+	URL   string
+}
+
+// Target holds the resolved repository and category IDs needed for
+// discussion operations.
+type Target struct {
+	RepoID     string
+	CategoryID string
+}
+
+// Publisher manages GitHub discussion creation and commenting via the
+// gh CLI's GraphQL endpoint.
+type Publisher struct {
+	Runner CommandRunner
+}
+
+// ResolveTarget resolves a repository owner/name and category name into
+// their GraphQL node IDs.
+func (p *Publisher) ResolveTarget(ctx context.Context, owner, repo, category string) (Target, error) {
+	out, err := p.Runner.RunOutput(ctx, "gh", "api", "graphql",
+		"-f", "query="+resolveQuery,
+		"-f", "owner="+owner,
+		"-f", "repo="+repo)
+	if err != nil {
+		return Target{}, fmt.Errorf("resolve repo %s/%s: %w", owner, repo, err)
+	}
+
+	var resp struct {
+		Data struct {
+			Repository struct {
+				ID                   string `json:"id"`
+				DiscussionCategories struct {
+					Nodes []struct {
+						ID   string `json:"id"`
+						Name string `json:"name"`
+					} `json:"nodes"`
+				} `json:"discussionCategories"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return Target{}, fmt.Errorf("parse discussion target response: %w", err)
+	}
+	if resp.Data.Repository.ID == "" {
+		return Target{}, fmt.Errorf("could not resolve repository %s/%s", owner, repo)
+	}
+
+	for _, node := range resp.Data.Repository.DiscussionCategories.Nodes {
+		if node.Name == category {
+			return Target{RepoID: resp.Data.Repository.ID, CategoryID: node.ID}, nil
+		}
+	}
+	return Target{}, fmt.Errorf("discussion category %q not found in %s/%s", category, owner, repo)
+}
+
+// FindExisting searches recent discussions in the given repository and
+// category for one whose title starts with titlePrefix.
+func (p *Publisher) FindExisting(ctx context.Context, repoID, categoryID, titlePrefix string) (Ref, error) {
+	out, err := p.Runner.RunOutput(ctx, "gh", "api", "graphql",
+		"-f", "query="+searchQuery,
+		"-f", "repoId="+repoID,
+		"-f", "catId="+categoryID)
+	if err != nil {
+		return Ref{}, fmt.Errorf("search discussions: %w", err)
+	}
+
+	var resp struct {
+		Data struct {
+			Node struct {
+				Discussions struct {
+					Nodes []struct {
+						ID    string `json:"id"`
+						Title string `json:"title"`
+						URL   string `json:"url"`
+					} `json:"nodes"`
+				} `json:"discussions"`
+			} `json:"node"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return Ref{}, fmt.Errorf("parse discussion search response: %w", err)
+	}
+
+	for _, node := range resp.Data.Node.Discussions.Nodes {
+		if strings.HasPrefix(node.Title, titlePrefix) {
+			return Ref{ID: node.ID, Title: node.Title, URL: node.URL}, nil
+		}
+	}
+	return Ref{}, nil
+}
+
+// Comment adds a comment to an existing discussion.
+func (p *Publisher) Comment(ctx context.Context, discussionID, body string) error {
+	if _, err := p.Runner.RunOutput(ctx, "gh", "api", "graphql",
+		"-f", "query="+commentMutation,
+		"-f", "discussionId="+discussionID,
+		"-f", "body="+body); err != nil {
+		return fmt.Errorf("add discussion comment: %w", err)
+	}
+	return nil
+}
+
+// Create creates a new discussion and returns a reference to it.
+func (p *Publisher) Create(ctx context.Context, repoID, categoryID, title, body string) (Ref, error) {
+	out, err := p.Runner.RunOutput(ctx, "gh", "api", "graphql",
+		"-f", "query="+createMutation,
+		"-f", "repoId="+repoID,
+		"-f", "catId="+categoryID,
+		"-f", "title="+title,
+		"-f", "body="+body)
+	if err != nil {
+		return Ref{}, err
+	}
+
+	var resp struct {
+		Data struct {
+			CreateDiscussion struct {
+				Discussion struct {
+					ID    string `json:"id"`
+					Title string `json:"title"`
+					URL   string `json:"url"`
+				} `json:"discussion"`
+			} `json:"createDiscussion"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return Ref{}, fmt.Errorf("parse create discussion response: %w", err)
+	}
+	if resp.Data.CreateDiscussion.Discussion.ID == "" {
+		return Ref{}, fmt.Errorf("create discussion response missing discussion id")
+	}
+	return Ref{
+		ID:    resp.Data.CreateDiscussion.Discussion.ID,
+		Title: resp.Data.CreateDiscussion.Discussion.Title,
+		URL:   resp.Data.CreateDiscussion.Discussion.URL,
+	}, nil
+}
+
+// FindOrComment is a high-level flow that resolves a discussion target,
+// searches for an existing discussion by title prefix, and either comments
+// on it or creates a new one. Returns the discussion URL.
+func (p *Publisher) FindOrComment(ctx context.Context, owner, repo, category, titlePrefix, title, body string) (string, error) {
+	target, err := p.ResolveTarget(ctx, owner, repo, category)
+	if err != nil {
+		return "", err
+	}
+
+	existing, err := p.FindExisting(ctx, target.RepoID, target.CategoryID, titlePrefix)
+	if err != nil {
+		return "", err
+	}
+	if existing.ID != "" {
+		if err := p.Comment(ctx, existing.ID, body); err != nil {
+			return "", fmt.Errorf("comment existing discussion %q: %w", existing.Title, err)
+		}
+		return existing.URL, nil
+	}
+
+	created, err := p.Create(ctx, target.RepoID, target.CategoryID, title, body)
+	if err != nil {
+		return "", fmt.Errorf("create discussion %q: %w", title, err)
+	}
+	return created.URL, nil
+}
+
+// SplitRepoSlug parses an "owner/repo" string into its components.
+func SplitRepoSlug(slug string) (owner, repo string, err error) {
+	slug = strings.TrimSpace(slug)
+	parts := strings.Split(slug, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", "", fmt.Errorf("repo slug %q must be in owner/repo form", slug)
+	}
+	return parts[0], parts[1], nil
+}

--- a/cli/internal/discussion/discussion_test.go
+++ b/cli/internal/discussion/discussion_test.go
@@ -1,0 +1,429 @@
+package discussion
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// mockResponse pairs output bytes with an optional error for a single call.
+type mockResponse struct {
+	output []byte
+	err    error
+}
+
+// mockRunner records every RunOutput invocation and replays canned responses
+// keyed by the joined (name + args) string.
+type mockRunner struct {
+	calls     [][]string
+	responses map[string]mockResponse
+}
+
+func (m *mockRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	m.calls = append(m.calls, call)
+
+	key := strings.Join(call, "\x00")
+	if resp, ok := m.responses[key]; ok {
+		return resp.output, resp.err
+	}
+	return nil, errors.New("unexpected call: " + strings.Join(call, " "))
+}
+
+// responseKey builds the lookup key that mockRunner uses.
+func responseKey(name string, args ...string) string {
+	return strings.Join(append([]string{name}, args...), "\x00")
+}
+
+// --- helpers to build realistic GraphQL JSON responses ---
+
+func resolveJSON(repoID string, categories map[string]string) []byte {
+	type catNode struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	nodes := make([]catNode, 0, len(categories))
+	for name, id := range categories {
+		nodes = append(nodes, catNode{ID: id, Name: name})
+	}
+	resp := struct {
+		Data struct {
+			Repository struct {
+				ID                   string `json:"id"`
+				DiscussionCategories struct {
+					Nodes []catNode `json:"nodes"`
+				} `json:"discussionCategories"`
+			} `json:"repository"`
+		} `json:"data"`
+	}{}
+	resp.Data.Repository.ID = repoID
+	resp.Data.Repository.DiscussionCategories.Nodes = nodes
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+func searchJSON(discussions []Ref) []byte {
+	type disc struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+		URL   string `json:"url"`
+	}
+	nodes := make([]disc, 0, len(discussions))
+	for _, d := range discussions {
+		nodes = append(nodes, disc(d))
+	}
+	resp := struct {
+		Data struct {
+			Node struct {
+				Discussions struct {
+					Nodes []disc `json:"nodes"`
+				} `json:"discussions"`
+			} `json:"node"`
+		} `json:"data"`
+	}{}
+	resp.Data.Node.Discussions.Nodes = nodes
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+func createJSON(id, title, url string) []byte {
+	resp := struct {
+		Data struct {
+			CreateDiscussion struct {
+				Discussion struct {
+					ID    string `json:"id"`
+					Title string `json:"title"`
+					URL   string `json:"url"`
+				} `json:"discussion"`
+			} `json:"createDiscussion"`
+		} `json:"data"`
+	}{}
+	resp.Data.CreateDiscussion.Discussion.ID = id
+	resp.Data.CreateDiscussion.Discussion.Title = title
+	resp.Data.CreateDiscussion.Discussion.URL = url
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+func commentJSON() []byte {
+	resp := struct {
+		Data struct {
+			AddDiscussionComment struct {
+				Comment struct {
+					URL string `json:"url"`
+				} `json:"comment"`
+			} `json:"addDiscussionComment"`
+		} `json:"data"`
+	}{}
+	resp.Data.AddDiscussionComment.Comment.URL = "https://github.com/owner/repo/discussions/1#comment-42"
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+// --- Tests ---
+
+func TestResolveTarget(t *testing.T) {
+	m := &mockRunner{responses: map[string]mockResponse{
+		responseKey("gh", "api", "graphql",
+			"-f", "query="+resolveQuery,
+			"-f", "owner=acme",
+			"-f", "repo=widgets"): {
+			output: resolveJSON("R_abc123", map[string]string{
+				"General":       "DC_general",
+				"Announcements": "DC_announce",
+			}),
+		},
+	}}
+
+	p := Publisher{Runner: m}
+	target, err := p.ResolveTarget(context.Background(), "acme", "widgets", "General")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if target.RepoID != "R_abc123" {
+		t.Errorf("RepoID = %q, want %q", target.RepoID, "R_abc123")
+	}
+	if target.CategoryID != "DC_general" {
+		t.Errorf("CategoryID = %q, want %q", target.CategoryID, "DC_general")
+	}
+}
+
+func TestResolveTarget_CategoryNotFound(t *testing.T) {
+	m := &mockRunner{responses: map[string]mockResponse{
+		responseKey("gh", "api", "graphql",
+			"-f", "query="+resolveQuery,
+			"-f", "owner=acme",
+			"-f", "repo=widgets"): {
+			output: resolveJSON("R_abc123", map[string]string{
+				"General": "DC_general",
+			}),
+		},
+	}}
+
+	p := Publisher{Runner: m}
+	_, err := p.ResolveTarget(context.Background(), "acme", "widgets", "Missing")
+	if err == nil {
+		t.Fatal("expected error for missing category")
+	}
+	if !strings.Contains(err.Error(), `"Missing"`) {
+		t.Errorf("error = %q, want mention of category name", err.Error())
+	}
+}
+
+func TestFindExisting(t *testing.T) {
+	refs := []Ref{
+		{ID: "D_99", Title: "Weekly Report 2026-04-12", URL: "https://github.com/acme/widgets/discussions/99"},
+		{ID: "D_98", Title: "Weekly Report 2026-04-05", URL: "https://github.com/acme/widgets/discussions/98"},
+	}
+	m := &mockRunner{responses: map[string]mockResponse{
+		responseKey("gh", "api", "graphql",
+			"-f", "query="+searchQuery,
+			"-f", "repoId=R_abc123",
+			"-f", "catId=DC_general"): {
+			output: searchJSON(refs),
+		},
+	}}
+
+	p := Publisher{Runner: m}
+	got, err := p.FindExisting(context.Background(), "R_abc123", "DC_general", "Weekly Report")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID != "D_99" {
+		t.Errorf("ID = %q, want %q", got.ID, "D_99")
+	}
+	if got.Title != "Weekly Report 2026-04-12" {
+		t.Errorf("Title = %q, want %q", got.Title, "Weekly Report 2026-04-12")
+	}
+	if got.URL != "https://github.com/acme/widgets/discussions/99" {
+		t.Errorf("URL = %q, want full discussion URL", got.URL)
+	}
+}
+
+func TestFindExisting_NoMatch(t *testing.T) {
+	refs := []Ref{
+		{ID: "D_50", Title: "Something else entirely", URL: "https://github.com/acme/widgets/discussions/50"},
+	}
+	m := &mockRunner{responses: map[string]mockResponse{
+		responseKey("gh", "api", "graphql",
+			"-f", "query="+searchQuery,
+			"-f", "repoId=R_abc123",
+			"-f", "catId=DC_general"): {
+			output: searchJSON(refs),
+		},
+	}}
+
+	p := Publisher{Runner: m}
+	got, err := p.FindExisting(context.Background(), "R_abc123", "DC_general", "Weekly Report")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID != "" {
+		t.Errorf("expected empty Ref, got ID=%q", got.ID)
+	}
+}
+
+func TestComment(t *testing.T) {
+	key := responseKey("gh", "api", "graphql",
+		"-f", "query="+commentMutation,
+		"-f", "discussionId=D_99",
+		"-f", "body=Hello world")
+
+	m := &mockRunner{responses: map[string]mockResponse{
+		key: {output: commentJSON()},
+	}}
+
+	p := Publisher{Runner: m}
+	err := p.Comment(context.Background(), "D_99", "Hello world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(m.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(m.calls))
+	}
+	call := m.calls[0]
+	// Verify key args passed to gh.
+	if call[0] != "gh" {
+		t.Errorf("binary = %q, want gh", call[0])
+	}
+	// The call should include the discussion ID and body verbatim.
+	joined := strings.Join(call, " ")
+	if !strings.Contains(joined, "discussionId=D_99") {
+		t.Error("call missing discussionId field")
+	}
+	if !strings.Contains(joined, "body=Hello world") {
+		t.Error("call missing body field")
+	}
+}
+
+func TestCreate(t *testing.T) {
+	key := responseKey("gh", "api", "graphql",
+		"-f", "query="+createMutation,
+		"-f", "repoId=R_abc123",
+		"-f", "catId=DC_general",
+		"-f", "title=New Discussion",
+		"-f", "body=Some content")
+
+	m := &mockRunner{responses: map[string]mockResponse{
+		key: {output: createJSON("D_100", "New Discussion", "https://github.com/acme/widgets/discussions/100")},
+	}}
+
+	p := Publisher{Runner: m}
+	ref, err := p.Create(context.Background(), "R_abc123", "DC_general", "New Discussion", "Some content")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ref.ID != "D_100" {
+		t.Errorf("ID = %q, want %q", ref.ID, "D_100")
+	}
+	if ref.Title != "New Discussion" {
+		t.Errorf("Title = %q, want %q", ref.Title, "New Discussion")
+	}
+	if ref.URL != "https://github.com/acme/widgets/discussions/100" {
+		t.Errorf("URL = %q, want full discussion URL", ref.URL)
+	}
+}
+
+func TestFindOrComment_ExistingDiscussion(t *testing.T) {
+	resolveKey := responseKey("gh", "api", "graphql",
+		"-f", "query="+resolveQuery,
+		"-f", "owner=acme",
+		"-f", "repo=widgets")
+	searchKey := responseKey("gh", "api", "graphql",
+		"-f", "query="+searchQuery,
+		"-f", "repoId=R_abc123",
+		"-f", "catId=DC_general")
+	commentKey := responseKey("gh", "api", "graphql",
+		"-f", "query="+commentMutation,
+		"-f", "discussionId=D_99",
+		"-f", "body=update body")
+
+	m := &mockRunner{responses: map[string]mockResponse{
+		resolveKey: {output: resolveJSON("R_abc123", map[string]string{"General": "DC_general"})},
+		searchKey: {output: searchJSON([]Ref{
+			{ID: "D_99", Title: "Weekly Report 2026-04-12", URL: "https://github.com/acme/widgets/discussions/99"},
+		})},
+		commentKey: {output: commentJSON()},
+	}}
+
+	p := Publisher{Runner: m}
+	url, err := p.FindOrComment(context.Background(), "acme", "widgets", "General", "Weekly Report", "Weekly Report 2026-04-12", "update body")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if url != "https://github.com/acme/widgets/discussions/99" {
+		t.Errorf("URL = %q, want existing discussion URL", url)
+	}
+
+	// Verify Comment was called, not Create.
+	for _, call := range m.calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, createMutation) {
+			t.Error("Create mutation was called; expected only Comment")
+		}
+	}
+	// Verify Comment WAS called.
+	found := false
+	for _, call := range m.calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, commentMutation) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Comment mutation was not called")
+	}
+}
+
+func TestFindOrComment_NewDiscussion(t *testing.T) {
+	resolveKey := responseKey("gh", "api", "graphql",
+		"-f", "query="+resolveQuery,
+		"-f", "owner=acme",
+		"-f", "repo=widgets")
+	searchKey := responseKey("gh", "api", "graphql",
+		"-f", "query="+searchQuery,
+		"-f", "repoId=R_abc123",
+		"-f", "catId=DC_general")
+	createKey := responseKey("gh", "api", "graphql",
+		"-f", "query="+createMutation,
+		"-f", "repoId=R_abc123",
+		"-f", "catId=DC_general",
+		"-f", "title=Weekly Report 2026-04-12",
+		"-f", "body=fresh body")
+
+	m := &mockRunner{responses: map[string]mockResponse{
+		resolveKey: {output: resolveJSON("R_abc123", map[string]string{"General": "DC_general"})},
+		searchKey:  {output: searchJSON(nil)}, // no existing discussions
+		createKey:  {output: createJSON("D_200", "Weekly Report 2026-04-12", "https://github.com/acme/widgets/discussions/200")},
+	}}
+
+	p := Publisher{Runner: m}
+	url, err := p.FindOrComment(context.Background(), "acme", "widgets", "General", "Weekly Report", "Weekly Report 2026-04-12", "fresh body")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if url != "https://github.com/acme/widgets/discussions/200" {
+		t.Errorf("URL = %q, want newly created discussion URL", url)
+	}
+
+	// Verify Create was called, not Comment.
+	for _, call := range m.calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, commentMutation) {
+			t.Error("Comment mutation was called; expected only Create")
+		}
+	}
+	found := false
+	for _, call := range m.calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, createMutation) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Create mutation was not called")
+	}
+}
+
+func TestSplitRepoSlug(t *testing.T) {
+	tests := []struct {
+		slug      string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{slug: "owner/repo", wantOwner: "owner", wantRepo: "repo"},
+		{slug: "bad", wantErr: true},
+		{slug: "", wantErr: true},
+		{slug: "a/", wantErr: true},
+		{slug: "/b", wantErr: true},
+		{slug: "a/b/c", wantErr: true},
+		{slug: "  owner/repo  ", wantOwner: "owner", wantRepo: "repo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.slug, func(t *testing.T) {
+			owner, repo, err := SplitRepoSlug(tt.slug)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("SplitRepoSlug(%q) expected error, got owner=%q repo=%q", tt.slug, owner, repo)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SplitRepoSlug(%q) unexpected error: %v", tt.slug, err)
+			}
+			if owner != tt.wantOwner {
+				t.Errorf("owner = %q, want %q", owner, tt.wantOwner)
+			}
+			if repo != tt.wantRepo {
+				t.Errorf("repo = %q, want %q", repo, tt.wantRepo)
+			}
+		})
+	}
+}

--- a/cli/internal/notify/discussion.go
+++ b/cli/internal/notify/discussion.go
@@ -1,0 +1,56 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// DiscussionPoster abstracts the find-or-create + comment flow for GitHub
+// Discussions. Satisfied by *discussion.Publisher.
+type DiscussionPoster interface {
+	FindOrComment(ctx context.Context, owner, repo, category, titlePrefix, title, body string) (string, error)
+}
+
+// Discussion posts status reports as comments on a GitHub Discussion.
+type Discussion struct {
+	poster   DiscussionPoster
+	owner    string
+	repo     string
+	category string
+	title    string
+}
+
+// NewDiscussion creates a Discussion notifier. repoSlug must be "owner/repo".
+func NewDiscussion(poster DiscussionPoster, repoSlug, category, title string) (*Discussion, error) {
+	parts := strings.SplitN(repoSlug, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("invalid repo slug %q: expected owner/repo", repoSlug)
+	}
+	return &Discussion{
+		poster:   poster,
+		owner:    parts[0],
+		repo:     parts[1],
+		category: category,
+		title:    title,
+	}, nil
+}
+
+func (d *Discussion) Name() string { return "github_discussion" }
+
+// PostStatus posts the report as a comment on the status Discussion, creating
+// the Discussion if it does not yet exist. Each call resolves the discussion
+// target and searches for an existing discussion by title — two GraphQL calls
+// per invocation. At hourly frequency this is well within GitHub's rate limits.
+func (d *Discussion) PostStatus(ctx context.Context, report StatusReport) error {
+	_, err := d.poster.FindOrComment(ctx, d.owner, d.repo, d.category, d.title, d.title, report.Markdown)
+	if err != nil {
+		return fmt.Errorf("post status to discussion: %w", err)
+	}
+	return nil
+}
+
+// SendAlert is a no-op -- Discussion is for status only.
+func (d *Discussion) SendAlert(_ context.Context, _ Alert) error {
+	return nil
+}

--- a/cli/internal/notify/discussion_test.go
+++ b/cli/internal/notify/discussion_test.go
@@ -1,0 +1,128 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// mockDiscussionPoster implements DiscussionPoster for testing.
+type mockDiscussionPoster struct {
+	findOrCommentCalls []findOrCommentCall
+	findOrCommentURL   string
+	findOrCommentErr   error
+}
+
+type findOrCommentCall struct {
+	owner, repo, category, titlePrefix, title, body string
+}
+
+func (m *mockDiscussionPoster) FindOrComment(_ context.Context, owner, repo, category, titlePrefix, title, body string) (string, error) {
+	m.findOrCommentCalls = append(m.findOrCommentCalls, findOrCommentCall{
+		owner: owner, repo: repo, category: category,
+		titlePrefix: titlePrefix, title: title, body: body,
+	})
+	return m.findOrCommentURL, m.findOrCommentErr
+}
+
+func TestDiscussion_PostStatus_CallsFindOrComment(t *testing.T) {
+	mock := &mockDiscussionPoster{
+		findOrCommentURL: "https://github.com/owner/repo/discussions/42",
+	}
+	d, err := NewDiscussion(mock, "owner/repo", "General", "Status")
+	if err != nil {
+		t.Fatalf("NewDiscussion: %v", err)
+	}
+
+	report := StatusReport{Markdown: "report body"}
+	if err := d.PostStatus(context.Background(), report); err != nil {
+		t.Fatalf("PostStatus: %v", err)
+	}
+
+	if len(mock.findOrCommentCalls) != 1 {
+		t.Fatalf("expected 1 FindOrComment call, got %d", len(mock.findOrCommentCalls))
+	}
+	call := mock.findOrCommentCalls[0]
+	if call.owner != "owner" || call.repo != "repo" {
+		t.Errorf("expected owner/repo, got %s/%s", call.owner, call.repo)
+	}
+	if call.category != "General" {
+		t.Errorf("expected category General, got %q", call.category)
+	}
+	if call.title != "Status" {
+		t.Errorf("expected title Status, got %q", call.title)
+	}
+	if call.body != "report body" {
+		t.Errorf("expected body 'report body', got %q", call.body)
+	}
+}
+
+func TestDiscussion_PostStatus_PropagatesError(t *testing.T) {
+	mock := &mockDiscussionPoster{
+		findOrCommentErr: errors.New("graphql: forbidden"),
+	}
+	d, err := NewDiscussion(mock, "owner/repo", "General", "Status")
+	if err != nil {
+		t.Fatalf("NewDiscussion: %v", err)
+	}
+
+	err = d.PostStatus(context.Background(), StatusReport{Markdown: "body"})
+	if err == nil {
+		t.Fatal("expected error from PostStatus, got nil")
+	}
+	if !errors.Is(err, mock.findOrCommentErr) {
+		// The error is wrapped, so check the message contains the original.
+		if got := err.Error(); got == "" {
+			t.Errorf("expected wrapped error, got empty")
+		}
+	}
+}
+
+func TestDiscussion_SendAlert_IsNoop(t *testing.T) {
+	mock := &mockDiscussionPoster{}
+	d, err := NewDiscussion(mock, "owner/repo", "General", "Status")
+	if err != nil {
+		t.Fatalf("NewDiscussion: %v", err)
+	}
+
+	err = d.SendAlert(context.Background(), Alert{Code: "test"})
+	if err != nil {
+		t.Fatalf("SendAlert should return nil, got: %v", err)
+	}
+	if len(mock.findOrCommentCalls) != 0 {
+		t.Error("SendAlert should not call any poster methods")
+	}
+}
+
+func TestNewDiscussion_InvalidRepoSlug(t *testing.T) {
+	tests := []struct {
+		name string
+		slug string
+	}{
+		{"empty", ""},
+		{"no slash", "ownerrepo"},
+		{"empty owner", "/repo"},
+		{"empty repo", "owner/"},
+	}
+
+	mock := &mockDiscussionPoster{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewDiscussion(mock, tt.slug, "General", "Status")
+			if err == nil {
+				t.Errorf("expected error for slug %q, got nil", tt.slug)
+			}
+		})
+	}
+}
+
+func TestDiscussion_Name(t *testing.T) {
+	mock := &mockDiscussionPoster{}
+	d, err := NewDiscussion(mock, "owner/repo", "General", "Status")
+	if err != nil {
+		t.Fatalf("NewDiscussion: %v", err)
+	}
+	if d.Name() != "github_discussion" {
+		t.Errorf("expected Name()=github_discussion, got %q", d.Name())
+	}
+}

--- a/cli/internal/notify/escalation.go
+++ b/cli/internal/notify/escalation.go
@@ -1,0 +1,237 @@
+package notify
+
+import (
+	"fmt"
+	"time"
+)
+
+// EscalationRule defines when an alert should fire.
+type EscalationRule struct {
+	Code     string
+	Severity AlertSeverity
+	Check    func(state FleetState) *Alert
+}
+
+// FleetState is the input to escalation checks, collected by the reporter.
+type FleetState struct {
+	// Vessel counts by state.
+	Pending   int
+	Running   int
+	Completed int
+	Failed    int
+	TimedOut  int
+	Waiting   int
+	Cancelled int
+
+	// Recent history (within evaluation window).
+	RecentFailures    []VesselFailure
+	RecentCompletions int
+
+	// Health check findings from daemon.
+	HealthChecks []HealthCheck
+
+	// Queue age.
+	OldestPendingAge time.Duration
+
+	// Upgrade state.
+	UpgradeOverdue   bool
+	UpgradeOverdueBy time.Duration
+}
+
+// VesselFailure captures a recent vessel failure for pattern detection.
+type VesselFailure struct {
+	VesselID  string
+	Error     string
+	Timestamp time.Time
+}
+
+// HealthCheck mirrors daemonhealth.Check for escalation evaluation.
+type HealthCheck struct {
+	Code    string
+	Level   string // "ok", "warning", "critical"
+	Message string
+}
+
+// DefaultRules returns the standard escalation rules.
+func DefaultRules() []EscalationRule {
+	return []EscalationRule{
+		{
+			Code:     "auth_failure",
+			Severity: SeverityCritical,
+			Check: func(s FleetState) *Alert {
+				authFailures := filterFailures(s.RecentFailures, isAuthError)
+				if len(authFailures) < 3 {
+					return nil
+				}
+				ids := failureIDs(authFailures)
+				return &Alert{
+					Severity:  SeverityCritical,
+					Code:      "auth_failure",
+					Title:     "Authentication Failure",
+					Detail:    fmt.Sprintf("%d vessels failed with authentication errors. Credentials may need renewal.", len(authFailures)),
+					Timestamp: time.Now(),
+					VesselIDs: ids,
+				}
+			},
+		},
+		{
+			Code:     "high_failure_rate",
+			Severity: SeverityCritical,
+			Check: func(s FleetState) *Alert {
+				total := s.RecentCompletions + len(s.RecentFailures)
+				if total < 5 {
+					return nil // not enough data
+				}
+				failRate := float64(len(s.RecentFailures)) / float64(total)
+				if failRate <= 0.5 {
+					return nil
+				}
+				return &Alert{
+					Severity:  SeverityCritical,
+					Code:      "high_failure_rate",
+					Title:     "High Failure Rate",
+					Detail:    fmt.Sprintf("%.0f%% of recent vessels failed (%d/%d).", failRate*100, len(s.RecentFailures), total),
+					Timestamp: time.Now(),
+					VesselIDs: failureIDs(s.RecentFailures),
+				}
+			},
+		},
+		{
+			Code:     "all_vessels_failing",
+			Severity: SeverityCritical,
+			Check: func(s FleetState) *Alert {
+				if len(s.RecentFailures) < 5 || s.RecentCompletions > 0 {
+					return nil
+				}
+				return &Alert{
+					Severity:  SeverityCritical,
+					Code:      "all_vessels_failing",
+					Title:     "All Vessels Failing",
+					Detail:    fmt.Sprintf("Last %d consecutive vessels all failed with zero completions.", len(s.RecentFailures)),
+					Timestamp: time.Now(),
+					VesselIDs: failureIDs(s.RecentFailures),
+				}
+			},
+		},
+		{
+			Code:     "stall_detected",
+			Severity: SeverityWarning,
+			Check: func(s FleetState) *Alert {
+				for _, hc := range s.HealthChecks {
+					if hc.Level == "critical" {
+						return &Alert{
+							Severity:  SeverityWarning,
+							Code:      "stall_detected",
+							Title:     "Stall Detected",
+							Detail:    hc.Message,
+							Timestamp: time.Now(),
+						}
+					}
+				}
+				return nil
+			},
+		},
+		{
+			Code:     "queue_backlog",
+			Severity: SeverityWarning,
+			Check: func(s FleetState) *Alert {
+				if s.Pending <= 10 || s.OldestPendingAge < 30*time.Minute {
+					return nil
+				}
+				return &Alert{
+					Severity:  SeverityWarning,
+					Code:      "queue_backlog",
+					Title:     "Queue Backlog Growing",
+					Detail:    fmt.Sprintf("%d pending vessels, oldest waiting %s.", s.Pending, s.OldestPendingAge.Truncate(time.Minute)),
+					Timestamp: time.Now(),
+				}
+			},
+		},
+		{
+			Code:     "upgrade_stuck",
+			Severity: SeverityWarning,
+			Check: func(s FleetState) *Alert {
+				if !s.UpgradeOverdue {
+					return nil
+				}
+				return &Alert{
+					Severity:  SeverityWarning,
+					Code:      "upgrade_stuck",
+					Title:     "Auto-Upgrade Stuck",
+					Detail:    fmt.Sprintf("Daemon auto-upgrade is overdue by %s.", s.UpgradeOverdueBy.Truncate(time.Minute)),
+					Timestamp: time.Now(),
+				}
+			},
+		},
+	}
+}
+
+// Evaluate runs all rules against the current fleet state and returns fired alerts.
+func Evaluate(rules []EscalationRule, state FleetState) []Alert {
+	var alerts []Alert
+	for _, rule := range rules {
+		if alert := rule.Check(state); alert != nil {
+			alerts = append(alerts, *alert)
+		}
+	}
+	return alerts
+}
+
+func isAuthError(f VesselFailure) bool {
+	for _, keyword := range []string{"auth", "token", "credential", "login", "401", "403"} {
+		if containsCI(f.Error, keyword) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsCI reports whether s contains substr, case-insensitively.
+func containsCI(s, substr string) bool {
+	sl := len(substr)
+	if sl > len(s) {
+		return false
+	}
+	for i := 0; i <= len(s)-sl; i++ {
+		match := true
+		for j := 0; j < sl; j++ {
+			a, b := s[i+j], substr[j]
+			if a >= 'A' && a <= 'Z' {
+				a += 32
+			}
+			if b >= 'A' && b <= 'Z' {
+				b += 32
+			}
+			if a != b {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func filterFailures(failures []VesselFailure, pred func(VesselFailure) bool) []VesselFailure {
+	var result []VesselFailure
+	for _, f := range failures {
+		if pred(f) {
+			result = append(result, f)
+		}
+	}
+	return result
+}
+
+func failureIDs(failures []VesselFailure) []string {
+	seen := map[string]bool{}
+	var ids []string
+	for _, f := range failures {
+		if !seen[f.VesselID] {
+			seen[f.VesselID] = true
+			ids = append(ids, f.VesselID)
+		}
+	}
+	return ids
+}

--- a/cli/internal/notify/escalation_test.go
+++ b/cli/internal/notify/escalation_test.go
@@ -1,0 +1,351 @@
+package notify
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// helper: find a rule by code from DefaultRules.
+func findRule(t *testing.T, code string) EscalationRule {
+	t.Helper()
+	for _, r := range DefaultRules() {
+		if r.Code == code {
+			return r
+		}
+	}
+	t.Fatalf("no rule found with code %q", code)
+	return EscalationRule{} // unreachable
+}
+
+// helper: generate N auth-related failures.
+func authFailures(n int) []VesselFailure {
+	failures := make([]VesselFailure, n)
+	for i := range failures {
+		failures[i] = VesselFailure{
+			VesselID:  "v" + string(rune('0'+i)),
+			Error:     "authentication failed: token expired",
+			Timestamp: time.Now(),
+		}
+	}
+	return failures
+}
+
+// helper: generate N generic failures.
+func genericFailures(n int) []VesselFailure {
+	failures := make([]VesselFailure, n)
+	for i := range failures {
+		failures[i] = VesselFailure{
+			VesselID:  "v" + string(rune('0'+i)),
+			Error:     "something went wrong",
+			Timestamp: time.Now(),
+		}
+	}
+	return failures
+}
+
+func TestEscalation_AuthFailure_FiresAt3(t *testing.T) {
+	rule := findRule(t, "auth_failure")
+	state := FleetState{
+		RecentFailures: authFailures(3),
+	}
+	alert := rule.Check(state)
+	if alert == nil {
+		t.Fatal("expected auth_failure alert with 3 auth failures, got nil")
+	}
+	if alert.Code != "auth_failure" {
+		t.Errorf("expected code auth_failure, got %q", alert.Code)
+	}
+	if alert.Severity != SeverityCritical {
+		t.Errorf("expected severity critical, got %q", alert.Severity)
+	}
+	if !strings.Contains(alert.Detail, "3 vessels") {
+		t.Errorf("expected detail to mention 3 vessels, got: %q", alert.Detail)
+	}
+}
+
+func TestEscalation_AuthFailure_DoesNotFireAt2(t *testing.T) {
+	rule := findRule(t, "auth_failure")
+	state := FleetState{
+		RecentFailures: authFailures(2),
+	}
+	alert := rule.Check(state)
+	if alert != nil {
+		t.Errorf("expected no alert with only 2 auth failures, got: %+v", alert)
+	}
+}
+
+func TestEscalation_AuthFailure_IgnoresNonAuthErrors(t *testing.T) {
+	rule := findRule(t, "auth_failure")
+	state := FleetState{
+		RecentFailures: genericFailures(10),
+	}
+	alert := rule.Check(state)
+	if alert != nil {
+		t.Errorf("expected no alert with non-auth failures, got: %+v", alert)
+	}
+}
+
+func TestEscalation_HighFailureRate_FiresAbove50Pct(t *testing.T) {
+	rule := findRule(t, "high_failure_rate")
+	state := FleetState{
+		RecentFailures:    genericFailures(4),
+		RecentCompletions: 1,
+	}
+	// 4 failures out of 5 total = 80%
+	alert := rule.Check(state)
+	if alert == nil {
+		t.Fatal("expected high_failure_rate alert at 80% failure rate, got nil")
+	}
+	if alert.Code != "high_failure_rate" {
+		t.Errorf("expected code high_failure_rate, got %q", alert.Code)
+	}
+}
+
+func TestEscalation_HighFailureRate_DoesNotFireWithFewTotal(t *testing.T) {
+	rule := findRule(t, "high_failure_rate")
+	state := FleetState{
+		RecentFailures:    genericFailures(3),
+		RecentCompletions: 0,
+	}
+	// 3 failures out of 3 total = 100%, but total < 5
+	alert := rule.Check(state)
+	if alert != nil {
+		t.Errorf("expected no alert with total < 5, got: %+v", alert)
+	}
+}
+
+func TestEscalation_HighFailureRate_DoesNotFireAt50Pct(t *testing.T) {
+	rule := findRule(t, "high_failure_rate")
+	state := FleetState{
+		RecentFailures:    genericFailures(5),
+		RecentCompletions: 5,
+	}
+	// 5/10 = 50%, check is > 0.5 (strict)
+	alert := rule.Check(state)
+	if alert != nil {
+		t.Errorf("expected no alert at exactly 50%%, got: %+v", alert)
+	}
+}
+
+func TestEscalation_AllVesselsFailing_Fires(t *testing.T) {
+	rule := findRule(t, "all_vessels_failing")
+	state := FleetState{
+		RecentFailures:    genericFailures(5),
+		RecentCompletions: 0,
+	}
+	alert := rule.Check(state)
+	if alert == nil {
+		t.Fatal("expected all_vessels_failing alert, got nil")
+	}
+	if alert.Code != "all_vessels_failing" {
+		t.Errorf("expected code all_vessels_failing, got %q", alert.Code)
+	}
+}
+
+func TestEscalation_AllVesselsFailing_DoesNotFireWithCompletion(t *testing.T) {
+	rule := findRule(t, "all_vessels_failing")
+	state := FleetState{
+		RecentFailures:    genericFailures(5),
+		RecentCompletions: 1,
+	}
+	alert := rule.Check(state)
+	if alert != nil {
+		t.Errorf("expected no alert when there are completions, got: %+v", alert)
+	}
+}
+
+func TestEscalation_AllVesselsFailing_DoesNotFireWithFewFailures(t *testing.T) {
+	rule := findRule(t, "all_vessels_failing")
+	state := FleetState{
+		RecentFailures:    genericFailures(4),
+		RecentCompletions: 0,
+	}
+	alert := rule.Check(state)
+	if alert != nil {
+		t.Errorf("expected no alert with < 5 failures, got: %+v", alert)
+	}
+}
+
+func TestEscalation_StallDetected_FiresOnCriticalHealthCheck(t *testing.T) {
+	rule := findRule(t, "stall_detected")
+	state := FleetState{
+		HealthChecks: []HealthCheck{
+			{Code: "phase_stall", Level: "ok", Message: "all good"},
+			{Code: "orphan", Level: "critical", Message: "vessel stuck for 2h"},
+		},
+	}
+	alert := rule.Check(state)
+	if alert == nil {
+		t.Fatal("expected stall_detected alert on critical health check, got nil")
+	}
+	if alert.Detail != "vessel stuck for 2h" {
+		t.Errorf("expected detail from critical check, got: %q", alert.Detail)
+	}
+	if alert.Severity != SeverityWarning {
+		t.Errorf("expected severity warning, got %q", alert.Severity)
+	}
+}
+
+func TestEscalation_StallDetected_DoesNotFireWithoutCritical(t *testing.T) {
+	rule := findRule(t, "stall_detected")
+	state := FleetState{
+		HealthChecks: []HealthCheck{
+			{Code: "phase_stall", Level: "ok", Message: "fine"},
+			{Code: "orphan", Level: "warning", Message: "meh"},
+		},
+	}
+	alert := rule.Check(state)
+	if alert != nil {
+		t.Errorf("expected no alert without critical health checks, got: %+v", alert)
+	}
+}
+
+func TestEscalation_QueueBacklog_FiresWithBothConditions(t *testing.T) {
+	rule := findRule(t, "queue_backlog")
+	state := FleetState{
+		Pending:          11,
+		OldestPendingAge: 31 * time.Minute,
+	}
+	alert := rule.Check(state)
+	if alert == nil {
+		t.Fatal("expected queue_backlog alert, got nil")
+	}
+	if alert.Code != "queue_backlog" {
+		t.Errorf("expected code queue_backlog, got %q", alert.Code)
+	}
+}
+
+func TestEscalation_QueueBacklog_DoesNotFireWithLowPending(t *testing.T) {
+	rule := findRule(t, "queue_backlog")
+	state := FleetState{
+		Pending:          10, // <= 10 threshold
+		OldestPendingAge: 1 * time.Hour,
+	}
+	alert := rule.Check(state)
+	if alert != nil {
+		t.Errorf("expected no alert with pending <= 10, got: %+v", alert)
+	}
+}
+
+func TestEscalation_QueueBacklog_DoesNotFireWithShortAge(t *testing.T) {
+	rule := findRule(t, "queue_backlog")
+	state := FleetState{
+		Pending:          20,
+		OldestPendingAge: 29 * time.Minute, // < 30min threshold
+	}
+	alert := rule.Check(state)
+	if alert != nil {
+		t.Errorf("expected no alert with age < 30m, got: %+v", alert)
+	}
+}
+
+func TestEscalation_UpgradeStuck_Fires(t *testing.T) {
+	rule := findRule(t, "upgrade_stuck")
+	state := FleetState{
+		UpgradeOverdue:   true,
+		UpgradeOverdueBy: 15 * time.Minute,
+	}
+	alert := rule.Check(state)
+	if alert == nil {
+		t.Fatal("expected upgrade_stuck alert, got nil")
+	}
+	if alert.Code != "upgrade_stuck" {
+		t.Errorf("expected code upgrade_stuck, got %q", alert.Code)
+	}
+	if !strings.Contains(alert.Detail, "15m") {
+		t.Errorf("expected overdue duration in detail, got: %q", alert.Detail)
+	}
+}
+
+func TestEscalation_UpgradeStuck_DoesNotFireWhenNotOverdue(t *testing.T) {
+	rule := findRule(t, "upgrade_stuck")
+	state := FleetState{
+		UpgradeOverdue: false,
+	}
+	alert := rule.Check(state)
+	if alert != nil {
+		t.Errorf("expected no alert when not overdue, got: %+v", alert)
+	}
+}
+
+func TestEvaluate_ReturnsAllFiredRules(t *testing.T) {
+	rules := DefaultRules()
+	state := FleetState{
+		// Auth failure condition: 3+ auth errors.
+		RecentFailures: authFailures(5),
+		// High failure rate: 5/5 = 100% (also triggers all_vessels_failing).
+		RecentCompletions: 0,
+		// Stall detected: critical health check.
+		HealthChecks: []HealthCheck{
+			{Code: "test", Level: "critical", Message: "stuck"},
+		},
+		// Queue backlog: >10 pending, >30min old.
+		Pending:          20,
+		OldestPendingAge: 1 * time.Hour,
+		// Upgrade stuck.
+		UpgradeOverdue:   true,
+		UpgradeOverdueBy: 10 * time.Minute,
+	}
+
+	alerts := Evaluate(rules, state)
+
+	// With this state, we expect all 6 rules to fire.
+	codes := make(map[string]bool)
+	for _, a := range alerts {
+		codes[a.Code] = true
+	}
+
+	expected := []string{
+		"auth_failure",
+		"high_failure_rate",
+		"all_vessels_failing",
+		"stall_detected",
+		"queue_backlog",
+		"upgrade_stuck",
+	}
+	for _, code := range expected {
+		if !codes[code] {
+			t.Errorf("expected rule %q to fire, but it did not. Fired rules: %v", code, codes)
+		}
+	}
+}
+
+func TestEvaluate_ReturnsNilWhenNoRulesFire(t *testing.T) {
+	rules := DefaultRules()
+	state := FleetState{} // empty state, nothing should fire
+
+	alerts := Evaluate(rules, state)
+	if len(alerts) != 0 {
+		t.Errorf("expected 0 alerts on empty state, got %d: %+v", len(alerts), alerts)
+	}
+}
+
+func TestContainsCI(t *testing.T) {
+	tests := []struct {
+		s      string
+		substr string
+		want   bool
+	}{
+		{"authentication failed", "auth", true},
+		{"AUTHENTICATION FAILED", "auth", true},
+		{"Authentication Failed", "AUTH", true},
+		{"some error", "auth", false},
+		{"", "auth", false},
+		{"auth", "", true},
+		{"short", "this is longer than the input", false},
+		{"Token expired", "token", true},
+		{"error 401 unauthorized", "401", true},
+		{"error 403 forbidden", "403", true},
+		{"credential renewal needed", "CREDENTIAL", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.s+"_"+tt.substr, func(t *testing.T) {
+			got := containsCI(tt.s, tt.substr)
+			if got != tt.want {
+				t.Errorf("containsCI(%q, %q) = %v, want %v", tt.s, tt.substr, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/internal/notify/notify.go
+++ b/cli/internal/notify/notify.go
@@ -1,0 +1,62 @@
+package notify
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// AlertSeverity indicates how urgent an alert is.
+type AlertSeverity string
+
+const (
+	SeverityCritical AlertSeverity = "critical"
+	SeverityWarning  AlertSeverity = "warning"
+)
+
+// Alert represents an escalation event requiring operator attention.
+type Alert struct {
+	Severity  AlertSeverity
+	Code      string // machine-readable: "auth_failure", "high_failure_rate", etc.
+	Title     string // short heading
+	Detail    string // longer description
+	Timestamp time.Time
+	VesselIDs []string // affected vessels, if any
+}
+
+// StatusReport is passed by the reporter package (defined here as an interface
+// to avoid circular imports -- reporter imports notify, not the other way).
+type StatusReport struct {
+	Markdown string // pre-rendered Markdown for Discussion
+}
+
+// Notifier sends notifications to a single channel.
+type Notifier interface {
+	PostStatus(ctx context.Context, report StatusReport) error
+	SendAlert(ctx context.Context, alert Alert) error
+	Name() string
+}
+
+// Multi dispatches to multiple notifiers. Errors are logged, not propagated --
+// a failure in one channel must not block others.
+type Multi struct {
+	Notifiers []Notifier
+}
+
+func (m *Multi) PostStatus(ctx context.Context, report StatusReport) error {
+	for _, n := range m.Notifiers {
+		if err := n.PostStatus(ctx, report); err != nil {
+			slog.Warn("notify: status post failed", "notifier", n.Name(), "error", err)
+		}
+	}
+	return nil
+}
+
+func (m *Multi) SendAlert(ctx context.Context, alert Alert) error {
+	for _, n := range m.Notifiers {
+		if err := n.SendAlert(ctx, alert); err != nil {
+			slog.Warn("notify: alert send failed", "notifier", n.Name(), "error", err)
+		}
+	}
+	return nil
+}

--- a/cli/internal/notify/notify_test.go
+++ b/cli/internal/notify/notify_test.go
@@ -1,0 +1,122 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// stubNotifier records calls and optionally returns errors.
+type stubNotifier struct {
+	name string
+
+	mu          sync.Mutex
+	statusCalls []StatusReport
+	alertCalls  []Alert
+	statusErr   error
+	alertErr    error
+}
+
+func (s *stubNotifier) Name() string { return s.name }
+
+func (s *stubNotifier) PostStatus(_ context.Context, report StatusReport) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.statusCalls = append(s.statusCalls, report)
+	return s.statusErr
+}
+
+func (s *stubNotifier) SendAlert(_ context.Context, alert Alert) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.alertCalls = append(s.alertCalls, alert)
+	return s.alertErr
+}
+
+func TestMulti_PostStatus_CallsAllNotifiers(t *testing.T) {
+	n1 := &stubNotifier{name: "n1"}
+	n2 := &stubNotifier{name: "n2"}
+	m := &Multi{Notifiers: []Notifier{n1, n2}}
+
+	report := StatusReport{Markdown: "test report"}
+	err := m.PostStatus(context.Background(), report)
+	if err != nil {
+		t.Fatalf("PostStatus returned error: %v", err)
+	}
+
+	if len(n1.statusCalls) != 1 {
+		t.Errorf("n1 expected 1 status call, got %d", len(n1.statusCalls))
+	}
+	if len(n2.statusCalls) != 1 {
+		t.Errorf("n2 expected 1 status call, got %d", len(n2.statusCalls))
+	}
+	if n1.statusCalls[0].Markdown != "test report" {
+		t.Errorf("n1 got wrong report: %q", n1.statusCalls[0].Markdown)
+	}
+}
+
+func TestMulti_SendAlert_CallsAllNotifiers(t *testing.T) {
+	n1 := &stubNotifier{name: "n1"}
+	n2 := &stubNotifier{name: "n2"}
+	m := &Multi{Notifiers: []Notifier{n1, n2}}
+
+	alert := Alert{
+		Severity: SeverityCritical,
+		Code:     "test_alert",
+		Title:    "Test",
+		Detail:   "detail",
+	}
+	err := m.SendAlert(context.Background(), alert)
+	if err != nil {
+		t.Fatalf("SendAlert returned error: %v", err)
+	}
+
+	if len(n1.alertCalls) != 1 {
+		t.Errorf("n1 expected 1 alert call, got %d", len(n1.alertCalls))
+	}
+	if len(n2.alertCalls) != 1 {
+		t.Errorf("n2 expected 1 alert call, got %d", len(n2.alertCalls))
+	}
+	if n1.alertCalls[0].Code != "test_alert" {
+		t.Errorf("n1 got wrong alert code: %q", n1.alertCalls[0].Code)
+	}
+}
+
+func TestMulti_PostStatus_FailingNotifierDoesNotBlockOthers(t *testing.T) {
+	failing := &stubNotifier{name: "failing", statusErr: errors.New("boom")}
+	ok := &stubNotifier{name: "ok"}
+	m := &Multi{Notifiers: []Notifier{failing, ok}}
+
+	report := StatusReport{Markdown: "data"}
+	err := m.PostStatus(context.Background(), report)
+	if err != nil {
+		t.Fatalf("PostStatus should not propagate notifier errors, got: %v", err)
+	}
+
+	if len(failing.statusCalls) != 1 {
+		t.Errorf("failing notifier should still have been called, got %d calls", len(failing.statusCalls))
+	}
+	if len(ok.statusCalls) != 1 {
+		t.Errorf("ok notifier should have been called despite prior failure, got %d calls", len(ok.statusCalls))
+	}
+}
+
+func TestMulti_SendAlert_FailingNotifierDoesNotBlockOthers(t *testing.T) {
+	failing := &stubNotifier{name: "failing", alertErr: errors.New("boom")}
+	ok := &stubNotifier{name: "ok"}
+	m := &Multi{Notifiers: []Notifier{failing, ok}}
+
+	alert := Alert{Code: "test"}
+	err := m.SendAlert(context.Background(), alert)
+	if err != nil {
+		t.Fatalf("SendAlert should not propagate notifier errors, got: %v", err)
+	}
+
+	if len(failing.alertCalls) != 1 {
+		t.Errorf("failing notifier should still have been called, got %d calls", len(failing.alertCalls))
+	}
+	if len(ok.alertCalls) != 1 {
+		t.Errorf("ok notifier should have been called despite prior failure, got %d calls", len(ok.alertCalls))
+	}
+}

--- a/cli/internal/notify/telegram.go
+++ b/cli/internal/notify/telegram.go
@@ -1,0 +1,170 @@
+package notify
+
+// Telegram sends alerts via the Telegram Bot API.
+// It is send-only (no webhook listener, no callback handling).
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	telegramAPIBase      = "https://api.telegram.org/bot"
+	telegramMaxMsgLen    = 4096
+	defaultAlertCooldown = 30 * time.Minute
+)
+
+// Telegram delivers alerts to a Telegram chat via the Bot API.
+type Telegram struct {
+	token  string
+	chatID string
+	levels map[AlertSeverity]bool
+	client *http.Client
+
+	// cooldown dedup: code -> last sent time
+	mu       sync.Mutex
+	lastSent map[string]time.Time
+	cooldown time.Duration
+}
+
+// NewTelegram creates a Telegram notifier. levels controls which severities
+// are delivered (e.g. ["critical", "warning"]).
+func NewTelegram(token, chatID string, levels []string) *Telegram {
+	lvl := make(map[AlertSeverity]bool, len(levels))
+	for _, l := range levels {
+		lvl[AlertSeverity(l)] = true
+	}
+	return &Telegram{
+		token:    token,
+		chatID:   chatID,
+		levels:   lvl,
+		client:   &http.Client{Timeout: 10 * time.Second},
+		lastSent: make(map[string]time.Time),
+		cooldown: defaultAlertCooldown,
+	}
+}
+
+func (t *Telegram) Name() string { return "telegram" }
+
+// PostStatus is a no-op -- Telegram is for alerts only.
+func (t *Telegram) PostStatus(_ context.Context, _ StatusReport) error {
+	return nil
+}
+
+// SendAlert delivers an alert to the configured Telegram chat. Alerts are
+// suppressed if the same code was sent within the cooldown window.
+func (t *Telegram) SendAlert(ctx context.Context, alert Alert) error {
+	if !t.levels[alert.Severity] {
+		return nil
+	}
+	if t.isDuplicate(alert.Code) {
+		slog.Debug("notify: telegram alert suppressed by cooldown", "code", alert.Code)
+		return nil
+	}
+
+	msg := formatTelegramAlert(alert)
+	if err := t.sendMessage(ctx, msg); err != nil {
+		return fmt.Errorf("telegram send alert: %w", err)
+	}
+	t.recordSent(alert.Code)
+	return nil
+}
+
+func (t *Telegram) isDuplicate(code string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	last, ok := t.lastSent[code]
+	if !ok {
+		return false
+	}
+	return time.Since(last) < t.cooldown
+}
+
+func (t *Telegram) recordSent(code string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lastSent[code] = time.Now()
+}
+
+func formatTelegramAlert(alert Alert) string {
+	var b strings.Builder
+	severity := strings.ToUpper(string(alert.Severity))
+	// Use HTML formatting (most reliable for Telegram).
+	b.WriteString(fmt.Sprintf("<b>%s</b>: %s\n\n", severity, html.EscapeString(alert.Title)))
+	b.WriteString(html.EscapeString(alert.Detail))
+	if len(alert.VesselIDs) > 0 {
+		b.WriteString("\n\n<b>Affected:</b> ")
+		ids := alert.VesselIDs
+		if len(ids) > 10 {
+			ids = ids[:10]
+		}
+		for i, id := range ids {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString("<code>")
+			b.WriteString(html.EscapeString(id))
+			b.WriteString("</code>")
+		}
+		if len(alert.VesselIDs) > 10 {
+			b.WriteString(fmt.Sprintf(" (+%d more)", len(alert.VesselIDs)-10))
+		}
+	}
+	msg := b.String()
+	if len(msg) > telegramMaxMsgLen {
+		msg = msg[:telegramMaxMsgLen-3] + "..."
+	}
+	return msg
+}
+
+type telegramRequest struct {
+	ChatID    string `json:"chat_id"`
+	Text      string `json:"text"`
+	ParseMode string `json:"parse_mode"`
+}
+
+type telegramResponse struct {
+	OK          bool   `json:"ok"`
+	Description string `json:"description,omitempty"`
+}
+
+func (t *Telegram) sendMessage(ctx context.Context, text string) error {
+	body, err := json.Marshal(telegramRequest{
+		ChatID:    t.chatID,
+		Text:      text,
+		ParseMode: "HTML",
+	})
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	url := telegramAPIBase + t.token + "/sendMessage"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("post: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var apiResp telegramResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if !apiResp.OK {
+		return fmt.Errorf("telegram API: %s", apiResp.Description)
+	}
+	return nil
+}

--- a/cli/internal/notify/telegram.go
+++ b/cli/internal/notify/telegram.go
@@ -98,7 +98,7 @@ func formatTelegramAlert(alert Alert) string {
 	var b strings.Builder
 	severity := strings.ToUpper(string(alert.Severity))
 	// Use HTML formatting (most reliable for Telegram).
-	b.WriteString(fmt.Sprintf("<b>%s</b>: %s\n\n", severity, html.EscapeString(alert.Title)))
+	fmt.Fprintf(&b, "<b>%s</b>: %s\n\n", severity, html.EscapeString(alert.Title))
 	b.WriteString(html.EscapeString(alert.Detail))
 	if len(alert.VesselIDs) > 0 {
 		b.WriteString("\n\n<b>Affected:</b> ")
@@ -115,7 +115,7 @@ func formatTelegramAlert(alert Alert) string {
 			b.WriteString("</code>")
 		}
 		if len(alert.VesselIDs) > 10 {
-			b.WriteString(fmt.Sprintf(" (+%d more)", len(alert.VesselIDs)-10))
+			fmt.Fprintf(&b, " (+%d more)", len(alert.VesselIDs)-10)
 		}
 	}
 	msg := b.String()

--- a/cli/internal/notify/telegram_test.go
+++ b/cli/internal/notify/telegram_test.go
@@ -1,0 +1,274 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// tryNewServer attempts to create an httptest.Server. If port binding is
+// blocked (e.g. in a sandboxed environment), it calls t.Skip instead of
+// letting the panic propagate.
+func tryNewServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Skipf("httptest.NewServer unavailable (sandbox): %v", r)
+			}
+		}()
+		srv = httptest.NewServer(handler)
+	}()
+	if srv == nil {
+		t.Skip("httptest.NewServer returned nil")
+	}
+	return srv
+}
+
+// newTestTelegram creates a Telegram notifier pointed at the given test server
+// instead of the real Telegram API. The token is set to "test-token" and the
+// chat ID to "12345".
+func newTestTelegram(serverURL string, levels []string) *Telegram {
+	tg := NewTelegram("test-token", "12345", levels)
+	tg.client = &http.Client{Timeout: 5 * time.Second}
+	// We cannot change telegramAPIBase (const), so we redirect requests at the
+	// transport level to point at the test server.
+	tg.client.Transport = &rewriteTransport{target: serverURL}
+	return tg
+}
+
+// rewriteTransport rewrites every request to point at a test server URL.
+type rewriteTransport struct {
+	target string
+}
+
+func (rt *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req2 := req.Clone(req.Context())
+	req2.URL.Scheme = "http"
+	req2.URL.Host = strings.TrimPrefix(rt.target, "http://")
+	return http.DefaultTransport.RoundTrip(req2)
+}
+
+func TestTelegram_SendAlert_Success(t *testing.T) {
+	var received telegramRequest
+	srv := tryNewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Errorf("failed to decode request: %v", err)
+		}
+		json.NewEncoder(w).Encode(telegramResponse{OK: true})
+	}))
+	defer srv.Close()
+
+	tg := newTestTelegram(srv.URL, []string{"critical", "warning"})
+	alert := Alert{
+		Severity:  SeverityCritical,
+		Code:      "test_alert",
+		Title:     "Test Title",
+		Detail:    "Something broke",
+		Timestamp: time.Now(),
+		VesselIDs: []string{"v1", "v2"},
+	}
+
+	err := tg.SendAlert(context.Background(), alert)
+	if err != nil {
+		t.Fatalf("SendAlert returned error: %v", err)
+	}
+
+	if received.ChatID != "12345" {
+		t.Errorf("expected chat_id=12345, got %q", received.ChatID)
+	}
+	if received.ParseMode != "HTML" {
+		t.Errorf("expected parse_mode=HTML, got %q", received.ParseMode)
+	}
+	if received.Text == "" {
+		t.Error("expected non-empty text")
+	}
+}
+
+func TestTelegram_SendAlert_SeverityFiltered(t *testing.T) {
+	// Severity filtering happens before any HTTP call, so no server needed.
+	tg := NewTelegram("test-token", "12345", []string{"critical"})
+
+	alert := Alert{
+		Severity: SeverityWarning,
+		Code:     "warning_alert",
+		Title:    "Warning",
+		Detail:   "Something mild",
+	}
+
+	err := tg.SendAlert(context.Background(), alert)
+	if err != nil {
+		t.Fatalf("SendAlert returned error: %v", err)
+	}
+	// If severity filtering works, sendMessage is never called, so no HTTP
+	// error even though the token/URL are fake.
+}
+
+func TestTelegram_CooldownDedup_SameCodeWithinWindow(t *testing.T) {
+	callCount := 0
+	srv := tryNewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		json.NewEncoder(w).Encode(telegramResponse{OK: true})
+	}))
+	defer srv.Close()
+
+	tg := newTestTelegram(srv.URL, []string{"critical"})
+	tg.cooldown = 1 * time.Hour // large window so second call is always within it
+
+	alert := Alert{
+		Severity: SeverityCritical,
+		Code:     "dup_code",
+		Title:    "Dup",
+		Detail:   "Duplicate",
+	}
+
+	if err := tg.SendAlert(context.Background(), alert); err != nil {
+		t.Fatalf("first send: %v", err)
+	}
+	if err := tg.SendAlert(context.Background(), alert); err != nil {
+		t.Fatalf("second send: %v", err)
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected 1 API call (second suppressed by cooldown), got %d", callCount)
+	}
+}
+
+func TestTelegram_CooldownDedup_SameCodeAfterWindow(t *testing.T) {
+	callCount := 0
+	srv := tryNewServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		json.NewEncoder(w).Encode(telegramResponse{OK: true})
+	}))
+	defer srv.Close()
+
+	tg := newTestTelegram(srv.URL, []string{"critical"})
+	tg.cooldown = 1 * time.Millisecond // tiny window so it expires immediately
+
+	alert := Alert{
+		Severity: SeverityCritical,
+		Code:     "dup_code",
+		Title:    "Dup",
+		Detail:   "Duplicate",
+	}
+
+	if err := tg.SendAlert(context.Background(), alert); err != nil {
+		t.Fatalf("first send: %v", err)
+	}
+	// Wait for the cooldown to expire.
+	time.Sleep(5 * time.Millisecond)
+
+	if err := tg.SendAlert(context.Background(), alert); err != nil {
+		t.Fatalf("second send: %v", err)
+	}
+
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls (cooldown expired), got %d", callCount)
+	}
+}
+
+func TestTelegram_PostStatus_IsNoop(t *testing.T) {
+	// PostStatus returns nil without any HTTP call.
+	tg := NewTelegram("test-token", "12345", []string{"critical", "warning"})
+	err := tg.PostStatus(context.Background(), StatusReport{Markdown: "hello"})
+	if err != nil {
+		t.Fatalf("PostStatus returned error: %v", err)
+	}
+}
+
+func TestTelegram_FormatAlert_HTMLContent(t *testing.T) {
+	alert := Alert{
+		Severity:  SeverityCritical,
+		Code:      "test",
+		Title:     "Auth <Failure>",
+		Detail:    "Token expired & invalid",
+		VesselIDs: []string{"v1", "v2", "v3"},
+	}
+
+	msg := formatTelegramAlert(alert)
+
+	// Check severity is uppercased and bold.
+	if !strings.Contains(msg, "<b>CRITICAL</b>") {
+		t.Errorf("expected bold CRITICAL in message, got: %s", msg)
+	}
+	// Check title is HTML-escaped.
+	if !strings.Contains(msg, "Auth &lt;Failure&gt;") {
+		t.Errorf("expected HTML-escaped title, got: %s", msg)
+	}
+	// Check detail is HTML-escaped.
+	if !strings.Contains(msg, "Token expired &amp; invalid") {
+		t.Errorf("expected HTML-escaped detail, got: %s", msg)
+	}
+	// Check vessel IDs are in code tags.
+	if !strings.Contains(msg, "<code>v1</code>") {
+		t.Errorf("expected vessel ID in code tag, got: %s", msg)
+	}
+	// Check the "Affected" label is present.
+	if !strings.Contains(msg, "<b>Affected:</b>") {
+		t.Errorf("expected Affected label, got: %s", msg)
+	}
+}
+
+func TestTelegram_FormatAlert_VesselIDTruncation(t *testing.T) {
+	ids := make([]string, 15)
+	for i := range ids {
+		ids[i] = "vessel-" + string(rune('A'+i))
+	}
+	alert := Alert{
+		Severity:  SeverityWarning,
+		Code:      "test",
+		Title:     "Test",
+		Detail:    "Detail",
+		VesselIDs: ids,
+	}
+
+	msg := formatTelegramAlert(alert)
+
+	// Should contain the first 10 IDs.
+	if !strings.Contains(msg, "<code>vessel-A</code>") {
+		t.Error("expected first vessel ID")
+	}
+	if !strings.Contains(msg, "<code>vessel-J</code>") {
+		t.Error("expected 10th vessel ID (vessel-J)")
+	}
+	// Should NOT contain the 11th ID.
+	if strings.Contains(msg, "<code>vessel-K</code>") {
+		t.Error("11th vessel ID should not appear directly")
+	}
+	// Should contain "+N more" suffix.
+	if !strings.Contains(msg, "(+5 more)") {
+		t.Errorf("expected (+5 more) truncation notice, got: %s", msg)
+	}
+}
+
+func TestTelegram_FormatAlert_LongMessageTruncation(t *testing.T) {
+	// Build a detail string that exceeds 4096 chars.
+	longDetail := strings.Repeat("x", 5000)
+	alert := Alert{
+		Severity: SeverityCritical,
+		Code:     "test",
+		Title:    "Test",
+		Detail:   longDetail,
+	}
+
+	msg := formatTelegramAlert(alert)
+
+	if len(msg) > telegramMaxMsgLen {
+		t.Errorf("message length %d exceeds max %d", len(msg), telegramMaxMsgLen)
+	}
+	if !strings.HasSuffix(msg, "...") {
+		t.Error("truncated message should end with '...'")
+	}
+}
+
+func TestTelegram_Name(t *testing.T) {
+	tg := NewTelegram("tok", "123", []string{"critical"})
+	if tg.Name() != "telegram" {
+		t.Errorf("expected Name()=telegram, got %q", tg.Name())
+	}
+}

--- a/cli/internal/reporter/format.go
+++ b/cli/internal/reporter/format.go
@@ -1,0 +1,172 @@
+package reporter
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// FormatMarkdown renders the report as GitHub-flavored Markdown suitable for
+// posting to a Discussion or comment body.
+func FormatMarkdown(r StatusReport) string {
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("## Xylem Status -- %s\n\n", r.Timestamp.UTC().Format("2006-01-02 15:04 UTC")))
+
+	// Daemon section.
+	b.WriteString("### Daemon\n")
+	b.WriteString("| | |\n|---|---|\n")
+	b.WriteString(fmt.Sprintf("| PID | %d |\n", r.Daemon.PID))
+	b.WriteString(fmt.Sprintf("| Uptime | %s |\n", formatStatusDuration(r.Daemon.Uptime)))
+	if r.Daemon.Binary != "" {
+		b.WriteString(fmt.Sprintf("| Binary | `%s` |\n", r.Daemon.Binary))
+	}
+	if !r.Daemon.LastUpgradeAt.IsZero() {
+		b.WriteString(fmt.Sprintf("| Last upgrade | %s |\n", r.Daemon.LastUpgradeAt.UTC().Format("15:04 UTC")))
+	}
+	b.WriteString("\n")
+
+	// Vessel metrics.
+	b.WriteString("### Vessels\n")
+	b.WriteString("| State | Count |\n|-------|-------|\n")
+	b.WriteString(fmt.Sprintf("| Pending | %d |\n", r.Vessels.Pending))
+	b.WriteString(fmt.Sprintf("| Running | %d |\n", r.Vessels.Running))
+	b.WriteString(fmt.Sprintf("| Completed | %d |\n", r.Vessels.Completed))
+	b.WriteString(fmt.Sprintf("| Failed | %d |\n", r.Vessels.Failed))
+	b.WriteString(fmt.Sprintf("| Timed Out | %d |\n", r.Vessels.TimedOut))
+	b.WriteString(fmt.Sprintf("| Waiting | %d |\n", r.Vessels.Waiting))
+	b.WriteString(fmt.Sprintf("| Cancelled | %d |\n", r.Vessels.Cancelled))
+	b.WriteString("\n")
+
+	// Active vessels.
+	if len(r.ActiveVessels) > 0 {
+		b.WriteString("### Active Vessels\n")
+		b.WriteString("| Vessel | Phase | Duration | Workflow |\n")
+		b.WriteString("|--------|-------|----------|----------|\n")
+		for _, av := range r.ActiveVessels {
+			phase := av.Phase
+			if phase == "" {
+				phase = "-"
+			}
+			b.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
+				av.ID, phase, formatStatusDuration(av.Duration), av.Workflow))
+		}
+		b.WriteString("\n")
+	}
+
+	// Fleet health.
+	total := r.Fleet.Healthy + r.Fleet.Degraded + r.Fleet.Unhealthy
+	if total > 0 {
+		b.WriteString("### Fleet Health\n")
+		healthPct := float64(r.Fleet.Healthy) / float64(total) * 100
+		b.WriteString(fmt.Sprintf("- %.0f%% healthy (%d/%d vessels)\n", healthPct, r.Fleet.Healthy, total))
+		if len(r.Fleet.Patterns) > 0 {
+			b.WriteString(fmt.Sprintf("- Patterns: %s\n", formatFleetPatterns(r.Fleet.Patterns)))
+		}
+		b.WriteString("\n")
+	}
+
+	// Recent failures.
+	if len(r.RecentFailures) > 0 {
+		b.WriteString("### Recent Failures (24h)\n")
+		b.WriteString("| Vessel | Phase | Error |\n|--------|-------|-------|\n")
+		limit := len(r.RecentFailures)
+		if limit > 10 {
+			limit = 10
+		}
+		for _, f := range r.RecentFailures[:limit] {
+			errMsg := f.Error
+			if len(errMsg) > 80 {
+				errMsg = errMsg[:80] + "..."
+			}
+			phase := f.Phase
+			if phase == "" {
+				phase = "-"
+			}
+			b.WriteString(fmt.Sprintf("| %s | %s | %s |\n", f.ID, phase, errMsg))
+		}
+		if len(r.RecentFailures) > 10 {
+			b.WriteString(fmt.Sprintf("\n*+%d more failures not shown*\n", len(r.RecentFailures)-10))
+		}
+		b.WriteString("\n")
+	}
+
+	// Warnings.
+	if len(r.Warnings) > 0 {
+		b.WriteString("### Warnings\n")
+		for _, w := range r.Warnings {
+			b.WriteString(fmt.Sprintf("- %s\n", w))
+		}
+	}
+
+	return b.String()
+}
+
+// FormatPlainText renders the report for terminal output.
+func FormatPlainText(r StatusReport) string {
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("Xylem Status -- %s\n\n", r.Timestamp.UTC().Format("2006-01-02 15:04 UTC")))
+
+	b.WriteString(fmt.Sprintf("Daemon: PID %d | Uptime %s | Binary %s\n",
+		r.Daemon.PID, formatStatusDuration(r.Daemon.Uptime), r.Daemon.Binary))
+	if !r.Daemon.LastUpgradeAt.IsZero() {
+		b.WriteString(fmt.Sprintf("  Last upgrade: %s\n", r.Daemon.LastUpgradeAt.UTC().Format("15:04 UTC")))
+	}
+	b.WriteString("\n")
+
+	b.WriteString(fmt.Sprintf("Vessels: %d pending, %d running, %d completed, %d failed, %d timed_out, %d waiting, %d cancelled\n",
+		r.Vessels.Pending, r.Vessels.Running, r.Vessels.Completed,
+		r.Vessels.Failed, r.Vessels.TimedOut, r.Vessels.Waiting, r.Vessels.Cancelled))
+	b.WriteString("\n")
+
+	if len(r.ActiveVessels) > 0 {
+		b.WriteString("Active:\n")
+		for _, av := range r.ActiveVessels {
+			phase := av.Phase
+			if phase == "" {
+				phase = "-"
+			}
+			b.WriteString(fmt.Sprintf("  %-20s %s (%s) [%s]\n",
+				av.ID, phase, formatStatusDuration(av.Duration), av.Workflow))
+		}
+		b.WriteString("\n")
+	}
+
+	total := r.Fleet.Healthy + r.Fleet.Degraded + r.Fleet.Unhealthy
+	if total > 0 {
+		b.WriteString(fmt.Sprintf("Fleet: %d healthy, %d degraded, %d unhealthy\n",
+			r.Fleet.Healthy, r.Fleet.Degraded, r.Fleet.Unhealthy))
+		if len(r.Fleet.Patterns) > 0 {
+			b.WriteString(fmt.Sprintf("  Patterns: %s\n", formatFleetPatterns(r.Fleet.Patterns)))
+		}
+		b.WriteString("\n")
+	}
+
+	if len(r.Warnings) > 0 {
+		b.WriteString("Warnings:\n")
+		for _, w := range r.Warnings {
+			b.WriteString(fmt.Sprintf("  - %s\n", w))
+		}
+	}
+
+	return b.String()
+}
+
+// formatStatusDuration renders a duration as a compact human-readable string.
+// Named with "Status" prefix to avoid collision with any existing
+// formatDuration in the package.
+func formatStatusDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	hours := int(d.Hours())
+	mins := int(d.Minutes()) % 60
+	if mins == 0 {
+		return fmt.Sprintf("%dh", hours)
+	}
+	return fmt.Sprintf("%dh %dm", hours, mins)
+}

--- a/cli/internal/reporter/format.go
+++ b/cli/internal/reporter/format.go
@@ -11,31 +11,31 @@ import (
 func FormatMarkdown(r StatusReport) string {
 	var b strings.Builder
 
-	b.WriteString(fmt.Sprintf("## Xylem Status -- %s\n\n", r.Timestamp.UTC().Format("2006-01-02 15:04 UTC")))
+	fmt.Fprintf(&b, "## Xylem Status -- %s\n\n", r.Timestamp.UTC().Format("2006-01-02 15:04 UTC"))
 
 	// Daemon section.
 	b.WriteString("### Daemon\n")
 	b.WriteString("| | |\n|---|---|\n")
-	b.WriteString(fmt.Sprintf("| PID | %d |\n", r.Daemon.PID))
-	b.WriteString(fmt.Sprintf("| Uptime | %s |\n", formatStatusDuration(r.Daemon.Uptime)))
+	fmt.Fprintf(&b, "| PID | %d |\n", r.Daemon.PID)
+	fmt.Fprintf(&b, "| Uptime | %s |\n", formatStatusDuration(r.Daemon.Uptime))
 	if r.Daemon.Binary != "" {
-		b.WriteString(fmt.Sprintf("| Binary | `%s` |\n", r.Daemon.Binary))
+		fmt.Fprintf(&b, "| Binary | `%s` |\n", r.Daemon.Binary)
 	}
 	if !r.Daemon.LastUpgradeAt.IsZero() {
-		b.WriteString(fmt.Sprintf("| Last upgrade | %s |\n", r.Daemon.LastUpgradeAt.UTC().Format("15:04 UTC")))
+		fmt.Fprintf(&b, "| Last upgrade | %s |\n", r.Daemon.LastUpgradeAt.UTC().Format("15:04 UTC"))
 	}
 	b.WriteString("\n")
 
 	// Vessel metrics.
 	b.WriteString("### Vessels\n")
 	b.WriteString("| State | Count |\n|-------|-------|\n")
-	b.WriteString(fmt.Sprintf("| Pending | %d |\n", r.Vessels.Pending))
-	b.WriteString(fmt.Sprintf("| Running | %d |\n", r.Vessels.Running))
-	b.WriteString(fmt.Sprintf("| Completed | %d |\n", r.Vessels.Completed))
-	b.WriteString(fmt.Sprintf("| Failed | %d |\n", r.Vessels.Failed))
-	b.WriteString(fmt.Sprintf("| Timed Out | %d |\n", r.Vessels.TimedOut))
-	b.WriteString(fmt.Sprintf("| Waiting | %d |\n", r.Vessels.Waiting))
-	b.WriteString(fmt.Sprintf("| Cancelled | %d |\n", r.Vessels.Cancelled))
+	fmt.Fprintf(&b, "| Pending | %d |\n", r.Vessels.Pending)
+	fmt.Fprintf(&b, "| Running | %d |\n", r.Vessels.Running)
+	fmt.Fprintf(&b, "| Completed | %d |\n", r.Vessels.Completed)
+	fmt.Fprintf(&b, "| Failed | %d |\n", r.Vessels.Failed)
+	fmt.Fprintf(&b, "| Timed Out | %d |\n", r.Vessels.TimedOut)
+	fmt.Fprintf(&b, "| Waiting | %d |\n", r.Vessels.Waiting)
+	fmt.Fprintf(&b, "| Cancelled | %d |\n", r.Vessels.Cancelled)
 	b.WriteString("\n")
 
 	// Active vessels.
@@ -48,8 +48,8 @@ func FormatMarkdown(r StatusReport) string {
 			if phase == "" {
 				phase = "-"
 			}
-			b.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
-				av.ID, phase, formatStatusDuration(av.Duration), av.Workflow))
+			fmt.Fprintf(&b, "| %s | %s | %s | %s |\n",
+				av.ID, phase, formatStatusDuration(av.Duration), av.Workflow)
 		}
 		b.WriteString("\n")
 	}
@@ -59,9 +59,9 @@ func FormatMarkdown(r StatusReport) string {
 	if total > 0 {
 		b.WriteString("### Fleet Health\n")
 		healthPct := float64(r.Fleet.Healthy) / float64(total) * 100
-		b.WriteString(fmt.Sprintf("- %.0f%% healthy (%d/%d vessels)\n", healthPct, r.Fleet.Healthy, total))
+		fmt.Fprintf(&b, "- %.0f%% healthy (%d/%d vessels)\n", healthPct, r.Fleet.Healthy, total)
 		if len(r.Fleet.Patterns) > 0 {
-			b.WriteString(fmt.Sprintf("- Patterns: %s\n", formatFleetPatterns(r.Fleet.Patterns)))
+			fmt.Fprintf(&b, "- Patterns: %s\n", formatFleetPatterns(r.Fleet.Patterns))
 		}
 		b.WriteString("\n")
 	}
@@ -83,10 +83,10 @@ func FormatMarkdown(r StatusReport) string {
 			if phase == "" {
 				phase = "-"
 			}
-			b.WriteString(fmt.Sprintf("| %s | %s | %s |\n", f.ID, phase, errMsg))
+			fmt.Fprintf(&b, "| %s | %s | %s |\n", f.ID, phase, errMsg)
 		}
 		if len(r.RecentFailures) > 10 {
-			b.WriteString(fmt.Sprintf("\n*+%d more failures not shown*\n", len(r.RecentFailures)-10))
+			fmt.Fprintf(&b, "\n*+%d more failures not shown*\n", len(r.RecentFailures)-10)
 		}
 		b.WriteString("\n")
 	}
@@ -95,7 +95,7 @@ func FormatMarkdown(r StatusReport) string {
 	if len(r.Warnings) > 0 {
 		b.WriteString("### Warnings\n")
 		for _, w := range r.Warnings {
-			b.WriteString(fmt.Sprintf("- %s\n", w))
+			fmt.Fprintf(&b, "- %s\n", w)
 		}
 	}
 
@@ -106,18 +106,18 @@ func FormatMarkdown(r StatusReport) string {
 func FormatPlainText(r StatusReport) string {
 	var b strings.Builder
 
-	b.WriteString(fmt.Sprintf("Xylem Status -- %s\n\n", r.Timestamp.UTC().Format("2006-01-02 15:04 UTC")))
+	fmt.Fprintf(&b, "Xylem Status -- %s\n\n", r.Timestamp.UTC().Format("2006-01-02 15:04 UTC"))
 
-	b.WriteString(fmt.Sprintf("Daemon: PID %d | Uptime %s | Binary %s\n",
-		r.Daemon.PID, formatStatusDuration(r.Daemon.Uptime), r.Daemon.Binary))
+	fmt.Fprintf(&b, "Daemon: PID %d | Uptime %s | Binary %s\n",
+		r.Daemon.PID, formatStatusDuration(r.Daemon.Uptime), r.Daemon.Binary)
 	if !r.Daemon.LastUpgradeAt.IsZero() {
-		b.WriteString(fmt.Sprintf("  Last upgrade: %s\n", r.Daemon.LastUpgradeAt.UTC().Format("15:04 UTC")))
+		fmt.Fprintf(&b, "  Last upgrade: %s\n", r.Daemon.LastUpgradeAt.UTC().Format("15:04 UTC"))
 	}
 	b.WriteString("\n")
 
-	b.WriteString(fmt.Sprintf("Vessels: %d pending, %d running, %d completed, %d failed, %d timed_out, %d waiting, %d cancelled\n",
+	fmt.Fprintf(&b, "Vessels: %d pending, %d running, %d completed, %d failed, %d timed_out, %d waiting, %d cancelled\n",
 		r.Vessels.Pending, r.Vessels.Running, r.Vessels.Completed,
-		r.Vessels.Failed, r.Vessels.TimedOut, r.Vessels.Waiting, r.Vessels.Cancelled))
+		r.Vessels.Failed, r.Vessels.TimedOut, r.Vessels.Waiting, r.Vessels.Cancelled)
 	b.WriteString("\n")
 
 	if len(r.ActiveVessels) > 0 {
@@ -127,18 +127,18 @@ func FormatPlainText(r StatusReport) string {
 			if phase == "" {
 				phase = "-"
 			}
-			b.WriteString(fmt.Sprintf("  %-20s %s (%s) [%s]\n",
-				av.ID, phase, formatStatusDuration(av.Duration), av.Workflow))
+			fmt.Fprintf(&b, "  %-20s %s (%s) [%s]\n",
+				av.ID, phase, formatStatusDuration(av.Duration), av.Workflow)
 		}
 		b.WriteString("\n")
 	}
 
 	total := r.Fleet.Healthy + r.Fleet.Degraded + r.Fleet.Unhealthy
 	if total > 0 {
-		b.WriteString(fmt.Sprintf("Fleet: %d healthy, %d degraded, %d unhealthy\n",
-			r.Fleet.Healthy, r.Fleet.Degraded, r.Fleet.Unhealthy))
+		fmt.Fprintf(&b, "Fleet: %d healthy, %d degraded, %d unhealthy\n",
+			r.Fleet.Healthy, r.Fleet.Degraded, r.Fleet.Unhealthy)
 		if len(r.Fleet.Patterns) > 0 {
-			b.WriteString(fmt.Sprintf("  Patterns: %s\n", formatFleetPatterns(r.Fleet.Patterns)))
+			fmt.Fprintf(&b, "  Patterns: %s\n", formatFleetPatterns(r.Fleet.Patterns))
 		}
 		b.WriteString("\n")
 	}
@@ -146,7 +146,7 @@ func FormatPlainText(r StatusReport) string {
 	if len(r.Warnings) > 0 {
 		b.WriteString("Warnings:\n")
 		for _, w := range r.Warnings {
-			b.WriteString(fmt.Sprintf("  - %s\n", w))
+			fmt.Fprintf(&b, "  - %s\n", w)
 		}
 	}
 

--- a/cli/internal/reporter/status.go
+++ b/cli/internal/reporter/status.go
@@ -1,0 +1,207 @@
+package reporter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/daemonhealth"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+// StatusReport holds a complete status snapshot.
+type StatusReport struct {
+	Timestamp      time.Time
+	Daemon         DaemonStatus
+	Vessels        VesselMetrics
+	Fleet          FleetHealth
+	ActiveVessels  []ActiveVessel
+	RecentFailures []RecentFailure
+	Warnings       []string
+}
+
+// DaemonStatus holds the daemon's current health state.
+type DaemonStatus struct {
+	PID           int
+	StartedAt     time.Time
+	Uptime        time.Duration
+	Binary        string
+	LastUpgradeAt time.Time
+	Checks        []daemonhealth.Check
+}
+
+// VesselMetrics holds counts by vessel state.
+type VesselMetrics struct {
+	Pending   int
+	Running   int
+	Completed int
+	Failed    int
+	TimedOut  int
+	Waiting   int
+	Cancelled int
+	Total     int
+}
+
+// FleetHealth is a local representation of fleet-level health metrics.
+// It mirrors runner.FleetStatusReport to avoid an import cycle (runner
+// already imports reporter for issue commenting).
+type FleetHealth struct {
+	Healthy   int
+	Degraded  int
+	Unhealthy int
+	Patterns  []FleetPattern
+}
+
+// FleetPattern pairs an anomaly code with its occurrence count.
+type FleetPattern struct {
+	Code  string
+	Count int
+}
+
+// ActiveVessel describes a currently running vessel.
+type ActiveVessel struct {
+	ID       string
+	Phase    string
+	Duration time.Duration
+	Workflow string
+}
+
+// RecentFailure describes a vessel that failed or timed out recently.
+type RecentFailure struct {
+	ID        string
+	Error     string
+	Phase     string
+	Timestamp time.Time
+}
+
+// StatusDeps provides the status collector's dependencies via interfaces.
+type StatusDeps struct {
+	StateDir string
+	Queue    QueueReader
+
+	// FleetAnalyzer computes fleet-level health from the vessel list. When
+	// nil, the Fleet field is left at its zero value. Callers typically wire
+	// this to a closure over runner.LoadVesselSummaries and
+	// runner.AnalyzeFleetStatus.
+	FleetAnalyzer func(stateDir string, vessels []queue.Vessel) FleetHealth
+}
+
+// QueueReader is the subset of queue.Queue needed by the status collector.
+type QueueReader interface {
+	List() ([]queue.Vessel, error)
+}
+
+// CollectStatus gathers a complete status snapshot from the daemon's state
+// files and queue. It does not send notifications; the notify package handles
+// that.
+func CollectStatus(ctx context.Context, deps StatusDeps, now time.Time) StatusReport {
+	report := StatusReport{Timestamp: now}
+
+	// Daemon health.
+	if snapshot, err := daemonhealth.Load(deps.StateDir); err == nil {
+		report.Daemon = DaemonStatus{
+			PID:           snapshot.PID,
+			StartedAt:     snapshot.StartedAt,
+			Uptime:        now.Sub(snapshot.StartedAt),
+			Binary:        snapshot.Binary,
+			LastUpgradeAt: snapshot.LastUpgradeAt,
+			Checks:        snapshot.Checks,
+		}
+	}
+
+	// Queue state.
+	vessels, err := deps.Queue.List()
+	if err != nil {
+		report.Warnings = append(report.Warnings, "Failed to read queue: "+err.Error())
+		return report
+	}
+
+	for _, v := range vessels {
+		switch v.State {
+		case queue.StatePending:
+			report.Vessels.Pending++
+		case queue.StateRunning:
+			report.Vessels.Running++
+		case queue.StateCompleted:
+			report.Vessels.Completed++
+		case queue.StateFailed:
+			report.Vessels.Failed++
+		case queue.StateTimedOut:
+			report.Vessels.TimedOut++
+		case queue.StateWaiting:
+			report.Vessels.Waiting++
+		case queue.StateCancelled:
+			report.Vessels.Cancelled++
+		}
+		report.Vessels.Total++
+	}
+
+	// Active vessels (running).
+	for _, v := range vessels {
+		if v.State != queue.StateRunning {
+			continue
+		}
+		var dur time.Duration
+		if v.StartedAt != nil {
+			dur = now.Sub(*v.StartedAt)
+		}
+		report.ActiveVessels = append(report.ActiveVessels, ActiveVessel{
+			ID:       v.ID,
+			Phase:    v.FailedPhase,
+			Duration: dur,
+			Workflow: v.Workflow,
+		})
+	}
+
+	// Recent failures (last 24h).
+	cutoff := now.Add(-24 * time.Hour)
+	for _, v := range vessels {
+		if v.State != queue.StateFailed && v.State != queue.StateTimedOut {
+			continue
+		}
+		if v.EndedAt == nil || !v.EndedAt.After(cutoff) {
+			continue
+		}
+		report.RecentFailures = append(report.RecentFailures, RecentFailure{
+			ID:        v.ID,
+			Error:     v.Error,
+			Phase:     v.FailedPhase,
+			Timestamp: *v.EndedAt,
+		})
+	}
+
+	// Fleet health (caller provides the analyzer to avoid runner import cycle).
+	if deps.FleetAnalyzer != nil {
+		report.Fleet = deps.FleetAnalyzer(deps.StateDir, vessels)
+	}
+
+	// Warnings.
+	if report.Vessels.Failed > 5 {
+		report.Warnings = append(report.Warnings,
+			fmt.Sprintf("%d failed vessels in queue", report.Vessels.Failed))
+	}
+	if report.Vessels.Pending > 10 {
+		report.Warnings = append(report.Warnings,
+			fmt.Sprintf("%d pending vessels in backlog", report.Vessels.Pending))
+	}
+	for _, check := range report.Daemon.Checks {
+		if check.Level == daemonhealth.LevelCritical || check.Level == daemonhealth.LevelWarning {
+			report.Warnings = append(report.Warnings, check.Message)
+		}
+	}
+
+	return report
+}
+
+// formatFleetPatterns renders fleet patterns as a compact string.
+func formatFleetPatterns(patterns []FleetPattern) string {
+	if len(patterns) == 0 {
+		return ""
+	}
+	parts := make([]string, len(patterns))
+	for i, p := range patterns {
+		parts[i] = fmt.Sprintf("%s=%d", p.Code, p.Count)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/cli/internal/runner/discussion.go
+++ b/cli/internal/runner/discussion.go
@@ -2,15 +2,18 @@ package runner
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/nicholls-inc/xylem/cli/internal/discussion"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/workflow"
 )
 
+// GraphQL constants kept as package-level aliases so that tests in this
+// package can match mock hook calls against the exact query text sent by
+// discussion.Publisher.
 const (
 	discussionResolveQuery = `query($owner: String!, $repo: String!) {
   repository(owner: $owner, name: $repo) {
@@ -40,13 +43,7 @@ const (
 )
 
 type discussionPublisher struct {
-	runner CommandRunner
-}
-
-type discussionRef struct {
-	ID    string
-	Title string
-	URL   string
+	pub *discussion.Publisher
 }
 
 func (r *Runner) publishPhaseOutput(ctx context.Context, vessel queue.Vessel, p workflow.Phase, td phase.TemplateData, body string) error {
@@ -57,7 +54,8 @@ func (r *Runner) publishPhaseOutput(ctx context.Context, vessel queue.Vessel, p 
 	switch p.Output {
 	case "discussion":
 		repoSlug := r.resolveRepo(vessel)
-		if _, err := (discussionPublisher{runner: r.Runner}).Publish(ctx, repoSlug, p.Name, p.Discussion, td, body); err != nil {
+		dp := discussionPublisher{pub: &discussion.Publisher{Runner: r.Runner}}
+		if _, err := dp.Publish(ctx, repoSlug, p.Name, p.Discussion, td, body); err != nil {
 			return err
 		}
 		return nil
@@ -66,15 +64,15 @@ func (r *Runner) publishPhaseOutput(ctx context.Context, vessel queue.Vessel, p 
 	}
 }
 
-func (p discussionPublisher) Publish(ctx context.Context, repoSlug string, phaseName string, cfg *workflow.DiscussionOutput, td phase.TemplateData, body string) (string, error) {
-	if p.runner == nil {
+func (dp discussionPublisher) Publish(ctx context.Context, repoSlug string, phaseName string, cfg *workflow.DiscussionOutput, td phase.TemplateData, body string) (string, error) {
+	if dp.pub == nil || dp.pub.Runner == nil {
 		return "", fmt.Errorf("publish discussion for phase %s: runner is required", phaseName)
 	}
 	if cfg == nil {
 		return "", fmt.Errorf("publish discussion for phase %s: discussion config is required", phaseName)
 	}
 
-	owner, repo, err := splitRepoSlug(repoSlug)
+	owner, repo, err := discussion.SplitRepoSlug(repoSlug)
 	if err != nil {
 		return "", fmt.Errorf("publish discussion for phase %s: %w", phaseName, err)
 	}
@@ -91,27 +89,33 @@ func (p discussionPublisher) Publish(ctx context.Context, repoSlug string, phase
 		}
 	}
 
-	target, err := p.resolveTarget(ctx, owner, repo, cfg.Category)
+	target, err := dp.pub.ResolveTarget(ctx, owner, repo, cfg.Category)
 	if err != nil {
 		return "", fmt.Errorf("publish discussion for phase %s: %w", phaseName, err)
 	}
 
-	existing, err := p.findExisting(ctx, target.repoID, target.categoryID, titleSearch)
+	existing, err := dp.pub.FindExisting(ctx, target.RepoID, target.CategoryID, titleSearch)
 	if err != nil {
 		return "", fmt.Errorf("publish discussion for phase %s: %w", phaseName, err)
 	}
 	if existing.ID != "" {
-		if err := p.comment(ctx, existing.ID, body); err != nil {
+		if err := dp.pub.Comment(ctx, existing.ID, body); err != nil {
 			return "", fmt.Errorf("publish discussion for phase %s: comment existing discussion %q: %w", phaseName, existing.Title, err)
 		}
 		return existing.URL, nil
 	}
 
-	created, err := p.create(ctx, target.repoID, target.categoryID, title, body)
+	created, err := dp.pub.Create(ctx, target.RepoID, target.CategoryID, title, body)
 	if err != nil {
 		return "", fmt.Errorf("publish discussion for phase %s: create discussion %q: %w", phaseName, title, err)
 	}
 	return created.URL, nil
+}
+
+// splitRepoSlug delegates to discussion.SplitRepoSlug. Kept as a package-
+// level function so that property tests in this package continue to compile.
+func splitRepoSlug(repoSlug string) (string, string, error) {
+	return discussion.SplitRepoSlug(repoSlug)
 }
 
 func renderDiscussionTemplate(phaseName, field, tmpl string, td phase.TemplateData) (string, error) {
@@ -127,134 +131,4 @@ func renderDiscussionTemplate(phaseName, field, tmpl string, td phase.TemplateDa
 		return "", err
 	}
 	return rendered, nil
-}
-
-func splitRepoSlug(repoSlug string) (string, string, error) {
-	repoSlug = strings.TrimSpace(repoSlug)
-	parts := strings.Split(repoSlug, "/")
-	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
-		return "", "", fmt.Errorf("repo slug %q must be in owner/repo form", repoSlug)
-	}
-	return parts[0], parts[1], nil
-}
-
-type discussionTarget struct {
-	repoID     string
-	categoryID string
-}
-
-func (p discussionPublisher) resolveTarget(ctx context.Context, owner, repo, category string) (discussionTarget, error) {
-	out, err := p.runner.RunOutput(ctx, "gh", "api", "graphql",
-		"-f", "query="+discussionResolveQuery,
-		"-f", "owner="+owner,
-		"-f", "repo="+repo)
-	if err != nil {
-		return discussionTarget{}, fmt.Errorf("resolve repo %s/%s: %w", owner, repo, err)
-	}
-
-	var resp struct {
-		Data struct {
-			Repository struct {
-				ID                   string `json:"id"`
-				DiscussionCategories struct {
-					Nodes []struct {
-						ID   string `json:"id"`
-						Name string `json:"name"`
-					} `json:"nodes"`
-				} `json:"discussionCategories"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(out, &resp); err != nil {
-		return discussionTarget{}, fmt.Errorf("parse discussion target response: %w", err)
-	}
-	if resp.Data.Repository.ID == "" {
-		return discussionTarget{}, fmt.Errorf("could not resolve repository %s/%s", owner, repo)
-	}
-
-	for _, node := range resp.Data.Repository.DiscussionCategories.Nodes {
-		if node.Name == category {
-			return discussionTarget{repoID: resp.Data.Repository.ID, categoryID: node.ID}, nil
-		}
-	}
-	return discussionTarget{}, fmt.Errorf("discussion category %q not found in %s/%s", category, owner, repo)
-}
-
-func (p discussionPublisher) findExisting(ctx context.Context, repoID, categoryID, titlePrefix string) (discussionRef, error) {
-	out, err := p.runner.RunOutput(ctx, "gh", "api", "graphql",
-		"-f", "query="+discussionSearchQuery,
-		"-f", "repoId="+repoID,
-		"-f", "catId="+categoryID)
-	if err != nil {
-		return discussionRef{}, fmt.Errorf("search discussions: %w", err)
-	}
-
-	var resp struct {
-		Data struct {
-			Node struct {
-				Discussions struct {
-					Nodes []struct {
-						ID    string `json:"id"`
-						Title string `json:"title"`
-						URL   string `json:"url"`
-					} `json:"nodes"`
-				} `json:"discussions"`
-			} `json:"node"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(out, &resp); err != nil {
-		return discussionRef{}, fmt.Errorf("parse discussion search response: %w", err)
-	}
-
-	for _, node := range resp.Data.Node.Discussions.Nodes {
-		if strings.HasPrefix(node.Title, titlePrefix) {
-			return discussionRef{ID: node.ID, Title: node.Title, URL: node.URL}, nil
-		}
-	}
-	return discussionRef{}, nil
-}
-
-func (p discussionPublisher) comment(ctx context.Context, discussionID, body string) error {
-	if _, err := p.runner.RunOutput(ctx, "gh", "api", "graphql",
-		"-f", "query="+discussionCommentMutation,
-		"-f", "discussionId="+discussionID,
-		"-f", "body="+body); err != nil {
-		return fmt.Errorf("add discussion comment: %w", err)
-	}
-	return nil
-}
-
-func (p discussionPublisher) create(ctx context.Context, repoID, categoryID, title, body string) (discussionRef, error) {
-	out, err := p.runner.RunOutput(ctx, "gh", "api", "graphql",
-		"-f", "query="+discussionCreateMutation,
-		"-f", "repoId="+repoID,
-		"-f", "catId="+categoryID,
-		"-f", "title="+title,
-		"-f", "body="+body)
-	if err != nil {
-		return discussionRef{}, err
-	}
-
-	var resp struct {
-		Data struct {
-			CreateDiscussion struct {
-				Discussion struct {
-					ID    string `json:"id"`
-					Title string `json:"title"`
-					URL   string `json:"url"`
-				} `json:"discussion"`
-			} `json:"createDiscussion"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(out, &resp); err != nil {
-		return discussionRef{}, fmt.Errorf("parse create discussion response: %w", err)
-	}
-	if resp.Data.CreateDiscussion.Discussion.ID == "" {
-		return discussionRef{}, fmt.Errorf("create discussion response missing discussion id")
-	}
-	return discussionRef{
-		ID:    resp.Data.CreateDiscussion.Discussion.ID,
-		Title: resp.Data.CreateDiscussion.Discussion.Title,
-		URL:   resp.Data.CreateDiscussion.Discussion.URL,
-	}, nil
 }

--- a/docs/plans/remote-monitoring-plan.md
+++ b/docs/plans/remote-monitoring-plan.md
@@ -1,0 +1,279 @@
+# Remote Monitoring, Status Reporting & Escalation
+
+## Problem
+
+An operator running the xylem daemon on a remote machine (home server, CI runner, cloud VM) has no visibility into daemon status without SSH access to the host. The supervisor loop in Claude Code provided this during development, but it is not a sustainable operational model. Operators need:
+
+1. **Periodic status snapshots** — vessel metrics, GitHub activity, daemon health — posted to a durable, append-only log they can check from any device.
+2. **Escalation alerts** — immediate notification when the daemon hits a state requiring human intervention (auth failure, disk full, persistent vessel failures).
+
+## Design
+
+### Architecture Overview
+
+```
+                                    ┌─────────────────────┐
+                                    │   GitHub Discussion  │
+                                    │  (hourly comments)   │
+                    ┌──────────────►│                      │
+                    │               └─────────────────────┘
+┌──────────────┐    │
+│ daemon loop  │────┤  reportTick (1h)
+│              │    │  escalationCheck (each tick)
+│   tickHook   │────┤
+└──────────────┘    │               ┌─────────────────────┐
+                    │               │   Telegram Bot       │
+                    └──────────────►│  (escalation alerts) │
+                                    └─────────────────────┘
+
+┌──────────────┐
+│ xylem report │─── ad-hoc posting to Discussion / stdout
+└──────────────┘
+```
+
+### Two notification channels
+
+| Channel | Purpose | Frequency | Direction |
+|---------|---------|-----------|-----------|
+| GitHub Discussion | Append-only status log | Hourly | Daemon → GitHub |
+| Telegram | Escalation alerts | On-event | Daemon → Operator |
+
+### New packages
+
+#### `cli/internal/notify/` — notification dispatch
+
+Three files:
+
+1. **`notify.go`** — `Notifier` interface + composite dispatcher
+   ```go
+   type Notifier interface {
+       PostStatus(ctx context.Context, report StatusReport) error
+       SendAlert(ctx context.Context, alert Alert) error
+       Name() string
+   }
+   ```
+
+2. **`telegram.go`** — Telegram Bot API client (zero external deps, `net/http` only)
+   - `SendAlert` sends HTML-formatted message via `POST /bot<token>/sendMessage`
+   - `PostStatus` is a no-op (Telegram is for alerts only)
+   - Reads token from env var (`XYLEM_TELEGRAM_TOKEN`)
+   - Reads chat ID from env var (`XYLEM_TELEGRAM_CHAT_ID`)
+   - Rate limiting: deduplicates repeat alerts within a cooldown window (default 30m)
+
+3. **`discussion.go`** — GitHub Discussion poster via `gh api graphql`
+   - `PostStatus` appends a comment to a pinned Discussion
+   - `SendAlert` is a no-op (Discussion is for status only)
+   - Uses `CmdRunner` interface (same pattern as `source/github.go`) to invoke `gh`
+   - Creates the Discussion on first run if it doesn't exist, persists the Discussion node ID to `state/discussion-id.txt`
+   - GraphQL mutations: `createDiscussion`, `addDiscussionComment`
+
+#### `cli/internal/reporter/` — metric collection and formatting
+
+Two files:
+
+1. **`reporter.go`** — `StatusReporter` that collects a snapshot:
+   ```go
+   type StatusReport struct {
+       Timestamp     time.Time
+       Daemon        DaemonStatus       // PID, uptime, binary, last upgrade
+       Vessels       VesselMetrics       // counts by state
+       Fleet         FleetStatusReport   // health analysis from runner.AnalyzeFleetStatus
+       GitHubActivity GitHubActivity     // issues/PRs opened/closed/merged in window
+       ActiveVessels []ActiveVessel      // running vessels with phase + duration
+       Warnings      []string           // human-readable warning lines
+   }
+   ```
+   - `Collect(ctx)` reads daemon-health.json, queue.jsonl, vessel summaries, and GitHub state via `gh`
+   - Pure data collection — no side effects
+
+2. **`format.go`** — renders `StatusReport` into Markdown (for Discussion) or plain text (for stdout/logs)
+   - `FormatMarkdown(report) string`
+   - `FormatPlainText(report) string`
+
+#### Alert types and escalation triggers
+
+```go
+type AlertSeverity string
+const (
+    SeverityCritical AlertSeverity = "critical" // Requires human action
+    SeverityWarning  AlertSeverity = "warning"  // Degraded, may self-heal
+)
+
+type Alert struct {
+    Severity    AlertSeverity
+    Code        string    // machine-readable (e.g. "auth_failure", "disk_full")
+    Title       string    // short heading
+    Detail      string    // longer description
+    Timestamp   time.Time
+    VesselIDs   []string  // affected vessels, if applicable
+}
+```
+
+**Escalation triggers** (checked each daemon tick):
+
+| Code | Severity | Condition |
+|------|----------|-----------|
+| `auth_failure` | critical | >=3 vessels failed in <5min with auth-related error |
+| `high_failure_rate` | critical | >50% of vessels in last hour are failed/timed_out |
+| `stall_detected` | warning | Stall monitor found phase stall or orphaned subprocess |
+| `queue_backlog` | warning | >10 pending vessels for >30min |
+| `upgrade_stuck` | warning | Auto-upgrade overdue for >3x upgrade_interval |
+| `all_vessels_failing` | critical | Last N consecutive vessels all failed (N=5) |
+
+Alert dedup: each `Code` has a cooldown (30min default for warning, 2h for critical) to prevent spam. Cooldown state lives in memory (resets on daemon restart, which is fine — a restart clears the condition).
+
+### Config additions
+
+```yaml
+notifications:
+  github_discussion:
+    enabled: true
+    repo: "owner/name"          # defaults to first source repo
+    category: "Reports"         # Discussion category name
+    interval: "1h"              # how often to post status
+    title: "Xylem Daemon Status Log"  # Discussion title
+  telegram:
+    enabled: true
+    token_env: "XYLEM_TELEGRAM_TOKEN"      # env var holding bot token
+    chat_id_env: "XYLEM_TELEGRAM_CHAT_ID"  # env var holding chat ID
+    levels:                                 # which severity levels to send
+      - critical
+      - warning
+```
+
+Added to `Config` struct as `Notifications NotificationsConfig`.
+
+### Daemon integration
+
+The daemon loop's `tickHook` is the natural integration point. Currently it writes `daemon-health.json`. We add two additional concerns, both gated on config:
+
+1. **Report tick** — if `notifications.github_discussion.enabled` and interval has elapsed since last post, collect status and post.
+2. **Escalation check** — if `notifications.telegram.enabled`, evaluate escalation conditions against current queue/fleet state and send alerts.
+
+Both run inside `tickHook` (not in a separate goroutine) to avoid concurrent queue reads. The tick already fires every ~30s, so the escalation check is near-real-time. The report interval (1h) is tracked by a simple `lastReportAt` timestamp.
+
+The `tickHook` closure in `cmdDaemon` already has access to `q`, `cfg`, `startedAt`, `lastUpgradeAt` — all the inputs the reporter needs.
+
+### CLI command: `xylem report`
+
+```
+xylem report [--post] [--json] [--root DIR]
+```
+
+- Default: collect and print status to stdout
+- `--post`: also post to configured GitHub Discussion
+- `--json`: output as JSON
+- `--root`: inspect state from a different root (like doctor)
+
+Reuses `reporter.Collect()` and `notify.Discussion.PostStatus()`.
+
+### Status report format (GitHub Discussion comment)
+
+```markdown
+## Xylem Status -- 2026-04-12 14:00 UTC
+
+### Daemon
+| | |
+|---|---|
+| PID | 12345 |
+| Uptime | 4h 32m |
+| Binary | `a70a1a2c` |
+| Last upgrade | 12:28 UTC |
+
+### Vessels
+| State | Count |
+|-------|-------|
+| Pending | 5 |
+| Running | 3 |
+| Completed | 42 |
+| Failed | 7 |
+| Timed Out | 2 |
+| Waiting | 1 |
+| Cancelled | 0 |
+
+### Active Vessels
+| Vessel | Phase | Duration |
+|--------|-------|----------|
+| issue-210 | implement | 12m |
+| issue-211 | verify | 3m |
+
+### GitHub Activity (last hour)
+| Metric | Count | Details |
+|--------|-------|---------|
+| Issues opened | 3 | #210, #211, #212 |
+| Issues closed | 2 | #205, #208 |
+| PRs opened | 4 | |
+| PRs merged | 3 | |
+
+### Fleet Health
+- 85% healthy (51/60 vessels)
+- Patterns: `gate_failed=4`, `timed_out=3`
+
+### Warnings
+- 7 failed vessels in last 24h
+- Pending backlog: 5 vessels queued >30min
+```
+
+### Telegram alert format
+
+```
+CRITICAL: Auth Failure
+
+3 vessels failed in 4 minutes with authentication errors.
+All retry paths exhausted.
+
+Affected: issue-405, issue-210, issue-211
+
+Action required: renew credentials and strip xylem-failed labels.
+```
+
+HTML formatted for Telegram's parse_mode.
+
+## What else an operator would want
+
+Beyond the minimum (Discussion + Telegram), the status report includes:
+
+1. **Daemon health** — PID, uptime, binary commit, last upgrade timestamp. Answers "is it even running?" and "is it on the latest code?"
+2. **Active vessel detail** — which vessels are running, what phase, how long. Answers "what's it doing right now?"
+3. **Fleet health analysis** — healthy/degraded/unhealthy percentages and dominant failure patterns. Answers "is the fleet generally healthy?"
+4. **GitHub activity window** — issues opened/closed, PRs opened/merged/failed in the reporting window. Answers "is it making progress?"
+5. **Throughput** — completed vessels in the window. Answers "how fast is it working?"
+6. **Warnings** — aggregated from stall monitor, backlog, fleet health. Answers "what should I worry about?"
+7. **Auto-upgrade status** — whether upgrade is current or overdue. Answers "is it running stale code?"
+
+These map directly to the questions a remote operator asks when checking in:
+- Is it alive? (daemon health)
+- Is it productive? (throughput + GitHub activity)
+- Is anything stuck? (active vessels + stall warnings)
+- Does it need me? (escalation alerts via Telegram)
+
+## Implementation order
+
+1. `cli/internal/config/` — add `NotificationsConfig` to config struct + defaults + validation
+2. `cli/internal/notify/telegram.go` — Telegram client (net/http, zero deps)
+3. `cli/internal/notify/discussion.go` — Discussion poster (gh api graphql via CmdRunner)
+4. `cli/internal/notify/notify.go` — composite notifier
+5. `cli/internal/reporter/reporter.go` — StatusReport collection
+6. `cli/internal/reporter/format.go` — Markdown + plain text formatters
+7. `cli/cmd/xylem/daemon.go` — wire reportTick + escalation into tickHook
+8. `cli/cmd/xylem/report.go` — xylem report CLI command
+9. Tests for all new packages
+
+## Testing strategy
+
+- **notify/telegram_test.go** — httptest.Server mocking Telegram API; verify request body, auth header, HTML formatting, cooldown dedup
+- **notify/discussion_test.go** — mock CmdRunner; verify GraphQL mutation shape, Discussion creation vs comment append, node ID persistence
+- **reporter/reporter_test.go** — temp dirs with synthetic queue.jsonl + daemon-health.json; verify metric collection
+- **reporter/format_test.go** — golden-file tests for Markdown and plain text output
+- **cmd/xylem/daemon_test.go** — verify report tick fires at correct interval in existing daemon loop test harness
+- **cmd/xylem/report_test.go** — verify CLI flag parsing and output modes
+
+No real GitHub or Telegram API calls in tests. All external interactions go through interfaces.
+
+## Non-goals (v1)
+
+- Telegram inline buttons / callback handling (requires long-polling or webhook server)
+- Slack integration (can be added as another Notifier impl later)
+- Grafana/Prometheus metrics export (OTel already covers this path)
+- Historical trend analysis (the Discussion comment log IS the history)
+- Two-way commands via Telegram (e.g., "retry vessel X" — too much attack surface for v1)


### PR DESCRIPTION
## Summary

- Adds **GitHub Discussion hourly status reports** (append-only) with vessel metrics, daemon health, fleet analysis, active vessels, and recent failures
- Adds **Telegram escalation alerts** for conditions requiring human intervention (auth failure, high failure rate, stalls, queue backlog, upgrade stuck)
- Extracts shared `discussion` package from runner to avoid GraphQL code duplication
- Adds `xylem report [--post] [--json]` CLI command for ad-hoc status reporting
- Config under `notifications:` with `github_discussion:` and `telegram:` sub-keys (both opt-in)

### New packages
| Package | Purpose |
|---------|---------|
| `cli/internal/discussion/` | Shared GitHub Discussion publisher (GraphQL via `gh` CLI) |
| `cli/internal/notify/` | Notifier interface, Multi dispatcher, Telegram client, Discussion notifier, 6 escalation rules |
| `cli/internal/reporter/` | StatusReport collection + Markdown/plain-text formatters |

### Architecture
- Zero new external dependencies (Telegram uses `net/http` only)
- Daemon integration via existing `tickHook` — no new goroutines
- Escalation rules use cooldown dedup to prevent alert spam
- Reporter avoids runner import cycle via `FleetAnalyzer` callback

## Test plan

- [x] `go build ./cmd/xylem/` — clean
- [x] `go vet ./...` — clean
- [x] `goimports -l .` — clean
- [x] `golangci-lint` — clean (via pre-commit hook)
- [x] 48+ new tests across `discussion`, `notify`, `reporter` packages
- [x] Existing `runner` and `config` tests still pass
- [x] Plan verified by crosscheck:byfuglien (7/7 PASS)
- [x] Implementation verified by crosscheck:byfuglien (7/7 PASS)
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)