### PR TITLE
feat: wire episodic memory persistence from phase outputs

### DIFF
--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/spf13/cobra"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+	"github.com/nicholls-inc/xylem/cli/internal/memory"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
@@ -141,6 +144,13 @@ func wireRunnerScaffolding(cfg *config.Config, r *runner.Runner, tracer *observa
 	r.Intermediary.SetMode(cfg.HarnessPolicyMode())
 	r.AuditLog = auditLog
 	r.Tracer = tracer
+
+	episodicPath := config.RuntimePath(cfg.StateDir, "state", "memory", "episodic.jsonl")
+	if err := os.MkdirAll(filepath.Dir(episodicPath), 0o755); err != nil {
+		slog.Warn("create episodic memory dir", "error", err)
+	} else {
+		r.EpisodicStore = memory.NewEpisodicStore(episodicPath)
+	}
 }
 
 var newConfiguredTracer = func(cfg observability.TracerConfig) (*observability.Tracer, error) {

--- a/cli/internal/memory/episodic.go
+++ b/cli/internal/memory/episodic.go
@@ -1,0 +1,138 @@
+package memory
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+// EpisodicEntry records what happened during a single workflow phase.
+type EpisodicEntry struct {
+	VesselID   string    `json:"vessel_id"`
+	PhaseName  string    `json:"phase_name"`
+	RecordedAt time.Time `json:"recorded_at"`
+	// Outcome is one of "completed", "failed", or "no-op".
+	Outcome   string   `json:"outcome"`
+	Summary   string   `json:"summary"`
+	Citations []string `json:"citations,omitempty"`
+}
+
+// EpisodicStore is an append-only JSONL-backed store for episodic phase
+// records. It mirrors the AuditLog pattern in
+// cli/internal/intermediary/intermediary.go.
+type EpisodicStore struct {
+	path     string
+	lockPath string
+}
+
+// NewEpisodicStore creates an EpisodicStore writing to path.
+// The parent directory must already exist (caller's responsibility).
+func NewEpisodicStore(path string) *EpisodicStore {
+	return &EpisodicStore{
+		path:     path,
+		lockPath: path + ".lock",
+	}
+}
+
+// Append writes one EpisodicEntry as a JSONL line under an exclusive flock.
+// INV: each Append adds exactly one JSONL line, never modifies existing lines.
+func (s *EpisodicStore) Append(entry EpisodicEntry) error {
+	lock := flock.New(s.lockPath)
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("acquire episodic store lock: %w", err)
+	}
+	defer func() {
+		if err := lock.Unlock(); err != nil {
+			log.Printf("warn: failed to unlock episodic store: %v", err)
+		}
+	}()
+
+	f, err := os.OpenFile(s.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open episodic store: %w", err)
+	}
+	defer f.Close()
+
+	b, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshal episodic entry: %w", err)
+	}
+
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("write episodic entry: %w", err)
+	}
+	return nil
+}
+
+// All reads every entry from the file under a shared flock.
+// Returns an empty (non-nil) slice when the file does not exist.
+func (s *EpisodicStore) All() ([]EpisodicEntry, error) {
+	lock := flock.New(s.lockPath)
+	if err := lock.RLock(); err != nil {
+		return nil, fmt.Errorf("acquire episodic store read lock: %w", err)
+	}
+	defer func() {
+		if err := lock.Unlock(); err != nil {
+			log.Printf("warn: failed to unlock episodic store: %v", err)
+		}
+	}()
+
+	f, err := os.Open(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []EpisodicEntry{}, nil
+		}
+		return nil, fmt.Errorf("open episodic store: %w", err)
+	}
+	defer f.Close()
+
+	var entries []EpisodicEntry
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		var entry EpisodicEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			log.Printf("warn: skip malformed episodic entry: %v", err)
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read episodic store: %w", err)
+	}
+	if entries == nil {
+		entries = []EpisodicEntry{}
+	}
+	return entries, nil
+}
+
+// RecentForVessel returns the last n entries whose VesselID matches vesselID.
+// If n <= 0 all matching entries are returned.
+func (s *EpisodicStore) RecentForVessel(vesselID string, n int) ([]EpisodicEntry, error) {
+	all, err := s.All()
+	if err != nil {
+		return nil, err
+	}
+	var matched []EpisodicEntry
+	for _, e := range all {
+		if e.VesselID == vesselID {
+			matched = append(matched, e)
+		}
+	}
+	if n <= 0 || len(matched) <= n {
+		if matched == nil {
+			return []EpisodicEntry{}, nil
+		}
+		return matched, nil
+	}
+	return matched[len(matched)-n:], nil
+}

--- a/cli/internal/memory/episodic_prop_test.go
+++ b/cli/internal/memory/episodic_prop_test.go
@@ -1,0 +1,123 @@
+package memory
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+)
+
+// TestPropEpisodicAppendPreservesOrder asserts that All() returns entries in
+// the exact order they were appended, with all fields preserved.
+func TestPropEpisodicAppendPreservesOrder(t *testing.T) {
+	dir := tempDirForRapid(t)
+
+	rapid.Check(t, func(rt *rapid.T) {
+		// Fresh file per iteration.
+		path := filepath.Join(dir, rapid.StringMatching(`[a-z]{8}`).Draw(rt, "filename")+".jsonl")
+
+		n := rapid.IntRange(0, 20).Draw(rt, "n")
+		outcomes := []string{"completed", "failed", "no-op"}
+		vessels := []string{"v1", "v2", "v3"}
+
+		entries := make([]EpisodicEntry, n)
+		for i := range n {
+			entries[i] = EpisodicEntry{
+				VesselID:   rapid.SampledFrom(vessels).Draw(rt, "vessel"),
+				PhaseName:  rapid.StringMatching(`[a-z][a-z0-9-]{0,9}`).Draw(rt, "phase"),
+				RecordedAt: time.Now().UTC(),
+				Outcome:    rapid.SampledFrom(outcomes).Draw(rt, "outcome"),
+				Summary:    rapid.StringMatching(`[a-z ]{1,30}`).Draw(rt, "summary"),
+			}
+		}
+
+		s := NewEpisodicStore(path)
+		for _, e := range entries {
+			if err := s.Append(e); err != nil {
+				rt.Fatalf("Append: %v", err)
+			}
+		}
+
+		got, err := s.All()
+		if err != nil {
+			rt.Fatalf("All: %v", err)
+		}
+		if len(got) != len(entries) {
+			rt.Fatalf("All: got %d entries, want %d", len(got), len(entries))
+		}
+		for i := range entries {
+			if got[i].VesselID != entries[i].VesselID ||
+				got[i].PhaseName != entries[i].PhaseName ||
+				got[i].Outcome != entries[i].Outcome ||
+				got[i].Summary != entries[i].Summary {
+				rt.Fatalf("entry[%d] mismatch: got %+v, want %+v", i, got[i], entries[i])
+			}
+		}
+	})
+}
+
+// TestPropEpisodicRecentForVesselSubset asserts that RecentForVessel returns
+// a suffix of the vessel-filtered All() slice, with len ≤ min(n, total).
+func TestPropEpisodicRecentForVesselSubset(t *testing.T) {
+	dir := tempDirForRapid(t)
+
+	rapid.Check(t, func(rt *rapid.T) {
+		path := filepath.Join(dir, rapid.StringMatching(`[a-z]{8}`).Draw(rt, "filename")+".jsonl")
+
+		vessels := []string{"alpha", "beta", "gamma"}
+		total := rapid.IntRange(0, 30).Draw(rt, "total")
+		n := rapid.IntRange(1, 15).Draw(rt, "n")
+
+		s := NewEpisodicStore(path)
+		for range total {
+			e := EpisodicEntry{
+				VesselID:  rapid.SampledFrom(vessels).Draw(rt, "vessel"),
+				PhaseName: "phase",
+				Outcome:   "completed",
+				Summary:   "s",
+			}
+			if err := s.Append(e); err != nil {
+				rt.Fatalf("Append: %v", err)
+			}
+		}
+
+		target := rapid.SampledFrom(vessels).Draw(rt, "target")
+
+		all, err := s.All()
+		if err != nil {
+			rt.Fatalf("All: %v", err)
+		}
+
+		// Build expected: all filtered to target.
+		var filtered []EpisodicEntry
+		for _, e := range all {
+			if e.VesselID == target {
+				filtered = append(filtered, e)
+			}
+		}
+
+		got, err := s.RecentForVessel(target, n)
+		if err != nil {
+			rt.Fatalf("RecentForVessel: %v", err)
+		}
+
+		// len(got) <= min(n, len(filtered))
+		maxExpected := n
+		if len(filtered) < maxExpected {
+			maxExpected = len(filtered)
+		}
+		if len(got) != maxExpected {
+			rt.Fatalf("RecentForVessel len: got %d, want %d (filtered=%d, n=%d)", len(got), maxExpected, len(filtered), n)
+		}
+
+		// got must be a suffix of filtered.
+		offset := len(filtered) - len(got)
+		for i, e := range got {
+			if e.VesselID != filtered[offset+i].VesselID ||
+				e.PhaseName != filtered[offset+i].PhaseName {
+				rt.Fatalf("entry[%d] is not a suffix of filtered slice", i)
+			}
+		}
+	})
+}

--- a/cli/internal/memory/episodic_test.go
+++ b/cli/internal/memory/episodic_test.go
@@ -1,0 +1,235 @@
+package memory
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func makeEpisodicEntry(vesselID, phase, outcome string) EpisodicEntry {
+	return EpisodicEntry{
+		VesselID:   vesselID,
+		PhaseName:  phase,
+		RecordedAt: time.Now().UTC(),
+		Outcome:    outcome,
+		Summary:    "summary for " + phase,
+	}
+}
+
+// ---------- TestEpisodicStore_AppendAndAll ----------
+
+func TestEpisodicStore_AppendAndAll(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "episodic.jsonl")
+	s := NewEpisodicStore(path)
+
+	entries := []EpisodicEntry{
+		makeEpisodicEntry("v1", "phase-a", "completed"),
+		makeEpisodicEntry("v1", "phase-b", "completed"),
+		makeEpisodicEntry("v2", "phase-a", "failed"),
+	}
+	for _, e := range entries {
+		if err := s.Append(e); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+
+	got, err := s.All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(got) != len(entries) {
+		t.Fatalf("All: got %d entries, want %d", len(got), len(entries))
+	}
+	for i, e := range entries {
+		if got[i].VesselID != e.VesselID || got[i].PhaseName != e.PhaseName || got[i].Outcome != e.Outcome {
+			t.Errorf("entry[%d]: got %+v, want %+v", i, got[i], e)
+		}
+	}
+}
+
+// ---------- TestEpisodicStore_AllEmptyFileNotExist ----------
+
+func TestEpisodicStore_AllEmptyFileNotExist(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "no-such-file.jsonl")
+	s := NewEpisodicStore(path)
+
+	got, err := s.All()
+	if err != nil {
+		t.Fatalf("All on missing file: %v", err)
+	}
+	if got == nil {
+		t.Fatal("All: expected non-nil slice, got nil")
+	}
+	if len(got) != 0 {
+		t.Fatalf("All: got %d entries, want 0", len(got))
+	}
+}
+
+// ---------- TestEpisodicStore_RecentForVessel_Filter ----------
+
+func TestEpisodicStore_RecentForVessel_Filter(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "episodic.jsonl")
+	s := NewEpisodicStore(path)
+
+	for _, e := range []EpisodicEntry{
+		makeEpisodicEntry("vessel-A", "phase-a", "completed"),
+		makeEpisodicEntry("vessel-B", "phase-a", "completed"),
+		makeEpisodicEntry("vessel-A", "phase-b", "completed"),
+		makeEpisodicEntry("vessel-B", "phase-b", "failed"),
+	} {
+		if err := s.Append(e); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+
+	got, err := s.RecentForVessel("vessel-A", 0)
+	if err != nil {
+		t.Fatalf("RecentForVessel: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d entries for vessel-A, want 2", len(got))
+	}
+	for _, e := range got {
+		if e.VesselID != "vessel-A" {
+			t.Errorf("unexpected vessel ID %q in result", e.VesselID)
+		}
+	}
+}
+
+// ---------- TestEpisodicStore_RecentForVessel_Limit ----------
+
+func TestEpisodicStore_RecentForVessel_Limit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "episodic.jsonl")
+	s := NewEpisodicStore(path)
+
+	for i := range 20 {
+		e := EpisodicEntry{
+			VesselID:  "v1",
+			PhaseName: "phase",
+			Outcome:   "completed",
+			Summary:   strings.Repeat("x", i+1), // unique so we can identify
+		}
+		if err := s.Append(e); err != nil {
+			t.Fatalf("Append[%d]: %v", i, err)
+		}
+	}
+
+	got, err := s.RecentForVessel("v1", 5)
+	if err != nil {
+		t.Fatalf("RecentForVessel: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("got %d entries, want 5", len(got))
+	}
+	// The last 5 entries (i=15..19) have summaries of lengths 16..20, in that
+	// order. Verify both selection and append-order preservation.
+	for j, e := range got {
+		wantLen := 16 + j
+		if len(e.Summary) != wantLen {
+			t.Errorf("got[%d].Summary len = %d, want %d (entry %d of last-5)",
+				j, len(e.Summary), wantLen, j)
+		}
+	}
+}
+
+// ---------- TestEpisodicStore_RecentForVessel_ZeroN ----------
+
+func TestEpisodicStore_RecentForVessel_ZeroN(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "episodic.jsonl")
+	s := NewEpisodicStore(path)
+
+	for range 10 {
+		if err := s.Append(makeEpisodicEntry("v1", "p", "completed")); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+
+	for _, n := range []int{0, -1} {
+		got, err := s.RecentForVessel("v1", n)
+		if err != nil {
+			t.Fatalf("RecentForVessel(n=%d): %v", n, err)
+		}
+		if len(got) != 10 {
+			t.Errorf("RecentForVessel(n=%d): got %d entries, want 10", n, len(got))
+		}
+	}
+}
+
+// ---------- TestEpisodicStore_AppendConcurrent ----------
+
+func TestEpisodicStore_AppendConcurrent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "episodic.jsonl")
+	s := NewEpisodicStore(path)
+
+	const goroutines = 20
+	const perGoroutine = 5
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range perGoroutine {
+				e := EpisodicEntry{
+					VesselID:  "v1",
+					PhaseName: "phase",
+					Outcome:   "completed",
+					Summary:   strings.Repeat("x", g*perGoroutine+i),
+				}
+				if err := s.Append(e); err != nil {
+					t.Errorf("Append goroutine %d entry %d: %v", g, i, err)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	all, err := s.All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(all) != goroutines*perGoroutine {
+		t.Fatalf("got %d entries, want %d", len(all), goroutines*perGoroutine)
+	}
+
+	// Verify no JSONL corruption by confirming each line is valid JSON.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	for i, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var e EpisodicEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Errorf("line %d is corrupt JSON: %v", i, err)
+		}
+	}
+}
+
+// ---------- TestEpisodicStore_BlankLinesTolerated ----------
+
+func TestEpisodicStore_BlankLinesTolerated(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "episodic.jsonl")
+
+	// Manually write a file with blank lines interspersed.
+	e := makeEpisodicEntry("v1", "phase-a", "completed")
+	b, _ := json.Marshal(e)
+	content := "\n" + string(b) + "\n\n" + string(b) + "\n\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s := NewEpisodicStore(path)
+	all, err := s.All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("got %d entries, want 2", len(all))
+	}
+}

--- a/cli/internal/phase/phase.go
+++ b/cli/internal/phase/phase.go
@@ -8,6 +8,7 @@ import (
 	"text/template"
 
 	"github.com/nicholls-inc/xylem/cli/internal/ctxmgr"
+	"github.com/nicholls-inc/xylem/cli/internal/memory"
 )
 
 // Truncation limits (constants, not configurable).
@@ -39,6 +40,10 @@ type TemplateData struct {
 	Repo                RepoData
 	Source              SourceData
 	Validation          ValidationData
+	// EpisodicContext holds prior episodic entries for this vessel, most
+	// recent first. Populated by the runner for phase index > 0. Template
+	// authors should guard with {{if .EpisodicContext}}.
+	EpisodicContext []memory.EpisodicEntry
 }
 
 type RenderOptions struct {

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"github.com/nicholls-inc/xylem/cli/internal/gate"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+	"github.com/nicholls-inc/xylem/cli/internal/memory"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/orchestrator"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
@@ -103,6 +104,9 @@ type Runner struct {
 	Intermediary *intermediary.Intermediary // nil = no policy enforcement
 	AuditLog     *intermediary.AuditLog     // nil = no audit logging
 	Tracer       *observability.Tracer      // nil = no tracing
+	// EpisodicStore persists one entry per completed phase for cross-phase
+	// and cross-vessel recall. nil disables episodic persistence.
+	EpisodicStore *memory.EpisodicStore
 	// DrainBudget bounds the wall time that Drain() spends dequeueing new
 	// vessels. When the deadline elapses, Drain() stops dequeueing and
 	// returns immediately while already-started goroutines continue in the
@@ -710,6 +714,23 @@ func (r *Runner) runVessel(ctx context.Context, vessel queue.Vessel) (outcome st
 		case "timed_out":
 			return "timed_out"
 		case "completed", "no-op":
+			if r.EpisodicStore != nil {
+				summary := res.output
+				const maxSummaryLen = 512
+				if len(summary) > maxSummaryLen {
+					summary = summary[:maxSummaryLen]
+				}
+				entry := memory.EpisodicEntry{
+					VesselID:   vessel.ID,
+					PhaseName:  p.Name,
+					RecordedAt: r.runtimeNow().UTC(),
+					Outcome:    res.status,
+					Summary:    summary,
+				}
+				if err := r.EpisodicStore.Append(entry); err != nil {
+					log.Printf("warn: episodic store append for vessel %s phase %s: %v", vessel.ID, p.Name, err)
+				}
+			}
 			previousOutputs[p.Name] = res.output
 			vessel.CurrentPhase = i + 1
 			if vessel.PhaseOutputs == nil {
@@ -4093,6 +4114,19 @@ func (r *Runner) buildTemplateData(vessel queue.Vessel, wf *workflow.Workflow, i
 			Test:   strings.TrimSpace(r.Config.Validation.Test),
 		}
 	}
+	var episodicCtx []memory.EpisodicEntry
+	if r.EpisodicStore != nil && phaseIndex > 0 {
+		entries, err := r.EpisodicStore.RecentForVessel(vessel.ID, 10)
+		if err != nil {
+			log.Printf("warn: read episodic context for vessel %s: %v", vessel.ID, err)
+		} else {
+			// Reverse so most-recent is first.
+			for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+				entries[i], entries[j] = entries[j], entries[i]
+			}
+			episodicCtx = entries
+		}
+	}
 	return phase.TemplateData{
 		Date:  r.runtimeNow().UTC().Format("2006-01-02"),
 		Issue: issueData,
@@ -4118,7 +4152,8 @@ func (r *Runner) buildTemplateData(vessel queue.Vessel, wf *workflow.Workflow, i
 			Name: sourceName,
 			Repo: repoSlug,
 		},
-		Validation: validation,
+		Validation:      validation,
+		EpisodicContext: episodicCtx,
 	}
 }
 

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/evidence"
 	"github.com/nicholls-inc/xylem/cli/internal/gate"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+	"github.com/nicholls-inc/xylem/cli/internal/memory"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
 	"github.com/nicholls-inc/xylem/cli/internal/phase"
 	"github.com/nicholls-inc/xylem/cli/internal/policy"
@@ -10421,4 +10422,100 @@ func TestRunVesselLiveGateEmitsStepSpans(t *testing.T) {
 	assert.Equal(t, "http", stepAttrs["xylem.gate.step.mode"])
 	assert.Equal(t, "true", stepAttrs["xylem.gate.step.passed"])
 	assert.Equal(t, gateSpan.SpanContext().SpanID(), stepSpan.Parent().SpanID())
+}
+
+// ---------- Episodic memory integration ----------
+
+// TestEpisodicContextInjectedIntoPhase2 verifies that when an EpisodicStore is
+// set on the Runner and prior entries have been appended for a vessel,
+// buildTemplateData for phase index > 0 includes those entries in
+// EpisodicContext with the most-recent entry first (runner reverses append
+// order so callers see newest-first).
+func TestEpisodicContextInjectedIntoPhase2(t *testing.T) {
+	dir := t.TempDir()
+	episodicPath := filepath.Join(dir, "episodic.jsonl")
+	store := memory.NewEpisodicStore(episodicPath)
+
+	r := New(&config.Config{}, nil, nil, nil)
+	r.EpisodicStore = store
+
+	vessel := queue.Vessel{ID: "v-392", Source: "manual"}
+	wf := &workflow.Workflow{
+		Phases: []workflow.Phase{
+			{Name: "phase-a"},
+			{Name: "phase-b"},
+			{Name: "phase-c"},
+		},
+	}
+
+	// Seed three entries in chronological append order.
+	for _, e := range []memory.EpisodicEntry{
+		{VesselID: "v-392", PhaseName: "phase-a", Outcome: "completed", Summary: "a done"},
+		{VesselID: "v-392", PhaseName: "phase-b", Outcome: "completed", Summary: "b done"},
+		{VesselID: "v-392", PhaseName: "phase-c", Outcome: "failed", Summary: "c failed"},
+	} {
+		if err := store.Append(e); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+
+	td := r.buildTemplateData(vessel, wf, phase.IssueData{}, "phase-d", 3,
+		map[string]string{}, "", phase.EvaluationData{})
+
+	if len(td.EpisodicContext) != 3 {
+		t.Fatalf("EpisodicContext: got %d entries, want 3", len(td.EpisodicContext))
+	}
+	// Runner reverses so most-recent is first.
+	wantOrder := []string{"phase-c", "phase-b", "phase-a"}
+	for i, wantPhase := range wantOrder {
+		if td.EpisodicContext[i].PhaseName != wantPhase {
+			t.Errorf("EpisodicContext[%d].PhaseName = %q, want %q", i, td.EpisodicContext[i].PhaseName, wantPhase)
+		}
+		if td.EpisodicContext[i].VesselID != "v-392" {
+			t.Errorf("EpisodicContext[%d].VesselID = %q, want %q", i, td.EpisodicContext[i].VesselID, "v-392")
+		}
+	}
+}
+
+// TestEpisodicContextNilStoreIsEmpty verifies that when EpisodicStore is nil,
+// EpisodicContext is nil regardless of phase index. The nil guard
+// short-circuits before phaseIndex is checked, so a single call is sufficient
+// to cover this branch.
+func TestEpisodicContextNilStoreIsEmpty(t *testing.T) {
+	r := New(&config.Config{}, nil, nil, nil)
+	// r.EpisodicStore is nil
+
+	vessel := queue.Vessel{ID: "v-nil", Source: "manual"}
+	wf := &workflow.Workflow{
+		Phases: []workflow.Phase{{Name: "phase-a"}, {Name: "phase-b"}},
+	}
+
+	td := r.buildTemplateData(vessel, wf, phase.IssueData{}, "phase-b", 1,
+		map[string]string{}, "", phase.EvaluationData{})
+	if td.EpisodicContext != nil {
+		t.Errorf("EpisodicContext with nil store = %v, want nil", td.EpisodicContext)
+	}
+}
+
+// TestEpisodicContextPhaseZeroSkipped verifies that phase index 0 never
+// receives episodic context even when the store contains entries.
+func TestEpisodicContextPhaseZeroSkipped(t *testing.T) {
+	dir := t.TempDir()
+	store := memory.NewEpisodicStore(filepath.Join(dir, "episodic.jsonl"))
+	if err := store.Append(memory.EpisodicEntry{
+		VesselID: "v-1", PhaseName: "prior", Outcome: "completed",
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	r := New(&config.Config{}, nil, nil, nil)
+	r.EpisodicStore = store
+
+	vessel := queue.Vessel{ID: "v-1", Source: "manual"}
+	td := r.buildTemplateData(vessel, nil, phase.IssueData{}, "phase-a", 0,
+		map[string]string{}, "", phase.EvaluationData{})
+
+	if td.EpisodicContext != nil {
+		t.Errorf("EpisodicContext at phase 0 should be nil, got %v", td.EpisodicContext)
+	}
 }


### PR DESCRIPTION
## Summary

Wires `cli/internal/memory` for episodic memory persistence, implementing the third memory type required by SoTA spec §4.4. Resolves https://github.com/nicholls-inc/xylem/issues/392.

Each completed workflow phase now appends a record to `.xylem/state/memory/episodic.jsonl`. Subsequent phases in the same vessel receive the last 10 episodic entries injected into their `TemplateData.EpisodicContext`, enabling cross-phase recall without any subprocess or external dependency.

## Smoke scenarios covered

No formal smoke scenario IDs are assigned to this issue (confirmed in analysis — episodic memory was not scoped into WS1–WS6 harness smoke workstreams). Coverage is provided by the new unit, property, and integration tests:

- Append-and-read-all round-trip with field fidelity
- `All()` on a non-existent file returns empty slice (not error)
- `RecentForVessel` filters by vessel ID and respects the `n` limit
- `n ≤ 0` returns all matching entries
- 20-goroutine concurrent append produces exactly 100 uncorrupted JSONL lines
- Blank-line tolerance in `All()`
- Property: append preserves FIFO order across random entry sequences
- Property: `RecentForVessel` result is always a suffix of `All()` filtered to that vessel
- Runner integration: second phase's `TemplateData.EpisodicContext` is populated from seeded first-phase episodic data

## Changes summary

### New files

- `cli/internal/memory/episodic.go` — `EpisodicEntry` struct and `EpisodicStore` (append-only JSONL, flock-guarded, mirrors `intermediary.AuditLog` pattern). Public API: `NewEpisodicStore`, `Append`, `All`, `RecentForVessel`.
- `cli/internal/memory/episodic_test.go` — 7 unit tests covering append, read, filter, limit, concurrency, and blank-line tolerance.
- `cli/internal/memory/episodic_prop_test.go` — 2 property-based tests (`TestPropEpisodicAppendPreservesOrder`, `TestPropEpisodicRecentForVesselSubset`).

### Modified files

- `cli/internal/phase/phase.go` — added `EpisodicContext []memory.EpisodicEntry` field to `TemplateData`.
- `cli/internal/runner/runner.go` — added `EpisodicStore *memory.EpisodicStore` field to `Runner`; appends episodic entry after each phase completes (nil-guarded, log-and-continue on error); populates `EpisodicContext` in `buildTemplateData` for phase index > 0 (capped at 10 entries, reversed to most-recent-first).
- `cli/cmd/xylem/drain.go` — initialises `EpisodicStore` pointing to `<stateDir>/state/memory/episodic.jsonl`, creating the parent directory if absent.
- `cli/internal/runner/runner_test.go` — added `TestEpisodicContextInjectedIntoPhase2` integration test.

## Test plan

- [ ] `go test ./cli/internal/memory/...` — all 7 unit tests + 2 property tests green
- [ ] `go test ./cli/internal/runner/... -run TestEpisodicContextInjectedIntoPhase2` — integration test green
- [ ] `go test ./...` — full suite green
- [ ] After one clean vessel run: `.xylem/state/memory/episodic.jsonl` exists with ≥1 entry per completed phase
- [ ] Second phase of a two-phase workflow: rendered `.prompt` file references prior episodic data

Fixes #392