### PR TITLE
feat: add `xylem audit` CLI subcommand (tail / denied / counts / rule)

### DIFF
--- a/cli/cmd/xylem/audit.go
+++ b/cli/cmd/xylem/audit.go
@@ -1,0 +1,210 @@
+// audit.go — "xylem audit" command and subcommands.
+// Reads the JSONL intermediary audit log line-by-line without loading the
+// whole file. Output is plain lines suitable for piping to jq, rg, or shell
+// filters. Not related to builtin_audit.go (which handles scheduled vessel
+// workflows).
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+)
+
+func newAuditCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "audit",
+		Short: "Inspect the intermediary audit log",
+	}
+	cmd.AddCommand(
+		newAuditTailCmd(),
+		newAuditDeniedCmd(),
+		newAuditCountsCmd(),
+		newAuditRuleCmd(),
+	)
+	return cmd
+}
+
+func newAuditTailCmd() *cobra.Command {
+	var n int
+	cmd := &cobra.Command{
+		Use:   "tail",
+		Short: "Print the last N entries",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := config.RuntimePath(deps.cfg.StateDir, deps.cfg.EffectiveAuditLogPath())
+			return cmdAuditTail(os.Stdout, path, n)
+		},
+	}
+	cmd.Flags().IntVarP(&n, "lines", "n", 20, "Number of entries to print")
+	return cmd
+}
+
+func newAuditDeniedCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "denied",
+		Short: "List entries where decision=deny",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := config.RuntimePath(deps.cfg.StateDir, deps.cfg.EffectiveAuditLogPath())
+			return cmdAuditDenied(os.Stdout, path)
+		},
+	}
+}
+
+func newAuditCountsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "counts",
+		Short: "Print per-action operation counts",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := config.RuntimePath(deps.cfg.StateDir, deps.cfg.EffectiveAuditLogPath())
+			return cmdAuditCounts(os.Stdout, path)
+		},
+	}
+}
+
+func newAuditRuleCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "rule <rule-name>",
+		Short: "Show violation rate for a policy rule",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := config.RuntimePath(deps.cfg.StateDir, deps.cfg.EffectiveAuditLogPath())
+			return cmdAuditRule(os.Stdout, path, args[0])
+		},
+	}
+}
+
+// cmdAuditTail prints the last n entries from the audit log using a ring buffer.
+func cmdAuditTail(w io.Writer, path string, n int) error {
+	if n <= 0 {
+		return nil
+	}
+	ring := make([]string, n)
+	idx := 0
+	total := 0
+	err := scanAuditLines(path, func(rawLine string) {
+		ring[idx%n] = rawLine
+		idx++
+		total++
+	})
+	if err != nil {
+		return err
+	}
+	if total == 0 {
+		return nil
+	}
+	// Determine start position in ring buffer.
+	count := total
+	if count > n {
+		count = n
+	}
+	// When we've seen more entries than the ring size, idx%n points to the
+	// oldest kept entry. When total <= n all used slots start at index 0.
+	start := 0
+	if total > n {
+		start = idx % n
+	}
+	for i := 0; i < count; i++ {
+		pos := (start + i) % n
+		fmt.Fprintln(w, ring[pos])
+	}
+	return nil
+}
+
+// cmdAuditDenied streams the audit log and prints lines where decision=deny.
+func cmdAuditDenied(w io.Writer, path string) error {
+	return scanAuditEntries(path, func(entry intermediary.AuditEntry, rawLine string) error {
+		if entry.Decision == intermediary.Deny {
+			fmt.Fprintln(w, rawLine)
+		}
+		return nil
+	})
+}
+
+// cmdAuditCounts accumulates per-action counts and prints them sorted.
+func cmdAuditCounts(w io.Writer, path string) error {
+	counts := make(map[string]int)
+	err := scanAuditEntries(path, func(entry intermediary.AuditEntry, _ string) error {
+		action := entry.Intent.Action
+		if action == "" {
+			action = "-"
+		}
+		counts[action]++
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if len(counts) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(w, "%s\t%d\n", k, counts[k])
+	}
+	return nil
+}
+
+// cmdAuditRule prints the violation rate for a named policy rule.
+func cmdAuditRule(w io.Writer, path string, ruleName string) error {
+	var total, matched int
+	err := scanAuditEntries(path, func(entry intermediary.AuditEntry, _ string) error {
+		total++
+		if entry.RuleMatched == ruleName {
+			matched++
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "%d/%d violations for rule %s\n", matched, total, ruleName)
+	return nil
+}
+
+// scanAuditEntries opens path, decodes each JSONL line into an AuditEntry,
+// and calls fn. Malformed lines are skipped silently. A missing file returns nil.
+func scanAuditEntries(path string, fn func(entry intermediary.AuditEntry, rawLine string) error) error {
+	return scanAuditLines(path, func(rawLine string) {
+		var entry intermediary.AuditEntry
+		if err := json.Unmarshal([]byte(rawLine), &entry); err != nil {
+			return // skip malformed lines
+		}
+		fn(entry, rawLine) //nolint:errcheck
+	})
+}
+
+// scanAuditLines opens path and calls fn for each raw line. Missing file
+// returns nil. Uses a 1 MB scanner buffer to handle large JSON lines.
+func scanAuditLines(path string, fn func(rawLine string)) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		fn(line)
+	}
+	return scanner.Err()
+}

--- a/cli/cmd/xylem/audit_prop_test.go
+++ b/cli/cmd/xylem/audit_prop_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+
+	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+)
+
+// genAuditEntry generates a random AuditEntry.
+func genAuditEntry(t *rapid.T) intermediary.AuditEntry {
+	action := rapid.StringMatching(`[a-z]{1,10}`).Draw(t, "action")
+	effects := []intermediary.Effect{intermediary.Allow, intermediary.Deny, intermediary.RequireApproval}
+	effectIdx := rapid.IntRange(0, len(effects)-1).Draw(t, "effect_idx")
+	rule := rapid.StringMatching(`[a-z-]{0,15}`).Draw(t, "rule")
+	return intermediary.AuditEntry{
+		Intent:      intermediary.Intent{Action: action},
+		Decision:    effects[effectIdx],
+		Timestamp:   time.Now().UTC(),
+		RuleMatched: rule,
+	}
+}
+
+// writeAuditEntriesToPath writes entries as JSONL to path.
+func writeAuditEntriesToPath(t *rapid.T, path string, entries []intermediary.AuditEntry) {
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, e := range entries {
+		if err := enc.Encode(e); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}
+}
+
+// captureWriter captures output from a function writing to an io.Writer.
+func captureWriter(fn func(w io.Writer) error) (string, error) {
+	var buf bytes.Buffer
+	err := fn(&buf)
+	return buf.String(), err
+}
+
+// TestPropAuditCountsNeverExceedsTotal verifies that the sum of all action
+// counts equals the number of successfully-decoded lines.
+func TestPropAuditCountsNeverExceedsTotal(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		entries := rapid.SliceOf(rapid.Custom(genAuditEntry)).Draw(rt, "entries")
+		dir, err := os.MkdirTemp("", "xylem-audit-prop-*")
+		if err != nil {
+			rt.Fatalf("MkdirTemp: %v", err)
+		}
+		defer os.RemoveAll(dir)
+		path := filepath.Join(dir, "audit.jsonl")
+		writeAuditEntriesToPath(rt, path, entries)
+
+		out, err := captureWriter(func(w io.Writer) error {
+			return cmdAuditCounts(w, path)
+		})
+		if err != nil {
+			rt.Fatalf("cmdAuditCounts: %v", err)
+		}
+
+		// Sum all counts from output.
+		var sumCounts int
+		for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+			if line == "" {
+				continue
+			}
+			parts := strings.Split(line, "\t")
+			if len(parts) != 2 {
+				rt.Fatalf("malformed counts line: %q", line)
+			}
+			var c int
+			if _, err := fmt.Sscanf(parts[1], "%d", &c); err != nil {
+				rt.Fatalf("parse count %q: %v", parts[1], err)
+			}
+			sumCounts += c
+		}
+
+		if sumCounts != len(entries) {
+			rt.Fatalf("sum of counts %d != number of entries %d", sumCounts, len(entries))
+		}
+	})
+}
+
+// TestPropAuditTailNeverExceedsN verifies that tail output lines <= min(n, total).
+func TestPropAuditTailNeverExceedsN(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		entries := rapid.SliceOf(rapid.Custom(genAuditEntry)).Draw(rt, "entries")
+		n := rapid.IntRange(0, 50).Draw(rt, "n")
+		dir, err := os.MkdirTemp("", "xylem-audit-prop-*")
+		if err != nil {
+			rt.Fatalf("MkdirTemp: %v", err)
+		}
+		defer os.RemoveAll(dir)
+		path := filepath.Join(dir, "audit.jsonl")
+		writeAuditEntriesToPath(rt, path, entries)
+
+		out, err := captureWriter(func(w io.Writer) error {
+			return cmdAuditTail(w, path, n)
+		})
+		if err != nil {
+			rt.Fatalf("cmdAuditTail: %v", err)
+		}
+
+		var lineCount int
+		for _, line := range strings.Split(out, "\n") {
+			if strings.TrimSpace(line) != "" {
+				lineCount++
+			}
+		}
+
+		expected := n
+		if len(entries) < n {
+			expected = len(entries)
+		}
+		if lineCount != expected {
+			rt.Fatalf("tail returned %d lines, expected exactly %d (n=%d, total=%d)", lineCount, expected, n, len(entries))
+		}
+	})
+}
+
+// TestPropAuditDeniedSubsetOfAll verifies that denied line count <= total line
+// count and every denied line decodes with Decision==Deny.
+func TestPropAuditDeniedSubsetOfAll(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		entries := rapid.SliceOf(rapid.Custom(genAuditEntry)).Draw(rt, "entries")
+		dir, err := os.MkdirTemp("", "xylem-audit-prop-*")
+		if err != nil {
+			rt.Fatalf("MkdirTemp: %v", err)
+		}
+		defer os.RemoveAll(dir)
+		path := filepath.Join(dir, "audit.jsonl")
+		writeAuditEntriesToPath(rt, path, entries)
+
+		out, err := captureWriter(func(w io.Writer) error {
+			return cmdAuditDenied(w, path)
+		})
+		if err != nil {
+			rt.Fatalf("cmdAuditDenied: %v", err)
+		}
+
+		var deniedLines []string
+		for _, line := range strings.Split(out, "\n") {
+			if strings.TrimSpace(line) != "" {
+				deniedLines = append(deniedLines, line)
+			}
+		}
+
+		// Denied count must not exceed total
+		if len(deniedLines) > len(entries) {
+			rt.Fatalf("denied lines %d > total entries %d", len(deniedLines), len(entries))
+		}
+
+		// Every denied line must decode with Decision==Deny
+		for _, line := range deniedLines {
+			var e intermediary.AuditEntry
+			if err := json.Unmarshal([]byte(line), &e); err != nil {
+				rt.Fatalf("unmarshal denied line %q: %v", line, err)
+			}
+			if e.Decision != intermediary.Deny {
+				rt.Fatalf("denied output line has decision=%q, want deny", e.Decision)
+			}
+		}
+	})
+}

--- a/cli/cmd/xylem/audit_test.go
+++ b/cli/cmd/xylem/audit_test.go
@@ -1,0 +1,632 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
+)
+
+// writeAuditFixture marshals each entry as a JSON line and writes to path.
+func writeAuditFixture(t *testing.T, path string, entries []intermediary.AuditEntry) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create fixture %q: %v", path, err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, e := range entries {
+		if err := enc.Encode(e); err != nil {
+			t.Fatalf("encode entry: %v", err)
+		}
+	}
+}
+
+func makeEntry(action string, decision intermediary.Effect, rule string) intermediary.AuditEntry {
+	return intermediary.AuditEntry{
+		Intent:      intermediary.Intent{Action: action},
+		Decision:    decision,
+		Timestamp:   time.Now().UTC(),
+		RuleMatched: rule,
+	}
+}
+
+// --- tail ---
+
+func TestAuditTail_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	out := captureStdout(func() {
+		if err := cmdAuditTail(os.Stdout, path, 5); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected empty output for missing file, got %q", out)
+	}
+}
+
+func TestAuditTail_Empty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	writeAuditFixture(t, path, nil)
+	out := captureStdout(func() {
+		if err := cmdAuditTail(os.Stdout, path, 5); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected empty output, got %q", out)
+	}
+}
+
+func TestAuditTail_LessThanN(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	entries := []intermediary.AuditEntry{
+		makeEntry("read", intermediary.Allow, ""),
+		makeEntry("write", intermediary.Deny, "no-write"),
+	}
+	writeAuditFixture(t, path, entries)
+	out := captureStdout(func() {
+		if err := cmdAuditTail(os.Stdout, path, 10); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Errorf("expected 2 lines, got %d: %q", len(lines), out)
+	}
+}
+
+func TestAuditTail_ExactlyN(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	entries := []intermediary.AuditEntry{
+		makeEntry("a", intermediary.Allow, ""),
+		makeEntry("b", intermediary.Allow, ""),
+		makeEntry("c", intermediary.Allow, ""),
+	}
+	writeAuditFixture(t, path, entries)
+	out := captureStdout(func() {
+		if err := cmdAuditTail(os.Stdout, path, 3); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	lines := nonEmptyLines(out)
+	if len(lines) != 3 {
+		t.Errorf("expected 3 lines, got %d: %q", len(lines), out)
+	}
+}
+
+func TestAuditTail_MoreThanN(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	entries := []intermediary.AuditEntry{
+		makeEntry("a", intermediary.Allow, ""),
+		makeEntry("b", intermediary.Allow, ""),
+		makeEntry("c", intermediary.Allow, ""),
+		makeEntry("d", intermediary.Allow, ""),
+		makeEntry("e", intermediary.Allow, ""),
+	}
+	writeAuditFixture(t, path, entries)
+	out := captureStdout(func() {
+		if err := cmdAuditTail(os.Stdout, path, 3); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	lines := nonEmptyLines(out)
+	if len(lines) != 3 {
+		t.Errorf("expected 3 lines, got %d", len(lines))
+	}
+	// Last 3 entries should be c, d, e — verify first and last lines.
+	if !strings.Contains(lines[0], `"c"`) {
+		t.Errorf("expected first line to contain action 'c' (oldest kept), got: %q", lines[0])
+	}
+	if !strings.Contains(lines[len(lines)-1], `"e"`) {
+		t.Errorf("expected last line to contain action 'e' (newest), got: %q", lines[len(lines)-1])
+	}
+}
+
+func TestAuditTail_ZeroN(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	writeAuditFixture(t, path, []intermediary.AuditEntry{makeEntry("x", intermediary.Allow, "")})
+	out := captureStdout(func() {
+		if err := cmdAuditTail(os.Stdout, path, 0); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected empty output for n=0, got %q", out)
+	}
+}
+
+// --- denied ---
+
+func TestAuditDenied_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	out := captureStdout(func() {
+		if err := cmdAuditDenied(os.Stdout, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected empty output, got %q", out)
+	}
+}
+
+func TestAuditDenied_Empty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	writeAuditFixture(t, path, nil)
+	out := captureStdout(func() {
+		if err := cmdAuditDenied(os.Stdout, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected empty output, got %q", out)
+	}
+}
+
+func TestAuditDenied_FiltersDeny(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	entries := []intermediary.AuditEntry{
+		makeEntry("read", intermediary.Allow, ""),
+		makeEntry("write", intermediary.Deny, "no-write"),
+		makeEntry("exec", intermediary.Allow, ""),
+		makeEntry("delete", intermediary.Deny, "no-delete"),
+	}
+	writeAuditFixture(t, path, entries)
+	out := captureStdout(func() {
+		if err := cmdAuditDenied(os.Stdout, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Errorf("expected 2 denied lines, got %d: %q", len(lines), out)
+	}
+	for _, line := range lines {
+		var e intermediary.AuditEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("unmarshal output line: %v", err)
+		}
+		if e.Decision != intermediary.Deny {
+			t.Errorf("expected deny decision, got %q", e.Decision)
+		}
+	}
+}
+
+// --- counts ---
+
+func TestAuditCounts_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	out := captureStdout(func() {
+		if err := cmdAuditCounts(os.Stdout, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected empty output, got %q", out)
+	}
+}
+
+func TestAuditCounts_Empty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	writeAuditFixture(t, path, nil)
+	out := captureStdout(func() {
+		if err := cmdAuditCounts(os.Stdout, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected empty output, got %q", out)
+	}
+}
+
+func TestAuditCounts_MultipleActions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	entries := []intermediary.AuditEntry{
+		makeEntry("read", intermediary.Allow, ""),
+		makeEntry("write", intermediary.Deny, ""),
+		makeEntry("read", intermediary.Allow, ""),
+		makeEntry("exec", intermediary.Allow, ""),
+	}
+	writeAuditFixture(t, path, entries)
+	out := captureStdout(func() {
+		if err := cmdAuditCounts(os.Stdout, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	lines := nonEmptyLines(out)
+	if len(lines) != 3 {
+		t.Errorf("expected 3 lines (exec, read, write), got %d: %q", len(lines), out)
+	}
+	if !strings.Contains(out, "read\t2") {
+		t.Errorf("expected 'read\\t2' in output, got: %q", out)
+	}
+	if !strings.Contains(out, "write\t1") {
+		t.Errorf("expected 'write\\t1' in output, got: %q", out)
+	}
+	if !strings.Contains(out, "exec\t1") {
+		t.Errorf("expected 'exec\\t1' in output, got: %q", out)
+	}
+}
+
+func TestAuditCounts_EmptyActionFallback(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	// Entry with no action field (pre-#366 style)
+	entries := []intermediary.AuditEntry{
+		{Decision: intermediary.Allow, Timestamp: time.Now().UTC()},
+	}
+	writeAuditFixture(t, path, entries)
+	out := captureStdout(func() {
+		if err := cmdAuditCounts(os.Stdout, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "-\t1") {
+		t.Errorf("expected '-\\t1' for empty action, got: %q", out)
+	}
+}
+
+func TestAuditCounts_SortedOutput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	entries := []intermediary.AuditEntry{
+		makeEntry("zebra", intermediary.Allow, ""),
+		makeEntry("alpha", intermediary.Allow, ""),
+		makeEntry("mango", intermediary.Allow, ""),
+	}
+	writeAuditFixture(t, path, entries)
+	out := captureStdout(func() {
+		if err := cmdAuditCounts(os.Stdout, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	lines := nonEmptyLines(out)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+	if !strings.HasPrefix(lines[0], "alpha") {
+		t.Errorf("line[0] should start with 'alpha', got %q", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "mango") {
+		t.Errorf("line[1] should start with 'mango', got %q", lines[1])
+	}
+	if !strings.HasPrefix(lines[2], "zebra") {
+		t.Errorf("line[2] should start with 'zebra', got %q", lines[2])
+	}
+}
+
+// --- rule ---
+
+func TestAuditRule_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	out := captureStdout(func() {
+		if err := cmdAuditRule(os.Stdout, path, "my-rule"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "0/0 violations for rule my-rule") {
+		t.Errorf("expected 0/0 violations message, got: %q", out)
+	}
+}
+
+func TestAuditRule_NoEntries(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	writeAuditFixture(t, path, nil)
+	out := captureStdout(func() {
+		if err := cmdAuditRule(os.Stdout, path, "my-rule"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "0/0 violations for rule my-rule") {
+		t.Errorf("expected 0/0 violations message, got: %q", out)
+	}
+}
+
+func TestAuditRule_MatchesRule(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	entries := []intermediary.AuditEntry{
+		makeEntry("write", intermediary.Deny, "no-write"),
+		makeEntry("read", intermediary.Allow, ""),
+		makeEntry("exec", intermediary.Deny, "no-write"),
+	}
+	writeAuditFixture(t, path, entries)
+	out := captureStdout(func() {
+		if err := cmdAuditRule(os.Stdout, path, "no-write"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "2/3 violations for rule no-write") {
+		t.Errorf("expected '2/3 violations for rule no-write', got: %q", out)
+	}
+}
+
+func TestAuditRule_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	entries := []intermediary.AuditEntry{
+		makeEntry("write", intermediary.Deny, "other-rule"),
+	}
+	writeAuditFixture(t, path, entries)
+	out := captureStdout(func() {
+		if err := cmdAuditRule(os.Stdout, path, "no-such-rule"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "0/1 violations for rule no-such-rule") {
+		t.Errorf("expected '0/1 violations for rule no-such-rule', got: %q", out)
+	}
+}
+
+// --- malformed lines ---
+
+// malformedFixture returns a JSONL file path containing 2 valid entries and 1
+// malformed line: read/allow, not-valid-json, write/deny.
+func malformedFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	content := `{"intent":{"action":"read"},"decision":"allow","timestamp":"2024-01-01T00:00:00Z"}
+not-valid-json
+{"intent":{"action":"write"},"decision":"deny","timestamp":"2024-01-01T00:00:00Z"}
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestAuditMalformedLinesSkipped(t *testing.T) {
+	path := malformedFixture(t)
+	// denied: only the valid deny line should appear
+	out := captureStdout(func() {
+		if err := cmdAuditDenied(os.Stdout, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	lines := nonEmptyLines(out)
+	if len(lines) != 1 {
+		t.Errorf("denied: expected 1 line (malformed skipped), got %d: %q", len(lines), out)
+	}
+}
+
+func TestAuditMalformedLines_Counts(t *testing.T) {
+	path := malformedFixture(t)
+	// counts: malformed line must not be counted; only read=1, write=1 from 2 valid lines
+	out := captureStdout(func() {
+		if err := cmdAuditCounts(os.Stdout, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Errorf("counts: expected 2 action lines (read, write), got %d: %q", len(lines), out)
+	}
+	if !strings.Contains(out, "read\t1") {
+		t.Errorf("counts: expected 'read\\t1', got: %q", out)
+	}
+	if !strings.Contains(out, "write\t1") {
+		t.Errorf("counts: expected 'write\\t1', got: %q", out)
+	}
+}
+
+func TestAuditMalformedLines_Rule(t *testing.T) {
+	path := malformedFixture(t)
+	// rule: total should be 2 (valid lines only), not 3 (which would include the malformed line)
+	out := captureStdout(func() {
+		if err := cmdAuditRule(os.Stdout, path, "no-such-rule"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "0/2 violations for rule no-such-rule") {
+		t.Errorf("rule: expected '0/2 violations' (malformed excluded from total), got: %q", out)
+	}
+}
+
+// --- cobra wiring ---
+
+func TestAuditTail_CobraWiring(t *testing.T) {
+	setupTestDeps(t)
+	// Write a fixture to the expected audit path
+	auditPath := filepath.Join(deps.cfg.StateDir, "audit.jsonl")
+	entries := []intermediary.AuditEntry{
+		makeEntry("a", intermediary.Allow, ""),
+		makeEntry("b", intermediary.Allow, ""),
+		makeEntry("c", intermediary.Allow, ""),
+		makeEntry("d", intermediary.Allow, ""),
+		makeEntry("e", intermediary.Allow, ""),
+	}
+	writeAuditFixture(t, auditPath, entries)
+
+	cmd := newRootCmd()
+	cmd.PersistentPreRunE = nil
+	cmd.SetArgs([]string{"audit", "tail", "-n", "3"})
+
+	out := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	lines := nonEmptyLines(out)
+	if len(lines) != 3 {
+		t.Errorf("expected 3 lines from tail -n 3, got %d: %q", len(lines), out)
+	}
+}
+
+// nonEmptyLines splits s by newline and returns non-empty lines.
+func nonEmptyLines(s string) []string {
+	var result []string
+	for _, l := range strings.Split(s, "\n") {
+		if strings.TrimSpace(l) != "" {
+			result = append(result, l)
+		}
+	}
+	return result
+}
+
+// --- smoke scenarios (§13.3 acceptance criteria) ---
+// Each TestSmoke_S* maps directly to one acceptance criterion from issue #387.
+// Tests use full cobra wiring (cmd.Execute) to verify the end-to-end path,
+// not just the internal cmdAudit* helpers.
+
+// TestSmoke_S1_TailPrintsLastNEntries verifies AC2:
+// "xylem audit tail -n 5 prints last 5 entries from
+// config.RuntimePath(state_dir, 'audit.jsonl')".
+func TestSmoke_S1_TailPrintsLastNEntries(t *testing.T) {
+	setupTestDeps(t)
+	auditPath := filepath.Join(deps.cfg.StateDir, "audit.jsonl")
+	// Write 8 entries: tail -n 5 should return only the last 5.
+	entries := []intermediary.AuditEntry{
+		makeEntry("a", intermediary.Allow, ""),
+		makeEntry("b", intermediary.Allow, ""),
+		makeEntry("c", intermediary.Allow, ""),
+		makeEntry("d", intermediary.Allow, ""),
+		makeEntry("e", intermediary.Allow, ""),
+		makeEntry("f", intermediary.Allow, ""),
+		makeEntry("g", intermediary.Allow, ""),
+		makeEntry("h", intermediary.Allow, ""),
+	}
+	writeAuditFixture(t, auditPath, entries)
+
+	cmd := newRootCmd()
+	cmd.PersistentPreRunE = nil
+	cmd.SetArgs([]string{"audit", "tail", "-n", "5"})
+
+	out := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	lines := nonEmptyLines(out)
+	if len(lines) != 5 {
+		t.Errorf("expected 5 lines from tail -n 5 on 8 entries, got %d: %q", len(lines), out)
+	}
+	// The last entry should be "h" (newest).
+	if !strings.Contains(lines[len(lines)-1], `"h"`) {
+		t.Errorf("expected last line to contain action 'h', got: %q", lines[len(lines)-1])
+	}
+	// The first kept entry should be "d" (oldest in the last 5).
+	if !strings.Contains(lines[0], `"d"`) {
+		t.Errorf("expected first line to contain action 'd', got: %q", lines[0])
+	}
+}
+
+// TestSmoke_S2_DeniedEmptyOnCleanLog verifies AC3 (first half):
+// "xylem audit denied is empty on a pre-#366 log".
+// A log containing only Allow entries should produce no output.
+func TestSmoke_S2_DeniedEmptyOnCleanLog(t *testing.T) {
+	setupTestDeps(t)
+	auditPath := filepath.Join(deps.cfg.StateDir, "audit.jsonl")
+	// Pre-#366-style log: entries exist but none are denied.
+	entries := []intermediary.AuditEntry{
+		makeEntry("read", intermediary.Allow, ""),
+		makeEntry("exec", intermediary.Allow, ""),
+	}
+	writeAuditFixture(t, auditPath, entries)
+
+	cmd := newRootCmd()
+	cmd.PersistentPreRunE = nil
+	cmd.SetArgs([]string{"audit", "denied"})
+
+	out := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected empty output for all-allow log, got: %q", out)
+	}
+}
+
+// TestSmoke_S2b_DeniedNonEmptyAfterDeny verifies AC3 (second half):
+// "xylem audit denied is non-empty after a deny".
+func TestSmoke_S2b_DeniedNonEmptyAfterDeny(t *testing.T) {
+	setupTestDeps(t)
+	auditPath := filepath.Join(deps.cfg.StateDir, "audit.jsonl")
+	entries := []intermediary.AuditEntry{
+		makeEntry("read", intermediary.Allow, ""),
+		makeEntry("write", intermediary.Deny, "no-write"),
+	}
+	writeAuditFixture(t, auditPath, entries)
+
+	cmd := newRootCmd()
+	cmd.PersistentPreRunE = nil
+	cmd.SetArgs([]string{"audit", "denied"})
+
+	out := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	lines := nonEmptyLines(out)
+	if len(lines) != 1 {
+		t.Errorf("expected 1 denied line, got %d: %q", len(lines), out)
+	}
+	// Verify the emitted line decodes to a deny entry.
+	var e intermediary.AuditEntry
+	if err := json.Unmarshal([]byte(lines[0]), &e); err != nil {
+		t.Fatalf("unmarshal denied output: %v", err)
+	}
+	if e.Decision != intermediary.Deny {
+		t.Errorf("expected deny decision in output, got %q", e.Decision)
+	}
+}
+
+// TestSmoke_S3_CountsIncludesEveryDistinctAction verifies AC4:
+// "xylem audit counts output includes every distinct action present in the log".
+func TestSmoke_S3_CountsIncludesEveryDistinctAction(t *testing.T) {
+	setupTestDeps(t)
+	auditPath := filepath.Join(deps.cfg.StateDir, "audit.jsonl")
+	entries := []intermediary.AuditEntry{
+		makeEntry("read", intermediary.Allow, ""),
+		makeEntry("write", intermediary.Deny, ""),
+		makeEntry("exec", intermediary.Allow, ""),
+		makeEntry("read", intermediary.Allow, ""),
+		makeEntry("delete", intermediary.Deny, ""),
+	}
+	writeAuditFixture(t, auditPath, entries)
+
+	cmd := newRootCmd()
+	cmd.PersistentPreRunE = nil
+	cmd.SetArgs([]string{"audit", "counts"})
+
+	out := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	// Every distinct action must appear in the output.
+	for _, action := range []string{"read", "write", "exec", "delete"} {
+		if !strings.Contains(out, action) {
+			t.Errorf("expected action %q in counts output, got: %q", action, out)
+		}
+	}
+	// read appears twice — verify count is 2.
+	if !strings.Contains(out, "read\t2") {
+		t.Errorf("expected 'read\\t2' in counts output, got: %q", out)
+	}
+	// Exactly 4 distinct actions → 4 output lines.
+	lines := nonEmptyLines(out)
+	if len(lines) != 4 {
+		t.Errorf("expected 4 lines (4 distinct actions), got %d: %q", len(lines), out)
+	}
+}

--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -38,7 +38,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "bootstrap", "config", "workflow", "continuous-improvement", "continuous-simplicity", "release-cadence", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "recovery", "report", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report"}
+	expected := []string{"init", "bootstrap", "config", "workflow", "continuous-improvement", "continuous-simplicity", "release-cadence", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "recovery", "report", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report", "audit"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -52,6 +52,8 @@ func newRootCmd() *cobra.Command {
 				commandPath == "xylem harden score" ||
 				commandPath == "xylem harden track" ||
 				commandPath == "xylem field-report generate" ||
+				commandPath == "xylem audit" ||
+				strings.HasPrefix(commandPath, "xylem audit ") ||
 				commandPath == "xylem daemon stop" ||
 				commandPath == "xylem daemon reload"
 
@@ -125,6 +127,7 @@ func newRootCmd() *cobra.Command {
 		newVisualizeCmd(),
 		newVersionCmd(),
 		newFieldReportCmd(),
+		newAuditCmd(),
 	)
 
 	return cmd


### PR DESCRIPTION
## Summary

Adds the `xylem audit` command with four subcommands for inspecting the intermediary audit log. Implements [#387](https://github.com/nicholls-inc/xylem/issues/387).

- `xylem audit tail [-n N]` — streams the last N entries (ring buffer, O(1) memory)
- `xylem audit denied` — lists entries where `decision=deny`
- `xylem audit counts` — per-action operation counts, sorted alphabetically
- `xylem audit rule <rule-name>` — violation rate for one policy rule

All output is plain lines suitable for piping to `jq`, `rg`, or shell filters. The JSONL file is read line-by-line via `bufio.Scanner`; the whole file is never loaded into memory.

## Smoke scenarios covered

| ID | Title | Test function |
|---|---|---|
| AC1 | `go test ./cli/cmd/xylem/...` green | All tests pass |
| AC2 | `xylem audit tail -n 5` prints last 5 entries from `audit.jsonl` | `TestSmoke_S1_TailPrintsLastNEntries`, `TestAuditTail_MoreThanN`, `TestAuditTail_ExactlyN` |
| AC3 | `denied` empty on all-allow log, non-empty after a deny | `TestSmoke_S2_DeniedEmptyOnCleanLog`, `TestSmoke_S2b_DeniedNonEmptyAfterDeny` |
| AC4 | `counts` output includes every distinct `action` in the log | `TestSmoke_S3_CountsIncludesEveryDistinctAction`, `TestAuditCounts_MultipleActions`, `TestAuditCounts_SortedOutput` |

## Changes summary

### Files added

- **`cli/cmd/xylem/audit.go`** — Production implementation. Exports `newAuditCmd()` plus four subcommand constructors (`newAuditTailCmd`, `newAuditDeniedCmd`, `newAuditCountsCmd`, `newAuditRuleCmd`). Core functions: `cmdAuditTail`, `cmdAuditDenied`, `cmdAuditCounts`, `cmdAuditRule`, and the shared `scanAuditEntries` / `scanAuditLines` helpers.
- **`cli/cmd/xylem/audit_test.go`** — 20+ unit tests covering all four subcommands, edge cases (missing file, empty log, malformed lines, n=0), and three smoke tests (`TestSmoke_S1`, `TestSmoke_S2`, `TestSmoke_S2b`, `TestSmoke_S3`) that exercise the full cobra wiring.
- **`cli/cmd/xylem/audit_prop_test.go`** — Three property-based tests using `pgregory.net/rapid`: `TestPropAuditCountsNeverExceedsTotal`, `TestPropAuditTailNeverExceedsN`, `TestPropAuditDeniedSubsetOfAll`.

### Files modified

- **`cli/cmd/xylem/root.go`** — Registered `newAuditCmd()` in `cmd.AddCommand(...)` and added `xylem audit` / `xylem audit *` to the `skipTooling` block so the command works without `git`/`gh` on PATH.
- **`cli/cmd/xylem/cobra_test.go`** — Added `"audit"` to the expected subcommand list in `TestCobraSubcommandRegistration`.

## Test plan

- [x] `go vet ./...` passes
- [x] `go build ./cmd/xylem` passes
- [x] `go test ./cmd/xylem/... -run TestAudit` — all 20+ unit tests pass
- [x] `go test ./cmd/xylem/... -run TestSmoke` — all smoke tests pass
- [x] `go test ./cmd/xylem/... -run TestProp` — all property-based tests pass (100 cases each)
- [x] `go test ./cmd/xylem/...` — full package passes
- [x] golangci-lint passes (enforced by pre-commit hook)
- [x] goimports passes (enforced by pre-commit hook)

Fixes #387