### PR TITLE
fix: raise analyze and plan max_turns from 30 to 50 in implement-harness workflow

### DIFF
--- a/.xylem/workflows/implement-harness.yaml
+++ b/.xylem/workflows/implement-harness.yaml
@@ -3,12 +3,12 @@ description: "Implement a harness spec step with verification, testing, and smok
 phases:
   - name: analyze
     prompt_file: .xylem/prompts/implement-harness/analyze.md
-    max_turns: 30
+    max_turns: 50
     noop:
       match: XYLEM_NOOP
   - name: plan
     prompt_file: .xylem/prompts/implement-harness/plan.md
-    max_turns: 30
+    max_turns: 50
   - name: implement
     prompt_file: .xylem/prompts/implement-harness/implement.md
     max_turns: 80

--- a/cli/internal/workflow/implement_harness_workflow_test.go
+++ b/cli/internal/workflow/implement_harness_workflow_test.go
@@ -148,3 +148,57 @@ func TestSmoke_S4_ImplementHarnessPRDraftPromptRequiresRebaseRetestAndForcePush(
 		"git push --force-with-lease",
 	))
 }
+
+func TestSmoke_S5_AnalyzePhaseMaxTurnsIs50(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := checkedInWorkflowPath(t, "implement-harness.yaml")
+	data, err := os.ReadFile(workflowPath)
+	require.NoError(t, err, "ReadFile(%q)", workflowPath)
+
+	var wf Workflow
+	require.NoError(t, yaml.Unmarshal(data, &wf), "yaml.Unmarshal(%q)", workflowPath)
+
+	analyze := findPhaseByName(t, wf.Phases, "analyze")
+	assert.Equal(t, 50, analyze.MaxTurns, "analyze phase max_turns should be 50")
+}
+
+func TestSmoke_S6_PlanPhaseMaxTurnsIs50(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := checkedInWorkflowPath(t, "implement-harness.yaml")
+	data, err := os.ReadFile(workflowPath)
+	require.NoError(t, err, "ReadFile(%q)", workflowPath)
+
+	var wf Workflow
+	require.NoError(t, yaml.Unmarshal(data, &wf), "yaml.Unmarshal(%q)", workflowPath)
+
+	plan := findPhaseByName(t, wf.Phases, "plan")
+	assert.Equal(t, 50, plan.MaxTurns, "plan phase max_turns should be 50")
+}
+
+func TestSmoke_S7_OtherPhaseMaxTurnsAreUnchanged(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := checkedInWorkflowPath(t, "implement-harness.yaml")
+	data, err := os.ReadFile(workflowPath)
+	require.NoError(t, err, "ReadFile(%q)", workflowPath)
+
+	var wf Workflow
+	require.NoError(t, yaml.Unmarshal(data, &wf), "yaml.Unmarshal(%q)", workflowPath)
+
+	cases := []struct {
+		name      string
+		wantTurns int
+	}{
+		{"implement", 80},
+		{"verify", 80},
+		{"test_critic", 50},
+		{"smoke", 60},
+		{"pr_draft", 50},
+	}
+	for _, tc := range cases {
+		phase := findPhaseByName(t, wf.Phases, tc.name)
+		assert.Equal(t, tc.wantTurns, phase.MaxTurns, "phase %q max_turns", tc.name)
+	}
+}


### PR DESCRIPTION
## Summary

Raises `max_turns` for the `analyze` and `plan` phases in `.xylem/workflows/implement-harness.yaml` from 30 to 50, matching the precedent set by PR #421 for `test_critic` and `pr_draft`.

Related: https://github.com/nicholls-inc/xylem/issues/432

## Smoke scenarios covered

- **S5** — `TestSmoke_S5_AnalyzePhaseMaxTurnsIs50`: asserts `analyze` phase `max_turns` equals 50
- **S6** — `TestSmoke_S6_PlanPhaseMaxTurnsIs50`: asserts `plan` phase `max_turns` equals 50
- **S7** — `TestSmoke_S7_OtherPhaseMaxTurnsAreUnchanged`: asserts `implement` (80), `verify` (80), `test_critic` (50), `smoke` (60), and `pr_draft` (50) are unchanged

## Changes summary

**Modified files:**

- `.xylem/workflows/implement-harness.yaml` — `analyze` phase `max_turns: 30` → `max_turns: 50`; `plan` phase `max_turns: 30` → `max_turns: 50`. All other phases unchanged.
- `cli/internal/workflow/implement_harness_workflow_test.go` — added `TestSmoke_S5_AnalyzePhaseMaxTurnsIs50`, `TestSmoke_S6_PlanPhaseMaxTurnsIs50`, and `TestSmoke_S7_OtherPhaseMaxTurnsAreUnchanged` to lock in the new values and guard against regression.

No new files added. No Go production code changed.

## Test plan

- [x] `go vet ./...` — passes
- [x] `go build ./cmd/xylem` — passes
- [x] `go test ./...` — all packages pass, including new S5/S6/S7 smoke tests
- [x] Branch rebased onto `origin/main` before push

Fixes #432