### PR TITLE
feat: daemon re-syncs profile assets from embedded FS when digest drifts

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/daemonhealth"
 	"github.com/nicholls-inc/xylem/cli/internal/dtu"
+	"github.com/nicholls-inc/xylem/cli/internal/profiles"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
 	"github.com/nicholls-inc/xylem/cli/internal/scanner"
@@ -35,14 +36,15 @@ func newDaemonCmd() *cobra.Command {
 		Use:   "daemon",
 		Short: "Run continuous scan-drain loop",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmdDaemon(deps.cfg, deps.q, deps.wt)
+			return cmdDaemon(cmd, deps.cfg, deps.q, deps.wt)
 		},
 	}
+	cmd.Flags().Bool("no-profile-sync", false, "Skip profile asset re-sync on startup")
 	cmd.AddCommand(newDaemonStopCmd(), newDaemonReloadCmd())
 	return cmd
 }
 
-func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
+func cmdDaemon(cmd *cobra.Command, cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	slog.Info("daemon starting", "commit", buildInfo())
 
 	// Isolation check: refuse to run in the main git worktree because vessel
@@ -96,7 +98,8 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	// P0-2: Reconcile any vessels left in running state from a previous daemon.
 	// The singleton lock guarantees no other daemon is running, so all running
 	// vessels are definitionally orphaned.
-	if err := daemonStartup(context.Background(), cfg, q, wt, newCommandRunner(cfg)); err != nil {
+	noProfileSync, _ := cmd.Flags().GetBool("no-profile-sync")
+	if err := daemonStartup(context.Background(), cfg, q, wt, newCommandRunner(cfg), noProfileSync); err != nil {
 		return err
 	}
 
@@ -220,12 +223,39 @@ func cmdDaemon(cfg *config.Config, q *queue.Queue, wt *worktree.Manager) error {
 	return commandErr
 }
 
-func daemonStartup(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *worktree.Manager, seedRunner adaptRepoSeedRunner) error {
+func daemonStartup(ctx context.Context, cfg *config.Config, q *queue.Queue, wt *worktree.Manager, seedRunner adaptRepoSeedRunner, noProfileSync bool) error {
 	reconcileStaleVessels(q, wt)
+
+	if !noProfileSync && len(cfg.Profiles) > 0 {
+		if err := maybeResyncProfileAssets(cfg); err != nil {
+			slog.Warn("daemon profile re-sync failed, continuing", "error", err)
+		}
+	}
 
 	if _, err := ensureAdaptRepoSeeded(ctx, cfg, seedRunner, adaptRepoSeededByDaemon); err != nil {
 		slog.Warn("seed adapt-repo issue failed, continuing", "error", err)
 	}
+	return nil
+}
+
+func maybeResyncProfileAssets(cfg *config.Config) error {
+	composed, err := profiles.Compose(cfg.Profiles...)
+	if err != nil {
+		return fmt.Errorf("compose profiles for digest check: %w", err)
+	}
+	embedded := profiles.ComputeEmbeddedDigest(composed)
+	runtime := profiles.ComputeRuntimeDigest(cfg.StateDir)
+	if embedded == runtime {
+		slog.Debug("daemon profile assets up-to-date", "digest", embedded)
+		return nil
+	}
+	slog.Info("daemon profile assets stale; re-syncing",
+		"embedded_digest", embedded,
+		"runtime_digest", runtime)
+	if err := syncProfileAssets(cfg.StateDir, composed, true); err != nil {
+		return fmt.Errorf("re-sync profile assets: %w", err)
+	}
+	slog.Info("daemon profile assets re-synced")
 	return nil
 }
 

--- a/cli/cmd/xylem/daemon_prop_test.go
+++ b/cli/cmd/xylem/daemon_prop_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"github.com/nicholls-inc/xylem/cli/internal/config"
+	"github.com/nicholls-inc/xylem/cli/internal/profiles"
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
+)
+
+// validProfileCombinations is the set of profile combinations that Compose
+// accepts. Drawing from this small set keeps property runs fast.
+var validProfileCombinations = [][]string{
+	{"core"},
+	{"core", "self-hosting-xylem"},
+}
+
+// TestProp_DaemonStartupConvergesProfileDigest asserts that for any valid
+// profile combination, one call to daemonStartup causes the runtime digest
+// to equal the embedded digest.
+func TestProp_DaemonStartupConvergesProfileDigest(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		profileNames := rapid.SampledFrom(validProfileCombinations).Draw(rt, "profiles")
+
+		dir := t.TempDir()
+		stateDir := filepath.Join(dir, ".xylem")
+
+		cfg := &config.Config{
+			Profiles: profileNames,
+			StateDir: stateDir,
+		}
+		q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+		err := daemonStartup(context.Background(), cfg, q, nil, &seedRunnerStub{}, false)
+		if err != nil {
+			rt.Fatalf("daemonStartup failed: %v", err)
+		}
+
+		composed, err := profiles.Compose(profileNames...)
+		if err != nil {
+			rt.Fatalf("Compose(%v) failed: %v", profileNames, err)
+		}
+		embedded := profiles.ComputeEmbeddedDigest(composed)
+		runtime := profiles.ComputeRuntimeDigest(stateDir)
+
+		if embedded != runtime {
+			rt.Fatalf("digest mismatch after daemonStartup:\n  embedded=%s\n  runtime=%s",
+				embedded, runtime)
+		}
+	})
+}
+
+// TestProp_DaemonStartupIdempotentOnSecondCall asserts that calling
+// daemonStartup twice with the same config leaves the runtime digest equal to
+// the embedded digest — i.e. the second call does not corrupt or regress the
+// state written by the first.
+func TestProp_DaemonStartupIdempotentOnSecondCall(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		profileNames := rapid.SampledFrom(validProfileCombinations).Draw(rt, "profiles")
+
+		dir := t.TempDir()
+		stateDir := filepath.Join(dir, ".xylem")
+
+		cfg := &config.Config{
+			Profiles: profileNames,
+			StateDir: stateDir,
+		}
+		q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+		// First call — materialises the assets.
+		if err := daemonStartup(context.Background(), cfg, q, nil, &seedRunnerStub{}, false); err != nil {
+			rt.Fatalf("first daemonStartup failed: %v", err)
+		}
+
+		// Second call — must leave digests unchanged.
+		if err := daemonStartup(context.Background(), cfg, q, nil, &seedRunnerStub{}, false); err != nil {
+			rt.Fatalf("second daemonStartup failed: %v", err)
+		}
+
+		// Digests must agree after both calls. This directly proves idempotence:
+		// if the second call re-synced unnecessarily it would still produce a
+		// matching digest, but if it overwrote with wrong content it would not.
+		composed, err := profiles.Compose(profileNames...)
+		if err != nil {
+			rt.Fatalf("Compose(%v) failed: %v", profileNames, err)
+		}
+		embedded := profiles.ComputeEmbeddedDigest(composed)
+		runtime := profiles.ComputeRuntimeDigest(stateDir)
+		if embedded != runtime {
+			rt.Fatalf("digest mismatch after second daemonStartup:\n  embedded=%s\n  runtime=%s",
+				embedded, runtime)
+		}
+	})
+}

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/dtushim"
 	"github.com/nicholls-inc/xylem/cli/internal/intermediary"
 	"github.com/nicholls-inc/xylem/cli/internal/observability"
+	"github.com/nicholls-inc/xylem/cli/internal/profiles"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
 	"github.com/nicholls-inc/xylem/cli/internal/scanner"
@@ -320,7 +321,7 @@ func TestSmoke_S7_DaemonStartupContinuesWhenAdaptRepoSearchFails(t *testing.T) {
 		},
 	}
 
-	err := daemonStartup(context.Background(), cfg, q, nil, runner)
+	err := daemonStartup(context.Background(), cfg, q, nil, runner, true)
 	require.NoError(t, err)
 	_, statErr := os.Stat(markerPath)
 	require.Error(t, statErr)
@@ -357,7 +358,7 @@ func TestSmoke_S8_DaemonStartupLeavesMarkerAbsentWhenAdaptRepoCreateFails(t *tes
 	require.Error(t, statErr)
 	require.True(t, os.IsNotExist(statErr))
 
-	err := daemonStartup(context.Background(), cfg, q, nil, runner)
+	err := daemonStartup(context.Background(), cfg, q, nil, runner, true)
 	require.NoError(t, err)
 	_, statErr = os.Stat(markerPath)
 	require.Error(t, statErr)
@@ -1175,6 +1176,132 @@ func TestSmoke_S28_CLIWiringInDaemonGoCreatesIntermediaryFromConfig(t *testing.T
 	require.Len(t, entries, 1)
 	assert.Equal(t, entry.Intent, entries[0].Intent)
 	assert.Equal(t, entry.Decision, entries[0].Decision)
+}
+
+// TestSmoke_S49_DaemonStartupResyncsProfileAssetsWhenDigestDrifts verifies
+// that daemonStartup overwrites stale workflow files when the embedded digest
+// differs from the runtime digest.
+func TestSmoke_S49_DaemonStartupResyncsProfileAssetsWhenDigestDrifts(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, ".xylem")
+	require.NoError(t, os.MkdirAll(filepath.Join(stateDir, "workflows"), 0o755))
+	// Write stale content to one workflow file so the runtime digest differs.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(stateDir, "workflows", "fix-bug.yaml"),
+		[]byte("stale: true"),
+		0o644,
+	))
+
+	cfg := &config.Config{
+		Profiles: []string{"core"},
+		StateDir: stateDir,
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	logs := withBufferedDefaultLogger(t)
+
+	err := daemonStartup(context.Background(), cfg, q, nil, &seedRunnerStub{}, false)
+	require.NoError(t, err)
+
+	// Embedded content should have replaced the stale file — assert the exact
+	// embedded bytes, not just that the stale value is gone.
+	composed, composeErr := profiles.Compose("core")
+	require.NoError(t, composeErr)
+	embeddedContent, ok := composed.Workflows["fix-bug"]
+	require.True(t, ok, "core profile must contain fix-bug workflow")
+
+	data, readErr := os.ReadFile(filepath.Join(stateDir, "workflows", "fix-bug.yaml"))
+	require.NoError(t, readErr)
+	assert.Equal(t, embeddedContent, data, "stale workflow should be replaced with the exact embedded content")
+	assert.Contains(t, logs.String(), "daemon profile assets stale; re-syncing")
+}
+
+// TestSmoke_S50_DaemonStartupSkipsResyncWhenDigestsMatch verifies that
+// daemonStartup does not re-write files when the runtime digest already
+// matches the embedded digest.
+func TestSmoke_S50_DaemonStartupSkipsResyncWhenDigestsMatch(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, ".xylem")
+
+	// Run a full init-style sync first so the runtime dir is current.
+	cfg := &config.Config{
+		Profiles: []string{"core"},
+		StateDir: stateDir,
+	}
+	composed, err := profiles.Compose("core")
+	require.NoError(t, err)
+	require.NoError(t, syncProfileAssets(stateDir, composed, true))
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	logs := withBufferedDefaultLogger(t)
+
+	err = daemonStartup(context.Background(), cfg, q, nil, &seedRunnerStub{}, false)
+	require.NoError(t, err)
+
+	assert.NotContains(t, logs.String(), "daemon profile assets stale; re-syncing",
+		"no re-sync expected when digests already match")
+}
+
+// TestSmoke_S51_DaemonStartupNoProfileSyncFlagSkipsResync verifies that
+// noProfileSync=true prevents re-sync even when the runtime dir is stale.
+func TestSmoke_S51_DaemonStartupNoProfileSyncFlagSkipsResync(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, ".xylem")
+	require.NoError(t, os.MkdirAll(filepath.Join(stateDir, "workflows"), 0o755))
+	staleContent := []byte("stale: true")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(stateDir, "workflows", "fix-bug.yaml"),
+		staleContent,
+		0o644,
+	))
+
+	cfg := &config.Config{
+		Profiles: []string{"core"},
+		StateDir: stateDir,
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	logs := withBufferedDefaultLogger(t)
+
+	err := daemonStartup(context.Background(), cfg, q, nil, &seedRunnerStub{}, true)
+	require.NoError(t, err)
+
+	// File must NOT have been overwritten.
+	data, readErr := os.ReadFile(filepath.Join(stateDir, "workflows", "fix-bug.yaml"))
+	require.NoError(t, readErr)
+	assert.Equal(t, staleContent, data, "no-profile-sync should leave stale file untouched")
+	assert.NotContains(t, logs.String(), "daemon profile assets stale; re-syncing")
+}
+
+// TestSmoke_S52_DaemonStartupContinuesWhenProfileComposeFails verifies that
+// a profile compose error is logged as a warning and daemonStartup returns nil.
+func TestSmoke_S52_DaemonStartupContinuesWhenProfileComposeFails(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Profiles: []string{"nonexistent-profile"},
+		StateDir: filepath.Join(dir, ".xylem"),
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	logs := withBufferedDefaultLogger(t)
+
+	err := daemonStartup(context.Background(), cfg, q, nil, &seedRunnerStub{}, false)
+	require.NoError(t, err, "daemonStartup must continue even when profile compose fails")
+	assert.Contains(t, logs.String(), "daemon profile re-sync failed, continuing")
+}
+
+// TestSmoke_S53_DaemonStartupSkipsResyncWhenProfilesEmpty verifies that
+// daemonStartup does not attempt any profile sync when cfg.Profiles is empty.
+func TestSmoke_S53_DaemonStartupSkipsResyncWhenProfilesEmpty(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Profiles: nil,
+		StateDir: filepath.Join(dir, ".xylem"),
+	}
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	logs := withBufferedDefaultLogger(t)
+
+	err := daemonStartup(context.Background(), cfg, q, nil, &seedRunnerStub{}, false)
+	require.NoError(t, err)
+	assert.NotContains(t, logs.String(), "re-sync")
+	assert.NotContains(t, logs.String(), "compose profiles")
 }
 
 func TestReconcileStaleVessels(t *testing.T) {

--- a/cli/internal/profiles/profiles.go
+++ b/cli/internal/profiles/profiles.go
@@ -1,10 +1,13 @@
 package profiles
 
 import (
+	"crypto/sha256"
 	"embed"
 	"fmt"
 	"io/fs"
+	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -179,6 +182,110 @@ func mergeSources(profileName, filePath string, data []byte, dest map[string][]b
 	}
 
 	return nil
+}
+
+// ComputeEmbeddedDigest returns a deterministic SHA-256 hex digest over all
+// workflow, prompt, and script content in composed. Keys are sorted before
+// hashing so the result is independent of map iteration order.
+// Returns "" if composed is nil.
+func ComputeEmbeddedDigest(composed *ComposedProfile) string {
+	if composed == nil {
+		return ""
+	}
+	var entries []string
+	for _, name := range sortedByteMapKeys(composed.Workflows) {
+		entries = append(entries, "workflows/"+name+":"+hexHash(composed.Workflows[name]))
+	}
+	for _, name := range sortedByteMapKeys(composed.Prompts) {
+		entries = append(entries, "prompts/"+name+":"+hexHash(composed.Prompts[name]))
+	}
+	for _, name := range sortedByteMapKeys(composed.Scripts) {
+		entries = append(entries, "scripts/"+name+":"+hexHash(composed.Scripts[name]))
+	}
+	sort.Strings(entries)
+	sum := sha256.Sum256([]byte(strings.Join(entries, "\n")))
+	return fmt.Sprintf("%x", sum)
+}
+
+// ComputeRuntimeDigest returns a deterministic SHA-256 hex digest over the
+// workflow YAML files, prompt MD files, and script files currently on disk
+// under stateDir. Returns "" if stateDir does not exist or is unreadable.
+func ComputeRuntimeDigest(stateDir string) string {
+	var entries []string
+
+	// workflows/<name>.yaml → key "workflows/<name>"
+	workflowsDir := filepath.Join(stateDir, "workflows")
+	if infos, err := os.ReadDir(workflowsDir); err == nil {
+		for _, info := range infos {
+			if info.IsDir() || !strings.HasSuffix(info.Name(), ".yaml") {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(workflowsDir, info.Name()))
+			if err != nil {
+				continue
+			}
+			name := strings.TrimSuffix(info.Name(), ".yaml")
+			entries = append(entries, "workflows/"+name+":"+hexHash(data))
+		}
+	}
+
+	// prompts/**/*.md → key "prompts/<rel-without-ext>" (forward slashes)
+	promptsDir := filepath.Join(stateDir, "prompts")
+	//nolint:errcheck // non-existent promptsDir and internal walk errors are intentionally ignored
+	_ = filepath.WalkDir(promptsDir, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+		rel, err := filepath.Rel(promptsDir, p)
+		if err != nil {
+			return nil
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return nil
+		}
+		key := strings.TrimSuffix(filepath.ToSlash(rel), ".md")
+		entries = append(entries, "prompts/"+key+":"+hexHash(data))
+		return nil
+	})
+
+	// scripts/<rel> → key "scripts/<rel>" (forward slashes)
+	scriptsDir := filepath.Join(stateDir, "scripts")
+	//nolint:errcheck // non-existent scriptsDir and internal walk errors are intentionally ignored
+	_ = filepath.WalkDir(scriptsDir, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(scriptsDir, p)
+		if err != nil {
+			return nil
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return nil
+		}
+		key := filepath.ToSlash(rel)
+		entries = append(entries, "scripts/"+key+":"+hexHash(data))
+		return nil
+	})
+
+	sort.Strings(entries)
+	sum := sha256.Sum256([]byte(strings.Join(entries, "\n")))
+	return fmt.Sprintf("%x", sum)
+}
+
+func hexHash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum)
+}
+
+func sortedByteMapKeys(m map[string][]byte) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func cloneBytes(data []byte) []byte {


### PR DESCRIPTION
## Summary

Fixes the root cause of stale runtime workflows described in https://github.com/nicholls-inc/xylem/issues/402.

On daemon startup, the control plane now compares a deterministic SHA-256 digest of the embedded profile assets (workflows + prompts + scripts) against the same digest computed from the files currently on disk under `<stateDir>/`. If the digests differ — indicating that the binary was upgraded but the runtime assets were not refreshed — it calls `syncProfileAssets` with `force=true` to overwrite stale files. A `--no-profile-sync` flag lets operators opt out.

## Smoke scenarios covered

| ID | Title |
|---|---|
| S49 | `DaemonStartupResyncsProfileAssetsWhenDigestDrifts` — stale runtime YAML is overwritten on startup |
| S50 | `DaemonStartupSkipsResyncWhenDigestsMatch` — no re-sync emitted when runtime is already current |
| S51 | `DaemonStartupNoProfileSyncFlagSkipsResync` — `noProfileSync=true` suppresses re-sync even when stale |
| S52 | `DaemonStartupContinuesWhenProfileComposeFails` — unknown profile name → `slog.Warn`, no crash |
| S53 | `DaemonStartupSkipsResyncWhenProfilesEmpty` — empty `cfg.Profiles` skips compose entirely |

Property tests:
- `TestProp_DaemonStartupConvergesProfileDigest` — for any valid profile combination, one `daemonStartup` call brings runtime digest equal to embedded digest
- `TestProp_DaemonStartupIdempotentOnSecondCall` — two consecutive calls leave digests equal (second call does not corrupt or regress state)

## Changes summary

**`cli/internal/profiles/profiles.go`** (modified)
- Added `ComputeEmbeddedDigest(composed *ComposedProfile) string` — deterministic SHA-256 over sorted workflow + prompt + script content in the in-memory composed profile
- Added `ComputeRuntimeDigest(stateDir string) string` — same digest computed from files on disk under `<stateDir>/workflows/`, `<stateDir>/prompts/`, and `<stateDir>/scripts/`
- Added private helpers `hexHash` and `sortedByteMapKeys`

**`cli/cmd/xylem/daemon.go`** (modified)
- `daemonStartup` gains a `noProfileSync bool` parameter
- New `maybeResyncProfileAssets(cfg)` helper: composes the profile, compares digests, calls `syncProfileAssets(force=true)` on mismatch
- `newDaemonCmd()` adds `--no-profile-sync` flag
- `cmdDaemon` reads the flag and threads it through to `daemonStartup`

**`cli/cmd/xylem/daemon_test.go`** (modified)
- S49–S53 smoke tests appended

**`cli/cmd/xylem/daemon_prop_test.go`** (new)
- Convergence and idempotence property tests using `pgregory.net/rapid`

## Test plan

- [x] `go vet ./...` passes
- [x] `go build ./cmd/xylem` succeeds
- [x] `go test ./cmd/xylem/... ./internal/profiles/...` passes (S49–S53 + property tests)
- [x] `golangci-lint run` reports 0 issues
- [x] `goimports -l .` reports no formatting drift
- [ ] Manual: start daemon with stale workflow YAML in `.xylem/workflows/`; confirm `daemon profile assets stale; re-syncing` is logged and file is refreshed
- [ ] Manual: `xylem daemon --no-profile-sync` with stale assets; confirm no re-sync occurs

Fixes #402