### PR TITLE
fix: replace bare 'xylem' with './cli/xylem' in release-cadence gate command

### DIFF
--- a/.xylem/workflows/release-cadence.yaml
+++ b/.xylem/workflows/release-cadence.yaml
@@ -4,6 +4,6 @@ description: "Periodically promote mature release-please PRs into the daemon aut
 phases:
   - name: label_ready
     type: command
-    run: xylem release-cadence label-ready --repo nicholls-inc/xylem
+    run: ./cli/xylem release-cadence label-ready --repo nicholls-inc/xylem
     noop:
       match: XYLEM_NOOP

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -363,7 +363,7 @@ func TestSmoke_S6_SelfHostingProfileScaffoldsReleaseCadenceWorkflow(t *testing.T
 	require.Len(t, wf.Phases, 1)
 	assert.Equal(t, "label_ready", wf.Phases[0].Name)
 	assert.Equal(t, "command", wf.Phases[0].Type)
-	assert.Contains(t, wf.Phases[0].Run, "xylem release-cadence label-ready --repo {{ .Repo }}")
+	assert.Contains(t, wf.Phases[0].Run, "./cli/xylem release-cadence label-ready --repo {{ .Repo }}")
 	require.NotNil(t, wf.Phases[0].NoOp)
 	assert.Equal(t, "XYLEM_NOOP", wf.Phases[0].NoOp.Match)
 }

--- a/cli/internal/profiles/self-hosting-xylem/workflows/release-cadence.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/release-cadence.yaml
@@ -4,6 +4,6 @@ description: "Periodically promote mature release-please PRs into the daemon aut
 phases:
   - name: label_ready
     type: command
-    run: xylem release-cadence label-ready --repo {{ .Repo }}
+    run: ./cli/xylem release-cadence label-ready --repo {{ .Repo }}
     noop:
       match: XYLEM_NOOP


### PR DESCRIPTION
## Summary

Fixes https://github.com/nicholls-inc/xylem/issues/435.

The daemon runs worktrees from the repo root, where `go build ./cmd/xylem` places the binary at `./cli/xylem`. The `$PATH` does not include `./cli/`, so `run: xylem ...` in a `type: command` phase fails with exit 127. This PR replaces the bare `xylem` invocation with `./cli/xylem` in the release-cadence workflow so the gate command resolves correctly at runtime.

## Smoke scenarios covered

- **S6 — `TestSmoke_S6_SelfHostingProfileScaffoldsReleaseCadenceWorkflow`** (`cli/internal/profiles/profiles_test.go:344`): verifies that the composed self-hosting-xylem profile includes a release-cadence workflow whose `label_ready` phase runs `./cli/xylem release-cadence label-ready --repo {{ .Repo }}`.

## Changes

**Modified files:**

| File | Change |
|---|---|
| `cli/internal/profiles/self-hosting-xylem/workflows/release-cadence.yaml` | `run: xylem ...` → `run: ./cli/xylem ...` (embedded FS source, canonical) |
| `.xylem/workflows/release-cadence.yaml` | `run: xylem ...` → `run: ./cli/xylem ...` (materialized runtime file) |
| `cli/internal/profiles/profiles_test.go` | Updated S6 assertion to match `./cli/xylem release-cadence label-ready --repo {{ .Repo }}` |

No new files added. No other workflows are in scope — `core/` profile workflows intentionally use bare `xylem` for target repos where it is on `$PATH`.

## Test plan

- [x] `go test ./internal/profiles/... -run TestSmoke_S6` passes
- [x] `go test ./...` passes (pre-existing runner port-bind flake confirmed present on `main` before this branch)
- [x] `go vet ./...` clean
- [x] `go build ./cmd/xylem` succeeds
- [x] `goimports -l .` reports no violations

Fixes #435