### PR TITLE
chore: enable notifications (Discussion reports + Telegram alerts)

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -191,6 +191,18 @@ sources:
       unblock-deps:
         workflow: unblock-wave
 
+notifications:
+  github_discussion:
+    enabled: true
+    repo: nicholls-inc/xylem
+    category: "Status Reports"
+    interval: "1h"
+  telegram:
+    enabled: true
+    token_env: "TELEGRAM_BOT_TOKEN"
+    chat_id_env: "TELEGRAM_CHAT_ID"
+    levels: [critical, warning]
+
 observability:
   enabled: true
   endpoint: "localhost:4317"


### PR DESCRIPTION
## Summary
- Adds `notifications:` config block to `.xylem.yml` enabling both channels shipped in #425
- GitHub Discussion: hourly status reports posted to "Status Reports" category in nicholls-inc/xylem
- Telegram: critical + warning alerts via bot token/chat ID read from `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` env vars (already in `.daemon-root/.env`)

## Test plan
- [ ] Daemon restart picks up the new config section without errors
- [ ] First hourly tick creates a Discussion thread in the "Status Reports" category
- [ ] Trigger a vessel failure and verify Telegram alert arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)