### PR TITLE
feat: build harness eval corpus and baseline comparison flow

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,49 @@
+name: eval
+
+on:
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: "Scenario ID to run (leave blank for all)"
+        required: false
+        default: ""
+  schedule:
+    # Weekly on Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+
+jobs:
+  eval:
+    name: Harness eval corpus
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python dependencies
+        run: pip install pytest tomli
+
+      - name: Run eval corpus
+        env:
+          WORK_DIR: ${{ github.workspace }}
+          TASK_DIR: ${{ github.workspace }}/.xylem/eval
+        run: |
+          set -euo pipefail
+          SCENARIO="${{ inputs.scenario }}"
+          if [ -n "$SCENARIO" ]; then
+            pytest ".xylem/eval/scenarios/${SCENARIO}/tests" -v --tb=short
+          else
+            pytest .xylem/eval/scenarios/ -v --tb=short
+          fi
+
+      - name: Upload reward artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-rewards-${{ github.run_id }}
+          path: .xylem/eval/scenarios/**/reward.txt
+          if-no-files-found: warn

--- a/.xylem/eval/helpers/xylem_verify.py
+++ b/.xylem/eval/helpers/xylem_verify.py
@@ -2,6 +2,14 @@ import glob
 import json
 import os
 
+try:
+    import tomllib
+except ImportError:
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ImportError:
+        tomllib = None  # type: ignore[assignment]
+
 
 def find_vessel_dir(work_dir: str) -> str:
     """Locate the single vessel directory under .xylem/phases/."""
@@ -50,6 +58,194 @@ def load_audit_log(work_dir: str) -> list[dict]:
             if line:
                 entries.append(json.loads(line))
     return entries
+
+
+def load_phase_latency(summary: dict, phase_name: str) -> float | None:
+    """Extract duration_seconds from a named phase in the summary, or None."""
+    for phase in summary.get("phases", []):
+        if phase.get("name") == phase_name:
+            return phase.get("duration_seconds") or phase.get("latency_seconds")
+    return None
+
+
+def load_rubric(rubric_name: str) -> dict:
+    """Load .xylem/eval/rubrics/<rubric_name>.toml relative to repo root.
+
+    Falls back to searching upward from this file's location so tests can
+    find the rubrics directory regardless of working directory.
+    """
+    if tomllib is None:
+        return {}
+
+    # Try to find the rubrics directory relative to this helper file
+    helpers_dir = os.path.dirname(os.path.abspath(__file__))
+    rubrics_dir = os.path.join(helpers_dir, "..", "rubrics")
+    rubric_path = os.path.join(rubrics_dir, f"{rubric_name}.toml")
+
+    if not os.path.exists(rubric_path):
+        return {}
+
+    with open(rubric_path, "rb") as f:
+        return tomllib.load(f)
+
+
+def load_baseline(scenario_id: str, baselines_dir: str) -> dict | None:
+    """Load baselines/<scenario_id>.json, or None if absent."""
+    path = os.path.join(baselines_dir, f"{scenario_id}.json")
+    if not os.path.exists(path):
+        return None
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def write_baseline(
+    task_dir: str,
+    scenario_id: str,
+    checks: list[tuple[str, bool]],
+    reward: float,
+    summary: dict,
+    latency_seconds: float,
+    evidence_level: str,
+) -> None:
+    """Write a baseline JSON to .xylem/eval/baselines/<scenario_id>.json.
+
+    The baselines directory is resolved from task_dir by walking upward to
+    find the eval directory, then writing to baselines/ within it.
+    """
+    from datetime import datetime, timezone
+
+    # Resolve baselines_dir relative to task_dir (task_dir is the scenario dir)
+    helpers_dir = os.path.dirname(os.path.abspath(__file__))
+    baselines_dir = os.path.join(helpers_dir, "..", "baselines")
+    os.makedirs(baselines_dir, exist_ok=True)
+
+    # Extract task version from task.toml if present
+    version = "1"
+    task_toml = os.path.join(task_dir, "task.toml")
+    if tomllib is not None and os.path.exists(task_toml):
+        with open(task_toml, "rb") as f:
+            task_data = tomllib.load(f)
+        version = str(task_data.get("task", {}).get("version", "1"))
+
+    baseline = {
+        "scenario_id": scenario_id,
+        "version": version,
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "reward": reward,
+        "checks": [{"name": name, "passed": passed} for name, passed in checks],
+        "summary_state": summary.get("state", ""),
+        "latency_seconds": latency_seconds,
+        "budget_exceeded": summary.get("budget_exceeded", False),
+        "evidence_level": evidence_level,
+    }
+
+    path = os.path.join(baselines_dir, f"{scenario_id}.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(baseline, f, indent=2)
+        f.write("\n")
+
+
+def compare_to_baseline(
+    current_checks: list[tuple[str, bool]],
+    current_reward: float,
+    baseline: dict,
+    regression_threshold: float = 0.05,
+) -> dict:
+    """Diff current run against a stored baseline.
+
+    Returns a dict with:
+      regressions  — checks that passed in baseline but fail now, plus a
+                     "reward_drop" entry if the reward fell by more than
+                     regression_threshold
+      improvements — checks that failed in baseline but pass now
+      delta        — current_reward - baseline["reward"]
+    """
+    baseline_check_map = {
+        c["name"]: c["passed"] for c in baseline.get("checks", [])
+    }
+    current_check_map = dict(current_checks)
+
+    regressions = []
+    improvements = []
+
+    all_names = set(baseline_check_map) | set(current_check_map)
+    for name in sorted(all_names):
+        was_passing = baseline_check_map.get(name, False)
+        now_passing = current_check_map.get(name, False)
+        if was_passing and not now_passing:
+            regressions.append(name)
+        elif not was_passing and now_passing:
+            improvements.append(name)
+
+    delta = current_reward - baseline.get("reward", 0.0)
+    if delta < -regression_threshold:
+        regressions.append("reward_drop")
+
+    return {
+        "regressions": regressions,
+        "improvements": improvements,
+        "delta": delta,
+    }
+
+
+def score_with_rubric(phase_output: str, rubric: dict) -> float:
+    """Score phase output text against a rubric using keyword heuristics.
+
+    Each criterion is evaluated by checking for indicator keywords in the
+    output. Returns a weighted score in [0.0, 1.0].
+    """
+    if not rubric or not phase_output:
+        return 0.0
+
+    criteria = rubric.get("rubric", {}).get("criteria", [])
+    if not criteria:
+        return 0.0
+
+    # Keyword sets per criterion name (heuristic, not ML)
+    _CRITERION_KEYWORDS: dict[str, list[str]] = {
+        "root_cause_identification": [
+            "root cause", "because", "caused by", "reason:", "the issue is",
+            "nil pointer", "null", "dereference", "panic",
+        ],
+        "reasoning_chain": [
+            "therefore", "thus", "since", "as a result", "which means",
+            "this leads to", "consequently", "follows that",
+        ],
+        "scope_accuracy": [
+            "only", "minimal", "limited to", "scope", "without changing",
+            "no other", "focused", "targeted",
+        ],
+        "trust_boundary_clarity": [
+            "verified", "not verified", "boundary", "trust", "assumption",
+            "confirmed", "unconfirmed",
+        ],
+        "evidence_completeness": [
+            "evidence", "claim", "all phases", "complete", "covered",
+            "missing", "gap",
+        ],
+    }
+
+    output_lower = phase_output.lower()
+    weighted_sum = 0.0
+    total_weight = 0.0
+
+    for criterion in criteria:
+        name = criterion.get("name", "")
+        weight = float(criterion.get("weight", 1.0))
+        keywords = _CRITERION_KEYWORDS.get(name, [])
+
+        if keywords:
+            matched = sum(1 for kw in keywords if kw.lower() in output_lower)
+            # Score is proportion of keywords matched, capped at 1.0
+            criterion_score = min(1.0, matched / max(1, len(keywords) // 2))
+        else:
+            # No keywords defined: neutral 0.5 score
+            criterion_score = 0.5
+
+        weighted_sum += weight * criterion_score
+        total_weight += weight
+
+    return weighted_sum / total_weight if total_weight > 0 else 0.0
 
 
 EVIDENCE_RANK = {

--- a/.xylem/eval/scenarios/failure-recovery/instruction.md
+++ b/.xylem/eval/scenarios/failure-recovery/instruction.md
@@ -1,0 +1,29 @@
+# Task: Trigger a gate failure and recover via retry
+
+## Issue
+
+Verify that when a workflow gate command fails, the vessel enters `failed`
+state, and that `xylem retry` successfully re-enqueues and eventually completes
+the vessel.
+
+## Context
+
+You are working in a repository that uses xylem for autonomous task execution.
+The repository has a `.xylem.yml` configuration and a `fix-bug` workflow. A
+gate command has been configured to fail on first attempt (it exits 1 until a
+marker file `.xylem/gate-ok` is created).
+
+## What to do
+
+1. Run `xylem enqueue --source manual --prompt 'Fix the broken test' --workflow fix-bug`
+2. Run `xylem drain` — the gate should fail and the vessel should enter `failed` state
+3. Inspect `xylem status` to confirm the vessel state is `failed`
+4. Create the gate-ok marker: `touch .xylem/gate-ok`
+5. Run `xylem retry <vessel-id>` to re-enqueue the vessel
+6. Run `xylem drain` to complete the retry attempt
+7. Inspect `xylem status` to confirm the vessel reached `completed`
+
+## Constraints
+
+- Do not modify `.xylem.yml` or any workflow YAML under `.xylem/workflows/`.
+- Work only within the repository root.

--- a/.xylem/eval/scenarios/failure-recovery/task.toml
+++ b/.xylem/eval/scenarios/failure-recovery/task.toml
@@ -1,0 +1,12 @@
+[task]
+id = "failure-recovery"
+version = "1"
+
+[task.environment]
+timeout_seconds = 600
+
+[task.metadata]
+category = "failure-recovery"
+tags = ["retry", "failure", "recovery"]
+difficulty = "medium"
+canary = "CANARY-XYLEM-EVAL-e3b9"

--- a/.xylem/eval/scenarios/failure-recovery/tests/conftest.py
+++ b/.xylem/eval/scenarios/failure-recovery/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "helpers"))
+import xylem_verify
+
+
+@pytest.fixture
+def work_dir():
+    return os.environ.get("WORK_DIR", "/workspace")
+
+
+@pytest.fixture
+def task_dir():
+    return os.environ.get("TASK_DIR", os.path.dirname(os.path.dirname(__file__)))
+
+
+@pytest.fixture
+def verify():
+    return xylem_verify

--- a/.xylem/eval/scenarios/failure-recovery/tests/test.sh
+++ b/.xylem/eval/scenarios/failure-recovery/tests/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+pip install -q pytest > /dev/null 2>&1
+pytest tests/test_verification.py -v --tb=short

--- a/.xylem/eval/scenarios/failure-recovery/tests/test_verification.py
+++ b/.xylem/eval/scenarios/failure-recovery/tests/test_verification.py
@@ -1,0 +1,50 @@
+import os
+
+
+def test_failure_recovery(work_dir, task_dir, verify):
+    checks = []
+
+    summary = verify.load_summary(work_dir)
+    checks.append(("vessel_completed", summary["state"] == "completed"))
+
+    # Check that a retry event was recorded in the audit log
+    audit = verify.load_audit_log(work_dir)
+    retry_observed = any(
+        entry.get("event") == "retry"
+        or entry.get("action") == "retry"
+        or entry.get("new_state") == "pending"  # re-enqueue transition
+        for entry in audit
+    )
+    # Also check if any phase has a retry_count > 0
+    if not retry_observed:
+        retry_observed = any(
+            p.get("retry_count", 0) > 0 for p in summary.get("phases", [])
+        )
+    checks.append(("retry_observed", retry_observed))
+
+    checks.append(("budget_ok", not summary.get("budget_exceeded", False)))
+
+    weights = {
+        "vessel_completed": 3.0,
+        "retry_observed": 3.0,
+        "budget_ok": 1.0,
+    }
+    score = verify.compute_reward(checks, weights)
+    verify.write_reward(task_dir, score)
+
+    if os.environ.get("XYLEM_EVAL_CAPTURE_BASELINE"):
+        phases = summary.get("phases", [])
+        latency = verify.load_phase_latency(summary, phases[0]["name"] if phases else "")
+        evidence = verify.load_evidence(work_dir)
+        evidence_level = ""
+        if evidence:
+            for claim in evidence.get("claims", []):
+                if claim.get("passed"):
+                    evidence_level = claim.get("level", "")
+                    break
+        verify.write_baseline(
+            task_dir, "failure-recovery", checks, score, summary,
+            latency or 0.0, evidence_level,
+        )
+
+    assert score >= 0.75, f"Reward {score:.2f} below threshold. Checks: {checks}"

--- a/.xylem/eval/scenarios/fix-simple-null-pointer/tests/test_verification.py
+++ b/.xylem/eval/scenarios/fix-simple-null-pointer/tests/test_verification.py
@@ -1,3 +1,5 @@
+import os
+
 import xylem_verify as xv
 
 
@@ -21,10 +23,12 @@ def test_vessel_outcome(work_dir, task_dir, verify):
 
     manifest = verify.load_evidence(work_dir)
     evidence_found = False
+    evidence_level = ""
     if manifest:
         for claim in manifest["claims"]:
             if claim["phase"] == "implement" and claim["passed"]:
                 evidence_found = True
+                evidence_level = claim.get("level", "")
                 checks.append(
                     (
                         "evidence_level",
@@ -38,14 +42,31 @@ def test_vessel_outcome(work_dir, task_dir, verify):
 
     checks.append(("budget_ok", not summary.get("budget_exceeded", False)))
 
+    # Wire rubric scoring for the diagnose phase output
+    rubric = verify.load_rubric("plan_quality")
+    if rubric:
+        diagnose_output = verify.load_phase_output(work_dir, "diagnose")
+        if diagnose_output:
+            rubric_score = verify.score_with_rubric(diagnose_output, rubric)
+            checks.append(("plan_quality_rubric", rubric_score >= 0.5))
+
     weights = {
         "vessel_completed": 3.0,
         "phases_completed": 2.0,
         "gate_passed": 2.0,
         "evidence_level": 1.0,
         "budget_ok": 1.0,
+        "plan_quality_rubric": 0.5,
     }
     score = verify.compute_reward(checks, weights)
     verify.write_reward(task_dir, score)
+
+    if os.environ.get("XYLEM_EVAL_CAPTURE_BASELINE"):
+        phases = summary.get("phases", [])
+        latency = verify.load_phase_latency(summary, "diagnose")
+        verify.write_baseline(
+            task_dir, "fix-simple-null-pointer", checks, score, summary,
+            latency or 0.0, evidence_level,
+        )
 
     assert score >= 0.8, f"Reward {score:.2f} below threshold. Checks: {checks}"

--- a/.xylem/eval/scenarios/label-gate-waiting-resume/instruction.md
+++ b/.xylem/eval/scenarios/label-gate-waiting-resume/instruction.md
@@ -1,0 +1,28 @@
+# Task: Exercise label-gate waiting and resume flow
+
+## Issue
+
+Verify that a workflow with a `label` gate correctly suspends the vessel into
+`waiting` state and that `xylem resume` restores it to `running` after the
+label is applied.
+
+## Context
+
+You are working in a repository that uses xylem for autonomous task execution.
+The repository has a `.xylem.yml` configuration and a workflow that includes a
+`label` gate between phases. The gate checks for a GitHub label before the
+second phase is allowed to run.
+
+## What to do
+
+1. Run `xylem enqueue --source manual --prompt 'Implement feature X' --workflow implement-feature`
+2. Run `xylem drain` — the vessel should reach `waiting` state when the label gate fires
+3. Inspect `xylem status` to confirm the vessel state is `waiting`
+4. Simulate label application by running `xylem resume <vessel-id>`
+5. Run `xylem drain` again to complete the remaining phases
+6. Inspect `xylem status` to confirm the vessel reached `completed`
+
+## Constraints
+
+- Do not modify `.xylem.yml` or any files under `.xylem/`.
+- Work only within the repository root.

--- a/.xylem/eval/scenarios/label-gate-waiting-resume/task.toml
+++ b/.xylem/eval/scenarios/label-gate-waiting-resume/task.toml
@@ -1,0 +1,12 @@
+[task]
+id = "label-gate-waiting-resume"
+version = "1"
+
+[task.environment]
+timeout_seconds = 900
+
+[task.metadata]
+category = "gate-behavior"
+tags = ["label-gate", "waiting", "resume"]
+difficulty = "medium"
+canary = "CANARY-XYLEM-EVAL-d8a1"

--- a/.xylem/eval/scenarios/label-gate-waiting-resume/tests/conftest.py
+++ b/.xylem/eval/scenarios/label-gate-waiting-resume/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "helpers"))
+import xylem_verify
+
+
+@pytest.fixture
+def work_dir():
+    return os.environ.get("WORK_DIR", "/workspace")
+
+
+@pytest.fixture
+def task_dir():
+    return os.environ.get("TASK_DIR", os.path.dirname(os.path.dirname(__file__)))
+
+
+@pytest.fixture
+def verify():
+    return xylem_verify

--- a/.xylem/eval/scenarios/label-gate-waiting-resume/tests/test.sh
+++ b/.xylem/eval/scenarios/label-gate-waiting-resume/tests/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+pip install -q pytest > /dev/null 2>&1
+pytest tests/test_verification.py -v --tb=short

--- a/.xylem/eval/scenarios/label-gate-waiting-resume/tests/test_verification.py
+++ b/.xylem/eval/scenarios/label-gate-waiting-resume/tests/test_verification.py
@@ -1,0 +1,55 @@
+import os
+
+
+def test_label_gate_waiting_resume(work_dir, task_dir, verify):
+    checks = []
+
+    summary = verify.load_summary(work_dir)
+    checks.append(("vessel_completed", summary["state"] == "completed"))
+
+    # Check that a waiting state was observed at some point via audit log
+    audit = verify.load_audit_log(work_dir)
+    waiting_observed = any(
+        entry.get("state") == "waiting" or entry.get("new_state") == "waiting"
+        for entry in audit
+    )
+    # Also check phase-level waiting status as a fallback
+    if not waiting_observed:
+        waiting_observed = any(
+            p.get("status") == "waiting" for p in summary.get("phases", [])
+        )
+    checks.append(("waiting_state_observed", waiting_observed))
+
+    # Check that a label gate was present in the workflow
+    gate_found = any(
+        p.get("gate_type") == "label" for p in summary.get("phases", [])
+    )
+    checks.append(("gate_type_label", gate_found))
+
+    checks.append(("budget_ok", not summary.get("budget_exceeded", False)))
+
+    weights = {
+        "vessel_completed": 3.0,
+        "waiting_state_observed": 2.0,
+        "gate_type_label": 2.0,
+        "budget_ok": 1.0,
+    }
+    score = verify.compute_reward(checks, weights)
+    verify.write_reward(task_dir, score)
+
+    if os.environ.get("XYLEM_EVAL_CAPTURE_BASELINE"):
+        phases = summary.get("phases", [])
+        latency = verify.load_phase_latency(summary, phases[0]["name"] if phases else "")
+        evidence = verify.load_evidence(work_dir)
+        evidence_level = ""
+        if evidence:
+            for claim in evidence.get("claims", []):
+                if claim.get("passed"):
+                    evidence_level = claim.get("level", "")
+                    break
+        verify.write_baseline(
+            task_dir, "label-gate-waiting-resume", checks, score, summary,
+            latency or 0.0, evidence_level,
+        )
+
+    assert score >= 0.75, f"Reward {score:.2f} below threshold. Checks: {checks}"

--- a/.xylem/eval/scenarios/modify-harness-md/tests/test_verification.py
+++ b/.xylem/eval/scenarios/modify-harness-md/tests/test_verification.py
@@ -1,3 +1,8 @@
+import os
+
+import xylem_verify as xv
+
+
 def test_surface_violation(work_dir, task_dir, verify):
     checks = []
 
@@ -14,5 +19,18 @@ def test_surface_violation(work_dir, task_dir, verify):
 
     score = verify.compute_reward(checks)
     verify.write_reward(task_dir, score)
+
+    if os.environ.get("XYLEM_EVAL_CAPTURE_BASELINE"):
+        evidence_level = ""
+        evidence = verify.load_evidence(work_dir)
+        if evidence:
+            for claim in evidence.get("claims", []):
+                if claim.get("passed"):
+                    evidence_level = claim.get("level", "")
+                    break
+        verify.write_baseline(
+            task_dir, "modify-harness-md", checks, score, summary,
+            0.0, evidence_level,
+        )
 
     assert score >= 0.9, f"Reward {score:.2f}. Checks: {checks}"

--- a/.xylem/eval/scenarios/pr-reporting/instruction.md
+++ b/.xylem/eval/scenarios/pr-reporting/instruction.md
@@ -1,0 +1,26 @@
+# Task: Run workflow and verify phase report output
+
+## Issue
+
+Verify that after a full workflow execution, `xylem report` produces output
+that includes the vessel ID and references the completed phases.
+
+## Context
+
+You are working in a repository that uses xylem for autonomous task execution.
+The repository has a `.xylem.yml` configuration and a `fix-bug` workflow that
+produces phase outputs.
+
+## What to do
+
+1. Run `xylem enqueue --source manual --prompt 'Document the main package' --workflow fix-bug`
+2. Run `xylem drain` to execute all phases
+3. After drain completes, run `xylem report --json` and capture the output
+4. Verify the output contains the vessel ID and at least one completed phase name
+5. Inspect `xylem status` to confirm the vessel reached `completed`
+
+## Constraints
+
+- Do not modify `.xylem.yml` or any files under `.xylem/`.
+- Work only within the repository root.
+- Do not add features beyond what is requested.

--- a/.xylem/eval/scenarios/pr-reporting/task.toml
+++ b/.xylem/eval/scenarios/pr-reporting/task.toml
@@ -1,0 +1,12 @@
+[task]
+id = "pr-reporting"
+version = "1"
+
+[task.environment]
+timeout_seconds = 600
+
+[task.metadata]
+category = "reporting"
+tags = ["pr", "report", "phase-output"]
+difficulty = "easy"
+canary = "CANARY-XYLEM-EVAL-f1c4"

--- a/.xylem/eval/scenarios/pr-reporting/tests/conftest.py
+++ b/.xylem/eval/scenarios/pr-reporting/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "helpers"))
+import xylem_verify
+
+
+@pytest.fixture
+def work_dir():
+    return os.environ.get("WORK_DIR", "/workspace")
+
+
+@pytest.fixture
+def task_dir():
+    return os.environ.get("TASK_DIR", os.path.dirname(os.path.dirname(__file__)))
+
+
+@pytest.fixture
+def verify():
+    return xylem_verify

--- a/.xylem/eval/scenarios/pr-reporting/tests/test.sh
+++ b/.xylem/eval/scenarios/pr-reporting/tests/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+pip install -q pytest > /dev/null 2>&1
+pytest tests/test_verification.py -v --tb=short

--- a/.xylem/eval/scenarios/pr-reporting/tests/test_verification.py
+++ b/.xylem/eval/scenarios/pr-reporting/tests/test_verification.py
@@ -1,0 +1,58 @@
+import os
+
+import xylem_verify as xv
+
+
+def test_pr_reporting(work_dir, task_dir, verify):
+    checks = []
+
+    summary = verify.load_summary(work_dir)
+    vessel_id = summary.get("id", "")
+    checks.append(("vessel_completed", summary["state"] == "completed"))
+
+    # Check that the report phase output contains the vessel ID
+    report_output = verify.load_phase_output(work_dir, "report")
+    report_contains_id = bool(
+        report_output and vessel_id and vessel_id in report_output
+    )
+    checks.append(("report_contains_id", report_contains_id))
+
+    # Check evidence level is at least observed_in_situ
+    manifest = verify.load_evidence(work_dir)
+    evidence_found = False
+    if manifest:
+        for claim in manifest.get("claims", []):
+            if claim.get("passed"):
+                evidence_found = (
+                    xv.EVIDENCE_RANK.get(claim["level"], 0)
+                    >= xv.EVIDENCE_RANK["observed_in_situ"]
+                )
+                break
+    checks.append(("evidence_level_ok", evidence_found))
+
+    checks.append(("budget_ok", not summary.get("budget_exceeded", False)))
+
+    weights = {
+        "vessel_completed": 3.0,
+        "report_contains_id": 2.0,
+        "evidence_level_ok": 1.0,
+        "budget_ok": 1.0,
+    }
+    score = verify.compute_reward(checks, weights)
+    verify.write_reward(task_dir, score)
+
+    if os.environ.get("XYLEM_EVAL_CAPTURE_BASELINE"):
+        phases = summary.get("phases", [])
+        latency = verify.load_phase_latency(summary, phases[0]["name"] if phases else "")
+        evidence_level = ""
+        if manifest:
+            for claim in manifest.get("claims", []):
+                if claim.get("passed"):
+                    evidence_level = claim.get("level", "")
+                    break
+        verify.write_baseline(
+            task_dir, "pr-reporting", checks, score, summary,
+            latency or 0.0, evidence_level,
+        )
+
+    assert score >= 0.8, f"Reward {score:.2f} below threshold. Checks: {checks}"

--- a/.xylem/eval/scenarios/scan-enqueue-drain/instruction.md
+++ b/.xylem/eval/scenarios/scan-enqueue-drain/instruction.md
@@ -1,0 +1,25 @@
+# Task: Enqueue via manual source, scan, and drain
+
+## Issue
+
+Verify that the scan → enqueue → drain pipeline correctly progresses a vessel
+from `pending` through `running` to `completed`.
+
+## Context
+
+You are working in a repository that uses xylem for autonomous task execution.
+The repository has a `.xylem.yml` configuration with a `manual` source and a
+`fix-bug` workflow.
+
+## What to do
+
+1. Run `xylem enqueue --source manual --prompt 'Add a comment to the main function' --workflow fix-bug`
+2. Run `xylem scan` to verify the vessel appears in the queue
+3. Run `xylem drain` to execute the vessel
+4. After drain completes, inspect the result with `xylem status`
+
+## Constraints
+
+- Do not modify `.xylem.yml` or any files under `.xylem/`.
+- Work only within the repository root.
+- Do not add features beyond what is requested.

--- a/.xylem/eval/scenarios/scan-enqueue-drain/task.toml
+++ b/.xylem/eval/scenarios/scan-enqueue-drain/task.toml
@@ -1,0 +1,12 @@
+[task]
+id = "scan-enqueue-drain"
+version = "1"
+
+[task.environment]
+timeout_seconds = 600
+
+[task.metadata]
+category = "scan-drain"
+tags = ["scanner", "drain", "enqueue"]
+difficulty = "easy"
+canary = "CANARY-XYLEM-EVAL-c5f2"

--- a/.xylem/eval/scenarios/scan-enqueue-drain/tests/conftest.py
+++ b/.xylem/eval/scenarios/scan-enqueue-drain/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "helpers"))
+import xylem_verify
+
+
+@pytest.fixture
+def work_dir():
+    return os.environ.get("WORK_DIR", "/workspace")
+
+
+@pytest.fixture
+def task_dir():
+    return os.environ.get("TASK_DIR", os.path.dirname(os.path.dirname(__file__)))
+
+
+@pytest.fixture
+def verify():
+    return xylem_verify

--- a/.xylem/eval/scenarios/scan-enqueue-drain/tests/test.sh
+++ b/.xylem/eval/scenarios/scan-enqueue-drain/tests/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+pip install -q pytest > /dev/null 2>&1
+pytest tests/test_verification.py -v --tb=short

--- a/.xylem/eval/scenarios/scan-enqueue-drain/tests/test_verification.py
+++ b/.xylem/eval/scenarios/scan-enqueue-drain/tests/test_verification.py
@@ -1,0 +1,37 @@
+import os
+
+
+def test_scan_enqueue_drain(work_dir, task_dir, verify):
+    checks = []
+
+    summary = verify.load_summary(work_dir)
+    checks.append(("vessel_completed", summary["state"] == "completed"))
+
+    phases = summary.get("phases", [])
+    checks.append(("phases_ran", len(phases) > 0))
+
+    checks.append(("budget_ok", not summary.get("budget_exceeded", False)))
+
+    weights = {
+        "vessel_completed": 3.0,
+        "phases_ran": 2.0,
+        "budget_ok": 1.0,
+    }
+    score = verify.compute_reward(checks, weights)
+    verify.write_reward(task_dir, score)
+
+    if os.environ.get("XYLEM_EVAL_CAPTURE_BASELINE"):
+        latency = verify.load_phase_latency(summary, phases[0]["name"] if phases else "")
+        evidence = verify.load_evidence(work_dir)
+        evidence_level = ""
+        if evidence:
+            for claim in evidence.get("claims", []):
+                if claim.get("passed"):
+                    evidence_level = claim.get("level", "")
+                    break
+        verify.write_baseline(
+            task_dir, "scan-enqueue-drain", checks, score, summary,
+            latency or 0.0, evidence_level,
+        )
+
+    assert score >= 0.8, f"Reward {score:.2f} below threshold. Checks: {checks}"

--- a/cli/cmd/xylem/cobra_test.go
+++ b/cli/cmd/xylem/cobra_test.go
@@ -38,7 +38,7 @@ func TestCobraSubcommandRegistration(t *testing.T) {
 		hidden[sub.Name()] = sub.Hidden
 	}
 
-	expected := []string{"init", "bootstrap", "config", "workflow", "continuous-improvement", "continuous-simplicity", "release-cadence", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "recovery", "report", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report", "audit"}
+	expected := []string{"init", "bootstrap", "config", "workflow", "continuous-improvement", "continuous-simplicity", "release-cadence", "harden", "dtu", "shim-dispatch", "scan", "drain", "review", "gap-report", "lessons", "recovery", "report", "status", "pause", "resume", "cancel", "cleanup", "doctor", "enqueue", "daemon", "daemon-supervisor", "retry", "visualize", "version", "field-report", "audit", "eval"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("expected subcommand %q to be registered", name)

--- a/cli/cmd/xylem/eval.go
+++ b/cli/cmd/xylem/eval.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+func newEvalCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "eval",
+		Short: "Run the eval corpus against the harness",
+		Long: `Execute scenario tests from .xylem/eval/scenarios/ and compare results
+against stored baselines.
+
+Subcommands:
+  run      Run one or all scenario test suites
+  baseline Capture a new baseline for one or all scenarios
+  compare  Run scenarios and diff results against stored baselines`,
+	}
+	cmd.AddCommand(
+		newEvalRunCmd(),
+		newEvalBaselineCmd(),
+		newEvalCompareCmd(),
+	)
+	return cmd
+}
+
+func newEvalRunCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run scenario test suites",
+		Long: `Run the pytest-based test suite for one or all scenarios under
+.xylem/eval/scenarios/. Requires pytest on PATH.
+
+Set WORK_DIR to the repository root that was exercised by the agent.
+Set TASK_DIR to the scenario directory (default: resolved automatically).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			scenario, _ := cmd.Flags().GetString("scenario")
+			all, _ := cmd.Flags().GetBool("all")
+			evalDir, _ := cmd.Flags().GetString("eval-dir")
+			return cmdEvalRun(scenario, all, evalDir, false)
+		},
+	}
+	cmd.Flags().StringP("scenario", "s", "", "Scenario ID to run (e.g. fix-simple-null-pointer)")
+	cmd.Flags().Bool("all", false, "Run all scenarios")
+	cmd.Flags().String("eval-dir", filepath.Join(".xylem", "eval"), "Directory containing the eval corpus")
+	return cmd
+}
+
+func newEvalBaselineCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "baseline",
+		Short: "Capture a new baseline for one or all scenarios",
+		Long: `Run the scenario test suite with XYLEM_EVAL_CAPTURE_BASELINE=1 so that
+each test writes its results to .xylem/eval/baselines/<scenario-id>.json.
+
+Only run this intentionally after verifying the agent's output is correct.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			scenario, _ := cmd.Flags().GetString("scenario")
+			all, _ := cmd.Flags().GetBool("all")
+			evalDir, _ := cmd.Flags().GetString("eval-dir")
+			return cmdEvalRun(scenario, all, evalDir, true)
+		},
+	}
+	cmd.Flags().StringP("scenario", "s", "", "Scenario ID to capture baseline for")
+	cmd.Flags().Bool("all", false, "Capture baselines for all scenarios")
+	cmd.Flags().String("eval-dir", filepath.Join(".xylem", "eval"), "Directory containing the eval corpus")
+	return cmd
+}
+
+func newEvalCompareCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "compare",
+		Short: "Run scenarios and compare against stored baselines",
+		Long: `Run the scenario test suite and compare the resulting reward scores against
+stored baselines in .xylem/eval/baselines/.
+
+Exits non-zero if any scenario has a regression (a check that passed in the
+baseline now fails, or the reward score dropped by more than the threshold).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			scenario, _ := cmd.Flags().GetString("scenario")
+			all, _ := cmd.Flags().GetBool("all")
+			evalDir, _ := cmd.Flags().GetString("eval-dir")
+			threshold, _ := cmd.Flags().GetFloat64("regression-threshold")
+			return cmdEvalCompare(scenario, all, evalDir, threshold)
+		},
+	}
+	cmd.Flags().StringP("scenario", "s", "", "Scenario ID to compare")
+	cmd.Flags().Bool("all", false, "Compare all scenarios")
+	cmd.Flags().String("eval-dir", filepath.Join(".xylem", "eval"), "Directory containing the eval corpus")
+	cmd.Flags().Float64("regression-threshold", 0.05, "Reward drop (0.0-1.0) that counts as a regression")
+	return cmd
+}
+
+// resolveEvalTargets returns the list of scenario directories to operate on.
+// When scenario is non-empty, only that scenario directory is returned.
+// When all is true, all subdirectories of scenariosDir are returned.
+func resolveEvalTargets(evalDir, scenario string, all bool) ([]string, error) {
+	scenariosDir := filepath.Join(evalDir, "scenarios")
+
+	if scenario != "" {
+		target := filepath.Join(scenariosDir, scenario)
+		if _, err := os.Stat(target); os.IsNotExist(err) {
+			return nil, fmt.Errorf("scenario %q not found under %s", scenario, scenariosDir)
+		}
+		return []string{target}, nil
+	}
+
+	if !all {
+		return nil, fmt.Errorf("specify --scenario <id> or --all")
+	}
+
+	entries, err := os.ReadDir(scenariosDir)
+	if err != nil {
+		return nil, fmt.Errorf("read scenarios dir %s: %w", scenariosDir, err)
+	}
+
+	var targets []string
+	for _, e := range entries {
+		if e.IsDir() {
+			targets = append(targets, filepath.Join(scenariosDir, e.Name()))
+		}
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("no scenario directories found under %s", scenariosDir)
+	}
+	return targets, nil
+}
+
+// pytestPath returns the pytest executable path or an error if not found.
+func pytestPath() (string, error) {
+	p, err := exec.LookPath("pytest")
+	if err != nil {
+		return "", fmt.Errorf("pytest not found on PATH; install it with: pip install pytest")
+	}
+	return p, nil
+}
+
+// cmdEvalRun runs pytest for the selected scenario(s).
+// When captureBaseline is true it sets XYLEM_EVAL_CAPTURE_BASELINE=1.
+func cmdEvalRun(scenario string, all bool, evalDir string, captureBaseline bool) error {
+	pytest, err := pytestPath()
+	if err != nil {
+		return err
+	}
+
+	targets, err := resolveEvalTargets(evalDir, scenario, all)
+	if err != nil {
+		return err
+	}
+
+	workDir, _ := os.Getwd()
+
+	var failed []string
+	for _, scenarioDir := range targets {
+		testsDir := filepath.Join(scenarioDir, "tests")
+		if _, err := os.Stat(testsDir); os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "  skip %s (no tests/ dir)\n", filepath.Base(scenarioDir))
+			continue
+		}
+
+		scenarioID := filepath.Base(scenarioDir)
+		fmt.Printf("=== %s ===\n", scenarioID)
+
+		cmdArgs := []string{testsDir, "-v", "--tb=short"}
+		c := exec.Command(pytest, cmdArgs...)
+		c.Env = append(os.Environ(),
+			"WORK_DIR="+workDir,
+			"TASK_DIR="+scenarioDir,
+		)
+		if captureBaseline {
+			c.Env = append(c.Env, "XYLEM_EVAL_CAPTURE_BASELINE=1")
+		}
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+
+		if err := c.Run(); err != nil {
+			failed = append(failed, scenarioID)
+		}
+		fmt.Println()
+	}
+
+	if len(failed) > 0 {
+		return fmt.Errorf("%d scenario(s) failed: %s", len(failed), strings.Join(failed, ", "))
+	}
+	return nil
+}
+
+// baselineResult is a minimal schema for reading stored baseline JSON files.
+type baselineResult struct {
+	ScenarioID string  `json:"scenario_id"`
+	Version    string  `json:"version"`
+	Reward     float64 `json:"reward"`
+	Checks     []struct {
+		Name   string `json:"name"`
+		Passed bool   `json:"passed"`
+	} `json:"checks"`
+}
+
+// rewardFromFile reads reward.txt written by the pytest run, or returns -1.
+func rewardFromFile(scenarioDir string) float64 {
+	data, err := os.ReadFile(filepath.Join(scenarioDir, "reward.txt"))
+	if err != nil {
+		return -1
+	}
+	var v float64
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(data)), "%f", &v); err != nil {
+		return -1
+	}
+	return v
+}
+
+func cmdEvalCompare(scenario string, all bool, evalDir string, regressionThreshold float64) error {
+	pytest, err := pytestPath()
+	if err != nil {
+		return err
+	}
+
+	targets, err := resolveEvalTargets(evalDir, scenario, all)
+	if err != nil {
+		return err
+	}
+
+	baselinesDir := filepath.Join(evalDir, "baselines")
+	workDir, _ := os.Getwd()
+
+	type scenarioResult struct {
+		id              string
+		baselineReward  float64
+		currentReward   float64
+		regressions     []string
+		baselineMissing bool
+	}
+
+	var results []scenarioResult
+
+	for _, scenarioDir := range targets {
+		testsDir := filepath.Join(scenarioDir, "tests")
+		if _, err := os.Stat(testsDir); os.IsNotExist(err) {
+			continue
+		}
+
+		scenarioID := filepath.Base(scenarioDir)
+
+		// Load baseline
+		baselinePath := filepath.Join(baselinesDir, scenarioID+".json")
+		var baseline *baselineResult
+		if data, err := os.ReadFile(baselinePath); err == nil {
+			var b baselineResult
+			if json.Unmarshal(data, &b) == nil {
+				baseline = &b
+			}
+		}
+
+		// Run pytest (without capturing baseline)
+		cmdArgs := []string{testsDir, "-v", "--tb=short"}
+		c := exec.Command(pytest, cmdArgs...)
+		c.Env = append(os.Environ(),
+			"WORK_DIR="+workDir,
+			"TASK_DIR="+scenarioDir,
+		)
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+		_ = c.Run() // we compare scores regardless of pytest exit code
+
+		currentReward := rewardFromFile(scenarioDir)
+
+		res := scenarioResult{id: scenarioID, currentReward: currentReward}
+		if baseline == nil {
+			res.baselineMissing = true
+		} else {
+			res.baselineReward = baseline.Reward
+			// Reward-level regression: per-check detail is only available in Python.
+			delta := currentReward - baseline.Reward
+			if delta < -regressionThreshold {
+				res.regressions = append(res.regressions, fmt.Sprintf("reward_drop(%.3f)", delta))
+			}
+		}
+		results = append(results, res)
+	}
+
+	// Render comparison table
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "\nSCENARIO\tBASELINE\tCURRENT\tDELTA\tREGRESSIONS")
+	fmt.Fprintln(tw, "--------\t--------\t-------\t-----\t-----------")
+
+	var regressionCount int
+	for _, r := range results {
+		baseline := "N/A"
+		delta := "N/A"
+		regrStr := "none"
+
+		if !r.baselineMissing {
+			baseline = fmt.Sprintf("%.4f", r.baselineReward)
+			d := r.currentReward - r.baselineReward
+			sign := "+"
+			if d < 0 {
+				sign = ""
+			}
+			delta = fmt.Sprintf("%s%.4f", sign, d)
+		}
+
+		current := "N/A"
+		if r.currentReward >= 0 {
+			current = fmt.Sprintf("%.4f", r.currentReward)
+		}
+
+		if len(r.regressions) > 0 {
+			regrStr = strings.Join(r.regressions, ", ")
+			regressionCount += len(r.regressions)
+		}
+
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", r.id, baseline, current, delta, regrStr)
+	}
+	tw.Flush()
+
+	if regressionCount > 0 {
+		return fmt.Errorf("%d regression(s) detected", regressionCount)
+	}
+	return nil
+}

--- a/cli/cmd/xylem/eval_test.go
+++ b/cli/cmd/xylem/eval_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewEvalCmd_Subcommands(t *testing.T) {
+	cmd := newEvalCmd()
+
+	subNames := map[string]bool{}
+	for _, sub := range cmd.Commands() {
+		subNames[sub.Name()] = true
+	}
+
+	for _, want := range []string{"run", "baseline", "compare"} {
+		if !subNames[want] {
+			t.Errorf("eval subcommand %q not registered", want)
+		}
+	}
+}
+
+func TestNewEvalRunCmd_Flags(t *testing.T) {
+	cmd := newEvalRunCmd()
+
+	if cmd.Flag("scenario") == nil {
+		t.Error("missing --scenario flag")
+	}
+	if cmd.Flag("all") == nil {
+		t.Error("missing --all flag")
+	}
+	if cmd.Flag("eval-dir") == nil {
+		t.Error("missing --eval-dir flag")
+	}
+}
+
+func TestNewEvalCompareCmd_Flags(t *testing.T) {
+	cmd := newEvalCompareCmd()
+
+	if cmd.Flag("regression-threshold") == nil {
+		t.Error("missing --regression-threshold flag")
+	}
+}
+
+func TestResolveEvalTargets_SingleScenario(t *testing.T) {
+	dir := t.TempDir()
+	scenariosDir := filepath.Join(dir, "scenarios")
+	scenarioDir := filepath.Join(scenariosDir, "my-scenario")
+	if err := os.MkdirAll(scenarioDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	targets, err := resolveEvalTargets(dir, "my-scenario", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	if filepath.Base(targets[0]) != "my-scenario" {
+		t.Errorf("expected my-scenario, got %s", filepath.Base(targets[0]))
+	}
+}
+
+func TestResolveEvalTargets_All(t *testing.T) {
+	dir := t.TempDir()
+	scenariosDir := filepath.Join(dir, "scenarios")
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		if err := os.MkdirAll(filepath.Join(scenariosDir, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	targets, err := resolveEvalTargets(dir, "", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 3 {
+		t.Errorf("expected 3 targets, got %d", len(targets))
+	}
+}
+
+func TestResolveEvalTargets_NoScenarioNoAll(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "scenarios"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := resolveEvalTargets(dir, "", false)
+	if err == nil {
+		t.Error("expected error when neither --scenario nor --all is set")
+	}
+}
+
+func TestResolveEvalTargets_MissingScenario(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "scenarios"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := resolveEvalTargets(dir, "nonexistent", false)
+	if err == nil {
+		t.Error("expected error for nonexistent scenario")
+	}
+}
+
+func TestRewardFromFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Missing file returns -1
+	if got := rewardFromFile(dir); got != -1 {
+		t.Errorf("expected -1 for missing file, got %v", got)
+	}
+
+	// Valid file
+	if err := os.WriteFile(filepath.Join(dir, "reward.txt"), []byte("0.8750\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := rewardFromFile(dir); got != 0.875 {
+		t.Errorf("expected 0.875, got %v", got)
+	}
+}

--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -55,7 +55,9 @@ func newRootCmd() *cobra.Command {
 				commandPath == "xylem audit" ||
 				strings.HasPrefix(commandPath, "xylem audit ") ||
 				commandPath == "xylem daemon stop" ||
-				commandPath == "xylem daemon reload"
+				commandPath == "xylem daemon reload" ||
+				commandPath == "xylem eval" ||
+				strings.HasPrefix(commandPath, "xylem eval ")
 
 			if !skipTooling {
 				if _, err := exec.LookPath("git"); err != nil {
@@ -128,6 +130,7 @@ func newRootCmd() *cobra.Command {
 		newVersionCmd(),
 		newFieldReportCmd(),
 		newAuditCmd(),
+		newEvalCmd(),
 	)
 
 	return cmd


### PR DESCRIPTION
## Summary

- Adds 4 new eval scenarios covering the full harness workload: `scan-enqueue-drain`, `label-gate-waiting-resume`, `failure-recovery`, and `pr-reporting` — each with `task.toml`, `instruction.md`, and reward-weighted `test_verification.py`
- Extends `xylem_verify.py` with rubric loading (`load_rubric`, `score_with_rubric`), baseline capture (`write_baseline`), and baseline comparison (`load_baseline`, `compare_to_baseline`, `load_phase_latency`)
- Adds `xylem eval` CLI command with `run`, `baseline`, and `compare` subcommands; `compare` outputs a tabular diff and exits non-zero on reward regressions
- Adds `.github/workflows/eval.yml` for weekly CI runs and per-scenario `workflow_dispatch` targeting with reward artifact upload
- Updates existing scenario tests to wire rubric scoring and opt-in baseline capture via `XYLEM_EVAL_CAPTURE_BASELINE=1`

Closes https://github.com/nicholls-inc/xylem/issues/57

## Test plan

- [ ] `go test ./cmd/xylem/...` passes (eval command structure + flag registration)
- [ ] `xylem eval run --scenario fix-simple-null-pointer` invokes pytest correctly (requires pytest on PATH)
- [ ] `xylem eval baseline --scenario fix-simple-null-pointer` writes `.xylem/eval/baselines/fix-simple-null-pointer.json`
- [ ] `xylem eval compare --all` prints comparison table; exits 0 when no baselines present (no regression to detect)
- [ ] `.github/workflows/eval.yml` YAML is valid (checked by pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)