### PR TITLE
fix: add DaemonBinary template variable so release-cadence command phase uses the running binary

### DIFF
--- a/.xylem/workflows/release-cadence.yaml
+++ b/.xylem/workflows/release-cadence.yaml
@@ -4,6 +4,6 @@ description: "Periodically promote mature release-please PRs into the daemon aut
 phases:
   - name: label_ready
     type: command
-    run: ./cli/xylem release-cadence label-ready --repo nicholls-inc/xylem
+    run: "{{.DaemonBinary}} release-cadence label-ready --repo nicholls-inc/xylem"
     noop:
       match: XYLEM_NOOP

--- a/cli/internal/phase/phase.go
+++ b/cli/internal/phase/phase.go
@@ -44,6 +44,10 @@ type TemplateData struct {
 	// recent first. Populated by the runner for phase index > 0. Template
 	// authors should guard with {{if .EpisodicContext}}.
 	EpisodicContext []memory.EpisodicEntry
+	// DaemonBinary is the absolute path to the running xylem daemon binary.
+	// Use this in command phases that need to call back into xylem without
+	// requiring a built binary in the worktree.
+	DaemonBinary string
 }
 
 type RenderOptions struct {

--- a/cli/internal/phase/phase_test.go
+++ b/cli/internal/phase/phase_test.go
@@ -596,3 +596,18 @@ func TestSummarizeText(t *testing.T) {
 		}
 	})
 }
+
+func TestRenderPrompt_DaemonBinary(t *testing.T) {
+	data := TemplateData{
+		DaemonBinary: "/usr/local/bin/xylem",
+	}
+	got, err := RenderPrompt("{{.DaemonBinary}} release-cadence label-ready", data)
+	require.NoError(t, err)
+	assert.Equal(t, "/usr/local/bin/xylem release-cadence label-ready", got)
+}
+
+func TestRenderPrompt_DaemonBinaryEmpty(t *testing.T) {
+	got, err := RenderPrompt("{{.DaemonBinary}} subcommand", TemplateData{})
+	require.NoError(t, err)
+	assert.Equal(t, " subcommand", got)
+}

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -4143,6 +4143,11 @@ func (r *Runner) buildTemplateData(vessel queue.Vessel, wf *workflow.Workflow, i
 			episodicCtx = entries
 		}
 	}
+	daemonBinary, err := os.Executable()
+	if err != nil {
+		log.Printf("warn: os.Executable: %v", err)
+		daemonBinary = ""
+	}
 	return phase.TemplateData{
 		Date:  r.runtimeNow().UTC().Format("2006-01-02"),
 		Issue: issueData,
@@ -4170,6 +4175,7 @@ func (r *Runner) buildTemplateData(vessel queue.Vessel, wf *workflow.Workflow, i
 		},
 		Validation:      validation,
 		EpisodicContext: episodicCtx,
+		DaemonBinary:    daemonBinary,
 	}
 }
 

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -10584,3 +10584,25 @@ func TestEpisodicContextPhaseZeroSkipped(t *testing.T) {
 		t.Errorf("EpisodicContext at phase 0 should be nil, got %v", td.EpisodicContext)
 	}
 }
+
+func TestBuildTemplateData_DaemonBinaryRendersInCommand(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	r := &Runner{Config: cfg}
+
+	vessel := queue.Vessel{ID: "v-1", Source: "manual"}
+	td := r.buildTemplateData(vessel, nil, phase.IssueData{}, "label_ready", 0, nil, "", phase.EvaluationData{})
+
+	// DaemonBinary must be a non-empty absolute path (os.Executable succeeds in tests).
+	assert.NotEmpty(t, td.DaemonBinary)
+	assert.True(t, filepath.IsAbs(td.DaemonBinary), "DaemonBinary should be an absolute path, got %q", td.DaemonBinary)
+
+	rendered, err := renderCommandTemplate("label_ready", "command",
+		"{{.DaemonBinary}} release-cadence label-ready --repo nicholls-inc/xylem", td)
+	require.NoError(t, err)
+	assert.NotContains(t, rendered, "{{")
+	// Verify the substitution: rendered command must begin with the actual binary path.
+	assert.True(t, strings.HasPrefix(rendered, td.DaemonBinary), "rendered command %q should start with DaemonBinary %q", rendered, td.DaemonBinary)
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/nicholls-inc/xylem/issues/441.

The `release-cadence` workflow's `label_ready` command phase ran `./cli/xylem release-cadence label-ready ...` inside a freshly-checked-out git worktree. That path only exists in the daemon root — the worktree has no compiled binary — so the command exited 127 every run.

**Root cause:** `gate.RunCommand` executes the rendered command string in `worktreePath`. The workflow YAML hardcoded a relative path (`./cli/xylem`) that doesn't exist there.

**Fix:** Introduce a `DaemonBinary` field in `phase.TemplateData` populated via `os.Executable()` in `runner.buildTemplateData()`. The workflow YAML now references `{{.DaemonBinary}}`, so command phases always call back into the running daemon binary regardless of which directory they execute in.

## Smoke scenarios covered

- **SC-441-1 — command phase template renders DaemonBinary:** `TestBuildTemplateData_DaemonBinaryRendersInCommand` verifies that `buildTemplateData` sets a non-empty absolute path and that a template referencing `{{.DaemonBinary}}` renders without raw `{{` literals.
- **SC-441-2 — RenderPrompt with DaemonBinary value:** `TestRenderPrompt_DaemonBinary` verifies end-to-end template rendering with a known binary path.
- **SC-441-3 — RenderPrompt with zero-value DaemonBinary:** `TestRenderPrompt_DaemonBinaryEmpty` verifies `missingkey=zero` behaviour when `DaemonBinary` is unset (renders as empty string, no template error).

## Changes summary

| File | Change |
|------|--------|
| `cli/internal/phase/phase.go` | Added `DaemonBinary string` field to `TemplateData` with doc comment |
| `cli/internal/runner/runner.go` | Populated `DaemonBinary` from `os.Executable()` in `buildTemplateData()` |
| `.xylem/workflows/release-cadence.yaml` | Replaced `./cli/xylem` with `{{.DaemonBinary}}` in the `run:` field |
| `cli/internal/phase/phase_test.go` | Added `TestRenderPrompt_DaemonBinary` and `TestRenderPrompt_DaemonBinaryEmpty` |
| `cli/internal/runner/runner_test.go` | Added `TestBuildTemplateData_DaemonBinaryRendersInCommand` |

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./cmd/xylem` — clean
- [x] `go test ./...` — all packages pass
- [x] `goimports -l .` — no formatting issues (enforced by pre-commit hook)
- [x] `golangci-lint run` — no lint errors (enforced by pre-commit hook)
- [ ] Manual: trigger a `release-cadence` vessel and confirm the `label_ready` phase exits 0 rather than 127

Fixes #441