### PR TITLE
fix: improve queue UX in doctor/status/cleanup

### DIFF
--- a/cli/cmd/xylem/cleanup.go
+++ b/cli/cmd/xylem/cleanup.go
@@ -22,44 +22,55 @@ func newCleanupCmd() *cobra.Command {
 		Short: "Remove stale worktrees and old phase outputs",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
-			return cmdCleanup(deps.cfg, deps.q, deps.wt, dryRun)
+			retainStr, _ := cmd.Flags().GetString("retain")
+			retain := deps.cfg.CleanupAfterDuration()
+			if retainStr != "" {
+				d, err := time.ParseDuration(retainStr)
+				if err != nil {
+					return fmt.Errorf("invalid --retain value %q: %w", retainStr, err)
+				}
+				retain = d
+			}
+			return cmdCleanup(deps.cfg, deps.q, deps.wt, dryRun, retain)
 		},
 	}
 	cmd.Flags().Bool("dry-run", false, "Preview what would be removed")
+	cmd.Flags().String("retain", "", "remove terminal vessels older than this duration (default: cleanup_after from .xylem.yml, typically 168h)")
 	return cmd
 }
 
-func cmdCleanup(cfg *config.Config, q *queue.Queue, wt *worktree.Manager, dryRun bool) error {
+func cmdCleanup(cfg *config.Config, q *queue.Queue, wt *worktree.Manager, dryRun bool, retain time.Duration) error {
 	if err := cleanupWorktrees(wt, q, dryRun); err != nil {
 		return err
 	}
 
 	cleanupPhaseOutputs(cfg, q, dryRun)
-	compactQueue(q, dryRun)
+	compactQueue(q, retain, dryRun)
 
 	return nil
 }
 
-func compactQueue(q *queue.Queue, dryRun bool) {
+func compactQueue(q *queue.Queue, retain time.Duration, dryRun bool) {
+	cutoff := time.Now().Add(-retain)
 	if dryRun {
-		removed, err := q.CompactDryRun()
+		removed, err := q.CompactOlderThanDryRun(cutoff)
 		if err != nil {
 			slog.Warn("queue compaction dry-run check failed", "error", err)
 			return
 		}
 		if removed > 0 {
-			fmt.Printf("Would remove %d stale queue record(s) (dry-run — no changes made)\n", removed)
+			fmt.Printf("Would remove %d stale queue record(s) older than %s (dry-run — no changes made)\n", removed, retain)
 		}
 		return
 	}
 
-	removed, err := q.Compact()
+	removed, err := q.CompactOlderThan(cutoff)
 	if err != nil {
 		slog.Warn("queue compaction failed", "error", err)
 		return
 	}
 	if removed > 0 {
-		fmt.Printf("Compacted queue: removed %d stale record(s)\n", removed)
+		fmt.Printf("Compacted queue: removed %d stale record(s) older than %s\n", removed, retain)
 	}
 }
 

--- a/cli/cmd/xylem/cleanup_test.go
+++ b/cli/cmd/xylem/cleanup_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -65,7 +66,7 @@ func TestCleanupNoWorktrees(t *testing.T) {
 	wt := worktree.New(dir, &emptyWorktreeRunner{})
 
 	var err error
-	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false) })
+	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false, 168*time.Hour) })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -96,7 +97,7 @@ func TestCleanupDryRunWithWorktrees(t *testing.T) {
 	q := queue.New(filepath.Join(cfg.StateDir, "queue.jsonl"))
 
 	var err error
-	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, true) })
+	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, true, 168*time.Hour) })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -131,7 +132,7 @@ func TestCleanupActualRemoval(t *testing.T) {
 	q := queue.New(filepath.Join(cfg.StateDir, "queue.jsonl"))
 
 	var err error
-	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false) })
+	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false, 168*time.Hour) })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -178,7 +179,7 @@ func TestCleanupSkipsActiveWorktreeWhenQueuePathIsRelative(t *testing.T) {
 	}
 
 	var err error
-	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, true) })
+	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, true, 168*time.Hour) })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -219,7 +220,7 @@ func TestCleanupRemovalError(t *testing.T) {
 	os.Stderr = errPw
 
 	var err error
-	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false) })
+	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false, 168*time.Hour) })
 
 	errPw.Close()
 	os.Stderr = oldErr
@@ -265,7 +266,7 @@ func TestCleanupPartialFailure(t *testing.T) {
 	q := queue.New(filepath.Join(cfg.StateDir, "queue.jsonl"))
 
 	var err error
-	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false) })
+	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false, 168*time.Hour) })
 	if err != nil {
 		t.Fatalf("expected nil error (best-effort), got: %v", err)
 	}
@@ -329,7 +330,7 @@ func TestCleanupPhaseDirs(t *testing.T) {
 	})
 
 	var err error
-	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false) })
+	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false, 168*time.Hour) })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -367,7 +368,7 @@ func TestCleanupSkipsRecentPhaseDirs(t *testing.T) {
 	})
 
 	var err error
-	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false) })
+	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false, 168*time.Hour) })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -402,7 +403,7 @@ func TestCleanupDryRunPhaseDirs(t *testing.T) {
 	})
 
 	var err error
-	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, true) })
+	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, true, 168*time.Hour) })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -422,7 +423,7 @@ func TestCleanupNoPhasesDir(t *testing.T) {
 
 	// Do NOT create the phases directory -- it should not exist
 	var err error
-	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false) })
+	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false, 168*time.Hour) })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -454,7 +455,7 @@ func TestCleanupTimedOutPhaseDirs(t *testing.T) {
 	})
 
 	var err error
-	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false) })
+	out := captureStdout(func() { err = cmdCleanup(cfg, q, wt, false, 168*time.Hour) })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -465,5 +466,152 @@ func TestCleanupTimedOutPhaseDirs(t *testing.T) {
 	}
 	if !strings.Contains(out, "Removed phase outputs") {
 		t.Errorf("expected 'Removed phase outputs' in output, got: %s", out)
+	}
+}
+
+// --- Queue compaction (--retain) tests ---
+
+func TestCleanupCompactsOldTerminalVessels(t *testing.T) {
+	cfg, q := testCleanupConfig(t)
+	wt := worktree.New(t.TempDir(), &emptyWorktreeRunner{})
+
+	now := time.Now().UTC()
+	started := now.Add(-9 * 24 * time.Hour)
+	ended := now.Add(-8 * 24 * time.Hour)
+
+	// Three failed vessels older than 7d.
+	for i := 1; i <= 3; i++ {
+		q.Enqueue(queue.Vessel{ //nolint:errcheck
+			ID:        fmt.Sprintf("issue-%d", i),
+			Source:    "github-issue",
+			Workflow:  "fix-bug",
+			State:     queue.StateFailed,
+			CreatedAt: started,
+			StartedAt: &started,
+			EndedAt:   &ended,
+		})
+	}
+	// One pending vessel that must survive.
+	q.Enqueue(queue.Vessel{ //nolint:errcheck
+		ID:        "issue-pending",
+		Source:    "github-issue",
+		Workflow:  "fix-bug",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	})
+
+	out := captureStdout(func() {
+		if err := cmdCleanup(cfg, q, wt, false, 7*24*time.Hour); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "removed 3 stale record(s)") {
+		t.Errorf("expected 3 records removed, got: %s", out)
+	}
+
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Errorf("expected 1 vessel remaining (pending), got %d", len(vessels))
+	}
+	if len(vessels) > 0 && vessels[0].ID != "issue-pending" {
+		t.Errorf("expected pending vessel to survive, got %s", vessels[0].ID)
+	}
+}
+
+func TestCleanupRetainFlag_NilEndedAtKept(t *testing.T) {
+	cfg, q := testCleanupConfig(t)
+	wt := worktree.New(t.TempDir(), &emptyWorktreeRunner{})
+
+	// A failed vessel with no EndedAt (legacy) — must not be evicted.
+	q.Enqueue(queue.Vessel{ //nolint:errcheck
+		ID:       "issue-legacy",
+		Source:   "github-issue",
+		Workflow: "fix-bug",
+		State:    queue.StateFailed,
+	})
+
+	out := captureStdout(func() {
+		if err := cmdCleanup(cfg, q, wt, false, 0); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// No compaction message expected.
+	if strings.Contains(out, "stale record") {
+		t.Errorf("expected no stale records removed for nil-EndedAt vessel, got: %s", out)
+	}
+
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Errorf("expected legacy vessel to be kept, got %d vessels", len(vessels))
+	}
+}
+
+func TestCleanupRetainFlag_InvalidDuration(t *testing.T) {
+	// Exercise the cobra RunE path: --retain with an unparseable value must return
+	// a formatted error without touching the queue or worktrees.
+	dir := t.TempDir()
+	prev := deps
+	deps = &appDeps{
+		cfg: &config.Config{StateDir: dir},
+		q:   queue.New(filepath.Join(dir, "queue.jsonl")),
+		wt:  worktree.New(dir, &emptyWorktreeRunner{}),
+	}
+	t.Cleanup(func() { deps = prev })
+
+	cmd := newCleanupCmd()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"--retain", "notaduration"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid --retain value, got nil")
+	}
+	if !strings.Contains(err.Error(), `invalid --retain value "notaduration"`) {
+		t.Errorf("error = %q, want to contain expected message", err.Error())
+	}
+}
+
+func TestCleanupDryRunWithRetain(t *testing.T) {
+	cfg, q := testCleanupConfig(t)
+	wt := worktree.New(t.TempDir(), &emptyWorktreeRunner{})
+
+	now := time.Now().UTC()
+	started := now.Add(-9 * 24 * time.Hour)
+	ended := now.Add(-8 * 24 * time.Hour)
+	q.Enqueue(queue.Vessel{ //nolint:errcheck
+		ID:        "issue-dryrun",
+		Source:    "github-issue",
+		Workflow:  "fix-bug",
+		State:     queue.StateFailed,
+		CreatedAt: started,
+		StartedAt: &started,
+		EndedAt:   &ended,
+	})
+
+	out := captureStdout(func() {
+		if err := cmdCleanup(cfg, q, wt, true, 7*24*time.Hour); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Would remove 1 stale queue record(s)") {
+		t.Errorf("expected dry-run message, got: %s", out)
+	}
+
+	// Queue must be unchanged.
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Errorf("expected queue unchanged after dry-run, got %d vessels", len(vessels))
 	}
 }

--- a/cli/cmd/xylem/doctor.go
+++ b/cli/cmd/xylem/doctor.go
@@ -322,7 +322,27 @@ func checkQueueHealth(q *queue.Queue, report *doctorReport) {
 		report.add("queue_compaction", "ok", "Queue is compact")
 	}
 
-	report.add("queue", "ok", fmt.Sprintf("%d vessel(s) in queue", len(vessels)))
+	var pending, running, completed, failed, cancelled, timedOut int
+	for _, v := range vessels {
+		switch v.State {
+		case queue.StatePending:
+			pending++
+		case queue.StateRunning:
+			running++
+		case queue.StateCompleted:
+			completed++
+		case queue.StateFailed:
+			failed++
+		case queue.StateCancelled:
+			cancelled++
+		case queue.StateTimedOut:
+			timedOut++
+		}
+	}
+	report.add("queue", "ok", fmt.Sprintf(
+		"%d pending, %d running (%d completed, %d failed, %d cancelled, %d timed_out)",
+		pending, running, completed, failed, cancelled, timedOut,
+	))
 }
 
 func checkFleetHealth(cfg *config.Config, q *queue.Queue, report *doctorReport) {

--- a/cli/cmd/xylem/doctor_test.go
+++ b/cli/cmd/xylem/doctor_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -222,8 +223,12 @@ func TestDoctorQueueHealth(t *testing.T) {
 	if queueCheck.Status != "ok" {
 		t.Fatalf("queue status = %q, want ok", queueCheck.Status)
 	}
-	if queueCheck.Message != "1 vessel(s) in queue" {
-		t.Fatalf("queue message = %q, want %q", queueCheck.Message, "1 vessel(s) in queue")
+	// Message should show per-state breakdown: 0 pending, 0 running, 1 completed.
+	if !strings.Contains(queueCheck.Message, "0 pending") {
+		t.Fatalf("queue message = %q, want pending count", queueCheck.Message)
+	}
+	if !strings.Contains(queueCheck.Message, "1 completed") {
+		t.Fatalf("queue message = %q, want completed count", queueCheck.Message)
 	}
 
 	compactionCheck := requireDoctorCheck(t, report, "queue_compaction")
@@ -508,6 +513,65 @@ func TestSmoke_S2_DoctorDefaultBehaviorWithoutRootUnchanged(t *testing.T) {
 
 	assert.Contains(t, out, "pid=11111")
 	assert.NotContains(t, out, "pid=22222")
+}
+
+func TestCheckQueueHealthShowsStateCounts(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	// Set up a failed vessel first (pending → running → failed).
+	vf := queue.Vessel{
+		ID:        "failed-1",
+		Source:    "github-issue",
+		Workflow:  "fix-bug",
+		State:     queue.StatePending,
+		CreatedAt: time.Now(),
+	}
+	if _, err := q.Enqueue(vf); err != nil {
+		t.Fatalf("enqueue failed-1: %v", err)
+	}
+	if _, err := q.Dequeue(); err != nil { // pending → running
+		t.Fatalf("dequeue: %v", err)
+	}
+	if err := q.Update("failed-1", queue.StateFailed, "boom"); err != nil {
+		t.Fatalf("update to failed: %v", err)
+	}
+
+	// Enqueue 2 pending vessels after so they are not dequeued.
+	for i := 1; i <= 2; i++ {
+		v := queue.Vessel{
+			ID:        fmt.Sprintf("pending-%d", i),
+			Source:    "github-issue",
+			Workflow:  "fix-bug",
+			State:     queue.StatePending,
+			CreatedAt: time.Now(),
+		}
+		if _, err := q.Enqueue(v); err != nil {
+			t.Fatalf("enqueue pending-%d: %v", i, err)
+		}
+	}
+
+	report := &doctorReport{}
+	checkQueueHealth(q, report)
+
+	queueCheck := requireDoctorCheck(t, report, "queue")
+	assert.Equal(t, "ok", queueCheck.Status)
+	assert.Contains(t, queueCheck.Message, "2 pending")
+	assert.Contains(t, queueCheck.Message, "0 running")
+	assert.Contains(t, queueCheck.Message, "1 failed")
+}
+
+func TestCheckQueueHealthAllZeros(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	report := &doctorReport{}
+	checkQueueHealth(q, report)
+
+	queueCheck := requireDoctorCheck(t, report, "queue")
+	assert.Equal(t, "ok", queueCheck.Status)
+	assert.Contains(t, queueCheck.Message, "0 pending")
+	assert.Contains(t, queueCheck.Message, "0 running")
 }
 
 func TestSmoke_S3_DoctorJSONModeHonorsRootFlag(t *testing.T) {

--- a/cli/cmd/xylem/status.go
+++ b/cli/cmd/xylem/status.go
@@ -96,9 +96,9 @@ func cmdStatus(cfg *config.Config, q *queue.Queue, jsonMode bool, stateFilter st
 		counts[j.State]++
 	}
 
-	fmt.Printf("Queue: %d running, %d pending, %d completed, %d failed, %d cancelled, %d waiting, %d timed_out\n",
-		counts[queue.StateRunning], counts[queue.StatePending], counts[queue.StateCompleted],
-		counts[queue.StateFailed], counts[queue.StateCancelled], counts[queue.StateWaiting],
+	fmt.Printf("Queue: %d pending, %d running, %d waiting | %d completed, %d failed, %d cancelled, %d timed_out\n",
+		counts[queue.StatePending], counts[queue.StateRunning], counts[queue.StateWaiting],
+		counts[queue.StateCompleted], counts[queue.StateFailed], counts[queue.StateCancelled],
 		counts[queue.StateTimedOut])
 	renderDaemonHealth(daemonSnapshot)
 	if len(vessels) == 0 {

--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -483,6 +483,57 @@ func compactVessels(vessels []Vessel) ([]Vessel, int) {
 	return compacted, removed
 }
 
+// compactVesselsOlderThan removes terminal vessels whose EndedAt is before
+// cutoff, in addition to deduplication. Vessels with a nil EndedAt are always
+// kept regardless of state.
+func compactVesselsOlderThan(vessels []Vessel, cutoff time.Time) ([]Vessel, int) {
+	deduped, dedupRemoved := compactVessels(vessels)
+	var (
+		kept       []Vessel
+		ageRemoved int
+	)
+	for _, v := range deduped {
+		if v.State.IsTerminal() && v.EndedAt != nil && v.EndedAt.Before(cutoff) {
+			ageRemoved++
+		} else {
+			kept = append(kept, v)
+		}
+	}
+	return kept, dedupRemoved + ageRemoved
+}
+
+// CompactOlderThan removes terminal vessel records whose EndedAt is before
+// cutoff, in addition to deduplication. Vessels with a nil EndedAt are always
+// kept. Returns the count of records removed.
+func (q *Queue) CompactOlderThan(cutoff time.Time) (int, error) {
+	var removed int
+	err := q.withLock(func() error {
+		vessels, err := q.readAllVessels()
+		if err != nil {
+			return err
+		}
+		compacted, n := compactVesselsOlderThan(vessels, cutoff)
+		removed = n
+		return q.writeAllVessels(compacted)
+	})
+	return removed, err
+}
+
+// CompactOlderThanDryRun reports how many records CompactOlderThan would remove
+// without modifying the queue file.
+func (q *Queue) CompactOlderThanDryRun(cutoff time.Time) (int, error) {
+	var removable int
+	err := q.withRLock(func() error {
+		vessels, err := q.readAllVessels()
+		if err != nil {
+			return err
+		}
+		_, removable = compactVesselsOlderThan(vessels, cutoff)
+		return nil
+	})
+	return removable, err
+}
+
 func (q *Queue) HasRef(ref string) bool {
 	vessels, err := q.List()
 	if err != nil {

--- a/cli/internal/queue/queue_prop_test.go
+++ b/cli/internal/queue/queue_prop_test.go
@@ -90,3 +90,131 @@ func TestPropQueueRoundTripsWorkflowDigest(t *testing.T) {
 		}
 	})
 }
+
+// drawVesselState draws a random VesselState from the full set of known states.
+func drawVesselState(t *rapid.T, label string) VesselState {
+	states := []VesselState{
+		StatePending, StateRunning, StateCompleted,
+		StateFailed, StateCancelled, StateTimedOut, StateWaiting,
+	}
+	idx := rapid.IntRange(0, len(states)-1).Draw(t, label)
+	return states[idx]
+}
+
+// drawTime draws a random time within ±30 days of now.
+func drawTime(t *rapid.T, label string) time.Time {
+	offsetDays := rapid.IntRange(-30, 30).Draw(t, label)
+	return time.Now().UTC().Add(time.Duration(offsetDays) * 24 * time.Hour)
+}
+
+func TestPropCompactOlderThan_NeverRemovesNonTerminal(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(0, 10).Draw(t, "n")
+		vessels := make([]Vessel, n)
+		for i := range vessels {
+			st := drawVesselState(t, "state")
+			ended := drawTime(t, "ended")
+			var endedPtr *time.Time
+			if rapid.Bool().Draw(t, "has_ended") {
+				endedPtr = &ended
+			}
+			vessels[i] = Vessel{
+				ID:      rapid.StringMatching(`[a-z][a-z0-9]{0,7}`).Draw(t, "id"),
+				State:   st,
+				EndedAt: endedPtr,
+			}
+		}
+
+		cutoff := drawTime(t, "cutoff")
+		kept, _ := compactVesselsOlderThan(vessels, cutoff)
+
+		// Every non-terminal vessel from the input must appear in kept.
+		for _, v := range vessels {
+			if !v.State.IsTerminal() {
+				found := false
+				for _, k := range kept {
+					if k.ID == v.ID && k.State == v.State {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("non-terminal vessel %s/%s was removed by compactVesselsOlderThan", v.ID, v.State)
+				}
+			}
+		}
+	})
+}
+
+func TestPropCompactOlderThan_RetainsByAge(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cutoff := time.Now().UTC()
+
+		n := rapid.IntRange(1, 10).Draw(t, "n")
+		type entry struct {
+			id     string
+			ended  time.Time
+			before bool // true if EndedAt < cutoff
+		}
+		entries := make([]entry, n)
+		vessels := make([]Vessel, n)
+		for i := range entries {
+			offsetHours := rapid.IntRange(-48, 48).Draw(t, "offset_hours")
+			ended := cutoff.Add(time.Duration(offsetHours) * time.Hour)
+			e := entry{
+				id:     rapid.StringMatching(`[a-z][a-z0-9]{0,5}`).Draw(t, "id"),
+				ended:  ended,
+				before: ended.Before(cutoff),
+			}
+			entries[i] = e
+			vessels[i] = Vessel{
+				ID:      e.id,
+				State:   StateCompleted, // terminal, with EndedAt set
+				EndedAt: &ended,
+			}
+		}
+
+		kept, _ := compactVesselsOlderThan(vessels, cutoff)
+
+		// All kept vessels must have EndedAt >= cutoff (or nil EndedAt).
+		for _, k := range kept {
+			if k.EndedAt != nil && k.EndedAt.Before(cutoff) {
+				t.Fatalf("vessel %s with EndedAt %v before cutoff %v survived compaction", k.ID, k.EndedAt, cutoff)
+			}
+		}
+	})
+}
+
+func TestPropCompactOlderThan_SubsetOfInput(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(0, 15).Draw(t, "n")
+		vessels := make([]Vessel, n)
+		for i := range vessels {
+			ended := drawTime(t, "ended")
+			vessels[i] = Vessel{
+				ID:      rapid.StringMatching(`[a-z][a-z0-9]{0,7}`).Draw(t, "id"),
+				State:   drawVesselState(t, "state"),
+				EndedAt: &ended,
+			}
+		}
+
+		cutoff := drawTime(t, "cutoff")
+		kept, _ := compactVesselsOlderThan(vessels, cutoff)
+
+		// Build a set of input IDs for membership testing.
+		inputIDs := make(map[string]bool, len(vessels))
+		for _, v := range vessels {
+			inputIDs[v.ID] = true
+		}
+
+		for _, k := range kept {
+			if !inputIDs[k.ID] {
+				t.Fatalf("vessel %s in output was not in input", k.ID)
+			}
+		}
+
+		if len(kept) > len(vessels) {
+			t.Fatalf("output len %d > input len %d", len(kept), len(vessels))
+		}
+	})
+}

--- a/cli/internal/queue/queue_test.go
+++ b/cli/internal/queue/queue_test.go
@@ -2114,3 +2114,179 @@ func TestCompactDryRun(t *testing.T) {
 		t.Fatalf("dry run modified the file: before=%d lines, after=%d lines", len(linesBefore), len(linesAfter))
 	}
 }
+
+func TestCompactOlderThan(t *testing.T) {
+	q, path := newTestQueue(t)
+	now := time.Now().UTC()
+
+	// Three failed vessels: 8d ago, 6d ago, 1d ago.
+	for i, age := range []time.Duration{8 * 24 * time.Hour, 6 * 24 * time.Hour, 1 * 24 * time.Hour} {
+		v := testVessel(100 + i)
+		if _, err := q.Enqueue(v); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+		helperFailVessel(t, q, v.ID)
+		// Manually patch EndedAt in the JSONL by reading and writing.
+		vessels, err := q.List()
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		for j := range vessels {
+			if vessels[j].ID == v.ID {
+				ended := now.Add(-age)
+				vessels[j].EndedAt = &ended
+			}
+		}
+		// Re-write queue with patched EndedAt.
+		f, err := os.Create(path)
+		if err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		enc := json.NewEncoder(f)
+		for _, vv := range vessels {
+			if err := enc.Encode(vv); err != nil {
+				f.Close()
+				t.Fatalf("encode: %v", err)
+			}
+		}
+		f.Close()
+	}
+
+	linesBefore := readNonEmptyLines(t, path)
+	if len(linesBefore) != 3 {
+		t.Fatalf("expected 3 lines before compaction, got %d", len(linesBefore))
+	}
+
+	// Cutoff at 7 days ago — should remove only the 8d-old vessel.
+	cutoff := now.Add(-7 * 24 * time.Hour)
+	removed, err := q.CompactOlderThan(cutoff)
+	if err != nil {
+		t.Fatalf("CompactOlderThan: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("expected 1 removed, got %d", removed)
+	}
+
+	linesAfter := readNonEmptyLines(t, path)
+	if len(linesAfter) != 2 {
+		t.Fatalf("expected 2 lines after compaction, got %d", len(linesAfter))
+	}
+}
+
+func TestCompactOlderThanDryRun(t *testing.T) {
+	q, path := newTestQueue(t)
+	now := time.Now().UTC()
+
+	// One failed vessel with EndedAt 8 days ago.
+	v := testVessel(200)
+	if _, err := q.Enqueue(v); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	helperFailVessel(t, q, v.ID)
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	ended := now.Add(-8 * 24 * time.Hour)
+	vessels[0].EndedAt = &ended
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	enc := json.NewEncoder(f)
+	for _, vv := range vessels {
+		if err := enc.Encode(vv); err != nil {
+			f.Close()
+			t.Fatalf("encode: %v", err)
+		}
+	}
+	f.Close()
+
+	linesBefore := readNonEmptyLines(t, path)
+
+	cutoff := now.Add(-7 * 24 * time.Hour)
+	removable, err := q.CompactOlderThanDryRun(cutoff)
+	if err != nil {
+		t.Fatalf("CompactOlderThanDryRun: %v", err)
+	}
+	if removable != 1 {
+		t.Fatalf("expected 1 removable, got %d", removable)
+	}
+
+	// File must be unchanged.
+	linesAfter := readNonEmptyLines(t, path)
+	if len(linesAfter) != len(linesBefore) {
+		t.Fatalf("dry-run modified the file: before=%d lines, after=%d lines", len(linesBefore), len(linesAfter))
+	}
+}
+
+func TestCompactOlderThan_NilEndedAt(t *testing.T) {
+	q, _ := newTestQueue(t)
+
+	// Enqueue and fail without setting EndedAt (simulates legacy records).
+	v := testVessel(300)
+	if _, err := q.Enqueue(v); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if err := q.Update(v.ID, StateFailed, "legacy"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	// Patch EndedAt to nil by directly reading/writing the JSONL file.
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	// The queue normally sets EndedAt on failure; nil it out to simulate legacy.
+	f, err := os.Create(q.path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	enc := json.NewEncoder(f)
+	for i := range vessels {
+		vessels[i].EndedAt = nil
+		if err := enc.Encode(vessels[i]); err != nil {
+			f.Close()
+			t.Fatalf("encode: %v", err)
+		}
+	}
+	f.Close()
+
+	// Compact with a future cutoff — nil EndedAt vessels must be kept.
+	removed, err := q.CompactOlderThan(time.Now().Add(24 * time.Hour))
+	if err != nil {
+		t.Fatalf("CompactOlderThan: %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("expected 0 removed (nil EndedAt guard), got %d", removed)
+	}
+}
+
+func TestCompactOlderThan_NonTerminalKept(t *testing.T) {
+	q, _ := newTestQueue(t)
+
+	// Enqueue a pending vessel — must never be evicted.
+	v := testVessel(400)
+	if _, err := q.Enqueue(v); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	removed, err := q.CompactOlderThan(time.Now().Add(24 * time.Hour))
+	if err != nil {
+		t.Fatalf("CompactOlderThan: %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("expected 0 removed for non-terminal vessel, got %d", removed)
+	}
+
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
+	}
+}


### PR DESCRIPTION
## Summary

Addresses [#443](https://github.com/nicholls-inc/xylem/issues/443) — three UX fixes for the queue display across `doctor`, `cleanup`, and `status` commands.

**Problem:** `xylem doctor` reported `377 vessel(s) in queue` when the active queue was empty (all 377 were historical terminal records). `xylem cleanup` called `Compact()` which only deduplicates by vessel ID and never removes old terminal vessels. `xylem status` listed states in an arbitrary order mixing operational and historical counts.

## Changes

### Files modified

- **`cli/internal/queue/queue.go`** — Added `CompactOlderThan(cutoff time.Time) (int, error)` and `CompactOlderThanDryRun(cutoff time.Time) (int, error)` public methods, plus a `compactVesselsOlderThan` helper that removes terminal vessels with `EndedAt` before the cutoff (nil `EndedAt` is always kept for backwards compatibility).

- **`cli/cmd/xylem/doctor.go`** — Replaced the single `len(vessels)` count in `checkQueueHealth` with per-state counts: `"%d pending, %d running (%d completed, %d failed, %d cancelled, %d timed_out)"`.

- **`cli/cmd/xylem/cleanup.go`** — Added `--retain` flag (default: `cleanup_after` from `.xylem.yml`, typically 168h). `compactQueue` now calls `CompactOlderThan` with the cutoff derived from the retain duration instead of bare `Compact()`.

- **`cli/cmd/xylem/status.go`** — Reformatted the queue summary line to lead with operational states (`pending`, `running`, `waiting`) separated by `|` from historical counts (`completed`, `failed`, `cancelled`, `timed_out`).

- **`cli/internal/queue/queue_test.go`** — Added `TestCompactOlderThan`, `TestCompactOlderThanDryRun`, `TestCompactOlderThan_NilEndedAt`, `TestCompactOlderThan_NonTerminalKept`.

- **`cli/internal/queue/queue_prop_test.go`** — Added `TestPropCompactOlderThan_NeverRemovesNonTerminal`, `TestPropCompactOlderThan_RetainsByAge`, `TestPropCompactOlderThan_SubsetOfInput`.

- **`cli/cmd/xylem/cleanup_test.go`** — Added tests for `--retain` flag, dry-run mode, invalid duration, and nil `EndedAt` guard.

- **`cli/cmd/xylem/doctor_test.go`** — Added `TestCheckQueueHealthShowsStateCounts` and `TestCheckQueueHealthAllZeros` verifying the per-state message format.

## Smoke scenarios covered

- **SC-1**: `xylem doctor` on a queue with only historical terminal vessels reports `0 pending, 0 running` instead of the total record count.
- **SC-2**: `xylem cleanup` with default retention removes terminal vessels older than 7 days and prints the count removed.
- **SC-3**: `xylem cleanup --retain 0` removes all terminal vessels that have a non-nil `EndedAt`; vessels with nil `EndedAt` are preserved.
- **SC-4**: `xylem cleanup --dry-run` reports the count that would be removed without modifying the queue file.
- **SC-5**: `xylem cleanup --retain notaduration` exits with a parse error.
- **SC-6**: `xylem status` output leads with `pending/running/waiting` before the `|` separator.

## Test plan

- [ ] `go test ./internal/queue` — unit + property tests for `CompactOlderThan`/`CompactOlderThanDryRun`
- [ ] `go test ./cmd/xylem` — doctor state-count assertions and cleanup retain-flag tests
- [ ] Manual: run `xylem doctor` against a queue with historical records; confirm message shows per-state counts
- [ ] Manual: run `xylem cleanup --dry-run` and `xylem cleanup --retain 24h`; confirm counts and queue file size change as expected
- [ ] Manual: run `xylem status`; confirm operational states appear before `|`

Fixes #443