### PR TITLE
docs: document multi-repo daemon operation and isolation model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,20 @@ docker compose -f dev/docker-compose.yml down
   - `GET /api/traces?service=xylem&limit=10` — recent traces
   - `GET /api/traces/{traceID}` — full trace detail
 
+## Multi-repo operation
+
+Multiple xylem daemons can coexist across different repositories with no code changes. Each daemon is fully isolated.
+
+Key facts for agents operating in this context:
+
+- **CWD-scoped**: every daemon is bound to the directory it was started from. All state paths (`StateDir`, defaulting to `.xylem`) are relative to that repo's root. Never read or write another repo's `.xylem/` directory.
+- **No shared state**: separate flock on `state/daemon.pid` (which also stores the PID), separate queue (`state/queue.jsonl`), and separate phase outputs. There is no cross-repo IPC or global semaphore.
+- **Per-repo pause lever**: `state/paused` is the pause marker for a single daemon. Writing or removing it affects only the daemon whose state directory contains it.
+- **Concurrency and cost are per-daemon**: `concurrency` caps only the sessions spawned by one daemon; `cost.daily_budget_usd` tracks only the spend that daemon has incurred. Multiple running daemons multiply both without coordination.
+- **PID signaling caveat**: `xylem daemon stop` sends SIGTERM to the PID stored in `state/daemon.pid` without verifying the target is actually a xylem daemon. Do not signal PIDs from a different repo's PID file.
+
+See [docs/multi-repo.md](docs/multi-repo.md) for the full user-facing guide.
+
 ## Testing patterns
 
 - Tests use interfaces and stubs extensively (e.g., `CommandRunner`, `WorktreeManager`) — no real subprocesses or git operations in tests

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,6 +137,8 @@ daemon:
 | `observability` | object | see below | No | OpenTelemetry instrumentation settings. |
 | `cost` | object | see below | No | Token budget enforcement settings. |
 
+> **Multi-repo note:** `concurrency` limits are per-daemon. Running multiple daemons on the same machine multiplies the total concurrent sessions. See [Multi-repo daemon operation](multi-repo.md#resource-awareness).
+
 ### `daemon`
 
 | Field | Type | Default | Required | Description |
@@ -546,6 +548,8 @@ harness:
 
 The `observability` section controls OpenTelemetry instrumentation for tracing agent execution. Tracing requires an OTLP endpoint — when no endpoint is configured, tracing is silently disabled (no stdout fallback). This endpoint is used for traces only; xylem keeps daemon logs on stderr and `daemon.log`, and the bundled Jaeger dev stack does not ingest OTLP logs.
 
+> **Multi-repo note:** All daemons emit traces under the service name `"xylem"` with no per-repo identifier. Traces from multiple repos are indistinguishable in a shared collector. See [Multi-repo daemon operation](multi-repo.md#observability) for workarounds.
+
 | Field | Type | Default | Required | Description |
 |-------|------|---------|----------|-------------|
 | `observability.enabled` | bool | `true` | No | Enable or disable OpenTelemetry tracing. |
@@ -579,6 +583,8 @@ The `cost` section configures token budget enforcement for agent sessions.
 |-------|------|---------|----------|-------------|
 | `cost.budget.max_cost_usd` | float | `0` | No | Maximum cost in USD. Must be >= 0. Set to 0 to disable cost-based limits. |
 | `cost.budget.max_tokens` | integer | `0` | No | Maximum total tokens. Must be >= 0. Set to 0 to disable token-based limits. |
+
+> **Multi-repo note:** `cost.daily_budget_usd` is enforced per-daemon. There is no cross-repo budget aggregation — each daemon tracks only the spend it incurs. See [Multi-repo daemon operation](multi-repo.md#cost-budgets) for how to divide a total budget across repos.
 
 ## Duration strings
 

--- a/docs/multi-repo.md
+++ b/docs/multi-repo.md
@@ -1,0 +1,117 @@
+# Multi-repo daemon operation
+
+xylem supports running independent daemon instances across multiple repositories simultaneously. Each daemon instance is fully isolated — there is no shared state, no global coordination, and no cross-repo communication.
+
+## Setup
+
+Each repository needs three things:
+
+1. Its own `.xylem.yml` configuration file at the repo root.
+2. A dedicated daemon worktree created from the main branch:
+   ```bash
+   git worktree add .daemon-root main
+   ```
+3. A `xylem daemon` invocation started from inside that worktree:
+   ```bash
+   cd .daemon-root
+   xylem daemon
+   ```
+
+Repeat this for each repository. Each daemon runs independently in its own terminal session or process supervisor.
+
+## Isolation model
+
+All xylem state is relative to the daemon's working directory (`StateDir`, which defaults to `.xylem`). No paths are shared across repositories.
+
+| Resource | Location | Isolation |
+|---|---|---|
+| Work queue | `<state_dir>/state/queue.jsonl` | Per-repo |
+| Daemon lock / PID file | `<state_dir>/state/daemon.pid` | Per-repo — serves as both the exclusive flock and PID storage, preventing duplicate daemons in the same repo |
+| Pause marker | `<state_dir>/state/paused` | Per-repo — `xylem pause` affects only the local daemon |
+| Audit log | `<state_dir>/state/audit.jsonl` | Per-repo |
+| Phase outputs | `<state_dir>/state/phases/<vessel-id>/` | Per-repo |
+| Schedule state | `<state_dir>/state/schedule.json` | Per-repo |
+| Git worktrees | created under the repo root | Per-repo |
+
+There is no global semaphore, shared queue, or cross-repo IPC of any kind.
+
+## Resource awareness
+
+`concurrency` limits apply per-daemon. If you run three daemons each with `concurrency: 2`, up to six concurrent Claude sessions may be active at the same time. xylem has no awareness of other daemons running on the same machine.
+
+Plan your total concurrency as the sum across all active daemons:
+
+```yaml
+# repo-a/.xylem.yml
+concurrency: 2   # up to 2 sessions from this repo
+
+# repo-b/.xylem.yml
+concurrency: 1   # up to 1 session from this repo
+
+# combined: up to 3 concurrent sessions on this machine
+```
+
+If your machine or API key has a rate limit that covers the total, set per-repo concurrency to stay within that budget. xylem does not coordinate this for you.
+
+## Cost budgets
+
+`cost.daily_budget_usd` is enforced per-daemon. Each daemon tracks only the spend it has incurred — there is no cross-repo budget aggregation.
+
+If you want to cap total daily spend across multiple repos, divide the budget manually across each `.xylem.yml`:
+
+```yaml
+# repo-a/.xylem.yml — allocate $5 of a $10 total daily budget
+cost:
+  daily_budget_usd: 5.0
+
+# repo-b/.xylem.yml — allocate the other $5
+cost:
+  daily_budget_usd: 5.0
+```
+
+There is no mechanism to enforce a shared ceiling across running daemons. Monitor individual daemon logs or your API provider's usage dashboard to track combined spend.
+
+## Observability
+
+All daemons export traces under the service name `"xylem"` with no per-repo identifier attribute. If you point multiple daemons at the same OTLP collector (e.g., a shared Jaeger instance), their traces will be indistinguishable by service name.
+
+To separate traces in the collector, either:
+
+- Run a separate collector or Jaeger instance per repo and point each `observability.endpoint` at the appropriate one.
+- Add per-repo `resource.attributes` at the collector level if your OTLP pipeline supports attribute injection.
+
+There is currently no `observability.service_name` config field in `.xylem.yml`. If cross-repo trace separation is important to your workflow, track [nicholls-inc/xylem#446](https://github.com/nicholls-inc/xylem/issues/446) for future config support, or run separate collector instances as a workaround.
+
+## Known limitation: PID-reuse on stop
+
+`xylem daemon stop` works by reading the PID from `<state_dir>/state/daemon.pid` and sending it a `SIGTERM`. It does not verify that the target process is actually a xylem daemon before signaling.
+
+In the unlikely sequence:
+
+1. Daemon A crashes without cleaning up its PID file.
+2. The operating system reuses that PID for an unrelated process (or for daemon B in another repo).
+3. `xylem daemon stop` (run in repo A's directory) sends `SIGTERM` to the reused PID.
+
+Under this scenario, xylem could inadvertently signal the wrong process. The probability is low in practice — OS PID space is large and reuse takes time — but it is a known design limitation.
+
+**Workaround**: before running `xylem daemon stop`, verify that the daemon is healthy with `xylem status`. If the daemon has crashed and left a stale PID file, remove it manually:
+
+```bash
+rm .xylem/state/daemon.pid
+```
+
+Then start the daemon fresh.
+
+## Example: two repos on one machine
+
+```bash
+# Terminal 1 — repo-a
+cd ~/projects/repo-a/.daemon-root
+xylem daemon
+
+# Terminal 2 — repo-b
+cd ~/projects/repo-b/.daemon-root
+xylem daemon
+```
+
+Each daemon scans its own sources, maintains its own queue, and spawns Claude sessions in its own isolated worktrees. They do not interfere with each other.


### PR DESCRIPTION
## Summary

- Adds `docs/multi-repo.md` — comprehensive user-facing guide covering setup, the isolation model (separate flocks/queues/state dirs), resource awareness, cost budgets, observability limitations, and the PID-reuse known limitation
- Updates `CLAUDE.md` with an agent-facing "Multi-repo operation" section summarising the key isolation facts
- Adds cross-reference notes to `docs/configuration.md` under `concurrency` and `cost.daily_budget_usd`

Closes #446

## Test plan

- [ ] `docs/multi-repo.md` renders correctly (links, table formatting)
- [ ] Cross-references from `docs/configuration.md` point to correct anchors in `multi-repo.md`
- [ ] No code changes — CI passes trivially

🤖 Generated with [Claude Code](https://claude.com/claude-code)