### PR TITLE
fix: replace bash process substitution with POSIX temp file in backlog-refinement apply_actions

### DIFF
--- a/cli/internal/profiles/self-hosting-xylem/workflows/backlog-refinement.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/backlog-refinement.yaml
@@ -54,6 +54,10 @@ phases:
         exit 0
       fi
 
+      ACTIONS_TMP=$(mktemp)
+      trap 'rm -f "$ACTIONS_TMP"' EXIT
+      jq -c '.actions[]' "$ACTIONS_FILE" > "$ACTIONS_TMP"
+
       LABEL_EDITS=0
       COMMENTS=0
       while IFS= read -r action; do
@@ -72,7 +76,7 @@ phases:
         fi
 
         sleep 1
-      done < <(jq -c '.actions[]' "$ACTIONS_FILE")
+      done < "$ACTIONS_TMP"
 
       echo "Applied ${ACTION_COUNT} backlog actions (${LABEL_EDITS} label edits, ${COMMENTS} comments)"
   - name: persist_summary


### PR DESCRIPTION
## Summary

Fixes https://github.com/nicholls-inc/xylem/issues/452.

The `apply_actions` phase in `backlog-refinement.yaml` used bash-only process substitution (`< <(...)`) in its `run` script. The runner executes phase scripts via `sh -c`, which on many systems resolves to `dash` or another POSIX shell that does not support process substitution. This caused `apply_actions` to fail silently with a syntax error whenever the workflow ran.

The fix replaces the process substitution with a POSIX-compatible temp file pattern:

```sh
ACTIONS_TMP=$(mktemp)
trap 'rm -f "$ACTIONS_TMP"' EXIT
jq -c '.actions[]' "$ACTIONS_FILE" > "$ACTIONS_TMP"
while IFS= read -r action; do
  ...
done < "$ACTIONS_TMP"
```

This approach:
- Is fully POSIX-compatible (`sh`, `dash`, `bash`, `zsh --emulate sh`)
- Preserves `LABEL_EDITS` and `COMMENTS` counter variables in the main shell process (piping into `while` would run it in a subshell, losing counter values)
- Cleans up the temp file on exit via `trap`

**Note:** The live copy at `.xylem/workflows/backlog-refinement.yaml` is a protected surface and has not been modified. It will sync from this profile template on the next `xylem init` run.

## Smoke scenarios covered

No smoke scenario IDs are assigned to this issue. The fix is in a shell script embedded in a YAML workflow file. The `cli/internal/profiles` package test (`go test ./internal/profiles/...`) validates that the profile template YAML parses correctly — it passed.

## Changes summary

**Modified:**
- `cli/internal/profiles/self-hosting-xylem/workflows/backlog-refinement.yaml`
  - Added `ACTIONS_TMP=$(mktemp)` and `trap 'rm -f "$ACTIONS_TMP"' EXIT` before the while loop
  - Added `jq -c '.actions[]' "$ACTIONS_FILE" > "$ACTIONS_TMP"` to populate the temp file
  - Changed `done < <(jq -c '.actions[]' "$ACTIONS_FILE")` to `done < "$ACTIONS_TMP"`

**Unchanged:** `.xylem/workflows/backlog-refinement.yaml` (protected surface — syncs from profile on next init)

## Test plan

- [x] `go vet ./...` — passes
- [x] `go build ./cmd/xylem` — passes
- [x] `go test ./...` — all packages pass (one pre-existing sandbox TCP bind failure in `gate` unrelated to this change)
- [x] `check yaml` pre-commit hook — passes
- [ ] Manual: run `xylem drain` with a vessel targeting the `backlog-refinement` workflow to confirm `apply_actions` executes without `Syntax error: redirection unexpected`

Fixes #452