### PR TITLE
fix: walk up from CWD to find .xylem.yml when CLI runs from subdirectory

### DIFF
--- a/cli/cmd/xylem/root.go
+++ b/cli/cmd/xylem/root.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -31,7 +33,7 @@ func newRootCmd() *cobra.Command {
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			commandPath := cmd.CommandPath()
-			if cmd.Name() == "init" || cmd.Name() == "shim-dispatch" || cmd.Name() == "version" || commandPath == "xylem dtu" || strings.HasPrefix(commandPath, "xylem dtu ") || commandPath == "xylem bootstrap" || strings.HasPrefix(commandPath, "xylem bootstrap ") || commandPath == "xylem config" || strings.HasPrefix(commandPath, "xylem config ") || strings.HasPrefix(commandPath, "xylem continuous-simplicity") {
+			if cmd.Name() == "init" || cmd.Name() == "shim-dispatch" || cmd.Name() == "version" || commandPath == "xylem dtu" || strings.HasPrefix(commandPath, "xylem dtu ") || commandPath == "xylem bootstrap" || strings.HasPrefix(commandPath, "xylem bootstrap ") || commandPath == "xylem config" || strings.HasPrefix(commandPath, "xylem config ") {
 				return nil
 			}
 
@@ -65,7 +67,7 @@ func newRootCmd() *cobra.Command {
 				}
 			}
 
-			configPath := viper.GetString("config")
+			configPath := findConfigPath(viper.GetString("config"))
 			cfg, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("error loading config %s: %w", configPath, err)
@@ -134,6 +136,38 @@ func newRootCmd() *cobra.Command {
 	)
 
 	return cmd
+}
+
+// findConfigPath resolves a config file path by walking up from CWD.
+// Only walks up for bare filenames (no directory component) that don't exist
+// at the current working directory. Absolute paths and explicit relative paths
+// (e.g. "../foo.yml") are returned unchanged. Returns the original path if
+// no ancestor contains the file, preserving the error message from config.Load.
+func findConfigPath(path string) string {
+	if _, err := os.Stat(path); err == nil {
+		return path // already accessible at CWD
+	}
+	// Only walk up for bare filenames — explicit relative paths like
+	// "../custom.yml" are left unchanged so the caller gets a clear error.
+	if filepath.Base(path) != path {
+		return path
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		return path // CWD unavailable; surface error at config.Load
+	}
+	for {
+		candidate := filepath.Join(dir, path)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return path // not found; return original so error message is useful
 }
 
 func hasGitHubSource(cfg *config.Config) bool {

--- a/cli/cmd/xylem/root_prop_test.go
+++ b/cli/cmd/xylem/root_prop_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestPropFindConfigPath_NeverPanics(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		path := rapid.String().Draw(rt, "path")
+		// Must not panic regardless of input.
+		_ = findConfigPath(path)
+	})
+}
+
+func TestPropFindConfigPath_AbsoluteInputPassthrough(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		// Generate a plausible absolute path by prepending a separator.
+		rel := rapid.StringMatching(`[a-zA-Z0-9_.-]{1,30}`).Draw(rt, "rel")
+		abs := string(filepath.Separator) + rel
+		got := findConfigPath(abs)
+		if got != abs {
+			rt.Fatalf("findConfigPath(%q) = %q, want passthrough %q", abs, got, abs)
+		}
+	})
+}
+
+func TestPropFindConfigPath_FoundFileIsAccessible(t *testing.T) {
+	// Capture CWD once, before rapid.Check, so we can restore between iterations.
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+
+	rapid.Check(t, func(rt *rapid.T) {
+		// Restore CWD after each iteration so the next iteration starts clean.
+		defer os.Chdir(origWD) //nolint:errcheck
+
+		depth := rapid.IntRange(1, 4).Draw(rt, "depth")
+
+		rootDir := t.TempDir()
+
+		// Build a leaf directory nested `depth` levels under rootDir.
+		leafDir := rootDir
+		for i := 0; i < depth; i++ {
+			leafDir = filepath.Join(leafDir, "sub")
+		}
+		if err := os.MkdirAll(leafDir, 0o755); err != nil {
+			rt.Fatalf("MkdirAll: %v", err)
+		}
+
+		// Place .xylem.yml at rootDir (the top of the temp tree).
+		configFile := filepath.Join(rootDir, ".xylem.yml")
+		if err := os.WriteFile(configFile, []byte("repo: test\n"), 0o644); err != nil {
+			rt.Fatalf("WriteFile: %v", err)
+		}
+
+		if err := os.Chdir(leafDir); err != nil {
+			rt.Fatalf("Chdir: %v", err)
+		}
+
+		got := findConfigPath(".xylem.yml")
+
+		if _, err := os.Stat(got); err != nil {
+			rt.Fatalf("returned path %q is not accessible: %v", got, err)
+		}
+	})
+}

--- a/cli/cmd/xylem/root_test.go
+++ b/cli/cmd/xylem/root_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindConfigPath_FileAtCWD(t *testing.T) {
+	dir := t.TempDir()
+	origWD, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+
+	configFile := filepath.Join(dir, ".xylem.yml")
+	if err := os.WriteFile(configFile, []byte("repo: owner/repo\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := findConfigPath(".xylem.yml")
+	if got != ".xylem.yml" {
+		t.Errorf("got %q, want %q", got, ".xylem.yml")
+	}
+}
+
+func TestFindConfigPath_FileAtParent(t *testing.T) {
+	rootDir := t.TempDir()
+	subDir := filepath.Join(rootDir, "cli")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	configFile := filepath.Join(rootDir, ".xylem.yml")
+	if err := os.WriteFile(configFile, []byte("repo: owner/repo\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	origWD, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+	if err := os.Chdir(subDir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+
+	got := findConfigPath(".xylem.yml")
+	// Resolve symlinks for comparison (macOS /var -> /private/var).
+	wantReal, _ := filepath.EvalSymlinks(configFile)
+	gotReal, _ := filepath.EvalSymlinks(got)
+	if gotReal != wantReal {
+		t.Errorf("got %q (real: %q), want %q (real: %q)", got, gotReal, configFile, wantReal)
+	}
+}
+
+func TestFindConfigPath_FileAtGrandparent(t *testing.T) {
+	rootDir := t.TempDir()
+	leafDir := filepath.Join(rootDir, "cli", "cmd")
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	configFile := filepath.Join(rootDir, ".xylem.yml")
+	if err := os.WriteFile(configFile, []byte("repo: owner/repo\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	origWD, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+	if err := os.Chdir(leafDir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+
+	got := findConfigPath(".xylem.yml")
+	// Resolve symlinks for comparison (macOS /var -> /private/var).
+	wantReal, _ := filepath.EvalSymlinks(configFile)
+	gotReal, _ := filepath.EvalSymlinks(got)
+	if gotReal != wantReal {
+		t.Errorf("got %q (real: %q), want %q (real: %q)", got, gotReal, configFile, wantReal)
+	}
+}
+
+func TestFindConfigPath_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	origWD, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+
+	got := findConfigPath(".xylem.yml")
+	if got != ".xylem.yml" {
+		t.Errorf("got %q, want original %q", got, ".xylem.yml")
+	}
+}
+
+func TestFindConfigPath_AbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	abs := filepath.Join(dir, ".xylem.yml")
+	// File doesn't exist — absolute paths must not be walked up.
+	got := findConfigPath(abs)
+	if got != abs {
+		t.Errorf("got %q, want %q", got, abs)
+	}
+}
+
+func TestFindConfigPath_ExplicitRelativePath(t *testing.T) {
+	dir := t.TempDir()
+	origWD, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+
+	// A relative path with a directory component is left unchanged.
+	rel := "../custom.yml"
+	got := findConfigPath(rel)
+	if got != rel {
+		t.Errorf("got %q, want %q", got, rel)
+	}
+}
+
+func TestPersistentPreRunE_LoadsConfigFromParentDir(t *testing.T) {
+	rootDir := t.TempDir()
+	subDir := filepath.Join(rootDir, "cli")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	configPath := filepath.Join(rootDir, ".xylem.yml")
+	if err := cmdInit(configPath, false); err != nil {
+		t.Fatalf("cmdInit: %v", err)
+	}
+
+	// Also create a minimal state dir so Queue.New doesn't fail.
+	stateDir := filepath.Join(rootDir, ".xylem", "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll state: %v", err)
+	}
+
+	origWD, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(origWD) }) //nolint:errcheck
+	if err := os.Chdir(subDir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+
+	// Use daemon stop — it's in skipTooling so no git/gh tooling check runs.
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"daemon", "stop"})
+
+	// Should not fail with "no such file" — walk-up finds config at rootDir.
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("Execute() error = %v (expected config to be found via walk-up)", err)
+	}
+
+	// Confirm PersistentPreRunE actually populated deps from the walked-up config.
+	if deps == nil {
+		t.Fatal("deps is nil: PersistentPreRunE did not run or failed silently")
+	}
+	if deps.cfg == nil {
+		t.Fatal("deps.cfg is nil: config was not loaded")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/nicholls-inc/xylem/issues/453.

CLI subcommands (`gap-report`, `continuous-simplicity plan-prs`, etc.) failed when invoked from the `cli/` subdirectory because `viper.GetString("config")` returns the bare default `".xylem.yml"`, which resolves relative to CWD. When CWD is `cli/`, no config file exists there and every command aborted with `open .xylem.yml: no such file or directory`.

## Changes

### `cli/cmd/xylem/root.go`

- **Added `findConfigPath(path string) string`** — walks up from CWD to find a bare config filename (e.g. `.xylem.yml`) when it is not present at the current directory. Only walks for bare filenames (no directory component); absolute paths and explicit relative paths like `../foo.yml` are returned unchanged. Returns the original path if nothing is found so that `config.Load` produces a clear error.
- **Wired `findConfigPath` into `PersistentPreRunE`** — replaces the bare `viper.GetString("config")` call.
- **Removed `continuous-simplicity` exclusion from `PersistentPreRunE`** — this was a workaround for the config-not-found bug. With walk-up discovery in place, `plan-prs` correctly receives a populated `deps.cfg` and `effectiveRepo` returns the right value.

### `cli/cmd/xylem/root_test.go` (new)

Unit and integration tests:
- `TestFindConfigPath_FileAtCWD` — file present at CWD, path returned unchanged
- `TestFindConfigPath_FileAtParent` — CWD is `rootDir/cli`, config at `rootDir/.xylem.yml`
- `TestFindConfigPath_FileAtGrandparent` — two levels up
- `TestFindConfigPath_NotFound` — nowhere on walk, original path returned
- `TestFindConfigPath_AbsolutePath` — absolute input, no walk
- `TestFindConfigPath_ExplicitRelativePath` — `../custom.yml` returned unchanged
- `TestPersistentPreRunE_LoadsConfigFromParentDir` — `os.Chdir` into `cli/` subdir, run `daemon stop` without `--config`, assert no error and `deps.cfg` is populated

### `cli/cmd/xylem/root_prop_test.go` (new)

Property-based tests:
- `TestPropFindConfigPath_NeverPanics` — arbitrary string inputs never panic
- `TestPropFindConfigPath_AbsoluteInputPassthrough` — absolute paths always pass through unchanged
- `TestPropFindConfigPath_FoundFileIsAccessible` — when a file is placed at a random ancestor depth, the returned path is always `os.Stat`-accessible

## Smoke scenarios covered

No smoke scenario IDs are assigned to issue #453 (standalone bug fix outside the WS1–WS8 harness workstreams). The behavioral contract is covered by the unit and property tests above.

## Test plan

- `go vet ./...` — passes
- `go build ./cmd/xylem` — passes
- `go test ./...` — all packages pass (pre-existing `TestRunVesselLiveHTTPGatePersistsObservedInSituEvidence` panic in `internal/runner` is unrelated to this change and reproduced on `main` without modifications)
- `go test ./cmd/xylem -run 'TestFindConfigPath|TestPersistentPreRunE|TestPropFindConfigPath'` — all new tests pass

Fixes #453