### PR TITLE
fix: backlog-refinement active workflow still has bash-only process substitution

### DIFF
--- a/.xylem/workflows/backlog-refinement.yaml
+++ b/.xylem/workflows/backlog-refinement.yaml
@@ -54,6 +54,10 @@ phases:
         exit 0
       fi
 
+      ACTIONS_TMP=$(mktemp)
+      trap 'rm -f "$ACTIONS_TMP"' EXIT
+      jq -c '.actions[]' "$ACTIONS_FILE" > "$ACTIONS_TMP"
+
       LABEL_EDITS=0
       COMMENTS=0
       while IFS= read -r action; do
@@ -72,7 +76,7 @@ phases:
         fi
 
         sleep 1
-      done < <(jq -c '.actions[]' "$ACTIONS_FILE")
+      done < "$ACTIONS_TMP"
 
       echo "Applied ${ACTION_COUNT} backlog actions (${LABEL_EDITS} label edits, ${COMMENTS} comments)"
   - name: persist_summary


### PR DESCRIPTION
## Summary

Fixes https://github.com/nicholls-inc/xylem/issues/456

PR #454 fixed the bash-only process substitution (`< <(...)`) in the profile template (`cli/internal/profiles/self-hosting-xylem/workflows/backlog-refinement.yaml`) but missed the **active workflow** at `.xylem/workflows/backlog-refinement.yaml`. The active file still used the bash-only form, causing `apply_actions` to fail with `exit status 2` when the runner executes via `sh -c`.

## Changes

**`.xylem/workflows/backlog-refinement.yaml`** — 5-line change:
- Insert `ACTIONS_TMP=$(mktemp)`, `trap 'rm -f "$ACTIONS_TMP"' EXIT`, and `jq -c '.actions[]' "$ACTIONS_FILE" > "$ACTIONS_TMP"` before the `LABEL_EDITS=0` line
- Replace `done < <(jq -c '.actions[]' "$ACTIONS_FILE")` with `done < "$ACTIONS_TMP"`

This mirrors the fix already present in the profile template since #454.

## Smoke Scenarios

No formal smoke scenario IDs — this issue has no associated spec doc. Behavioral validation: the `apply_actions` phase completes without `exit status 2` when executed under `/bin/sh` on the next daemon run.

## Test Plan

- `go vet ./...` — passes (no Go changes)
- `go build ./cmd/xylem` — passes (no Go changes)
- `go test ./...` — all pass (no Go changes)
- Runtime: `apply_actions` phase must execute cleanly under `sh -c` without bash process substitution error

Fixes #456