### PR TITLE
fix: backlog-refinement apply_actions jq parse error on LLM-generated JSON with control chars

### DIFF
--- a/.xylem/prompts/backlog-refinement/analyze.md
+++ b/.xylem/prompts/backlog-refinement/analyze.md
@@ -118,7 +118,8 @@ Write valid JSON with this exact shape:
 Rules:
 
 - `add_labels` must contain only labels that already exist and are not already on the issue
-- `comment` may be empty, but never null
+- `comment` may be empty, but never null; use JSON escape sequences (`\n`, `\t`) for
+  newlines and tabs — never embed literal control characters in any string field
 - `confidence` must be between `0` and `1`
 - if there are no safe actions, still write a valid file with `"actions": []`
 

--- a/.xylem/workflows/backlog-refinement.yaml
+++ b/.xylem/workflows/backlog-refinement.yaml
@@ -48,6 +48,45 @@ phases:
         exit 1
       fi
 
+      # Sanitize literal control chars from LLM-generated JSON string values.
+      # LLMs sometimes embed raw newlines inside "comment" fields; jq rejects
+      # those per RFC 8259. This rewrites the file with properly escaped strings.
+      python3 -c '
+      import sys, json
+
+      def sanitize_json(text):
+          result = []
+          in_string = False
+          escaped = False
+          for ch in text:
+              if escaped:
+                  result.append(ch)
+                  escaped = False
+              elif ch == "\\" and in_string:
+                  result.append(ch)
+                  escaped = True
+              elif ch == "\"":
+                  result.append(ch)
+                  in_string = not in_string
+              elif in_string and ch == "\n":
+                  result.append("\\n")
+              elif in_string and ch == "\r":
+                  result.append("\\r")
+              elif in_string and ch == "\t":
+                  result.append("\\t")
+              else:
+                  result.append(ch)
+          return "".join(result)
+
+      filepath = sys.argv[1]
+      with open(filepath) as f:
+          raw = f.read()
+      sanitized = sanitize_json(raw)
+      data = json.loads(sanitized)
+      with open(filepath, "w") as f:
+          json.dump(data, f, ensure_ascii=False)
+      ' "$ACTIONS_FILE"
+
       ACTION_COUNT=$(jq '.actions | length' "$ACTIONS_FILE")
       if [ "$ACTION_COUNT" -eq 0 ]; then
         echo "No backlog refinement actions planned"

--- a/cli/internal/profiles/self-hosting-xylem/prompts/backlog-refinement/analyze.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/backlog-refinement/analyze.md
@@ -118,7 +118,8 @@ Write valid JSON with this exact shape:
 Rules:
 
 - `add_labels` must contain only labels that already exist and are not already on the issue
-- `comment` may be empty, but never null
+- `comment` may be empty, but never null; use JSON escape sequences (`\n`, `\t`) for
+  newlines and tabs — never embed literal control characters in any string field
 - `confidence` must be between `0` and `1`
 - if there are no safe actions, still write a valid file with `"actions": []`
 

--- a/cli/internal/profiles/self-hosting-xylem/workflows/backlog-refinement.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/backlog-refinement.yaml
@@ -48,6 +48,45 @@ phases:
         exit 1
       fi
 
+      # Sanitize literal control chars from LLM-generated JSON string values.
+      # LLMs sometimes embed raw newlines inside "comment" fields; jq rejects
+      # those per RFC 8259. This rewrites the file with properly escaped strings.
+      python3 -c '
+      import sys, json
+
+      def sanitize_json(text):
+          result = []
+          in_string = False
+          escaped = False
+          for ch in text:
+              if escaped:
+                  result.append(ch)
+                  escaped = False
+              elif ch == "\\" and in_string:
+                  result.append(ch)
+                  escaped = True
+              elif ch == "\"":
+                  result.append(ch)
+                  in_string = not in_string
+              elif in_string and ch == "\n":
+                  result.append("\\n")
+              elif in_string and ch == "\r":
+                  result.append("\\r")
+              elif in_string and ch == "\t":
+                  result.append("\\t")
+              else:
+                  result.append(ch)
+          return "".join(result)
+
+      filepath = sys.argv[1]
+      with open(filepath) as f:
+          raw = f.read()
+      sanitized = sanitize_json(raw)
+      data = json.loads(sanitized)
+      with open(filepath, "w") as f:
+          json.dump(data, f, ensure_ascii=False)
+      ' "$ACTIONS_FILE"
+
       ACTION_COUNT=$(jq '.actions | length' "$ACTIONS_FILE")
       if [ "$ACTION_COUNT" -eq 0 ]; then
         echo "No backlog refinement actions planned"


### PR DESCRIPTION
## Summary

Fixes https://github.com/nicholls-inc/xylem/issues/458

The `apply_actions` phase of the `backlog-refinement` scheduled workflow failed 5 consecutive times with a `jq` parse error. Root cause: when the LLM writes a multi-line `comment` string with literal newline bytes (0x0A) inside the `actions.json` output, `jq` rejects the file per RFC 8259. With `set -euo pipefail` the phase aborts immediately.

Two complementary fixes applied across all four affected files (active deployed + profile templates):

1. **Sanitizer** — a Python state-machine is inserted in the `apply_actions` phase before any `jq` call. It walks the raw JSON character-by-character, tracks whether it is inside a string, and rewrites literal `\n`, `\r`, `\t` to their RFC 8259 escape sequences. After sanitizing, it round-trips through `json.loads`/`json.dump` to produce canonical JSON and overwrites the file in place.

2. **Prompt guidance** — the `actions.json` contract in `analyze.md` now explicitly instructs the LLM to use JSON escape sequences (`\n`, `\t`) for newlines and tabs, never embedding literal control characters in any string field.

## Smoke scenarios covered

No smoke scenario IDs are assigned to this issue (no entries in `docs/design/harness-smoke-scenarios/` reference `apply_actions` or `backlog-refinement` jq behavior). Validation is integration-only: the next scheduled `backlog-refinement` run succeeds through `apply_actions` without a jq parse error.

## Changes summary

**Files modified (4):**

- `.xylem/workflows/backlog-refinement.yaml` — added 38-line Python sanitizer block in `apply_actions` phase between the file-existence check and the first `jq` call
- `cli/internal/profiles/self-hosting-xylem/workflows/backlog-refinement.yaml` — identical change to profile template (kept in sync)
- `.xylem/prompts/backlog-refinement/analyze.md` — amended `comment` rule in `actions.json` contract to require JSON escape sequences for control characters
- `cli/internal/profiles/self-hosting-xylem/prompts/backlog-refinement/analyze.md` — identical change to profile template prompt

**Key functions/logic:**

- `sanitize_json(text)` — Python state-machine function embedded in the workflow shell script; handles `\\` escape sequences correctly (including `\\"` and `\\\\` edge cases)
- Uses `ensure_ascii=False` on `json.dump` to preserve non-ASCII characters in UTF-8 rather than `\uXXXX`-encoding them
- If the LLM produces structurally invalid JSON (beyond control-char issues), `json.loads` raises `JSONDecodeError` and the phase fails loudly with a Python traceback — correct behavior

## Test plan

- [ ] All Go tests pass: `go test ./...` from `cli/` — confirmed clean (no Go changes)
- [ ] `go vet ./...` passes — confirmed
- [ ] `go build ./cmd/xylem` passes — confirmed
- [ ] Next scheduled `backlog-refinement` run (04:00 UTC) succeeds through the `apply_actions` phase without a jq parse error
- [ ] Verify both active workflow and profile template are identical at the `apply_actions` phase

Fixes #458