### PR TITLE
feat: add skip_first_run to schedule sources to suppress first-run vessels

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -118,16 +118,17 @@ type TierRouting struct {
 }
 
 type SourceConfig struct {
-	Type     string          `yaml:"type"`
-	Repo     string          `yaml:"repo,omitempty"`
-	Schedule string          `yaml:"schedule,omitempty"`
-	Cadence  string          `yaml:"cadence,omitempty"`
-	Workflow string          `yaml:"workflow,omitempty"`
-	LLM      string          `yaml:"llm,omitempty"`
-	Model    string          `yaml:"model,omitempty"`
-	Timeout  string          `yaml:"timeout,omitempty"`
-	Exclude  []string        `yaml:"exclude,omitempty"`
-	Tasks    map[string]Task `yaml:"tasks,omitempty"`
+	Type         string          `yaml:"type"`
+	Repo         string          `yaml:"repo,omitempty"`
+	Schedule     string          `yaml:"schedule,omitempty"`
+	Cadence      string          `yaml:"cadence,omitempty"`
+	Workflow     string          `yaml:"workflow,omitempty"`
+	LLM          string          `yaml:"llm,omitempty"`
+	Model        string          `yaml:"model,omitempty"`
+	Timeout      string          `yaml:"timeout,omitempty"`
+	Exclude      []string        `yaml:"exclude,omitempty"`
+	Tasks        map[string]Task `yaml:"tasks,omitempty"`
+	SkipFirstRun bool            `yaml:"skip_first_run,omitempty"`
 }
 
 type StatusLabels struct {
@@ -1803,6 +1804,9 @@ func validateGitHubSource(name string, src SourceConfig) error {
 	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
 		return fmt.Errorf("source %q (github): repo must be in owner/name format", name)
 	}
+	if src.SkipFirstRun {
+		return fmt.Errorf("source %q (github): skip_first_run is only valid for type: schedule", name)
+	}
 	if len(src.Tasks) == 0 {
 		return fmt.Errorf("source %q (github): at least one task is required", name)
 	}
@@ -1825,6 +1829,9 @@ func validateGitHubPREventsSource(name string, src SourceConfig) error {
 	parts := strings.Split(repo, "/")
 	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
 		return fmt.Errorf("source %q (github-pr-events): repo must be in owner/name format", name)
+	}
+	if src.SkipFirstRun {
+		return fmt.Errorf("source %q (github-pr-events): skip_first_run is only valid for type: schedule", name)
 	}
 	if len(src.Tasks) == 0 {
 		return fmt.Errorf("source %q (github-pr-events): at least one task is required", name)
@@ -1872,6 +1879,9 @@ func validateGitHubMergeSource(name string, src SourceConfig) error {
 	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
 		return fmt.Errorf("source %q (github-merge): repo must be in owner/name format", name)
 	}
+	if src.SkipFirstRun {
+		return fmt.Errorf("source %q (github-merge): skip_first_run is only valid for type: schedule", name)
+	}
 	if len(src.Tasks) == 0 {
 		return fmt.Errorf("source %q (github-merge): at least one task is required", name)
 	}
@@ -1898,6 +1908,9 @@ func validateScheduledSource(name string, src SourceConfig) error {
 	if _, err := parseScheduleValue(src.Schedule); err != nil {
 		return fmt.Errorf("source %q (scheduled): schedule is invalid: %w", name, err)
 	}
+	if src.SkipFirstRun {
+		return fmt.Errorf("source %q (scheduled): skip_first_run is only valid for type: schedule", name)
+	}
 	if len(src.Tasks) == 0 {
 		return fmt.Errorf("source %q (scheduled): at least one task is required", name)
 	}
@@ -1917,6 +1930,9 @@ func validateGitHubActionsSource(name string, src SourceConfig) error {
 	parts := strings.Split(repo, "/")
 	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
 		return fmt.Errorf("source %q (github-actions): repo must be in owner/name format", name)
+	}
+	if src.SkipFirstRun {
+		return fmt.Errorf("source %q (github-actions): skip_first_run is only valid for type: schedule", name)
 	}
 	if len(src.Tasks) == 0 {
 		return fmt.Errorf("source %q (github-actions): at least one task is required", name)

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -545,6 +545,86 @@ func TestValidateRejectsInvalidPhaseStallThreshold(t *testing.T) {
 	requireErrorContains(t, cfg.Validate(), "daemon.stall_monitor.phase_stall_threshold")
 }
 
+func TestValidateScheduledSourceRejectsSkipFirstRun(t *testing.T) {
+	cfg := validConfig()
+	cfg.Sources = map[string]SourceConfig{
+		"weekly-jobs": {
+			Type:         "scheduled",
+			Repo:         "owner/repo",
+			Schedule:     "@weekly",
+			SkipFirstRun: true,
+			Tasks: map[string]Task{
+				"job": {Workflow: "some-workflow"},
+			},
+		},
+	}
+
+	requireErrorContains(t, cfg.Validate(), `source "weekly-jobs" (scheduled): skip_first_run is only valid for type: schedule`)
+}
+
+func TestValidateGitHubSourceRejectsSkipFirstRun(t *testing.T) {
+	cfg := validConfig()
+	cfg.Sources = map[string]SourceConfig{
+		"my-github": {
+			Type:         "github",
+			Repo:         "owner/repo",
+			SkipFirstRun: true,
+			Tasks: map[string]Task{
+				"fix": {Labels: []string{"xylem"}, Workflow: "fix-bug"},
+			},
+		},
+	}
+	requireErrorContains(t, cfg.Validate(), `source "my-github" (github): skip_first_run is only valid for type: schedule`)
+}
+
+func TestValidateGitHubPREventsSourceRejectsSkipFirstRun(t *testing.T) {
+	cfg := validConfig()
+	cfg.Sources = map[string]SourceConfig{
+		"my-pr-events": {
+			Type:         "github-pr-events",
+			Repo:         "owner/repo",
+			SkipFirstRun: true,
+			Tasks: map[string]Task{
+				"review": {
+					Workflow: "fix-bug",
+					On:       &PREventsConfig{Labels: []string{"xylem"}},
+				},
+			},
+		},
+	}
+	requireErrorContains(t, cfg.Validate(), `source "my-pr-events" (github-pr-events): skip_first_run is only valid for type: schedule`)
+}
+
+func TestValidateGitHubMergeSourceRejectsSkipFirstRun(t *testing.T) {
+	cfg := validConfig()
+	cfg.Sources = map[string]SourceConfig{
+		"my-merge": {
+			Type:         "github-merge",
+			Repo:         "owner/repo",
+			SkipFirstRun: true,
+			Tasks: map[string]Task{
+				"merge": {Workflow: "merge-pr"},
+			},
+		},
+	}
+	requireErrorContains(t, cfg.Validate(), `source "my-merge" (github-merge): skip_first_run is only valid for type: schedule`)
+}
+
+func TestValidateGitHubActionsSourceRejectsSkipFirstRun(t *testing.T) {
+	cfg := validConfig()
+	cfg.Sources = map[string]SourceConfig{
+		"my-actions": {
+			Type:         "github-actions",
+			Repo:         "owner/repo",
+			SkipFirstRun: true,
+			Tasks: map[string]Task{
+				"fix": {Workflow: "fix-bug"},
+			},
+		},
+	}
+	requireErrorContains(t, cfg.Validate(), `source "my-actions" (github-actions): skip_first_run is only valid for type: schedule`)
+}
+
 func TestValidateScheduleSourceRejectsMalformedCadence(t *testing.T) {
 	cfg := validConfig()
 	cfg.Sources = map[string]SourceConfig{

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -222,11 +222,12 @@ func (s *Scanner) buildSources() []sourceEntry {
 		case "schedule":
 			entries = append(entries, sourceEntry{
 				src: &source.Schedule{
-					ConfigName: name,
-					Cadence:    srcCfg.Cadence,
-					Workflow:   srcCfg.Workflow,
-					StateDir:   s.Config.StateDir,
-					Queue:      s.Queue,
+					ConfigName:   name,
+					Cadence:      srcCfg.Cadence,
+					Workflow:     srcCfg.Workflow,
+					StateDir:     s.Config.StateDir,
+					Queue:        s.Queue,
+					SkipFirstRun: srcCfg.SkipFirstRun,
 				},
 				configName: name,
 			})

--- a/cli/internal/source/schedule.go
+++ b/cli/internal/source/schedule.go
@@ -19,12 +19,13 @@ import (
 const legacyScheduleStateFileName = "schedule-state.json"
 
 type Schedule struct {
-	ConfigName string
-	Cadence    string
-	Workflow   string
-	StateDir   string
-	Queue      *queue.Queue
-	Now        func() time.Time
+	ConfigName   string
+	Cadence      string
+	Workflow     string
+	StateDir     string
+	Queue        *queue.Queue
+	Now          func() time.Time
+	SkipFirstRun bool
 }
 
 type scheduleStateRecord struct {
@@ -53,6 +54,10 @@ func (s *Schedule) Scan(_ context.Context) ([]queue.Vessel, error) {
 	lastFiredAt, err := s.loadLastFiredAt()
 	if err != nil {
 		return nil, fmt.Errorf("schedule source %q: load last fired state: %w", s.ConfigName, err)
+	}
+
+	if lastFiredAt == nil && s.SkipFirstRun {
+		return nil, nil
 	}
 
 	firedAt, due := spec.FireTime(lastFiredAt, s.now())

--- a/cli/internal/source/schedule_test.go
+++ b/cli/internal/source/schedule_test.go
@@ -463,3 +463,77 @@ func TestSmoke_S3_ScheduleFallsBackToLegacyStateAndWritesRuntimeState(t *testing
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"lessons":{"cadence":"@daily","last_fired_at":"2026-04-09T06:00:00Z","next_due_at":"2026-04-10T00:00:00Z","last_vessel":"schedule-lessons-20260409t060000z"}}`, string(legacyBytes))
 }
+
+func TestScheduleScanSkipFirstRunSuppressesOnFirstScan(t *testing.T) {
+	now := time.Date(2026, time.April, 9, 6, 45, 12, 0, time.UTC)
+	s := &Schedule{
+		ConfigName:   "field-report",
+		Cadence:      "1h",
+		Workflow:     "field-report",
+		StateDir:     t.TempDir(),
+		Queue:        queue.New(filepath.Join(t.TempDir(), "queue.jsonl")),
+		SkipFirstRun: true,
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	vessels, err := s.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, vessels, "expected no vessel on first scan when skip_first_run=true")
+}
+
+func TestScheduleScanSkipFirstRunFiresAfterOnEnqueue(t *testing.T) {
+	stateDir := t.TempDir()
+	q := queue.New(filepath.Join(t.TempDir(), "queue.jsonl"))
+	now := time.Date(2026, time.April, 9, 6, 0, 0, 0, time.UTC)
+	s := &Schedule{
+		ConfigName:   "field-report",
+		Cadence:      "1h",
+		Workflow:     "field-report",
+		StateDir:     stateDir,
+		Queue:        q,
+		SkipFirstRun: true,
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	// First scan: skipped because no prior state.
+	vessels, err := s.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, vessels, "expected no vessel on first scan when skip_first_run=true")
+
+	// Simulate OnEnqueue by writing state directly via a non-skip-first-run instance.
+	bootstrapper := &Schedule{
+		ConfigName: "field-report",
+		StateDir:   stateDir,
+	}
+	require.NoError(t, bootstrapper.storeLastFiredAt(now))
+
+	// After state exists, advance time by cadence — should fire normally.
+	now = now.Add(time.Hour)
+	second, err := s.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, second, 1, "expected one vessel after cadence elapsed")
+	assert.Equal(t, "field-report", second[0].Meta["schedule.source_name"])
+}
+
+func TestScheduleScanSkipFirstRunFalseDefaultBehavior(t *testing.T) {
+	now := time.Date(2026, time.April, 9, 6, 45, 12, 0, time.UTC)
+	s := &Schedule{
+		ConfigName:   "field-report",
+		Cadence:      "1h",
+		Workflow:     "field-report",
+		StateDir:     t.TempDir(),
+		Queue:        queue.New(filepath.Join(t.TempDir(), "queue.jsonl")),
+		SkipFirstRun: false,
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	vessels, err := s.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, vessels, 1, "expected one vessel on first scan when skip_first_run=false")
+}


### PR DESCRIPTION
## Summary

- Adds `skip_first_run: true` opt-in field to `SourceConfig` (config YAML)
- When set and `loadLastFiredAt()` returns `nil` (no prior state — definitively a first run for this source), `Schedule.Scan()` returns `nil` without emitting a vessel
- Subsequent runs after `OnEnqueue` persists the fired-at state proceed normally under the regular cadence
- Validation rejects `skip_first_run` on `type: scheduled` sources with a clear error message
- Passes `SkipFirstRun` through `scanner.go` when constructing `source.Schedule{}`

## Test plan

- [ ] `TestScheduleScanSkipFirstRunSuppressesOnFirstScan` — `SkipFirstRun: true`, no state file → `Scan()` returns nil
- [ ] `TestScheduleScanSkipFirstRunFiresAfterOnEnqueue` — `SkipFirstRun: true`, after `OnEnqueue` persists state, advance time → vessel emitted normally
- [ ] `TestScheduleScanSkipFirstRunFalseDefaultBehavior` — `SkipFirstRun: false` (explicit) → first scan still emits vessel (regression guard)
- [ ] Config validation test: `skip_first_run: true` on `type: scheduled` source fails validation

Closes https://github.com/nicholls-inc/xylem/issues/463

🤖 Generated with [Claude Code](https://claude.com/claude-code)