### PR TITLE
feat: add daily doc-garden scheduled workflow

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -171,6 +171,16 @@ sources:
         workflow: backlog-refinement
         ref: backlog-refinement
 
+  doc-garden:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "@daily"
+    timeout: "90m"
+    tasks:
+      doc-garden:
+        workflow: doc-garden
+        ref: doc-garden
+
   harness-gap-analysis:
     type: scheduled
     repo: nicholls-inc/xylem


### PR DESCRIPTION
## Summary
- Adds a `@daily` scheduled trigger for the `doc-garden` workflow to `.xylem.yml`
- Detects and repairs stale documentation drift on a recurring cadence
- Uses 90m timeout, matching other daily maintenance workflows

## Test plan
- [ ] Daemon picks up the new source on next auto-upgrade
- [ ] `doc-garden` vessel fires on next daily schedule tick
- [ ] Workflow phases (analyze → implement → verify → pr) execute successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)