### PR TITLE
fix: daemon loads .env from daemon root, not double-nested path

### DIFF
--- a/cli/cmd/xylem/daemon_supervisor.go
+++ b/cli/cmd/xylem/daemon_supervisor.go
@@ -334,7 +334,7 @@ func daemonSupervisorCommandArgs(configPath string) []string {
 }
 
 func daemonSupervisorEnvFilePath(workingDir string) string {
-	return filepath.Join(workingDir, ".daemon-root", ".env")
+	return filepath.Join(workingDir, ".env")
 }
 
 func loadDaemonSupervisorEnvFile(path string) ([]string, error) {


### PR DESCRIPTION
## Summary

- `daemonSupervisorEnvFilePath` was constructing the `.env` path as `<workingDir>/.daemon-root/.env`
- Both callers (`cmdDaemon` and `cmdDaemonSupervisor`) already pass the daemon root as `workingDir`, so the resolved path was one level too deep
- Fix: drop the `.daemon-root` segment so the path resolves to `<daemonRoot>/.env` as intended

Fixes https://github.com/nicholls-inc/xylem/issues/467

## Test plan

- [ ] Existing `TestLoadDaemonStartupEnv` and `TestRunDaemonSupervisorRestartsAfterUnexpectedExitAndReloadsEnv` pass unchanged — they construct the path via `daemonSupervisorEnvFilePath` and automatically exercise the corrected path
- [ ] `go test ./cmd/xylem/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)