### PR TITLE
fix: replace gh search issues with gh issue list to avoid exit status 1 on empty results

### DIFF
--- a/cli/cmd/xylem/adapt_repo_seed.go
+++ b/cli/cmd/xylem/adapt_repo_seed.go
@@ -171,20 +171,20 @@ func findExistingAdaptRepoIssue(ctx context.Context, runner adaptRepoSeedRunner,
 }
 
 func findAdaptRepoIssueByState(ctx context.Context, runner adaptRepoSeedRunner, repo, state string) (*adaptRepoIssue, error) {
-	out, err := runner.Run(ctx, "gh", "search", "issues",
+	out, err := runner.Run(ctx, "gh", "issue", "list",
 		"--repo", repo,
 		"--state", state,
+		"--label", adaptRepoSeedLabel,
 		"--json", "number,title,url",
 		"--limit", "100",
-		"--search", adaptRepoIssueTitle,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("search adapt-repo seed issue in %s state: %w", state, err)
+		return nil, fmt.Errorf("list adapt-repo seed issues in %s state: %w", state, err)
 	}
 
 	var issues []adaptRepoIssue
 	if err := json.Unmarshal(out, &issues); err != nil {
-		return nil, fmt.Errorf("parse adapt-repo seed issue search output for %s state: %w", state, err)
+		return nil, fmt.Errorf("parse adapt-repo seed issue list output for %s state: %w", state, err)
 	}
 	for _, issue := range issues {
 		if issue.Title == adaptRepoIssueTitle {

--- a/cli/cmd/xylem/adapt_repo_seed_test.go
+++ b/cli/cmd/xylem/adapt_repo_seed_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func adaptRepoSearchCallForState(repo, state string) string {
-	return "gh search issues --repo " + repo + " --state " + state + " --json number,title,url --limit 100 --search " + adaptRepoIssueTitle
+func adaptRepoListCallForState(repo, state string) string {
+	return "gh issue list --repo " + repo + " --state " + state + " --label " + adaptRepoSeedLabel + " --json number,title,url --limit 100"
 }
 
 func adaptRepoCreateCall(repo string) string {
@@ -52,9 +52,9 @@ func TestSmoke_S3_DaemonSeedingCreatesIssueAndMarkerOnFreshRepo(t *testing.T) {
 	}
 	runner := &seedRunnerStub{
 		outputs: map[string][]byte{
-			adaptRepoSearchCallForState("owner/repo", "open"):   []byte("[]"),
-			adaptRepoSearchCallForState("owner/repo", "closed"): []byte("[]"),
-			adaptRepoCreateCall("owner/repo"):                   []byte("https://github.com/owner/repo/issues/34\n"),
+			adaptRepoListCallForState("owner/repo", "open"):   []byte("[]"),
+			adaptRepoListCallForState("owner/repo", "closed"): []byte("[]"),
+			adaptRepoCreateCall("owner/repo"):                 []byte("https://github.com/owner/repo/issues/34\n"),
 		},
 	}
 
@@ -84,8 +84,8 @@ func TestSmoke_S4_DaemonSeedingDedupesMatchingClosedIssueByTitle(t *testing.T) {
 	}
 	runner := &seedRunnerStub{
 		outputs: map[string][]byte{
-			adaptRepoSearchCallForState("owner/repo", "open"):   []byte("[]"),
-			adaptRepoSearchCallForState("owner/repo", "closed"): []byte(`[{"number":21,"title":"[xylem] adapt harness to this repository","url":"https://github.com/owner/repo/issues/21"}]`),
+			adaptRepoListCallForState("owner/repo", "open"):   []byte("[]"),
+			adaptRepoListCallForState("owner/repo", "closed"): []byte(`[{"number":21,"title":"[xylem] adapt harness to this repository","url":"https://github.com/owner/repo/issues/21"}]`),
 		},
 	}
 
@@ -114,9 +114,9 @@ func TestSmoke_S5_AdaptRepoSeedMarkerPreventsReseedingOnSubsequentBoots(t *testi
 	}
 	runner := &seedRunnerStub{
 		outputs: map[string][]byte{
-			adaptRepoSearchCallForState("owner/repo", "open"):   []byte("[]"),
-			adaptRepoSearchCallForState("owner/repo", "closed"): []byte("[]"),
-			adaptRepoCreateCall("owner/repo"):                   []byte("https://github.com/owner/repo/issues/34\n"),
+			adaptRepoListCallForState("owner/repo", "open"):   []byte("[]"),
+			adaptRepoListCallForState("owner/repo", "closed"): []byte("[]"),
+			adaptRepoCreateCall("owner/repo"):                 []byte("https://github.com/owner/repo/issues/34\n"),
 		},
 	}
 
@@ -162,8 +162,8 @@ func TestEnsureAdaptRepoSeededDedupesClosedIssues(t *testing.T) {
 	}
 	runner := &seedRunnerStub{
 		outputs: map[string][]byte{
-			adaptRepoSearchCallForState("owner/repo", "open"):   []byte("[]"),
-			adaptRepoSearchCallForState("owner/repo", "closed"): []byte(`[{"number":21,"title":"[xylem] adapt harness to this repository","url":"https://github.com/owner/repo/issues/21"}]`),
+			adaptRepoListCallForState("owner/repo", "open"):   []byte("[]"),
+			adaptRepoListCallForState("owner/repo", "closed"): []byte(`[{"number":21,"title":"[xylem] adapt harness to this repository","url":"https://github.com/owner/repo/issues/21"}]`),
 		},
 	}
 
@@ -189,7 +189,7 @@ func TestEnsureAdaptRepoSeededDedupesClosedIssues(t *testing.T) {
 func TestFindExistingAdaptRepoIssueStopsAfterOpenMatch(t *testing.T) {
 	runner := &seedRunnerStub{
 		outputs: map[string][]byte{
-			adaptRepoSearchCallForState("owner/repo", "open"): []byte(`[{"number":13,"title":"[xylem] adapt harness to this repository","url":"https://github.com/owner/repo/issues/13"}]`),
+			adaptRepoListCallForState("owner/repo", "open"): []byte(`[{"number":13,"title":"[xylem] adapt harness to this repository","url":"https://github.com/owner/repo/issues/13"}]`),
 		},
 	}
 
@@ -198,4 +198,19 @@ func TestFindExistingAdaptRepoIssueStopsAfterOpenMatch(t *testing.T) {
 	require.NotNil(t, issue)
 	assert.Equal(t, 13, issue.Number)
 	assert.Len(t, runner.calls, 1)
+}
+
+func TestFindAdaptRepoIssueByStateHandlesEmptyList(t *testing.T) {
+	// gh issue list returns [] with exit 0 on zero results.
+	// Confirms no error is returned and nil issue is returned when both states are empty.
+	runner := &seedRunnerStub{
+		outputs: map[string][]byte{
+			adaptRepoListCallForState("owner/repo", "open"):   []byte("[]"),
+			adaptRepoListCallForState("owner/repo", "closed"): []byte("[]"),
+		},
+	}
+
+	issue, err := findExistingAdaptRepoIssue(context.Background(), runner, "owner/repo")
+	require.NoError(t, err)
+	assert.Nil(t, issue)
 }

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -317,7 +317,7 @@ func TestSmoke_S7_DaemonStartupContinuesWhenAdaptRepoSearchFails(t *testing.T) {
 	markerPath := adaptRepoSeedMarkerPath(cfg.StateDir)
 	runner := &seedRunnerStub{
 		errors: map[string]error{
-			adaptRepoSearchCallForState("owner/repo", "open"): fmt.Errorf("gh unavailable"),
+			adaptRepoListCallForState("owner/repo", "open"): fmt.Errorf("gh unavailable"),
 		},
 	}
 
@@ -346,8 +346,8 @@ func TestSmoke_S8_DaemonStartupLeavesMarkerAbsentWhenAdaptRepoCreateFails(t *tes
 	logBuf := withBufferedDefaultLogger(t)
 	runner := &seedRunnerStub{
 		outputs: map[string][]byte{
-			adaptRepoSearchCallForState("owner/repo", "open"):   []byte("[]"),
-			adaptRepoSearchCallForState("owner/repo", "closed"): []byte("[]"),
+			adaptRepoListCallForState("owner/repo", "open"):   []byte("[]"),
+			adaptRepoListCallForState("owner/repo", "closed"): []byte("[]"),
 		},
 		errors: map[string]error{
 			adaptRepoCreateCall("owner/repo"): fmt.Errorf("gh create failed"),

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -443,9 +443,9 @@ func TestSmoke_S6_InitSeedCreatesAdaptRepoMarkerSynchronously(t *testing.T) {
 
 	runner := &seedRunnerStub{
 		outputs: map[string][]byte{
-			adaptRepoSearchCallForState("owner/name", "open"):   []byte("[]"),
-			adaptRepoSearchCallForState("owner/name", "closed"): []byte("[]"),
-			adaptRepoCreateCall("owner/name"):                   []byte("https://github.com/owner/name/issues/12\n"),
+			adaptRepoListCallForState("owner/name", "open"):   []byte("[]"),
+			adaptRepoListCallForState("owner/name", "closed"): []byte("[]"),
+			adaptRepoCreateCall("owner/name"):                 []byte("https://github.com/owner/name/issues/12\n"),
 		},
 	}
 


### PR DESCRIPTION
## Summary

- `gh search issues` returns exit status 1 when the query returns zero results, causing a spurious warning on every daemon startup for repos that don't yet have an adapt-repo tracking issue
- Replace with `gh issue list --label xylem-adapt-repo --state <state>`, which returns an empty JSON array `[]` with exit 0 on zero results
- Title equality check retained as a secondary guard against label collisions
- Updated all test stubs and helper from `adaptRepoSearchCallForState` → `adaptRepoListCallForState`
- Added `TestFindAdaptRepoIssueByStateHandlesEmptyList` to document the zero-result contract

Fixes https://github.com/nicholls-inc/xylem/issues/466

## Test plan

- [x] `go test ./cmd/xylem/...` passes
- [x] `goimports -l .` clean
- [x] `golangci-lint run` clean (pre-commit hook)
- [x] All existing adapt-repo seed tests updated and passing
- [x] New regression test for empty-list case added

🤖 Generated with [Claude Code](https://claude.com/claude-code)