### PR TITLE
fix: remove allowlist check for skipped entries in adapt-plan validation

### DIFF
--- a/cli/internal/bootstrap/adapt_plan.go
+++ b/cli/internal/bootstrap/adapt_plan.go
@@ -109,7 +109,7 @@ func WriteAdaptPlan(path string, plan *AdaptPlan) error {
 //   - schema_version must equal 1
 //   - each planned change: path relative and in allowlist, valid op, non-empty rationale
 //   - delete op only allowed for workflow YAML files under .xylem/workflows/
-//   - each skipped entry: path relative and in allowlist, non-empty reason
+//   - each skipped entry: path relative (no traversal), non-empty reason
 func (p *AdaptPlan) Validate() error {
 	if p.SchemaVersion != 1 {
 		return fmt.Errorf(`"schema_version" must equal 1`)
@@ -124,15 +124,11 @@ func (p *AdaptPlan) Validate() error {
 		}
 	}
 	for i, skipped := range p.Skipped {
-		path, err := normalizeAdaptPlanPath(skipped.Path)
-		if err != nil {
+		if _, err := normalizeAdaptPlanPath(skipped.Path); err != nil {
 			return fmt.Errorf(`"skipped[%d].path" %w`, i, err)
 		}
 		if strings.TrimSpace(skipped.Reason) == "" {
 			return fmt.Errorf(`"skipped[%d].reason" must not be empty`, i)
-		}
-		if !IsAllowedAdaptPlanPath(path) {
-			return fmt.Errorf(`"skipped[%d].path" %q is outside the adapt-plan allowlist`, i, path)
 		}
 	}
 	return nil
@@ -181,9 +177,6 @@ func normalizeRawAdaptPlan(raw rawAdaptPlan) (AdaptPlan, error) {
 		}
 		if strings.TrimSpace(skipped[i].Reason) == "" {
 			return AdaptPlan{}, fmt.Errorf(`"skipped[%d].reason" must not be empty`, i)
-		}
-		if !IsAllowedAdaptPlanPath(path) {
-			return AdaptPlan{}, fmt.Errorf(`"skipped[%d].path" %q is outside the adapt-plan allowlist`, i, path)
 		}
 		skipped[i].Path = path
 	}

--- a/cli/internal/bootstrap/adapt_plan_test.go
+++ b/cli/internal/bootstrap/adapt_plan_test.go
@@ -508,6 +508,42 @@ func TestIsAllowedAdaptPlanPath(t *testing.T) {
 	}
 }
 
+func TestReadAdaptPlan_AcceptsOutOfAllowlistSkipped(t *testing.T) {
+	dir := t.TempDir()
+	body := `{
+  "schema_version": 1,
+  "detected": {"languages":[],"build_tools":[],"test_runners":[],"linters":[],"has_frontend":false,"has_database":false,"entry_points":[]},
+  "planned_changes": [],
+  "skipped": [
+    {"path": "CHANGELOG.md", "reason": "not in scope"},
+    {"path": "Makefile", "reason": "out of scope"}
+  ]
+}`
+	path := writeAdaptPlanJSON(t, dir, body)
+
+	plan, err := ReadAdaptPlan(path)
+	if err != nil {
+		t.Fatalf("ReadAdaptPlan() unexpected error for out-of-allowlist skipped paths: %v", err)
+	}
+	if len(plan.Skipped) != 2 {
+		t.Errorf("len(Skipped) = %d, want 2", len(plan.Skipped))
+	}
+}
+
+func TestValidate_AcceptsOutOfAllowlistSkipped(t *testing.T) {
+	plan := AdaptPlan{
+		SchemaVersion:  1,
+		Detected:       AdaptPlanDetected{},
+		PlannedChanges: []AdaptPlanChange{},
+		Skipped: []AdaptPlanSkipped{
+			{Path: "Makefile", Reason: "out of scope"},
+		},
+	}
+	if err := plan.Validate(); err != nil {
+		t.Errorf("Validate() unexpected error for out-of-allowlist skipped path: %v", err)
+	}
+}
+
 func TestAdaptPlanSchema_IsEmbedded(t *testing.T) {
 	if len(AdaptPlanSchema) == 0 {
 		t.Fatal("AdaptPlanSchema is empty; embed may have failed")
@@ -541,7 +577,7 @@ func TestWriteReadRoundTrip(t *testing.T) {
 			{Path: "docs/setup.md", Op: "create", Rationale: "add docs"},
 		},
 		Skipped: []AdaptPlanSkipped{
-			{Path: "AGENTS.md", Reason: "already configured"},
+			{Path: "CHANGELOG.md", Reason: "already configured"},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Removes the `IsAllowedAdaptPlanPath` guard from `skipped[].path` validation in both `Validate` and `normalizeRawAdaptPlan`
- `skipped` entries are informational — the LLM documenting files it intentionally left alone — so write-scope gating has no relevance here
- Only `planned_changes[].path` should be allowlist-gated; path traversal sanity checks and non-empty `reason` checks are preserved
- Adds `TestReadAdaptPlan_AcceptsOutOfAllowlistSkipped` and `TestValidate_AcceptsOutOfAllowlistSkipped` to prove the fix

Fixes https://github.com/nicholls-inc/xylem/issues/475

## Test plan
- [ ] `go test ./internal/bootstrap/...` passes
- [ ] New tests verify `CHANGELOG.md` and `Makefile` in `skipped[]` are accepted without error
- [ ] Existing tests for `planned_changes` allowlist enforcement remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)