### PR TITLE
fix: move triage GH CLI side-effects into deterministic command phase

### DIFF
--- a/.xylem/prompts/triage/triage.md
+++ b/.xylem/prompts/triage/triage.md
@@ -10,20 +10,53 @@ Labels: {{.Issue.Labels}}
 
 ## Instructions
 
-**If the analysis says DO NOT split:**
+Based on the analysis above, write a JSON actions file to `.xylem/state/triage/actions.json` describing what should be done. Do NOT run any `gh` commands — the next phase will execute them deterministically.
 
-1. Add the type label and "needs-refinement":
-   `gh issue edit {{.Issue.Number}} --add-label "<type>,needs-refinement"`
-2. Remove "needs-triage":
-   `gh issue edit {{.Issue.Number}} --remove-label "needs-triage"`
+First, create the directory:
+```
+mkdir -p .xylem/state/triage
+```
 
-**If the analysis says SPLIT:**
+Then write the JSON file with this exact schema:
 
-1. For each sub-issue identified in the analysis, create it with:
-   `gh issue create --title "<title>" --label "<type>,needs-triage" --body "<relevant section of the original issue body>"`
-   Keep the body minimal — the refinement workflow will flesh it out.
-2. Update the original issue body to reference the created sub-issues with a "Split into:" prefix
-3. Close the original:
-   `gh issue close {{.Issue.Number}} --reason "not planned" --comment "Split into focused sub-issues."`
+```json
+{
+  "issue_number": {{.Issue.Number}},
+  "decision": "no_split",
+  "add_labels": ["bug", "needs-refinement"],
+  "remove_labels": ["needs-triage"],
+  "close_original": false,
+  "close_reason": "",
+  "close_comment": "",
+  "sub_issues": []
+}
+```
 
-Do not ask for user input. If the type is ambiguous, pick the best fit and note the reasoning in a comment.
+**Schema rules:**
+
+- `issue_number` — must be `{{.Issue.Number}}` (integer)
+- `decision` — either `"no_split"` or `"split"`
+- `add_labels` — labels to add to the original issue (always include the type label; include `"needs-refinement"` when not splitting)
+- `remove_labels` — labels to remove from the original issue (always include `"needs-triage"`)
+- `close_original` — `true` only when `decision` is `"split"`
+- `close_reason` — `"not planned"` when closing, otherwise `""`
+- `close_comment` — brief comment when closing (e.g. `"Split into focused sub-issues."`), otherwise `""`
+- `sub_issues` — array of sub-issues to create; empty when `decision` is `"no_split"`
+
+**Sub-issue object schema:**
+```json
+{
+  "title": "Short descriptive title",
+  "labels": ["bug", "needs-triage"],
+  "body": "Relevant section of the original issue body. Keep it minimal — the refinement workflow will flesh it out."
+}
+```
+
+**Decision guidance:**
+
+- **DO NOT split** — Add the type label and `needs-refinement` to the original issue. Remove `needs-triage`. Leave `close_original` false and `sub_issues` empty.
+- **SPLIT** — Create sub-issues for each focused piece identified in the analysis. Set `close_original` to `true`. Add the type label and remove `needs-triage` from the original. Each sub-issue gets `needs-triage` so it enters the triage queue.
+
+If the type is ambiguous, pick the best fit. Do not ask for user input.
+
+Write only the JSON file. Do not execute any GitHub CLI commands.

--- a/.xylem/workflows/triage.yaml
+++ b/.xylem/workflows/triage.yaml
@@ -7,3 +7,98 @@ phases:
   - name: triage
     prompt_file: .xylem/prompts/triage/triage.md
     max_turns: 20
+  - name: apply_actions
+    type: command
+    run: |
+      set -euo pipefail
+      ACTIONS_FILE=".xylem/state/triage/actions.json"
+      if [ ! -f "$ACTIONS_FILE" ]; then
+        echo "ERROR: triage phase did not produce $ACTIONS_FILE"
+        exit 1
+      fi
+
+      # Sanitize literal control chars from LLM-generated JSON string values.
+      # LLMs sometimes embed raw newlines inside string fields; jq rejects
+      # those per RFC 8259. This rewrites the file with properly escaped strings.
+      python3 -c '
+      import sys, json
+
+      def sanitize_json(text):
+          result = []
+          in_string = False
+          escaped = False
+          for ch in text:
+              if escaped:
+                  result.append(ch)
+                  escaped = False
+              elif ch == "\\" and in_string:
+                  result.append(ch)
+                  escaped = True
+              elif ch == "\"":
+                  result.append(ch)
+                  in_string = not in_string
+              elif in_string and ch == "\n":
+                  result.append("\\n")
+              elif in_string and ch == "\r":
+                  result.append("\\r")
+              elif in_string and ch == "\t":
+                  result.append("\\t")
+              else:
+                  result.append(ch)
+          return "".join(result)
+
+      filepath = sys.argv[1]
+      with open(filepath) as f:
+          raw = f.read()
+      sanitized = sanitize_json(raw)
+      data = json.loads(sanitized)
+      with open(filepath, "w") as f:
+          json.dump(data, f, ensure_ascii=False)
+      ' "$ACTIONS_FILE"
+
+      ISSUE_NUMBER=$(jq -r '.issue_number' "$ACTIONS_FILE")
+      EXPECTED="{{.Issue.Number}}"
+      if [ "$ISSUE_NUMBER" != "$EXPECTED" ]; then
+        echo "ERROR: actions.json issue_number ($ISSUE_NUMBER) does not match vessel issue ($EXPECTED)"
+        exit 1
+      fi
+
+      DECISION=$(jq -r '.decision' "$ACTIONS_FILE")
+
+      # Apply label edits to original issue
+      ADD_LABELS=$(jq -r '.add_labels // [] | map(select(length > 0)) | join(",")' "$ACTIONS_FILE")
+      REMOVE_LABELS=$(jq -r '.remove_labels // [] | map(select(length > 0)) | join(",")' "$ACTIONS_FILE")
+      if [ -n "$ADD_LABELS" ]; then
+        gh issue edit "$ISSUE_NUMBER" --repo nicholls-inc/xylem --add-label "$ADD_LABELS"
+      fi
+      if [ -n "$REMOVE_LABELS" ]; then
+        gh issue edit "$ISSUE_NUMBER" --repo nicholls-inc/xylem --remove-label "$REMOVE_LABELS"
+      fi
+
+      # Create sub-issues and close original only when splitting
+      if [ "$DECISION" = "split" ]; then
+        BODY_DIR=$(mktemp -d)
+        trap 'rm -rf "$BODY_DIR"' EXIT
+        SUB_COUNT=$(jq '.sub_issues // [] | length' "$ACTIONS_FILE")
+        for i in $(seq 0 $((SUB_COUNT - 1))); do
+          TITLE=$(jq -r ".sub_issues[$i].title" "$ACTIONS_FILE")
+          LABELS=$(jq -r ".sub_issues[$i].labels // [] | join(\",\")" "$ACTIONS_FILE")
+          BODY_FILE="$BODY_DIR/body_$i.txt"
+          jq -r ".sub_issues[$i].body" "$ACTIONS_FILE" > "$BODY_FILE"
+          if [ -n "$LABELS" ]; then
+            gh issue create --repo nicholls-inc/xylem --title "$TITLE" --label "$LABELS" --body-file "$BODY_FILE"
+          else
+            gh issue create --repo nicholls-inc/xylem --title "$TITLE" --body-file "$BODY_FILE"
+          fi
+          sleep 1
+        done
+
+        CLOSE=$(jq -r '.close_original // false' "$ACTIONS_FILE")
+        if [ "$CLOSE" = "true" ]; then
+          REASON=$(jq -r 'if (.close_reason // "") == "" then "not planned" else .close_reason end' "$ACTIONS_FILE")
+          COMMENT=$(jq -r '.close_comment // "Split into focused sub-issues."' "$ACTIONS_FILE")
+          gh issue close "$ISSUE_NUMBER" --repo nicholls-inc/xylem --reason "$REASON" --comment "$COMMENT"
+        fi
+      fi
+
+      echo "Triage actions applied: decision=$DECISION"


### PR DESCRIPTION
## Summary

- The triage prompt previously instructed the LLM to run `gh issue edit`, `gh issue create`, and `gh issue close` directly, which fails when GitHub auth expires mid-session
- The `triage` phase now writes a structured JSON actions file to `.xylem/state/triage/actions.json` describing all intended mutations — no GH CLI commands in the prompt
- A new `apply_actions` command phase reads the JSON and executes all GH CLI mutations deterministically, following the established `backlog-refinement` pattern
- Includes JSON sanitization (same Python sanitizer as backlog-refinement) and issue number validation before any mutations

Closes https://github.com/nicholls-inc/xylem/issues/479

## Test plan

- [ ] Verify YAML parses cleanly (CI workflow YAML validator added in #474)
- [ ] Confirm `triage.md` contains no `gh` commands
- [ ] Confirm `apply_actions` phase validates `issue_number` before mutating
- [ ] Confirm label edit guards handle empty arrays without passing empty string to `--add-label`

🤖 Generated with [Claude Code](https://claude.com/claude-code)