### PR TITLE
fix: switch scanner from gh search issues to gh issue list API

### DIFF
--- a/cli/cmd/xylem/scan_test.go
+++ b/cli/cmd/xylem/scan_test.go
@@ -92,7 +92,7 @@ func issuesJSON(issues []ghIssueJSON) []byte {
 func stubScanCommands(r *mockScanRunner, cfg *config.Config, issues []ghIssueJSON) {
 	ghSrc := cfg.Sources["github"]
 	for _, task := range ghSrc.Tasks {
-		r.set(issuesJSON(issues), "gh", "search", "issues", "--repo", ghSrc.Repo,
+		r.set(issuesJSON(issues), "gh", "issue", "list", "--repo", ghSrc.Repo,
 			"--state", "open", "--json", "number,title,body,url,labels",
 			"--limit", "20", "--label", task.Labels[0])
 	}
@@ -308,7 +308,7 @@ func TestScanPausedOutput(t *testing.T) {
 
 	// Stub the gh search command (paused scan short-circuits before this,
 	// but the mock would error on unstubbed commands)
-	r.set([]byte("[]"), "gh", "search", "issues", "--repo", "owner/repo",
+	r.set([]byte("[]"), "gh", "issue", "list", "--repo", "owner/repo",
 		"--state", "open", "--json", "number,title,body,url,labels",
 		"--limit", "20", "--label", "bug")
 
@@ -331,7 +331,7 @@ func TestScanDryRunEmpty(t *testing.T) {
 	r := newScanMock()
 
 	// Stub the gh search to return empty array
-	r.set([]byte("[]"), "gh", "search", "issues", "--repo", "owner/repo",
+	r.set([]byte("[]"), "gh", "issue", "list", "--repo", "owner/repo",
 		"--state", "open", "--json", "number,title,body,url,labels",
 		"--limit", "20", "--label", "bug")
 
@@ -364,7 +364,7 @@ func TestScanError(t *testing.T) {
 
 	// Stub gh search to return an error
 	r.setErr(errors.New("gh: not authenticated"),
-		"gh", "search", "issues", "--repo", "owner/repo",
+		"gh", "issue", "list", "--repo", "owner/repo",
 		"--state", "open", "--json", "number,title,body,url,labels",
 		"--limit", "20", "--label", "bug")
 

--- a/cli/internal/dtu/scenario_static_test.go
+++ b/cli/internal/dtu/scenario_static_test.go
@@ -101,7 +101,7 @@ func TestScenarioIssueDedupBranchExistsSkipsScan(t *testing.T) {
 	}
 
 	delta := eventDelta(t, env.store, before)
-	if got := len(filterShimEvents(delta, dtu.EventKindShimInvocation, "gh", []string{"search", "issues"})); got != 1 {
+	if got := len(filterShimEvents(delta, dtu.EventKindShimInvocation, "gh", []string{"issue", "list"})); got != 1 {
 		t.Fatalf("len(search invocations) = %d, want 1", got)
 	}
 	if got := len(filterShimEvents(delta, dtu.EventKindShimInvocation, "git", []string{"ls-remote", "--heads", "origin", "fix/issue-11-*"})); got != 1 {
@@ -234,7 +234,7 @@ func TestScenarioIssueDedupFailedFingerprintSkipsUnchangedFailure(t *testing.T) 
 	}
 
 	delta := eventDelta(t, env.store, before)
-	if got := len(filterShimEvents(delta, dtu.EventKindShimInvocation, "gh", []string{"search", "issues"})); got != 1 {
+	if got := len(filterShimEvents(delta, dtu.EventKindShimInvocation, "gh", []string{"issue", "list"})); got != 1 {
 		t.Fatalf("len(search invocations) = %d, want 1", got)
 	}
 	if got := len(filterShimEvents(delta, dtu.EventKindShimInvocation, "git", []string{"ls-remote"})); got != 0 {

--- a/cli/internal/dtu/scenario_test.go
+++ b/cli/internal/dtu/scenario_test.go
@@ -1388,8 +1388,8 @@ func TestScenarioIssueMalformedGHOutputFailsScan(t *testing.T) {
 	if err == nil {
 		t.Fatal("Scan() error = nil, want malformed gh parse error")
 	}
-	if !strings.Contains(err.Error(), "parse gh search output") {
-		t.Fatalf("Scan() error = %v, want parse gh search output", err)
+	if !strings.Contains(err.Error(), "parse gh issue list output") {
+		t.Fatalf("Scan() error = %v, want parse gh issue list output", err)
 	}
 
 	vessels, listErr := env.queue.List()
@@ -1401,7 +1401,7 @@ func TestScenarioIssueMalformedGHOutputFailsScan(t *testing.T) {
 	}
 
 	events := readEvents(t, env.store)
-	searchResults := filterShimEvents(events, dtu.EventKindShimResult, "gh", []string{"search", "issues"})
+	searchResults := filterShimEvents(events, dtu.EventKindShimResult, "gh", []string{"issue", "list"})
 	if len(searchResults) != 1 {
 		t.Fatalf("len(search results) = %d, want 1", len(searchResults))
 	}
@@ -1433,8 +1433,8 @@ func TestScenarioIssueGHAuthFailureFailsScan(t *testing.T) {
 	if err == nil {
 		t.Fatal("Scan() error = nil, want gh auth failure")
 	}
-	if !strings.Contains(err.Error(), "gh search issues") {
-		t.Fatalf("Scan() error = %v, want gh search issues", err)
+	if !strings.Contains(err.Error(), "gh issue list") {
+		t.Fatalf("Scan() error = %v, want gh issue list", err)
 	}
 	if !strings.Contains(err.Error(), "authentication required") {
 		t.Fatalf("Scan() error = %v, want authentication required", err)
@@ -1450,7 +1450,7 @@ func TestScenarioIssueGHAuthFailureFailsScan(t *testing.T) {
 	assertStringSliceEqual(t, readIssueLabels(t, env.store, "owner/repo", 5), []string{"bug"})
 
 	events := readEvents(t, env.store)
-	searchResults := filterShimEvents(events, dtu.EventKindShimResult, "gh", []string{"search", "issues"})
+	searchResults := filterShimEvents(events, dtu.EventKindShimResult, "gh", []string{"issue", "list"})
 	if len(searchResults) != 1 {
 		t.Fatalf("len(search results) = %d, want 1", len(searchResults))
 	}

--- a/cli/internal/dtu/testdata/issue-gh-auth-scan-failure.yaml
+++ b/cli/internal/dtu/testdata/issue-gh-auth-scan-failure.yaml
@@ -16,6 +16,6 @@ shim_faults:
   - name: gh-search-auth-failure
     command: gh
     match:
-      args_prefix: [search, issues]
+      args_prefix: [issue, list]
     stderr: "gh: authentication required"
     exit_code: 1

--- a/cli/internal/dtu/testdata/issue-gh-malformed.yaml
+++ b/cli/internal/dtu/testdata/issue-gh-malformed.yaml
@@ -16,6 +16,6 @@ shim_faults:
   - name: malformed-search
     command: gh
     match:
-      args_prefix: [search, issues]
+      args_prefix: [issue, list]
     stdout: '{"number":'
     exit_code: 0

--- a/cli/internal/dtu/testdata/live-verification.yaml
+++ b/cli/internal/dtu/testdata/live-verification.yaml
@@ -1,10 +1,10 @@
 version: v1
 differential:
-  - name: gh-search-issues-open-bug
+  - name: gh-issue-list-open-bug
     boundary: gh
     enabled_env: XYLEM_DTU_LIVE_GH_DIFFERENTIAL
     command: gh
-    args: [search, issues, --repo, owner/repo, --state, open, --json, number,title,body,url,labels, --limit, "20", --label, bug]
+    args: [issue, list, --repo, owner/repo, --state, open, --json, number,title,body,url,labels, --limit, "20", --label, bug]
     normalizer: issue_list
     fixture: issue-label-gate.yaml
   - name: gh-pr-list-open

--- a/cli/internal/dtu/verification_runner_test.go
+++ b/cli/internal/dtu/verification_runner_test.go
@@ -86,10 +86,10 @@ func TestRunLiveVerificationDifferentialMismatchUsesRegistryAndPolicy(t *testing
 			}
 		},
 		Runner: stubVerificationRunner{results: map[string]stubVerificationResult{
-			key("gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number", "title", "body", "url", "labels", "--limit", "20", "--label", "bug"): {
+			key("gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number", "title", "body", "url", "labels", "--limit", "20", "--label", "bug"): {
 				result: VerificationCommandResult{Stdout: `[{"number":1,"title":"flaky gate","body":"wait for plan approval","url":"https://example.test/issues/1","labels":[{"name":"bug"}]}]`},
 			},
-			key(verificationBinaryPath(t), "shim-dispatch", "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number", "title", "body", "url", "labels", "--limit", "20", "--label", "bug"): {
+			key(verificationBinaryPath(t), "shim-dispatch", "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number", "title", "body", "url", "labels", "--limit", "20", "--label", "bug"): {
 				result: VerificationCommandResult{Stdout: `[{"number":2,"title":"flaky gate","body":"wait for plan approval","url":"https://example.test/issues/1","labels":[{"name":"bug"}]}]`},
 			},
 			key("gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number", "title", "body", "url", "labels", "headRefName", "--limit", "20"): {
@@ -118,7 +118,7 @@ func TestRunLiveVerificationDifferentialMismatchUsesRegistryAndPolicy(t *testing
 	if report.Summary.Mismatches != 1 {
 		t.Fatalf("Mismatches = %d, want 1", report.Summary.Mismatches)
 	}
-	first := reportByName(t, report.Differential, "gh-search-issues-open-bug")
+	first := reportByName(t, report.Differential, "gh-issue-list-open-bug")
 	if first.Status != VerificationStatusMismatch {
 		t.Fatalf("Status = %q, want %q", first.Status, VerificationStatusMismatch)
 	}

--- a/cli/internal/dtushim/shim.go
+++ b/cli/internal/dtushim/shim.go
@@ -526,6 +526,9 @@ func shouldRecordObservation(command dtu.ShimCommand, args []string) bool {
 		if len(args) >= 2 && args[0] == "search" && args[1] == "issues" {
 			return true
 		}
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "list" {
+			return true
+		}
 		if len(args) >= 2 && args[0] == "issue" && args[1] == "view" {
 			return true
 		}
@@ -628,6 +631,8 @@ func runGH(ctx context.Context, store *dtu.Store, state *dtu.State, args []strin
 		}
 	case "issue":
 		switch args[1] {
+		case "list":
+			return runGHSearchIssues(ctx, store, state, args[2:], stdout, stderr)
 		case "create":
 			return runGHIssueCreate(ctx, store, args[2:], stdout, stderr)
 		case "edit":

--- a/cli/internal/dtushim/shim_test.go
+++ b/cli/internal/dtushim/shim_test.go
@@ -106,7 +106,7 @@ func TestExecuteGHSearchIssuesFiltersOpenLabelledIssues(t *testing.T) {
 	store, stateDir := testStore(t, state)
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), "gh", []string{"search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug"}, nil, &stdout, &stderr, envForStore(store, stateDir, state.UniverseID))
+	code := Execute(context.Background(), "gh", []string{"issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug"}, nil, &stdout, &stderr, envForStore(store, stateDir, state.UniverseID))
 	if code != 0 {
 		t.Fatalf("Execute() code = %d, stderr = %q", code, stderr.String())
 	}

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -124,7 +124,7 @@ func TestScanFindsIssues(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s := New(cfg, q, r)
 	result, err := s.Scan(context.Background())
@@ -183,8 +183,8 @@ func TestBacklogCountDeduplicatesAndSkipsExcludedIssues(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "incident"}}},
 	}
-	r.set(issueJSON(bugIssues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
-	r.set(issueJSON(incidentIssues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "incident")
+	r.set(issueJSON(bugIssues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(incidentIssues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "incident")
 
 	s := New(cfg, q, r)
 	count, err := s.BacklogCount(context.Background())
@@ -203,7 +203,7 @@ func TestScanExcludedLabel(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}, {Name: "wontfix"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s := New(cfg, q, r)
 	result, err := s.Scan(context.Background())
@@ -235,7 +235,7 @@ func TestScanAlreadyQueued(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s := New(cfg, q, r)
 	result, err := s.Scan(context.Background())
@@ -258,7 +258,7 @@ func TestScanExistingBranch(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	r.set([]byte("abc123\trefs/heads/fix/issue-42-something"), "git", "ls-remote", "--heads", "origin", "fix/issue-42-*")
 
 	s := New(cfg, q, r)
@@ -337,7 +337,7 @@ func TestSmoke_S4_ScannerSetsVesselTierFromTaskOrDefault(t *testing.T) {
 					Name string `json:"name"`
 				}{{Name: "bug"}}},
 			}
-			r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+			r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 			s := New(cfg, q, r)
 			result, err := s.Scan(context.Background())
@@ -363,7 +363,7 @@ func TestScanExistingPR(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	r.set([]byte(`[{"number":99,"headRefName":"fix/issue-55-null-fix"}]`),
 		"gh", "pr", "list", "--repo", "owner/repo", "--search", "head:fix/issue-55-", "--state", "open", "--json", "number,headRefName", "--limit", "5")
 
@@ -470,7 +470,7 @@ func TestScanSkipsUnchangedFailedIssue(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	for _, prefix := range []string{"fix", "feat"} {
 		r.set([]byte(""), "git", "ls-remote", "--heads", "origin", fmt.Sprintf("%s/issue-%d-*", prefix, 1))
 		r.set([]byte("[]"), "gh", "pr", "list", "--repo", "owner/repo", "--search", fmt.Sprintf("head:%s/issue-%d-", prefix, 1), "--state", "open", "--json", "number,headRefName", "--limit", "5")
@@ -520,7 +520,7 @@ func TestScanReenqueuesChangedFailedIssue(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	for _, prefix := range []string{"fix", "feat"} {
 		r.set([]byte(""), "git", "ls-remote", "--heads", "origin", fmt.Sprintf("%s/issue-%d-*", prefix, 1))
 		r.set([]byte("[]"), "gh", "pr", "list", "--repo", "owner/repo", "--search", fmt.Sprintf("head:%s/issue-%d-", prefix, 1), "--state", "open", "--json", "number,headRefName", "--limit", "5")
@@ -580,7 +580,7 @@ func TestScanRetriesUnchangedFailedIssueAfterCooldownWithoutRecoveryArtifact(t *
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	for _, prefix := range []string{"fix", "feat"} {
 		r.set([]byte(""), "git", "ls-remote", "--heads", "origin", fmt.Sprintf("%s/issue-%d-*", prefix, 1))
 		r.set([]byte("[]"), "gh", "pr", "list", "--repo", "owner/repo", "--search", fmt.Sprintf("head:%s/issue-%d-", prefix, 1), "--state", "open", "--json", "number,headRefName", "--limit", "5")
@@ -633,7 +633,7 @@ func TestScanPRFalsePositiveIgnored(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	r.set([]byte(`[{"number":200,"headRefName":"chore/priority-1-ci-fix"}]`),
 		"gh", "pr", "list", "--repo", "owner/repo", "--search", "head:fix/issue-1-", "--state", "open", "--json", "number,headRefName", "--limit", "5")
 	r.set([]byte(`[]`),
@@ -671,8 +671,8 @@ func TestScanCrossTaskDedupDeterministic(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}, {Name: "urgent"}}},
 	}
-	r.set(issueJSON(sharedIssue), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
-	r.set(issueJSON(sharedIssue), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "urgent")
+	r.set(issueJSON(sharedIssue), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(sharedIssue), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "urgent")
 
 	for i := 0; i < 5; i++ {
 		qFile := filepath.Join(dir, fmt.Sprintf("queue-%d.jsonl", i))
@@ -719,7 +719,7 @@ func TestScanGHFailure(t *testing.T) {
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
 	r := newMock()
 
-	r.setErr(errors.New("network error"), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.setErr(errors.New("network error"), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s := New(cfg, q, r)
 	_, err := s.Scan(context.Background())
@@ -757,8 +757,8 @@ func TestScanMultipleTasks(t *testing.T) {
 		}{{Name: "low-effort"}}},
 	}
 
-	r.set(issueJSON(bugIssues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
-	r.set(issueJSON(featureIssues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "low-effort")
+	r.set(issueJSON(bugIssues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(featureIssues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "low-effort")
 
 	s := New(cfg, q, r)
 	result, err := s.Scan(context.Background())
@@ -784,7 +784,7 @@ func TestScanGHReturnsMalformedJSON(t *testing.T) {
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
 	r := newMock()
 
-	r.set([]byte(`{not valid json`), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set([]byte(`{not valid json`), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s := New(cfg, q, r)
 	_, err := s.Scan(context.Background())
@@ -804,7 +804,7 @@ func TestHasOpenPRMalformedJSONIgnored(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	r.set([]byte(`not json at all`),
 		"gh", "pr", "list", "--repo", "owner/repo", "--search", "head:fix/issue-77-", "--state", "open", "--json", "number,headRefName", "--limit", "5")
 	r.set([]byte(`not json`),
@@ -831,7 +831,7 @@ func TestHasOpenPRGHErrorIgnored(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	r.setErr(errors.New("gh auth error"),
 		"gh", "pr", "list", "--repo", "owner/repo", "--search", "head:fix/issue-88-", "--state", "open", "--json", "number,headRefName", "--limit", "5")
 	r.setErr(errors.New("gh auth error"),
@@ -858,7 +858,7 @@ func TestScanExistingBranchFeatPrefix(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 	r.set([]byte(""), "git", "ls-remote", "--heads", "origin", "fix/issue-99-*")
 	r.set([]byte("abc123\trefs/heads/feat/issue-99-add-feature"), "git", "ls-remote", "--heads", "origin", "feat/issue-99-*")
 
@@ -899,7 +899,7 @@ func TestScanAppliesQueuedLabel(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s := New(cfg, q, r)
 	result, err := s.Scan(context.Background())
@@ -935,7 +935,7 @@ func TestScanNoQueuedLabelWhenNotConfigured(t *testing.T) {
 			Name string `json:"name"`
 		}{{Name: "bug"}}},
 	}
-	r.set(issueJSON(issues), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s := New(cfg, q, r)
 	result, err := s.Scan(context.Background())
@@ -1114,7 +1114,7 @@ func TestScanBudgetGateSkipDoesNotEnqueueOrRunHooks(t *testing.T) {
 		Labels: []struct {
 			Name string `json:"name"`
 		}{{Name: "bug"}},
-	}}), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	}}), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	gate := &stubBudgetGate{decision: cost.Decision{Allowed: false, Reason: "stub exhausted", RemainingUSD: 0}}
 	s := New(cfg, q, r)
@@ -1172,7 +1172,7 @@ func TestSmoke_S47_BudgetGateSkipLeavesSourceUnchanged(t *testing.T) {
 		Labels: []struct {
 			Name string `json:"name"`
 		}{{Name: "bug"}},
-	}}), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	}}), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	gate := &stubBudgetGate{decision: cost.Decision{Allowed: false, Reason: "stub exhausted", RemainingUSD: 0}}
 	s := New(cfg, q, r)
@@ -1266,7 +1266,7 @@ func TestSmoke_S49_RealBudgetGateTrackerDeniesOnDailyBudgetExceeded(t *testing.T
 		Labels: []struct {
 			Name string `json:"name"`
 		}{{Name: "bug"}},
-	}}), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	}}), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	// No BudgetGate override — scanner uses the real gate backed by the state dir.
 	s := New(cfg, q, r)
@@ -1316,7 +1316,7 @@ func TestSmoke_S49_RealBudgetGateTrackerDeniesOnDailyBudgetExceeded(t *testing.T
 		Labels: []struct {
 			Name string `json:"name"`
 		}{{Name: "bug"}},
-	}}), "gh", "search", "issues", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	}}), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
 
 	s2 := New(cfg2, q2, r2)
 	result2, err := s2.Scan(context.Background())

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -64,7 +64,7 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 	for _, task := range g.Tasks {
 		for _, label := range task.Labels {
 			args := []string{
-				"search", "issues",
+				"issue", "list",
 				"--repo", g.Repo,
 				"--state", "open",
 				"--json", "number,title,body,url,labels",
@@ -74,12 +74,12 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 
 			out, err := g.CmdRunner.Run(ctx, "gh", args...)
 			if err != nil {
-				return vessels, fmt.Errorf("gh search issues: %w", err)
+				return vessels, fmt.Errorf("gh issue list: %w", err)
 			}
 
 			var issues []ghIssue
 			if err := json.Unmarshal(out, &issues); err != nil {
-				return vessels, fmt.Errorf("parse gh search output: %w", err)
+				return vessels, fmt.Errorf("parse gh issue list output: %w", err)
 			}
 
 			for _, issue := range issues {
@@ -127,7 +127,7 @@ func (g *GitHub) BacklogCount(ctx context.Context) (int, error) {
 	for _, task := range g.Tasks {
 		for _, label := range task.Labels {
 			args := []string{
-				"search", "issues",
+				"issue", "list",
 				"--repo", g.Repo,
 				"--state", "open",
 				"--json", "number,title,body,url,labels",
@@ -137,12 +137,12 @@ func (g *GitHub) BacklogCount(ctx context.Context) (int, error) {
 
 			out, err := g.CmdRunner.Run(ctx, "gh", args...)
 			if err != nil {
-				return 0, fmt.Errorf("gh search issues: %w", err)
+				return 0, fmt.Errorf("gh issue list: %w", err)
 			}
 
 			var issues []ghIssue
 			if err := json.Unmarshal(out, &issues); err != nil {
-				return 0, fmt.Errorf("parse gh search output: %w", err)
+				return 0, fmt.Errorf("parse gh issue list output: %w", err)
 			}
 
 			for _, issue := range issues {

--- a/cli/internal/source/github_test.go
+++ b/cli/internal/source/github_test.go
@@ -152,7 +152,7 @@ func TestScanSkipsMergedPR(t *testing.T) {
 		},
 	}
 	issueBytes, _ := json.Marshal(issues)
-	r.set(issueBytes, "gh", "search", "issues",
+	r.set(issueBytes, "gh", "issue", "list",
 		"--repo", "owner/repo",
 		"--state", "open",
 		"--json", "number,title,body,url,labels",
@@ -205,7 +205,7 @@ func TestSmoke_S2_GitHubScanAutoRetriesEligibleTransientFailure(t *testing.T) {
 		}{{Name: "bug"}, {Name: "xylem-failed"}},
 	}}
 	issueBytes, _ := json.Marshal(issues)
-	r.set(issueBytes, "gh", "search", "issues",
+	r.set(issueBytes, "gh", "issue", "list",
 		"--repo", "owner/repo",
 		"--state", "open",
 		"--json", "number,title,body,url,labels",
@@ -278,7 +278,7 @@ func TestSmoke_S2b_GitHubScanRetriesAfterRecoveryRefreshChangesDecisionDigest(t 
 		}{{Name: "bug"}},
 	}}
 	issueBytes, _ := json.Marshal(issues)
-	r.set(issueBytes, "gh", "search", "issues",
+	r.set(issueBytes, "gh", "issue", "list",
 		"--repo", "owner/repo",
 		"--state", "open",
 		"--json", "number,title,body,url,labels",
@@ -448,7 +448,7 @@ func TestSmoke_S2_GitHubScanAutoRetriesEligibleTransientFailureIgnoresStaleBranc
 			r := newMock()
 
 			issueBytes, _ := json.Marshal([]ghIssue{issue})
-			r.set(issueBytes, "gh", "search", "issues",
+			r.set(issueBytes, "gh", "issue", "list",
 				"--repo", "owner/repo",
 				"--state", "open",
 				"--json", "number,title,body,url,labels",
@@ -570,7 +570,7 @@ func TestSmoke_S3_GitHubScanBlocksNonTransientRecoveryClasses(t *testing.T) {
 		}{{Name: "bug"}},
 	}}
 	issueBytes, _ := json.Marshal(issues)
-	r.set(issueBytes, "gh", "search", "issues",
+	r.set(issueBytes, "gh", "issue", "list",
 		"--repo", "owner/repo",
 		"--state", "open",
 		"--json", "number,title,body,url,labels",
@@ -635,7 +635,7 @@ func TestSmoke_S4_GitHubScanRetriesAfterCooldownWhenRecoveryArtifactMissing(t *t
 		}{{Name: "bug"}},
 	}}
 	issueBytes, _ := json.Marshal(issues)
-	r.set(issueBytes, "gh", "search", "issues",
+	r.set(issueBytes, "gh", "issue", "list",
 		"--repo", "owner/repo",
 		"--state", "open",
 		"--json", "number,title,body,url,labels",
@@ -697,7 +697,7 @@ func TestGitHubScanRetriesAfterCooldownWithoutArtifactFallsBackToStartedAt(t *te
 		}{{Name: "bug"}},
 	}}
 	issueBytes, _ := json.Marshal(issues)
-	r.set(issueBytes, "gh", "search", "issues",
+	r.set(issueBytes, "gh", "issue", "list",
 		"--repo", "owner/repo",
 		"--state", "open",
 		"--json", "number,title,body,url,labels",
@@ -759,7 +759,7 @@ func TestGitHubScanLegacyRunningLabelDoesNotChangeRetryFingerprint(t *testing.T)
 		}{{Name: "bug"}, {Name: "in-progress"}},
 	}}
 	issueBytes, _ := json.Marshal(issues)
-	r.set(issueBytes, "gh", "search", "issues",
+	r.set(issueBytes, "gh", "issue", "list",
 		"--repo", "owner/repo",
 		"--state", "open",
 		"--json", "number,title,body,url,labels",
@@ -820,7 +820,7 @@ func TestGitHubScanRetriesWhenOnlySourceFingerprintChanges(t *testing.T) {
 		}{{Name: "bug"}},
 	}}
 	issueBytes, _ := json.Marshal(issues)
-	r.set(issueBytes, "gh", "search", "issues",
+	r.set(issueBytes, "gh", "issue", "list",
 		"--repo", "owner/repo",
 		"--state", "open",
 		"--json", "number,title,body,url,labels",
@@ -903,7 +903,7 @@ func TestGitHubScanRetriesWhenOnlyHarnessDigestChanges(t *testing.T) {
 		}{{Name: "bug"}},
 	}}
 	issueBytes, _ := json.Marshal(issues)
-	r.set(issueBytes, "gh", "search", "issues",
+	r.set(issueBytes, "gh", "issue", "list",
 		"--repo", "owner/repo",
 		"--state", "open",
 		"--json", "number,title,body,url,labels",
@@ -977,7 +977,7 @@ func TestGitHubScanRetriesWhenOnlyDecisionDigestChanges(t *testing.T) {
 		}{{Name: "bug"}},
 	}}
 	issueBytes, _ := json.Marshal(issues)
-	r.set(issueBytes, "gh", "search", "issues",
+	r.set(issueBytes, "gh", "issue", "list",
 		"--repo", "owner/repo",
 		"--state", "open",
 		"--json", "number,title,body,url,labels",
@@ -1192,7 +1192,7 @@ func TestScanSkipsFailedStatusLabelWithoutEligibleRetry(t *testing.T) {
 		},
 	}
 	issueBytes, _ := json.Marshal(issues)
-	r.set(issueBytes, "gh", "search", "issues",
+	r.set(issueBytes, "gh", "issue", "list",
 		"--repo", "owner/repo",
 		"--state", "open",
 		"--json", "number,title,body,url,labels",
@@ -1235,7 +1235,7 @@ func TestBacklogCountIncludesEligibleRetryableFailedIssue(t *testing.T) {
 		}{{Name: "bug"}, {Name: "xylem-failed"}},
 	}}
 	issueBytes, _ := json.Marshal(issues)
-	r.set(issueBytes, "gh", "search", "issues",
+	r.set(issueBytes, "gh", "issue", "list",
 		"--repo", "owner/repo",
 		"--state", "open",
 		"--json", "number,title,body,url,labels",
@@ -1310,7 +1310,7 @@ func TestScanPersistsTriggerLabelInMeta(t *testing.T) {
 		},
 	}
 	issueBytes, _ := json.Marshal(issues)
-	r.set(issueBytes, "gh", "search", "issues",
+	r.set(issueBytes, "gh", "issue", "list",
 		"--repo", "owner/repo",
 		"--state", "open",
 		"--json", "number,title,body,url,labels",


### PR DESCRIPTION
## Summary

- Switches the GitHub source's `Scan()` and `BacklogCount()` from `gh search issues` to `gh issue list`, using the Issues REST API (5000 req/hr) instead of the Search API (30 req/min)
- Adds `gh issue list` dispatch to the DTU shim so it handles the new command format
- Updates all test mocks, DTU manifests, and assertion strings to match

## Context

The daemon runs 15+ sources with multiple labels each, making 30+ `gh search issues` calls per scan tick (every 60s). This exceeded GitHub's Search API rate limit, causing persistent `exit status 1` scan failures that prevented retrying eligible backlog items (#58, #60).

`gh search issues` is still used by other features (gapreport, hardening) that use `--search` for text queries at lower frequency — those are unaffected.

## Test plan

- [x] `go test ./internal/source/` passes
- [x] `go test ./internal/scanner/` passes
- [x] `go test ./internal/dtu/` passes
- [x] `go test ./internal/dtushim/` passes
- [x] `go test ./cmd/xylem/` passes
- [x] Full `go test ./...` passes (0 failures)
- [x] `goimports -l .` clean
- [ ] Daemon auto-upgrades and scans succeed without rate limit errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)