### PR TITLE
chore: drop harness-impl label, genericise merge and conflict-resolution

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -5,8 +5,7 @@ sources:
   bugs:
     type: github
     repo: nicholls-inc/xylem
-    exclude:
-      [wontfix, duplicate, in-progress, no-bot, harness-impl]
+    exclude: [wontfix, duplicate, in-progress, no-bot]
     tasks:
       fix-bugs:
         labels: [bug, ready-for-work]
@@ -18,8 +17,7 @@ sources:
   features:
     type: github
     repo: nicholls-inc/xylem
-    exclude:
-      [wontfix, duplicate, in-progress, no-bot, harness-impl]
+    exclude: [wontfix, duplicate, in-progress, no-bot]
     tasks:
       implement-features:
         labels: [enhancement, ready-for-work]
@@ -53,26 +51,8 @@ sources:
           failed: xylem-failed
           timed_out: xylem-failed
 
-  # Harness implementation issues
-  harness-impl:
-    type: github
-    repo: nicholls-inc/xylem
-    timeout: "90m"
-    exclude: [wontfix, duplicate, in-progress, no-bot, blocked]
-    tasks:
-      implement-harness-steps:
-        labels: [harness-impl, ready-for-work]
-        workflow: implement-harness
-        status_labels:
-          running: in-progress
-          failed: xylem-failed
-          timed_out: xylem-failed
-
-  # PR review + CI failure monitoring for harness PRs
-  # NOTE: review_submitted and checks_failed fire for ALL open PRs.
-  # Each workflow's analyze phase checks for harness-impl label and
-  # exits via XYLEM_NOOP if absent.
-  harness-pr-lifecycle:
+  # PR review + CI failure monitoring for open PRs
+  pr-lifecycle:
     type: github-pr-events
     repo: nicholls-inc/xylem
     exclude: [no-bot, pr-vessel-active]
@@ -94,28 +74,28 @@ sources:
         on:
           checks_failed: true
 
-  # Merge-ready harness PRs
-  harness-merge:
+  # Merge-ready PRs
+  merge:
     type: github-pr
     repo: nicholls-inc/xylem
     exclude: [no-bot, pr-vessel-active]
     tasks:
       merge-ready:
-        labels: [ready-to-merge, harness-impl]
+        labels: [ready-to-merge]
         workflow: merge-pr
         status_labels:
           running: pr-vessel-active
           completed: pr-vessel-merged
           failed: xylem-failed
 
-  # Conflict resolution for harness PRs
+  # Conflict resolution for PRs
   conflict-resolution:
     type: github-pr
     repo: nicholls-inc/xylem
     exclude: [no-bot, pr-vessel-active]
     tasks:
       resolve-conflicts:
-        labels: [needs-conflict-resolution, harness-impl]
+        labels: [needs-conflict-resolution]
         workflow: resolve-conflicts
         status_labels:
           running: pr-vessel-active
@@ -191,10 +171,8 @@ sources:
         workflow: harness-gap-analysis
         ref: harness-gap-analysis
 
-  # Post-merge wave dependency unblocking
-  # NOTE: github-merge has no label filtering. The unblock-wave prompt
-  # guards with XYLEM_NOOP for non-harness merges.
-  harness-post-merge:
+  # Post-merge dependency unblocking
+  post-merge:
     type: github-merge
     repo: nicholls-inc/xylem
     tasks:

--- a/.xylem/HARNESS.md
+++ b/.xylem/HARNESS.md
@@ -89,12 +89,10 @@ when they carry the required merge labels:
 - `ready-to-merge` is the daemon's merge-readiness signal for vessel PRs and promoted `release-please` PRs.
 - The `no-auto-admin-merge` label is an immediate opt-out and leaves the PR for manual handling.
 - Auto-admin-merge only fires when the PR is `MERGEABLE`, CI is fully green, and there is no active `CHANGES_REQUESTED` review state.
-- The scheduled `release-cadence` workflow is the only path that promotes a `release-please` PR into this merge loop; those PRs do not require `harness-impl`.
+- The scheduled `release-cadence` workflow is the only path that promotes a `release-please` PR into this merge loop; those PRs carry `ready-to-merge` like any other vessel PR.
 - Human-authored PRs that do not match the xylem issue-branch or promoted `release-please` contract remain outside this path and still require normal manual merge decisions.
 
-Separately, the checked-in self-hosting `merge-pr` workflow remains scoped to
-`harness-impl` pull requests, so self-hosted harness PRs carry both
-`harness-impl` and `ready-to-merge`.
+The `merge-pr` workflow applies to all PRs labelled `ready-to-merge`.
 
 ### Do not finish `merge-pr` work with phase `merge` still failing due to `exit status`. <!-- xylem-lesson:lesson-c1f590566a94 -->
 - Rationale: This failure pattern recurred in 7 failed vessels for `merge-pr` and should be encoded as institutional memory instead of rediscovered in later runs.

--- a/.xylem/prompts/fix-pr-checks/diagnose.md
+++ b/.xylem/prompts/fix-pr-checks/diagnose.md
@@ -9,17 +9,7 @@ URL: {{.Issue.URL}}
 
 Run `gh pr checkout {{.Issue.Number}}` to switch to the PR branch.
 
-## Step 2: Guard — verify this is a harness implementation PR
-
-Check whether the PR has the `harness-impl` label:
-
-```
-gh pr view {{.Issue.Number}} --json labels --jq '.labels[].name' | grep -q harness-impl
-```
-
-If the `harness-impl` label is absent, output `XYLEM_NOOP` on its own line and stop. This workflow only applies to harness implementation PRs.
-
-## Step 3: Mutex — prevent concurrent vessels
+## Step 2: Mutex — prevent concurrent vessels
 
 Check whether the PR already has the `pr-vessel-active` label:
 
@@ -35,13 +25,13 @@ Otherwise, apply the mutex label immediately:
 gh pr edit {{.Issue.Number}} --add-label pr-vessel-active
 ```
 
-## Step 4: Read CI check results
+## Step 3: Read CI check results
 
 Run `gh pr checks {{.Issue.Number}}` to list all CI checks and their statuses.
 
 For each failing check, read its full log output to identify the root cause. Use `gh run view <run-id> --log-failed` or download logs as needed.
 
-## Step 5: Write diagnosis
+## Step 4: Write diagnosis
 
 Produce a structured diagnosis listing each failure:
 

--- a/.xylem/prompts/implement-harness/pr.md
+++ b/.xylem/prompts/implement-harness/pr.md
@@ -25,8 +25,8 @@ The PR body must include:
 - Changes summary (files added/modified, key types and functions)
 - Test plan
 
-After creating the PR, add the `harness-impl` label:
+After creating the PR, add the `ready-to-merge` label:
 
 ```
-gh pr edit --add-label harness-impl
+gh pr edit --add-label ready-to-merge
 ```

--- a/.xylem/prompts/merge-pr/check.md
+++ b/.xylem/prompts/merge-pr/check.md
@@ -12,7 +12,6 @@ Run all of the following checks and report each result:
 
 1. **Eligibility** -- Run `gh pr view {{.Issue.Number}} --json state,labels --jq '{state: .state, labels: [.labels[].name]}'` and confirm:
    - the PR is still `OPEN`
-   - it still has the `harness-impl` label
    - it does **not** have the `no-auto-admin-merge` label
 
 2. **CI status** -- Run `gh pr checks {{.Issue.Number}}` and confirm every required check has passed. If any check is failing or pending, record which ones.

--- a/.xylem/prompts/respond-to-pr-review/analyze.md
+++ b/.xylem/prompts/respond-to-pr-review/analyze.md
@@ -9,17 +9,7 @@ URL: {{.Issue.URL}}
 
 Run `gh pr checkout {{.Issue.Number}}` to switch to the PR branch.
 
-## Step 2: Guard — verify this is a harness implementation PR
-
-Check whether the PR has the `harness-impl` label:
-
-```
-gh pr view {{.Issue.Number}} --json labels --jq '.labels[].name' | grep -q harness-impl
-```
-
-If the `harness-impl` label is absent, output `XYLEM_NOOP` on its own line and stop. This workflow only applies to harness implementation PRs.
-
-## Step 3: Mutex — prevent concurrent vessels
+## Step 2: Mutex — prevent concurrent vessels
 
 Check whether the PR already has the `pr-vessel-active` label:
 
@@ -35,7 +25,7 @@ Otherwise, apply the mutex label immediately:
 gh pr edit {{.Issue.Number}} --add-label pr-vessel-active
 ```
 
-## Step 4: Fetch all review comments
+## Step 3: Fetch all review comments
 
 Retrieve all review comments on the PR:
 
@@ -49,7 +39,7 @@ Also retrieve top-level PR reviews for any body text:
 gh api repos/{owner}/{repo}/pulls/{{.Issue.Number}}/reviews
 ```
 
-## Step 5: Categorize each comment
+## Step 4: Categorize each comment
 
 For each review comment, classify it into one of three categories:
 
@@ -57,11 +47,11 @@ For each review comment, classify it into one of three categories:
 2. **Explanation needed** — the reviewer asked a question or expressed confusion that can be resolved with a reply. Draft the reply text.
 3. **Already resolved / outdated** — the comment refers to code that has already been changed or a thread that was resolved. Note why it can be skipped.
 
-## Step 6: Read affected files
+## Step 5: Read affected files
 
 For each comment requiring a code fix, read the file at the referenced path. Understand the surrounding context so fixes are correct.
 
-## Step 7: Produce the response plan
+## Step 6: Produce the response plan
 
 Output a structured plan listing each comment with:
 

--- a/.xylem/prompts/unblock-wave/check_deps.md
+++ b/.xylem/prompts/unblock-wave/check_deps.md
@@ -1,4 +1,4 @@
-Check whether a merged PR unblocks any dependent harness issues.
+Check whether a merged PR unblocks any dependent issues.
 
 Issue: {{.Issue.Title}}
 URL: {{.Issue.URL}}
@@ -6,26 +6,12 @@ PR Number: {{.Issue.Number}}
 
 {{.Issue.Body}}
 
-## Guard
-
-First, check if this PR carries the `harness-impl` label:
-
-```
-gh pr view {{.Issue.Number}} --json labels --jq '.labels[].name'
-```
-
-If `harness-impl` is NOT among the labels, this PR is not part of the harness implementation wave. Output the exact standalone line:
-
-XYLEM_NOOP
-
-And stop. No further work is needed.
-
 ## Find blocked issues
 
-List all open harness issues that are currently blocked:
+List all open issues that are currently blocked:
 
 ```
-gh issue list --repo nicholls-inc/xylem --label harness-impl --label blocked --state open --json number,title,body --limit 100
+gh issue list --repo nicholls-inc/xylem --label blocked --state open --json number,title,body --limit 100
 ```
 
 ## Check dependencies

--- a/.xylem/workflows/implement-harness.yaml
+++ b/.xylem/workflows/implement-harness.yaml
@@ -101,5 +101,4 @@ phases:
         --repo nicholls-inc/xylem \
         --title "$TITLE" \
         --body "$BODY" \
-        --label "harness-impl" \
         --label "ready-to-merge"

--- a/cli/internal/profiles/profiles_prop_test.go
+++ b/cli/internal/profiles/profiles_prop_test.go
@@ -163,7 +163,6 @@ var docGardenExpectedFragments = map[string]string{
 var implementHarnessPRCreateContract = []string{
 	`gh pr create`,
 	`--repo nicholls-inc/xylem`,
-	`--label "harness-impl"`,
 	`--label "ready-to-merge"`,
 }
 

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -202,8 +202,7 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	assert.Contains(t, sortedKeys(composed.Prompts), "hardening-audit/rank")
 	assert.Contains(t, sortedKeys(composed.Prompts), "backlog-refinement/analyze")
 	assert.Contains(t, sortedKeys(composed.Prompts), "backlog-refinement/report")
-	assert.Contains(t, sortedKeys(composed.Sources), "harness-impl")
-	assert.Contains(t, sortedKeys(composed.Sources), "harness-pr-lifecycle")
+	assert.Contains(t, sortedKeys(composed.Sources), "post-merge")
 	assert.Contains(t, sortedKeys(composed.Sources), "continuous-improvement")
 	assert.Contains(t, sortedKeys(composed.Sources), "continuous-simplicity")
 	assert.Contains(t, sortedKeys(composed.Sources), "hardening-audit")
@@ -223,7 +222,6 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 
 	implementHarnessWorkflow := string(composed.Workflows["implement-harness"])
 	assert.Contains(t, implementHarnessWorkflow, `--repo nicholls-inc/xylem`)
-	assert.Contains(t, implementHarnessWorkflow, `--label "harness-impl"`)
 	assert.Contains(t, implementHarnessWorkflow, `--label "ready-to-merge"`)
 }
 

--- a/cli/internal/profiles/self-hosting-xylem/prompts/implement-harness/pr.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/implement-harness/pr.md
@@ -25,8 +25,8 @@ The PR body must include:
 - Changes summary (files added/modified, key types and functions)
 - Test plan
 
-After creating the PR, add the `harness-impl` label:
+After creating the PR, add the `ready-to-merge` label:
 
 ```
-gh pr edit --add-label harness-impl
+gh pr edit --add-label ready-to-merge
 ```

--- a/cli/internal/profiles/self-hosting-xylem/prompts/unblock-wave/check_deps.md
+++ b/cli/internal/profiles/self-hosting-xylem/prompts/unblock-wave/check_deps.md
@@ -1,4 +1,4 @@
-Check whether a merged PR unblocks any dependent harness issues.
+Check whether a merged PR unblocks any dependent issues.
 
 Issue: {{.Issue.Title}}
 URL: {{.Issue.URL}}
@@ -6,26 +6,12 @@ PR Number: {{.Issue.Number}}
 
 {{.Issue.Body}}
 
-## Guard
-
-First, check if this PR carries the `harness-impl` label:
-
-```
-gh pr view {{.Issue.Number}} --json labels --jq '.labels[].name'
-```
-
-If `harness-impl` is NOT among the labels, this PR is not part of the harness implementation wave. Output the exact standalone line:
-
-XYLEM_NOOP
-
-And stop. No further work is needed.
-
 ## Find blocked issues
 
-List all open harness issues that are currently blocked:
+List all open issues that are currently blocked:
 
 ```
-gh issue list --repo nicholls-inc/xylem --label harness-impl --label blocked --state open --json number,title,body --limit 100
+gh issue list --repo nicholls-inc/xylem --label blocked --state open --json number,title,body --limit 100
 ```
 
 ## Check dependencies

--- a/cli/internal/profiles/self-hosting-xylem/workflows/implement-harness.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/implement-harness.yaml
@@ -101,5 +101,4 @@ phases:
         --repo nicholls-inc/xylem \
         --title "$TITLE" \
         --body "$BODY" \
-        --label "harness-impl" \
         --label "ready-to-merge"

--- a/cli/internal/profiles/self-hosting-xylem/workflows/initiative-tracker.yaml
+++ b/cli/internal/profiles/self-hosting-xylem/workflows/initiative-tracker.yaml
@@ -11,7 +11,7 @@ phases:
       mkdir -p .xylem/state/initiative
 
       # Collect issues by key labels.
-      for LABEL in harness-impl enhancement bug ready-for-work; do
+      for LABEL in enhancement bug ready-for-work; do
         gh issue list --repo nicholls-inc/xylem \
           --label "$LABEL" --state open \
           --json number,title,labels,updatedAt,assignees \

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -1,42 +1,4 @@
 sources:
-  pr-lifecycle:
-    type: github-pr-events
-    repo: "{{ .Repo }}"
-    exclude: [no-bot, pr-vessel-active]
-    tasks:
-      respond-reviews:
-        workflow: respond-to-pr-review
-        on:
-          review_submitted: true
-          author_allow:
-            - "copilot-pull-request-reviewer[bot]"
-      fix-checks:
-        workflow: fix-pr-checks
-        on:
-          checks_failed: true
-  merge:
-    type: github-pr
-    repo: "{{ .Repo }}"
-    exclude: [no-bot, pr-vessel-active]
-    tasks:
-      merge-ready:
-        labels: [ready-to-merge]
-        workflow: merge-pr
-        status_labels:
-          running: pr-vessel-active
-          completed: pr-vessel-merged
-          failed: xylem-failed
-  conflict-resolution:
-    type: github-pr
-    repo: "{{ .Repo }}"
-    exclude: [no-bot, pr-vessel-active]
-    tasks:
-      resolve-conflicts:
-        labels: [needs-conflict-resolution]
-        workflow: resolve-conflicts
-        status_labels:
-          running: pr-vessel-active
-          failed: xylem-failed
   sota-gap:
     type: scheduled
     repo: "{{ .Repo }}"

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -1,18 +1,5 @@
 sources:
-  harness-impl:
-    type: github
-    repo: "{{ .Repo }}"
-    timeout: "90m"
-    exclude: [wontfix, duplicate, in-progress, no-bot, blocked]
-    tasks:
-      implement-harness-steps:
-        labels: [harness-impl, ready-for-work]
-        workflow: implement-harness
-        status_labels:
-          running: in-progress
-          failed: xylem-failed
-          timed_out: xylem-failed
-  harness-pr-lifecycle:
+  pr-lifecycle:
     type: github-pr-events
     repo: "{{ .Repo }}"
     exclude: [no-bot, pr-vessel-active]
@@ -27,13 +14,13 @@ sources:
         workflow: fix-pr-checks
         on:
           checks_failed: true
-  harness-merge:
+  merge:
     type: github-pr
     repo: "{{ .Repo }}"
     exclude: [no-bot, pr-vessel-active]
     tasks:
       merge-ready:
-        labels: [ready-to-merge, harness-impl]
+        labels: [ready-to-merge]
         workflow: merge-pr
         status_labels:
           running: pr-vessel-active
@@ -45,7 +32,7 @@ sources:
     exclude: [no-bot, pr-vessel-active]
     tasks:
       resolve-conflicts:
-        labels: [needs-conflict-resolution, harness-impl]
+        labels: [needs-conflict-resolution]
         workflow: resolve-conflicts
         status_labels:
           running: pr-vessel-active
@@ -155,7 +142,7 @@ sources:
         workflow: ingest-field-reports
         ref: ingest-field-reports
 
-  harness-post-merge:
+  post-merge:
     type: github-merge
     repo: "{{ .Repo }}"
     tasks:

--- a/cli/internal/workflow/implement_harness_workflow_test.go
+++ b/cli/internal/workflow/implement_harness_workflow_test.go
@@ -22,7 +22,6 @@ const (
 	implementHarnessGoTest     = "go test ./..."
 	implementHarnessPRCreate   = "gh pr create"
 	implementHarnessRepoFlag   = "--repo nicholls-inc/xylem"
-	implementHarnessPRLabel    = `--label "harness-impl"`
 	implementHarnessMergeLabel = `--label "ready-to-merge"`
 )
 
@@ -114,7 +113,6 @@ func TestSmoke_S3_ImplementHarnessWorkflowChecksMainFreshnessBeforePRCreate(t *t
 	assert.Contains(t, prCreate.Run, implementHarnessFetchMain)
 	assert.Contains(t, prCreate.Run, implementHarnessMergeBase)
 	assert.Contains(t, prCreate.Run, implementHarnessRepoFlag)
-	assert.Contains(t, prCreate.Run, implementHarnessPRLabel)
 	assert.Contains(t, prCreate.Run, implementHarnessMergeLabel)
 	assert.Contains(t, prCreate.Run, `ERROR: branch is behind origin/main; rebase before creating the PR`)
 	assert.True(t, commandContainsInOrder(
@@ -122,7 +120,6 @@ func TestSmoke_S3_ImplementHarnessWorkflowChecksMainFreshnessBeforePRCreate(t *t
 		implementHarnessFetchMain,
 		implementHarnessMergeBase,
 		implementHarnessPRCreate,
-		implementHarnessPRLabel,
 		implementHarnessMergeLabel,
 	))
 }


### PR DESCRIPTION
## Summary
- Remove the `harness-impl` source entirely — all `enhancement` + `ready-for-work` issues now route through the existing `features` source
- Genericise `merge` source: triggers on `ready-to-merge` alone (was `ready-to-merge` + `harness-impl`)
- Genericise `conflict-resolution` source: triggers on `needs-conflict-resolution` alone (was `needs-conflict-resolution` + `harness-impl`)
- Remove `harness-impl` guards from PR lifecycle prompts (respond-to-pr-review, fix-pr-checks, merge-pr, unblock-wave)
- Update self-hosting overlay profile to match
- Rename sources: `harness-pr-lifecycle` → `pr-lifecycle`, `harness-merge` → `merge`, `harness-post-merge` → `post-merge`

## Test plan
- [ ] `xylem scan --dry-run` parses config cleanly
- [ ] PRs labelled `ready-to-merge` (without `harness-impl`) are picked up by the merge source
- [ ] PRs labelled `needs-conflict-resolution` (without `harness-impl`) are picked up by the conflict-resolution source
- [ ] PR review responses and CI fix workflows fire for all PRs, not just harness-impl PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)