### PR TITLE
feat: support configurable env_file path for daemon

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -58,7 +58,7 @@ func cmdDaemon(cmd *cobra.Command, cfg *config.Config, q *queue.Queue, wt *workt
 	if err != nil {
 		return fmt.Errorf("resolve working directory: %w", err)
 	}
-	if err := loadDaemonStartupEnv(rootDir); err != nil {
+	if err := loadDaemonStartupEnv(rootDir, cfg.Daemon.EffectiveEnvFile()); err != nil {
 		return err
 	}
 	if err := config.MigrateFlatStateToRuntime(cfg.StateDir); err != nil {

--- a/cli/cmd/xylem/daemon_env.go
+++ b/cli/cmd/xylem/daemon_env.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 )
 
-func loadDaemonStartupEnv(workingDir string) error {
-	envFile, err := loadDaemonSupervisorEnvFile(daemonSupervisorEnvFilePath(workingDir))
+func loadDaemonStartupEnv(workingDir, envFileName string) error {
+	envFile, err := loadDaemonSupervisorEnvFile(daemonSupervisorEnvFilePath(workingDir, envFileName))
 	if err != nil {
 		return fmt.Errorf("load daemon startup env: %w", err)
 	}

--- a/cli/cmd/xylem/daemon_env_test.go
+++ b/cli/cmd/xylem/daemon_env_test.go
@@ -12,14 +12,14 @@ import (
 
 func TestLoadDaemonStartupEnvAppliesDaemonRootEnv(t *testing.T) {
 	repoDir := t.TempDir()
-	envPath := daemonSupervisorEnvFilePath(repoDir)
+	envPath := daemonSupervisorEnvFilePath(repoDir, ".env")
 	require.NoError(t, os.MkdirAll(filepath.Dir(envPath), 0o755))
 	require.NoError(t, os.WriteFile(envPath, []byte("API_TOKEN=from-file\nEMPTY=\n"), 0o644))
 
 	t.Setenv("API_TOKEN", "from-process")
 	t.Setenv("EMPTY", "non-empty")
 
-	require.NoError(t, loadDaemonStartupEnv(repoDir))
+	require.NoError(t, loadDaemonStartupEnv(repoDir, ".env"))
 	assert.Equal(t, "from-file", os.Getenv("API_TOKEN"))
 	assert.Equal(t, "", os.Getenv("EMPTY"))
 }
@@ -28,20 +28,32 @@ func TestLoadDaemonStartupEnvMissingFileIsNoop(t *testing.T) {
 	repoDir := t.TempDir()
 	t.Setenv("API_TOKEN", "from-process")
 
-	require.NoError(t, loadDaemonStartupEnv(repoDir))
+	require.NoError(t, loadDaemonStartupEnv(repoDir, ".env"))
 	assert.Equal(t, "from-process", os.Getenv("API_TOKEN"))
 }
 
 func TestLoadDaemonStartupEnvReturnsParseError(t *testing.T) {
 	repoDir := t.TempDir()
-	envPath := daemonSupervisorEnvFilePath(repoDir)
+	envPath := daemonSupervisorEnvFilePath(repoDir, ".env")
 	require.NoError(t, os.MkdirAll(filepath.Dir(envPath), 0o755))
 	require.NoError(t, os.WriteFile(envPath, []byte("not-an-assignment\n"), 0o644))
 
-	err := loadDaemonStartupEnv(repoDir)
+	err := loadDaemonStartupEnv(repoDir, ".env")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "load daemon startup env")
 	assert.Contains(t, err.Error(), ".env")
+}
+
+func TestLoadDaemonStartupEnvUsesConfiguredEnvFile(t *testing.T) {
+	repoDir := t.TempDir()
+	envPath := daemonSupervisorEnvFilePath(repoDir, "secrets.env")
+	require.NoError(t, os.MkdirAll(filepath.Dir(envPath), 0o755))
+	require.NoError(t, os.WriteFile(envPath, []byte("CONFIGURED_KEY=configured-value\n"), 0o644))
+
+	t.Setenv("CONFIGURED_KEY", "original")
+
+	require.NoError(t, loadDaemonStartupEnv(repoDir, "secrets.env"))
+	assert.Equal(t, "configured-value", os.Getenv("CONFIGURED_KEY"))
 }
 
 func TestApplyDaemonEnvEntriesRejectsInvalidEntry(t *testing.T) {

--- a/cli/cmd/xylem/daemon_reload.go
+++ b/cli/cmd/xylem/daemon_reload.go
@@ -323,7 +323,7 @@ func (r *daemonRuntime) applyReload(ctx context.Context, req daemonReloadRequest
 
 	handle := before
 	if reloadErr == nil {
-		if err := loadDaemonStartupEnv(r.rootDir); err != nil {
+		if err := loadDaemonStartupEnv(r.rootDir, nextCfg.Daemon.EffectiveEnvFile()); err != nil {
 			reloadErr = fmt.Errorf("reload daemon startup env: %w", err)
 			result = "rejected"
 		}

--- a/cli/cmd/xylem/daemon_reload_test.go
+++ b/cli/cmd/xylem/daemon_reload_test.go
@@ -129,7 +129,7 @@ func TestDaemonRuntimeRetainsBusyRunnerAcrossReload(t *testing.T) {
 
 func TestDaemonRuntimeReloadReappliesDaemonRootEnv(t *testing.T) {
 	rootDir, configPath, _ := writeDaemonReloadRepo(t, "# Harness A\n")
-	envPath := daemonSupervisorEnvFilePath(rootDir)
+	envPath := daemonSupervisorEnvFilePath(rootDir, ".env")
 	require.NoError(t, os.MkdirAll(filepath.Dir(envPath), 0o755))
 	require.NoError(t, os.WriteFile(envPath, []byte("XYLEM_TEST_DAEMON_TOKEN=first\n"), 0o644))
 
@@ -154,7 +154,7 @@ func TestDaemonRuntimeReloadReappliesDaemonRootEnv(t *testing.T) {
 
 	cfg, err := config.Load(configPath)
 	require.NoError(t, err)
-	require.NoError(t, loadDaemonStartupEnv(rootDir))
+	require.NoError(t, loadDaemonStartupEnv(rootDir, ".env"))
 
 	q := queue.New(filepath.Join(cfg.StateDir, "queue.jsonl"))
 	rt, err := newDaemonRuntime(rootDir, configPath, q, worktree.New(rootDir, newCmdRunner(cfg)), cfg)

--- a/cli/cmd/xylem/daemon_supervisor.go
+++ b/cli/cmd/xylem/daemon_supervisor.go
@@ -152,7 +152,7 @@ func runDaemonSupervisor(ctx context.Context, opts daemonSupervisorOptions) erro
 			return clearDaemonSupervisorStopRequest(opts.Cfg)
 		}
 
-		env, err := daemonSupervisorProcessEnv(opts.WorkingDir)
+		env, err := daemonSupervisorProcessEnv(opts.WorkingDir, opts.Cfg.Daemon.EffectiveEnvFile())
 		if err != nil {
 			return err
 		}
@@ -316,8 +316,8 @@ func startDaemonSupervisorProcess(launch daemonSupervisorLaunch) (daemonSupervis
 	return &execDaemonSupervisorProcess{cmd: cmd}, nil
 }
 
-func daemonSupervisorProcessEnv(workingDir string) ([]string, error) {
-	envFile, err := loadDaemonSupervisorEnvFile(daemonSupervisorEnvFilePath(workingDir))
+func daemonSupervisorProcessEnv(workingDir, envFileName string) ([]string, error) {
+	envFile, err := loadDaemonSupervisorEnvFile(daemonSupervisorEnvFilePath(workingDir, envFileName))
 	if err != nil {
 		return nil, err
 	}
@@ -333,8 +333,8 @@ func daemonSupervisorCommandArgs(configPath string) []string {
 	return args
 }
 
-func daemonSupervisorEnvFilePath(workingDir string) string {
-	return filepath.Join(workingDir, ".env")
+func daemonSupervisorEnvFilePath(workingDir, envFileName string) string {
+	return filepath.Join(workingDir, envFileName)
 }
 
 func loadDaemonSupervisorEnvFile(path string) ([]string, error) {

--- a/cli/cmd/xylem/daemon_supervisor_test.go
+++ b/cli/cmd/xylem/daemon_supervisor_test.go
@@ -42,7 +42,7 @@ func (p *fakeDaemonSupervisorProcess) Wait() error {
 func TestRunDaemonSupervisorRestartsAfterUnexpectedExitAndReloadsEnv(t *testing.T) {
 	repoDir := t.TempDir()
 	cfg := &config.Config{StateDir: filepath.Join(repoDir, ".xylem")}
-	envPath := daemonSupervisorEnvFilePath(repoDir)
+	envPath := daemonSupervisorEnvFilePath(repoDir, ".env")
 	if err := os.MkdirAll(filepath.Dir(envPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(envPath), err)
 	}
@@ -395,6 +395,44 @@ func TestSmoke_S4_ManualDaemonStopDoesNotTriggerRestart(t *testing.T) {
 	assert.False(t, daemonSupervisorStopRequested(cfg))
 }
 
+func TestRunDaemonSupervisorUsesConfiguredEnvFileName(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{
+		StateDir: filepath.Join(repoDir, ".xylem"),
+		Daemon:   config.DaemonConfig{EnvFile: "secrets.env"},
+	}
+	envPath := daemonSupervisorEnvFilePath(repoDir, "secrets.env")
+	require.NoError(t, os.MkdirAll(filepath.Dir(envPath), 0o755))
+	require.NoError(t, os.WriteFile(envPath, []byte("SECRET_KEY=loaded-from-secrets\n"), 0o644))
+
+	var launches []daemonSupervisorLaunch
+
+	err := runDaemonSupervisor(context.Background(), daemonSupervisorOptions{
+		Cfg:            cfg,
+		ConfigPath:     ".xylem.yml",
+		ExecutablePath: "/tmp/xylem",
+		WorkingDir:     repoDir,
+		Start: func(launch daemonSupervisorLaunch) (daemonSupervisorProcess, error) {
+			launches = append(launches, launch)
+			return &fakeDaemonSupervisorProcess{
+				pid: 301,
+				waitFn: func() error {
+					return requestDaemonSupervisorStop(cfg)
+				},
+			}, nil
+		},
+		Sleep: func(_ context.Context, delay time.Duration) error {
+			t.Fatalf("unexpected sleep call with %s", delay)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, launches, 1)
+	if got := daemonEnvValue(launches[0].Env, "SECRET_KEY"); got != "loaded-from-secrets" {
+		t.Fatalf("SECRET_KEY = %q, want %q", got, "loaded-from-secrets")
+	}
+}
+
 func daemonEnvValue(env []string, key string) string {
 	prefix := key + "="
 	value := ""
@@ -411,7 +449,7 @@ func runDaemonSupervisorUnexpectedExitSmoke(t *testing.T) daemonSupervisorSmokeR
 
 	repoDir := t.TempDir()
 	cfg := &config.Config{StateDir: filepath.Join(repoDir, ".xylem")}
-	envPath := daemonSupervisorEnvFilePath(repoDir)
+	envPath := daemonSupervisorEnvFilePath(repoDir, ".env")
 	require.NoError(t, os.MkdirAll(filepath.Dir(envPath), 0o755))
 	require.NoError(t, os.WriteFile(envPath, []byte("API_TOKEN=first\n"), 0o644))
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -241,6 +241,9 @@ type DaemonConfig struct {
 	// AutoMergeReviewer is the GitHub login to request before enabling
 	// auto-merge. Defaults to empty, which skips reviewer requests.
 	AutoMergeReviewer string `yaml:"auto_merge_reviewer,omitempty"`
+	// EnvFile is the path (relative to the working directory) of the env file
+	// the daemon loads at startup. Defaults to ".env" when empty.
+	EnvFile string `yaml:"env_file,omitempty"`
 }
 
 type PhaseConfig struct {
@@ -808,6 +811,15 @@ func (d DaemonConfig) EffectiveAutoMergeReviewer() string {
 
 func (d DaemonConfig) EffectiveAutoAdminMergeOptOutLabel() string {
 	return DefaultAutoAdminMergeOptOutLabel
+}
+
+// EffectiveEnvFile returns the env file path to load at daemon startup.
+// Returns ".env" when EnvFile is empty, preserving backward compatibility.
+func (d DaemonConfig) EffectiveEnvFile() string {
+	if trimmed := strings.TrimSpace(d.EnvFile); trimmed != "" {
+		return trimmed
+	}
+	return ".env"
 }
 
 // CleanupAfterDuration returns the parsed cleanup_after duration, defaulting to

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -3796,3 +3796,23 @@ func TestValidateGitHubActionsEmptyConclusionRejected(t *testing.T) {
 	err := cfg.Validate()
 	requireErrorContains(t, err, "conclusions must not contain empty strings")
 }
+
+func TestEffectiveEnvFileDefaultsToEnv(t *testing.T) {
+	d := DaemonConfig{}
+	assert.Equal(t, ".env", d.EffectiveEnvFile())
+}
+
+func TestEffectiveEnvFileReturnsConfiguredValue(t *testing.T) {
+	d := DaemonConfig{EnvFile: "secrets.env"}
+	assert.Equal(t, "secrets.env", d.EffectiveEnvFile())
+}
+
+func TestEffectiveEnvFileTrimsWhitespace(t *testing.T) {
+	d := DaemonConfig{EnvFile: "  .env.local  "}
+	assert.Equal(t, ".env.local", d.EffectiveEnvFile())
+}
+
+func TestEffectiveEnvFileWhitespaceOnlyFallsBackToDefault(t *testing.T) {
+	d := DaemonConfig{EnvFile: "   "}
+	assert.Equal(t, ".env", d.EffectiveEnvFile())
+}


### PR DESCRIPTION
## Summary

- Add `env_file` field to `DaemonConfig` in `config.go` with YAML tag `env_file,omitempty`
- Add `EffectiveEnvFile()` helper on `DaemonConfig` that returns `.env` when unconfigured (backward compatible)
- Update `daemonSupervisorEnvFilePath`, `daemonSupervisorProcessEnv`, and `loadDaemonStartupEnv` to accept the resolved filename from the caller
- Thread `cfg.Daemon.EffectiveEnvFile()` through from `cmdDaemon` and `runDaemonSupervisor` call sites
- Add tests for `EffectiveEnvFile()` and the new `loadDaemonStartupEnv` / `daemonSupervisorProcessEnv` signatures

## Test plan

- [ ] `go test ./cmd/xylem/... ./internal/config/...` passes
- [ ] `TestEffectiveEnvFileDefaultsToEnv` — empty `EnvFile` → `".env"`
- [ ] `TestEffectiveEnvFileReturnsConfiguredValue` — non-empty `EnvFile` → configured value
- [ ] `TestLoadDaemonStartupEnvUsesConfiguredEnvFile` — loads from `secrets.env` when specified
- [ ] `TestRunDaemonSupervisorUsesConfiguredEnvFile` — supervisor picks up configured filename

Closes https://github.com/nicholls-inc/xylem/issues/492

🤖 Generated with [Claude Code](https://claude.com/claude-code)