### PR TITLE
feat: add weekly autonomy-review workflow with discussion publishing

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -211,6 +211,16 @@ sources:
         workflow: diagnose-failures
         ref: diagnose-failures
 
+  autonomy-review:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "@weekly"
+    timeout: "90m"
+    tasks:
+      weekly-autonomy-review:
+        workflow: autonomy-review
+        ref: autonomy-review
+
 notifications:
   github_discussion:
     enabled: true

--- a/.xylem/prompts/autonomy-review/report.md
+++ b/.xylem/prompts/autonomy-review/report.md
@@ -1,0 +1,82 @@
+Format the autonomy review findings into a polished markdown report for a GitHub Discussion.
+
+## Input
+
+Read the previous phase output:
+
+{{.PreviousOutputs.review}}
+
+Also read the structured findings file: `.xylem/state/autonomy-review/findings.json`
+
+## Output
+
+Write `.xylem/state/autonomy-review/report.md` with the following sections. Use clear markdown
+formatting suitable for GitHub Discussions rendering.
+
+### Report structure
+
+```markdown
+# Autonomy Review — {{.Date}}
+
+## Current State Summary
+
+- **Active workflows:** (count and list names)
+- **Source types:** (github, scheduled, github-pr, github-pr-events, github-merge — list which are configured)
+- **Scheduled tasks:** (list each with schedule interval)
+- **Daily throughput:** N vessels/day (past 7 days)
+- **Failure rate:** N% (failed + timed_out / total)
+
+## Coverage Gap Analysis
+
+For each gap found:
+
+### Gap: (short title)
+- **What's missing:** (description)
+- **Impact:** high/medium/low
+- **Suggested fix:** (concrete change with file path)
+
+## Throughput Recommendations
+
+| Parameter | Current | Suggested | Reason |
+|-----------|---------|-----------|--------|
+| ... | ... | ... | ... |
+
+## Quality Gate Review
+
+For each issue:
+- **Workflow:** (name)
+- **Issue:** (description)
+- **Suggestion:** (what to add or change)
+- **Trade-off:** (what could go wrong with the change)
+
+## Prompt Quality
+
+List specific prompt files that need changes, ordered by impact:
+
+1. **`path/to/prompt.md`** — (issue and suggested fix)
+
+## Quick Wins
+
+Immediate config or workflow changes that can be applied now:
+
+- [ ] (change with exact file path and what to modify)
+
+## Proposed Changes
+
+Larger changes that need design or new workflows:
+
+### (Change title)
+- **Justification:** (why)
+- **Scope:** (what files/workflows are affected)
+- **Risk:** (what could go wrong)
+```
+
+### Guidelines
+
+- Be specific: reference exact file paths, config keys, and workflow names
+- Be actionable: every finding should have a concrete next step
+- Be honest: if throughput is good, say so; do not manufacture problems
+- Keep the report under 3000 words — density over length
+- Do not include raw JSON dumps; synthesize the data into readable prose and tables
+
+After writing the file, print: `Report written: .xylem/state/autonomy-review/report.md`

--- a/.xylem/prompts/autonomy-review/review.md
+++ b/.xylem/prompts/autonomy-review/review.md
@@ -1,0 +1,146 @@
+Perform a comprehensive autonomy and velocity review of xylem's self-building capabilities.
+
+Repository: {{.Repo.Slug}}
+Date: {{.Date}}
+
+## Step 1 — Read configuration and workflow definitions
+
+Read these files:
+
+1. `.xylem.yml` (full config: sources, concurrency, timeouts, scheduling)
+2. All workflow files: `ls .xylem/workflows/*.yaml` then read each one
+3. `.xylem/HARNESS.md`
+
+Understand the full set of configured sources, workflows, phases, gates, and scheduling intervals.
+
+## Step 2 — Read operational data
+
+1. **Queue history**: Read the last 50 entries from `.xylem/state/queue.jsonl` (use `tail -50`).
+   Count total entries, then check: if fewer than 10 entries have timestamps after the last
+   autonomy review (or in the past 7 days if no prior review exists), output `XYLEM_NOOP` and stop.
+
+2. **Recent vessel outputs**: Find the 5 most recently modified directories under
+   `.xylem/state/phases/` (use `ls -t | head -5`). For each, read all `.output` files to
+   understand what work was attempted and how it concluded.
+
+## Step 3 — Analyze and evaluate
+
+### Workflow coverage
+
+Map the full self-building lifecycle: issue discovery, triage, refinement, implementation,
+testing, PR creation, review, merge, post-merge follow-up, failure diagnosis, and recovery.
+
+- Identify dead ends where work stalls with no next step
+- Identify missing transitions (e.g., a workflow produces output but nothing consumes it)
+- Check the failure-to-recovery loop: do failed vessels get diagnosed and re-attempted?
+- Check whether all issue label states have a corresponding source+workflow path
+
+### Throughput
+
+From the queue data, calculate:
+
+- Completion rate (completed / total vessels in the window)
+- Failure rate (failed + timed_out / total)
+- Average duration for completed vessels
+- Vessels per day
+
+Identify bottlenecks:
+
+- Is `concurrency.global` limiting throughput?
+- Are `max_turns` values causing unnecessary timeouts?
+- Are scheduling intervals too frequent or too sparse?
+- Are gate retries causing cascading delays?
+
+### Quality gates
+
+- Are gates applied consistently across similar workflows?
+- Are test/smoke phases present where code changes happen?
+- Is rebase-before-push applied universally to PR-producing workflows?
+- Are gates strict enough to prevent low-quality merges?
+
+### Prompt quality
+
+For each workflow's prompt files, check:
+
+- Specificity: are instructions concrete enough for autonomous execution?
+- Phase handoff: do later phases reference `{{.PreviousOutputs.*}}` to receive earlier results?
+- Gate retry feedback: do prompts use `{{.GateResult}}` where gates exist?
+- Scope creep protection: do prompts define clear boundaries on what to change?
+- Output contracts: do prompts specify exact file paths and formats for outputs?
+
+### Failure patterns
+
+From the recent vessel outputs and queue data:
+
+- Group failures by root cause category (scope too broad, missing context, gate failure, timeout, tool error)
+- Identify self-referential loops (e.g., a fix workflow that keeps failing on the same issue)
+- Find recurring patterns that should be encoded as workflow improvements or lessons
+
+## Step 4 — Write findings
+
+Create the state directory and write findings:
+
+```bash
+mkdir -p .xylem/state/autonomy-review
+```
+
+Write `.xylem/state/autonomy-review/findings.json` with this structure:
+
+```json
+{
+  "version": 1,
+  "generated_at": "RFC3339 timestamp",
+  "repo": "{{.Repo.Slug}}",
+  "window": {
+    "start": "RFC3339",
+    "end": "RFC3339",
+    "vessels_total": 0,
+    "vessels_completed": 0,
+    "vessels_failed": 0,
+    "vessels_timed_out": 0,
+    "completion_rate": 0.0,
+    "failure_rate": 0.0,
+    "avg_duration_minutes": 0.0,
+    "vessels_per_day": 0.0
+  },
+  "coverage_gaps": [
+    {
+      "gap": "description of the gap",
+      "impact": "high|medium|low",
+      "suggested_fix": "what to change"
+    }
+  ],
+  "throughput_recommendations": [
+    {
+      "parameter": "concurrency.global|max_turns|timeout|schedule",
+      "current_value": "...",
+      "suggested_value": "...",
+      "reason": "..."
+    }
+  ],
+  "quality_gate_issues": [
+    {
+      "workflow": "workflow name",
+      "issue": "description",
+      "suggestion": "what to add or change"
+    }
+  ],
+  "prompt_issues": [
+    {
+      "file": "path to prompt file",
+      "issue": "description",
+      "suggestion": "specific change"
+    }
+  ],
+  "failure_patterns": [
+    {
+      "pattern": "description",
+      "count": 0,
+      "root_cause": "category",
+      "mitigation": "suggested fix"
+    }
+  ]
+}
+```
+
+Also print a human-readable summary of the key findings to stdout.

--- a/.xylem/workflows/autonomy-review.yaml
+++ b/.xylem/workflows/autonomy-review.yaml
@@ -1,0 +1,29 @@
+name: autonomy-review
+class: harness-maintenance
+description: "Weekly autonomy & velocity review of xylem's self-building capabilities"
+phases:
+  - name: review
+    prompt_file: .xylem/prompts/autonomy-review/review.md
+    max_turns: 50
+    noop:
+      match: XYLEM_NOOP
+  - name: report
+    prompt_file: .xylem/prompts/autonomy-review/report.md
+    max_turns: 30
+  - name: post
+    type: command
+    noop:
+      match: XYLEM_NOOP
+    output: discussion
+    discussion:
+      category: "Status Reports"
+      title_template: "[autonomy-review] Weekly Report — {{.Date}}"
+      title_search_template: "[autonomy-review] Weekly Report"
+    run: |
+      set -euo pipefail
+      REPORT=".xylem/state/autonomy-review/report.md"
+      if [ ! -f "$REPORT" ]; then
+        echo "XYLEM_NOOP: no report to post"
+        exit 0
+      fi
+      cat "$REPORT"


### PR DESCRIPTION
## Summary
- Adds `autonomy-review` scheduled workflow (weekly, 90m timeout) with 3 phases: review, report, post
- Review phase reads queue state, phase outputs, workflow configs, and failure patterns
- Report phase formats findings as structured markdown
- Post phase publishes to GitHub Discussions "Status Reports" category via `output: discussion`

## Test plan
- [ ] Verify YAML parses correctly (`go build ./cmd/xylem`)
- [ ] Verify discussion config has required fields (category, title_template)
- [ ] Verify template variables are valid ({{.Date}}, {{.PreviousOutputs.review}}, {{.Repo.Slug}})
- [ ] Wait for first weekly execution to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)