### PR TITLE
fix: scope diagnose-failures to 3 recent vessels, remove doc-garden source

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -171,16 +171,6 @@ sources:
         workflow: backlog-refinement
         ref: backlog-refinement
 
-  doc-garden:
-    type: scheduled
-    repo: nicholls-inc/xylem
-    schedule: "@daily"
-    timeout: "90m"
-    tasks:
-      doc-garden:
-        workflow: doc-garden
-        ref: doc-garden
-
   harness-gap-analysis:
     type: scheduled
     repo: nicholls-inc/xylem
@@ -204,7 +194,7 @@ sources:
   diagnose-failures:
     type: scheduled
     repo: nicholls-inc/xylem
-    schedule: "1h"
+    schedule: "2h"
     timeout: "45m"
     tasks:
       hourly-diagnose-failures:

--- a/.xylem/prompts/diagnose-failures/diagnose.md
+++ b/.xylem/prompts/diagnose-failures/diagnose.md
@@ -2,6 +2,15 @@ Diagnose xylem vessel failures in this repository.
 
 ## Your Task
 
+## Scope Constraints
+
+To keep this analysis focused and completable within the turn budget:
+
+- Analyze at most the **3 most recent** failed vessels within the cutoff window
+- **Exclude** vessels from the `diagnose-failures` and `backlog-refinement` workflows — these have known recurring issues tracked separately and analyzing them creates a self-referential loop
+- For each qualifying vessel, read only the **last phase output** (the phase where execution stopped), not all phase outputs. The last phase output contains the failure information.
+- If no qualifying failures exist after applying these filters, output `XYLEM_NOOP`
+
 <!-- CONFIGURE: Change the number below to control how far back to look for failures -->
 Only consider vessels that failed within the last **24 hours**. Check each vessel's `created_at`
 field in `.xylem/queue.jsonl` against today's date and skip vessels older than the cutoff.

--- a/.xylem/workflows/diagnose-failures.yaml
+++ b/.xylem/workflows/diagnose-failures.yaml
@@ -3,7 +3,7 @@ description: "Diagnose xylem vessel failures and file refined GitHub issues"
 phases:
   - name: diagnose
     prompt_file: .xylem/prompts/diagnose-failures/diagnose.md
-    max_turns: 20
+    max_turns: 40
   - name: create_issues
     prompt_file: .xylem/prompts/diagnose-failures/create_issues.md
     max_turns: 20


### PR DESCRIPTION
## Summary
- Increase diagnose-failures `max_turns` from 20 to 40 (was hitting limit on every run)
- Add scope constraints to diagnose prompt: limit to 3 most recent non-meta failures, exclude self-referential workflows, read only last phase output per vessel
- Reduce schedule from 1h to 2h (unnecessary frequency at current failure volume)
- Remove `doc-garden` source block (references nonexistent workflow file, guaranteed failure)

## Test plan
- [ ] Verify max_turns change only on diagnose phase (create_issues=20, refine=40 unchanged)
- [ ] Verify doc-garden source fully removed from .xylem.yml
- [ ] Monitor next diagnose-failures run for successful completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)