### PR TITLE
feat: add pr-self-review workflow for quality checks before merge

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -121,6 +121,18 @@ sources:
           running: pr-vessel-active
           failed: xylem-failed
 
+  pr-self-review:
+    type: github-pr
+    repo: nicholls-inc/xylem
+    exclude: [no-bot, pr-vessel-active]
+    tasks:
+      self-review:
+        labels: [ready-to-merge]
+        workflow: pr-self-review
+        status_labels:
+          running: pr-vessel-active
+          failed: xylem-failed
+
   sota-gap:
     type: scheduled
     repo: nicholls-inc/xylem

--- a/.xylem/prompts/pr-self-review/apply_feedback.md
+++ b/.xylem/prompts/pr-self-review/apply_feedback.md
@@ -1,0 +1,30 @@
+Fix the quality issues identified in the self-review.
+
+PR: #{{.Issue.Number}}
+URL: {{.Issue.URL}}
+
+## Review Findings
+{{.PreviousOutputs.review}}
+
+{{if .GateResult}}
+## Previous Gate Failure
+The following gate check failed after the previous attempt. Fix the issues and try again:
+
+{{.GateResult}}
+{{end}}
+
+## Instructions
+
+For each finding in the review:
+
+1. Read the file at the specified path and line number
+2. Implement the suggested fix
+3. Verify the fix doesn't break anything by running `cd cli && go test ./...` locally
+
+After fixing all issues:
+
+1. Run `goimports -w .` from the `cli/` directory to fix any formatting
+2. Run `cd cli && go vet ./...` to check for issues
+3. Run `cd cli && go test ./...` to verify nothing is broken
+
+Do not make any changes beyond what the review findings specify. Do not add new features, refactor surrounding code, or "improve" things that weren't flagged.

--- a/.xylem/prompts/pr-self-review/push.md
+++ b/.xylem/prompts/pr-self-review/push.md
@@ -1,0 +1,23 @@
+Push the self-review fixes to the PR branch.
+
+PR: #{{.Issue.Number}}
+URL: {{.Issue.URL}}
+
+## Instructions
+
+1. Check what was changed:
+   ```
+   git status
+   git diff --stat
+   ```
+
+2. If there are no changes (the review found no issues or apply_feedback made no changes), do nothing and output: "No changes to push."
+
+3. If there are changes:
+   a. Stage all modified files: `git add -A`
+   b. Commit with message: `fix: address self-review findings for PR #{{.Issue.Number}}`
+   c. Push to the PR branch: `git push`
+
+4. Output a summary of what was pushed.
+
+Do not create a new PR. Do not modify the PR description. Just push the fixes to the existing branch.

--- a/.xylem/prompts/pr-self-review/review.md
+++ b/.xylem/prompts/pr-self-review/review.md
@@ -1,0 +1,52 @@
+Review a pull request for quality issues before it reaches external reviewers.
+
+PR: #{{.Issue.Number}}
+URL: {{.Issue.URL}}
+
+## Instructions
+
+### Step 1: Fetch the PR diff and context
+
+```
+gh pr view {{.Issue.Number}} --repo {{.Repo.Slug}} --json title,body,labels,files,additions,deletions
+gh pr diff {{.Issue.Number}} --repo {{.Repo.Slug}}
+```
+
+### Step 2: Review for these specific issues
+
+For each changed file, check:
+
+1. **Scope creep** — Changes that are unrelated to the PR title/description. Look for modifications to files not mentioned in the PR body, unrelated refactoring, or feature additions beyond the stated goal.
+
+2. **Unnecessary formatting changes** — Whitespace-only changes, import reordering without functional purpose, comment reformatting in code the PR doesn't otherwise touch.
+
+3. **Weak tests** — Test functions that:
+   - Only assert `err == nil` without checking return values
+   - Assert a mock returns what it was configured to return (tautological)
+   - Have more mock setup lines than assertion lines
+   - Are missing obvious edge cases (nil inputs, empty slices, zero values)
+
+4. **Debug leftovers** — `fmt.Println`, `fmt.Printf` used for debugging (not logging), `log.Printf("DEBUG` patterns, `TODO`/`FIXME`/`HACK` comments added in this PR, commented-out code.
+
+5. **Hardcoded values** — Magic numbers, hardcoded paths, embedded credentials or tokens, hardcoded repo names (should use template variables).
+
+### Step 3: Output
+
+If **no issues found**, output exactly:
+```
+XYLEM_NOOP: PR #{{.Issue.Number}} passes self-review — no issues found
+```
+
+If **issues found**, output a structured report:
+
+```
+## Self-Review Findings for PR #<number>
+
+### <Category>
+- **File:** `<path>` (line <N>)
+  **Issue:** <description>
+  **Fix:** <what to change>
+```
+
+List findings by severity (most impactful first). Be specific — include file paths and line numbers.
+Do not modify any files in this phase. This is read-only.

--- a/.xylem/workflows/pr-self-review.yaml
+++ b/.xylem/workflows/pr-self-review.yaml
@@ -1,0 +1,18 @@
+name: pr-self-review
+description: "Review PRs with ready-to-merge label for scope creep, weak tests, and debug leftovers"
+phases:
+  - name: review
+    prompt_file: .xylem/prompts/pr-self-review/review.md
+    max_turns: 30
+    noop:
+      match: XYLEM_NOOP
+  - name: apply_feedback
+    prompt_file: .xylem/prompts/pr-self-review/apply_feedback.md
+    max_turns: 40
+    gate:
+      type: command
+      run: "cd cli && go vet ./... && go build ./cmd/xylem && go test ./..."
+      retries: 1
+  - name: push
+    prompt_file: .xylem/prompts/pr-self-review/push.md
+    max_turns: 20


### PR DESCRIPTION
## Summary
- Adds `pr-self-review` workflow triggered by `ready-to-merge` label on any PR
- 3 phases: review (scope creep, weak tests, debug leftovers), apply_feedback (fix issues, gate: go test), push
- Uses `pr-vessel-active` mutual exclusion to prevent feedback loops with harness-merge and other PR workflows
- NOOPs when no issues found, avoiding unnecessary commits

## Test plan
- [ ] Verify YAML parses correctly (`go build ./cmd/xylem`)
- [ ] Verify source type is `github-pr` (not `github-pr-events`)
- [ ] Verify `pr-vessel-active` exclusion prevents concurrent PR vessels
- [ ] Monitor first execution on a real PR with `ready-to-merge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)