### PR TITLE
feat: add ci-watchdog workflow to monitor CI on main

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -223,6 +223,16 @@ sources:
         workflow: autonomy-review
         ref: autonomy-review
 
+  ci-watchdog:
+    type: scheduled
+    repo: nicholls-inc/xylem
+    schedule: "30m"
+    timeout: "30m"
+    tasks:
+      monitor-main-ci:
+        workflow: ci-watchdog
+        ref: ci-watchdog
+
 notifications:
   github_discussion:
     enabled: true

--- a/.xylem/prompts/ci-watchdog/diagnose.md
+++ b/.xylem/prompts/ci-watchdog/diagnose.md
@@ -1,0 +1,49 @@
+Diagnose a CI failure on the main branch.
+
+## CI Run Information
+{{.PreviousOutputs.check}}
+
+## Instructions
+
+1. Parse the run ID and URL from the CI run information above.
+
+2. Fetch the failing logs:
+   ```
+   gh run view <run-id> --log-failed 2>&1 | head -200
+   ```
+
+3. Identify the breaking commit:
+   ```
+   gh run view <run-id> --json headSha -q '.headSha'
+   git log --oneline -5 main
+   ```
+
+4. Determine the failure class:
+   - **Flake**: The failure is non-deterministic (test timeout, network issue, race condition). Evidence: the same test passed in a recent prior run, or the error message indicates transient infrastructure.
+   - **Regression**: The failure is deterministic and caused by a specific code change. Evidence: a new test failure that corresponds to recently changed code.
+   - **Infrastructure**: CI infrastructure issue (runner failure, Docker pull timeout, etc.). Evidence: failure before any test execution.
+
+5. Output a structured diagnosis:
+
+```
+## CI Failure Diagnosis
+
+**Run:** <url>
+**Commit:** <sha> — <commit message>
+**Failing step:** <step name>
+**Failure class:** flake | regression | infrastructure
+**Confidence:** high | medium | low
+
+### Error Summary
+<concise description of what failed and why>
+
+### Root Cause
+<for regressions: which commit/change caused it>
+<for flakes: what condition triggers the non-determinism>
+<for infrastructure: what CI component failed>
+
+### Recommended Action
+<specific fix description>
+```
+
+Do not modify any files. This is a read-only diagnostic phase.

--- a/.xylem/prompts/ci-watchdog/file_issue.md
+++ b/.xylem/prompts/ci-watchdog/file_issue.md
@@ -1,0 +1,48 @@
+File a GitHub issue for the CI failure diagnosed in the previous phase.
+
+## Diagnosis
+{{.PreviousOutputs.diagnose}}
+
+## Instructions
+
+### Step 1: Check for existing issues
+
+Before creating anything, check for existing open issues that already track this failure:
+
+```
+gh issue list --repo nicholls-inc/xylem --label bug --state open --json number,title --limit 50
+```
+
+Look for issues with similar titles (matching the failing step or error pattern). If a match exists,
+skip creation and output: "Existing issue #N already tracks this failure — skipping."
+
+### Step 2: Decide whether to file
+
+- **Regression** or **Infrastructure** with high/medium confidence → file an issue
+- **Flake** with high confidence → file an issue but add `flaky-test` to the labels if the label exists
+- Any failure class with **low confidence** → do not file, output: "Confidence too low to file — manual review recommended"
+
+### Step 3: Create the issue
+
+```
+gh issue create \
+  --repo nicholls-inc/xylem \
+  --title "CI: <failing step> — <brief description>" \
+  --label "bug" \
+  --label "ready-for-work" \
+  --body "<body>"
+```
+
+The issue body must include:
+- Link to the failing CI run
+- The breaking commit SHA and message
+- The failure class and confidence
+- The error summary from the diagnosis
+- The recommended action
+
+Keep the body under 2000 characters. Focus on the fix, not the full diagnosis.
+
+### Step 4: Output
+
+If an issue was created, output: "Filed #N: <title>"
+If skipped (existing or low confidence), output why.

--- a/.xylem/workflows/ci-watchdog.yaml
+++ b/.xylem/workflows/ci-watchdog.yaml
@@ -1,0 +1,24 @@
+name: ci-watchdog
+class: ops
+description: "Monitor CI status on main and file issues when CI fails"
+phases:
+  - name: check
+    type: command
+    run: |
+      set -euo pipefail
+      RESULT=$(gh run list --branch main --limit 1 --json databaseId,headSha,conclusion,event,url,name)
+      CONCLUSION=$(echo "$RESULT" | jq -r '.[0].conclusion')
+      if [ "$CONCLUSION" = "success" ] || [ "$CONCLUSION" = "" ] || [ "$CONCLUSION" = "null" ]; then
+        echo "XYLEM_NOOP: CI is green on main (conclusion=$CONCLUSION)"
+        exit 0
+      fi
+      echo "CI failure detected on main"
+      echo "$RESULT" | jq '.[0]'
+    noop:
+      match: XYLEM_NOOP
+  - name: diagnose
+    prompt_file: .xylem/prompts/ci-watchdog/diagnose.md
+    max_turns: 20
+  - name: file_issue
+    prompt_file: .xylem/prompts/ci-watchdog/file_issue.md
+    max_turns: 15


### PR DESCRIPTION
## Summary
- Adds a `ci-watchdog` scheduled workflow that runs every 30 minutes to check CI status on main
- When CI fails, diagnoses the failure (flake/regression/infrastructure) and files an issue with `bug` + `ready-for-work` labels
- Closes the post-merge monitoring gap so the existing `fix-bug` workflow can automatically pick up CI regressions

## Test plan
- [ ] Verify `go build ./cmd/xylem` succeeds
- [ ] Verify `go test ./...` passes
- [ ] Verify YAML parses correctly (pre-commit hook validates)
- [ ] Verify noop fires on green CI (check phase prints `XYLEM_NOOP` when conclusion is success/null/empty)
- [ ] E2E: daemon picks up workflow on schedule and correctly noops when CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)