### PR TITLE
fix: use ensure_ascii=True in JSON sanitizer to escape all non-ASCII

### DIFF
--- a/.xylem/workflows/backlog-refinement.yaml
+++ b/.xylem/workflows/backlog-refinement.yaml
@@ -86,7 +86,7 @@ phases:
       sanitized = sanitize_json(raw)
       data = json.loads(sanitized)
       with open(filepath, "w") as f:
-          json.dump(data, f, ensure_ascii=False)
+          json.dump(data, f, ensure_ascii=True)
       ' "$ACTIONS_FILE"
 
       ACTION_COUNT=$(jq '.actions | length' "$ACTIONS_FILE")

--- a/.xylem/workflows/triage.yaml
+++ b/.xylem/workflows/triage.yaml
@@ -55,7 +55,7 @@ phases:
       sanitized = sanitize_json(raw)
       data = json.loads(sanitized)
       with open(filepath, "w") as f:
-          json.dump(data, f, ensure_ascii=False)
+          json.dump(data, f, ensure_ascii=True)
       ' "$ACTIONS_FILE"
 
       ISSUE_NUMBER=$(jq -r '.issue_number' "$ACTIONS_FILE")


### PR DESCRIPTION
## Summary
- Changes `json.dump(data, f, ensure_ascii=False)` to `ensure_ascii=True` in both `backlog-refinement.yaml` and `triage.yaml`
- The previous fix (#497) correctly stripped raw control bytes, but `json.loads` decodes `\u001f`-style escape sequences into actual control characters, which `json.dump(ensure_ascii=False)` then writes back as raw bytes that jq rejects
- `ensure_ascii=True` forces all non-ASCII and control characters to `\uXXXX` escapes, which jq accepts per RFC 8259

## Evidence
First run after #497 merged still failed with the same jq error:
```
jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 11, column 267
```

## Test plan
- [ ] Monitor next backlog-refinement run for successful apply_actions completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)