### PR TITLE
fix: exclude github-merge source from stale PR cancellation

### DIFF
--- a/cli/internal/runner/stale_cancel.go
+++ b/cli/internal/runner/stale_cancel.go
@@ -15,17 +15,21 @@ import (
 // prRefPattern matches GitHub PR URLs and extracts the PR number.
 var prRefPattern = regexp.MustCompile(`/pull/(\d+)`)
 
-// prSources are the vessel source types that reference pull requests.
+// prSources are the vessel source types that reference pull requests and should
+// be cancelled when their PR is already merged or closed. github-merge is
+// intentionally excluded: those vessels are triggered *by* a PR merge, so a
+// merged PR is their entry condition, not an obsolescence signal.
 var prSources = map[string]bool{
 	"github-pr":        true,
 	"github-pr-events": true,
-	"github-merge":     true,
 }
 
 // CancelStalePRVessels checks pending vessels that reference pull requests and
 // cancels those whose PRs are already merged or closed. This prevents wasting
 // concurrency slots on work that can never succeed (e.g., merging an already-
-// merged PR, resolving conflicts on a closed PR).
+// merged PR, resolving conflicts on a closed PR). Vessels from the
+// github-merge source are excluded because a merged PR is their trigger, not
+// an obsolescence signal.
 //
 // Returns the number of vessels cancelled.
 func (r *Runner) CancelStalePRVessels(ctx context.Context) int {

--- a/cli/internal/runner/stale_cancel_test.go
+++ b/cli/internal/runner/stale_cancel_test.go
@@ -228,6 +228,65 @@ func TestCancelStalePRVessels_CancelsClosed(t *testing.T) {
 	}
 }
 
+func TestCancelStalePRVessels_SkipsGithubMergeSource(t *testing.T) {
+	dir := t.TempDir()
+	qPath := filepath.Join(dir, "queue.jsonl")
+	q := queue.New(qPath)
+
+	v := queue.Vessel{
+		ID:        "unblock-wave-pr-77",
+		Source:    "github-merge",
+		Ref:       "https://github.com/owner/repo/pull/77",
+		Workflow:  "unblock-wave",
+		State:     queue.StatePending,
+		CreatedAt: time.Now(),
+		Meta:      map[string]string{"pr_num": "77", "config_source": "merges"},
+	}
+	if _, err := q.Enqueue(v); err != nil {
+		t.Fatal(err)
+	}
+
+	// PR is MERGED — this is the vessel's trigger, not a stale signal.
+	resp, _ := json.Marshal(map[string]string{"state": "MERGED"})
+	ghCalled := false
+	mock := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name == "gh" {
+				ghCalled = true
+				return resp, nil, true
+			}
+			return nil, nil, false
+		},
+	}
+
+	cfg := &config.Config{
+		Timeout:  "45m",
+		StateDir: dir,
+	}
+
+	r := &Runner{
+		Config: cfg,
+		Queue:  q,
+		Runner: mock,
+	}
+
+	cancelled := r.CancelStalePRVessels(context.Background())
+	if cancelled != 0 {
+		t.Errorf("expected 0 cancelled, got %d", cancelled)
+	}
+	if ghCalled {
+		t.Error("gh should not be called for github-merge source vessels")
+	}
+
+	vessel, err := q.FindByID("unblock-wave-pr-77")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vessel.State != queue.StatePending {
+		t.Errorf("expected pending, got %s", vessel.State)
+	}
+}
+
 func TestExtractPRNumber(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- `github-merge` was incorrectly included in `prSources`, causing vessels triggered *by* a PR merge (e.g. `unblock-wave`) to be immediately cancelled when the stale-PR check found their referenced PR in `MERGED` state
- Removed `"github-merge": true` from the `prSources` map — vessels from this source type are post-merge workflows; a merged PR is their entry condition, not an obsolescence signal
- Updated the `prSources` comment and `CancelStalePRVessels` doc comment to make the exclusion explicit

## Test plan

- [ ] `TestCancelStalePRVessels_SkipsGithubMergeSource` — new regression test: asserts a `github-merge` vessel with a merged PR is not cancelled and `gh` is never called
- [ ] Existing tests (`CancelsMerged`, `KeepsOpen`, `SkipsNonPRSources`, `CancelsClosed`) all pass unmodified

Closes https://github.com/nicholls-inc/xylem/issues/501

🤖 Generated with [Claude Code](https://claude.com/claude-code)