### PR TITLE
fix: escape template syntax in autonomy-review prompt

### DIFF
--- a/.xylem/prompts/autonomy-review/review.md
+++ b/.xylem/prompts/autonomy-review/review.md
@@ -63,8 +63,8 @@ Identify bottlenecks:
 For each workflow's prompt files, check:
 
 - Specificity: are instructions concrete enough for autonomous execution?
-- Phase handoff: do later phases reference `{{.PreviousOutputs.*}}` to receive earlier results?
-- Gate retry feedback: do prompts use `{{.GateResult}}` where gates exist?
+- Phase handoff: do later phases reference `.PreviousOutputs.<key>` to receive earlier results?
+- Gate retry feedback: do prompts use `.GateResult` where gates exist?
 - Scope creep protection: do prompts define clear boundaries on what to change?
 - Output contracts: do prompts specify exact file paths and formats for outputs?
 


### PR DESCRIPTION
## Summary

- The `autonomy-review` workflow's `review.md` prompt contained `{{.PreviousOutputs.*}}` and `{{.GateResult}}` as documentation examples of template variable syntax
- Go's `text/template` parser treats any `{{...}}` as a template action regardless of markdown backtick fences, causing a parse error at render time due to the invalid `*` operand
- Replaced both with plain-text notation (`.PreviousOutputs.<key>` and `.GateResult`) that conveys the same meaning without triggering the parser

Fixes https://github.com/nicholls-inc/xylem/issues/503

## Test plan

- [ ] The `autonomy-review` scheduled workflow next runs and the `review` phase completes without a template parse error
- [ ] No other prompt files have the same `{{...}}` documentation pattern (confirmed by scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)