### PR TITLE
fix: reduce fix-pr-checks fix phase max_turns from 60 to 30

### DIFF
--- a/cli/internal/profiles/core/workflows/fix-pr-checks.yaml
+++ b/cli/internal/profiles/core/workflows/fix-pr-checks.yaml
@@ -8,7 +8,7 @@ phases:
       match: XYLEM_NOOP
   - name: fix
     prompt_file: .xylem/prompts/fix-pr-checks/fix.md
-    max_turns: 60
+    max_turns: 30
     gate:
       type: command
       run: "true"


### PR DESCRIPTION
## Summary

- Reduces `max_turns` in the `fix` phase of `fix-pr-checks` from 60 → 30
- The `fix` phase operates on a pre-diagnosed, bounded scope (formatting, build, test iteration) — 60 turns matched the heavy `implement` phase budget but was oversized for this workflow
- Consistent with the `diagnose` phase (30 turns) and resolves OOM/wall-clock kills observed in chainstats-fe-v1

Closes https://github.com/nicholls-inc/xylem/issues/513

## Test plan

- [ ] Profiles package tests pass (`go test ./internal/profiles/...`)
- [ ] fix-pr-checks workflow executes without OOM/wall-clock kill on next run in chainstats-fe-v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)