### PR TITLE
fix: inject git identity flags on lessons commit to avoid missing user config

### DIFF
--- a/cli/cmd/xylem/lessons.go
+++ b/cli/cmd/xylem/lessons.go
@@ -174,7 +174,7 @@ func createLessonsPullRequest(ctx context.Context, wt lessonsWorktree, runner le
 	if err := runner.RunProcess(ctx, worktreePath, "git", "add", proposal.HarnessPath); err != nil {
 		return fmt.Errorf("create lessons pull request %q: git add: %w", proposal.Branch, err)
 	}
-	if err := runner.RunProcess(ctx, worktreePath, "git", "commit", "-m", proposal.Title); err != nil {
+	if err := runner.RunProcess(ctx, worktreePath, "git", "-c", "user.name=xylem", "-c", "user.email=xylem@localhost", "commit", "-m", proposal.Title); err != nil {
 		return fmt.Errorf("create lessons pull request %q: git commit: %w", proposal.Branch, err)
 	}
 	if err := runner.RunProcess(ctx, worktreePath, "git", "push", "--set-upstream", "origin", proposal.Branch); err != nil {

--- a/cli/cmd/xylem/lessons_test.go
+++ b/cli/cmd/xylem/lessons_test.go
@@ -130,6 +130,20 @@ func TestCmdLessonsCreatesPullRequestsForGeneratedProposals(t *testing.T) {
 	if len(runner.processCalls) != 3 {
 		t.Fatalf("len(processCalls) = %d, want 3", len(runner.processCalls))
 	}
+	// Verify the commit call carries inline identity flags so it works in
+	// environments where git global user.name/user.email are not configured.
+	commitFound := false
+	for _, call := range runner.processCalls {
+		if strings.Contains(call, "commit") {
+			if !strings.Contains(call, "user.name=xylem") || !strings.Contains(call, "user.email=xylem@localhost") {
+				t.Fatalf("git commit call missing identity flags: %q", call)
+			}
+			commitFound = true
+		}
+	}
+	if !commitFound {
+		t.Fatal("no git commit call found in processCalls")
+	}
 	if len(runner.phaseCalls) != 2 {
 		t.Fatalf("len(phaseCalls) = %d, want 2", len(runner.phaseCalls))
 	}


### PR DESCRIPTION
## Summary

- Fixes `git commit` failure in `createLessonsPullRequest` when `user.name`/`user.email` are not configured in the global git config of the daemon environment
- Passes `-c user.name=xylem -c user.email=xylem@localhost` inline to `git commit` so the commit succeeds in any environment regardless of global git config
- Adds a test assertion to `TestCmdLessonsCreatesPullRequestsForGeneratedProposals` verifying the identity flags are present on the commit call

Closes https://github.com/nicholls-inc/xylem/issues/511

## Test plan
- [ ] `go test ./cmd/xylem/...` passes (new assertion verifies identity flags on commit invocation)
- [ ] `go build ./cmd/xylem` passes
- [ ] `golangci-lint run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)