### PR TITLE
feat: auto-sync profile workflows into daemon worktree on upgrade

### DIFF
--- a/cli/cmd/xylem/daemon.go
+++ b/cli/cmd/xylem/daemon.go
@@ -90,7 +90,9 @@ func cmdDaemon(cmd *cobra.Command, cfg *config.Config, q *queue.Queue, wt *workt
 		} else {
 			selfUpgrade(target.repoDir, target.executablePath)
 
-			upgrade = func() { selfUpgrade(target.repoDir, target.executablePath) }
+			upgrade = func() {
+				runUpgradeTick(target.repoDir, target.executablePath, cfg)
+			}
 			upgradeInterval = parseUpgradeInterval(cfg.Daemon)
 		}
 	}
@@ -262,6 +264,21 @@ func maybeResyncProfileAssets(cfg *config.Config) error {
 // parseUpgradeInterval returns the effective periodic upgrade interval. If
 // the config provides an explicit value, it is parsed; otherwise the default
 // is returned.
+// runUpgradeTick performs one upgrade cycle: it pulls and rebuilds the binary
+// via selfUpgrade, and if exec() did not fire (binary unchanged), it re-syncs
+// profile assets so any drift since the last startup is corrected.
+func runUpgradeTick(repoDir, executablePath string, cfg *config.Config) {
+	selfUpgrade(repoDir, executablePath)
+	// If exec() fired, the new process handles profile sync at daemonStartup.
+	// If exec() did not fire (binary unchanged), resync here to catch any
+	// profile drift since the last startup (e.g., manual file deletion).
+	if len(cfg.Profiles) > 0 {
+		if err := daemonResyncProfileAssets(cfg); err != nil {
+			slog.Warn("daemon upgrade profile re-sync failed", "error", err)
+		}
+	}
+}
+
 func parseUpgradeInterval(dc config.DaemonConfig) time.Duration {
 	if dc.UpgradeInterval == "" {
 		return defaultUpgradeInterval

--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -1180,18 +1180,17 @@ func TestSmoke_S28_CLIWiringInDaemonGoCreatesIntermediaryFromConfig(t *testing.T
 
 // TestSmoke_S49_DaemonStartupResyncsProfileAssetsWhenDigestDrifts verifies
 // that daemonStartup triggers a resync when the embedded digest differs from
-// the runtime digest: missing files are created and user-modified files are
-// preserved (not overwritten).
+// the runtime digest: stale files are overwritten and missing files are created.
 func TestSmoke_S49_DaemonStartupResyncsProfileAssetsWhenDigestDrifts(t *testing.T) {
 	dir := t.TempDir()
 	stateDir := filepath.Join(dir, ".xylem")
 	require.NoError(t, os.MkdirAll(filepath.Join(stateDir, "workflows"), 0o755))
 
-	// Write user-modified content to one workflow file so the runtime digest differs.
-	userContent := []byte("stale: true")
+	// Write stale content to one workflow file so the runtime digest differs.
+	staleContent := []byte("stale: true")
 	require.NoError(t, os.WriteFile(
 		filepath.Join(stateDir, "workflows", "fix-bug.yaml"),
-		userContent,
+		staleContent,
 		0o644,
 	))
 
@@ -1208,18 +1207,17 @@ func TestSmoke_S49_DaemonStartupResyncsProfileAssetsWhenDigestDrifts(t *testing.
 	// The resync log message must appear — digest drift was detected.
 	assert.Contains(t, logs.String(), "daemon profile assets stale; re-syncing")
 
-	// User-modified content must be preserved — resync does not overwrite files
-	// whose on-disk content differs from the embedded version.
-	data, readErr := os.ReadFile(filepath.Join(stateDir, "workflows", "fix-bug.yaml"))
-	require.NoError(t, readErr)
-	assert.Equal(t, userContent, data, "user-modified workflow must not be overwritten by resync")
-
-	// A workflow that was absent before resync must be created.
+	// The stale workflow must be overwritten with the embedded version.
 	composed, composeErr := profiles.Compose("core")
 	require.NoError(t, composeErr)
+	data, readErr := os.ReadFile(filepath.Join(stateDir, "workflows", "fix-bug.yaml"))
+	require.NoError(t, readErr)
+	assert.Equal(t, composed.Workflows["fix-bug"], data, "stale workflow must be overwritten by resync")
+
+	// A workflow that was absent before resync must be created.
 	for name, embeddedBytes := range composed.Workflows {
 		if name == "fix-bug" {
-			continue // we intentionally left this one modified
+			continue // already verified above
 		}
 		wfPath := filepath.Join(stateDir, "workflows", name+".yaml")
 		wfData, wfErr := os.ReadFile(wfPath)
@@ -1316,6 +1314,131 @@ func TestSmoke_S53_DaemonStartupSkipsResyncWhenProfilesEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, logs.String(), "re-sync")
 	assert.NotContains(t, logs.String(), "compose profiles")
+}
+
+// TestSmoke_S54_ResyncOverwritesStaleProfileWorkflow verifies that resyncProfileAssets
+// overwrites a profile-owned workflow file that exists on disk with stale content.
+func TestSmoke_S54_ResyncOverwritesStaleProfileWorkflow(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+	wfPath := filepath.Join(stateDir, "workflows", "fix-bug.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(wfPath), 0o755))
+	require.NoError(t, os.WriteFile(wfPath, []byte("stale: content\n"), 0o644))
+
+	composed := &profiles.ComposedProfile{
+		Workflows: map[string][]byte{
+			"fix-bug": []byte("version: 2\n"),
+		},
+	}
+	logs := withBufferedDefaultLogger(t)
+	require.NoError(t, resyncProfileAssets(stateDir, composed))
+
+	got, err := os.ReadFile(wfPath)
+	require.NoError(t, err)
+	assert.Equal(t, composed.Workflows["fix-bug"], got, "stale workflow must be overwritten")
+	assert.Contains(t, logs.String(), "updated file")
+}
+
+// TestSmoke_S55_ResyncCreatesMissingProfileWorkflow verifies that resyncProfileAssets
+// creates a profile-owned workflow file that does not yet exist on disk.
+func TestSmoke_S55_ResyncCreatesMissingProfileWorkflow(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+
+	composed := &profiles.ComposedProfile{
+		Workflows: map[string][]byte{
+			"fix-bug": []byte("workflow: fix\n"),
+		},
+	}
+	logs := withBufferedDefaultLogger(t)
+	require.NoError(t, resyncProfileAssets(stateDir, composed))
+
+	got, err := os.ReadFile(filepath.Join(stateDir, "workflows", "fix-bug.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, composed.Workflows["fix-bug"], got)
+	assert.Contains(t, logs.String(), "added file")
+}
+
+// TestSmoke_S56_ResyncPreservesDaemonOnlyWorkflow verifies that resyncProfileAssets
+// does not touch workflow files that are not part of the composed profile.
+func TestSmoke_S56_ResyncPreservesDaemonOnlyWorkflow(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+	daemonOnlyPath := filepath.Join(stateDir, "workflows", "custom-daemon.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(daemonOnlyPath), 0o755))
+	daemonContent := []byte("daemon: only\n")
+	require.NoError(t, os.WriteFile(daemonOnlyPath, daemonContent, 0o644))
+
+	// Profile only contains "fix-bug", not "custom-daemon".
+	composed := &profiles.ComposedProfile{
+		Workflows: map[string][]byte{
+			"fix-bug": []byte("workflow: fix\n"),
+		},
+	}
+	require.NoError(t, resyncProfileAssets(stateDir, composed))
+
+	got, err := os.ReadFile(daemonOnlyPath)
+	require.NoError(t, err)
+	assert.Equal(t, daemonContent, got, "daemon-only workflow must not be touched")
+}
+
+// TestSmoke_S57_UpgradeTickCallsResyncWhenBinaryUnchanged verifies that
+// runUpgradeTick calls maybeResyncProfileAssets (via the injectable
+// daemonResyncProfileAssets) even when selfUpgrade returns without exec()-ing
+// (binary hash unchanged path). If someone removes the resync call from
+// runUpgradeTick, this test fails.
+func TestSmoke_S57_UpgradeTickCallsResyncWhenBinaryUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, ".xylem")
+
+	cfg := &config.Config{
+		Profiles: []string{"core"},
+		StateDir: stateDir,
+	}
+
+	// Stub selfUpgrade so exec() is not called (binary unchanged path).
+	stubDaemonUpgradeDependencies(t,
+		func(string) error { return nil },
+		func(string, string) error { return nil },
+		func(string, []string, []string) error { return nil },
+	)
+
+	// Stub daemonResyncProfileAssets and record whether it was called with the
+	// correct config. This is the only assertion that matters: the real production
+	// function runUpgradeTick must invoke it.
+	resyncCalled := false
+	prev := daemonResyncProfileAssets
+	daemonResyncProfileAssets = func(c *config.Config) error {
+		assert.Equal(t, cfg, c, "resync must receive the daemon cfg")
+		resyncCalled = true
+		return nil
+	}
+	t.Cleanup(func() { daemonResyncProfileAssets = prev })
+
+	runUpgradeTick(dir, filepath.Join(dir, "xylem"), cfg)
+
+	assert.True(t, resyncCalled, "runUpgradeTick must call maybeResyncProfileAssets when profiles are configured")
+}
+
+// TestSmoke_S58_ResyncLogsAddedAndUpdatedFiles verifies that resyncProfileAssets
+// emits slog.Info messages for both added (new) and updated (stale) files.
+func TestSmoke_S58_ResyncLogsAddedAndUpdatedFiles(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), ".xylem")
+
+	// Pre-create one file with stale content (will be updated).
+	wfPath := filepath.Join(stateDir, "workflows", "fix-bug.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(wfPath), 0o755))
+	require.NoError(t, os.WriteFile(wfPath, []byte("old: content\n"), 0o644))
+
+	composed := &profiles.ComposedProfile{
+		Workflows: map[string][]byte{
+			"fix-bug":           []byte("new: content\n"),
+			"implement-feature": []byte("new workflow\n"),
+		},
+	}
+	logs := withBufferedDefaultLogger(t)
+	require.NoError(t, resyncProfileAssets(stateDir, composed))
+
+	logStr := logs.String()
+	assert.Contains(t, logStr, "updated file", "updated file must be logged")
+	assert.Contains(t, logStr, "added file", "added file must be logged")
 }
 
 func TestReconcileStaleVessels(t *testing.T) {

--- a/cli/cmd/xylem/init.go
+++ b/cli/cmd/xylem/init.go
@@ -278,18 +278,25 @@ func syncProfileAssets(stateDir string, composed *profiles.ComposedProfile, forc
 	return nil
 }
 
-// writeFileIfNotModified writes content to path with resync-safe semantics:
-// - If the file does not exist, it is created.
-// - If the file exists and its content matches the incoming content, it is a no-op.
-// - If the file exists with different content (user-modified), a warning is logged and the file is left unchanged.
-func writeFileIfNotModified(path string, content []byte) error {
+// writeFileForResync writes content to path with profile-authoritative semantics:
+//   - If the file does not exist, it is created and "added" is logged.
+//   - If the file exists with identical content, it is a no-op.
+//   - If the file exists with different content, it is overwritten and "updated" is logged.
+//
+// This is intentionally authoritative: profile-owned files are always brought
+// in sync with the embedded binary. Files not iterated by the caller (daemon-only
+// files not present in the composed profile) are never touched.
+func writeFileForResync(path string, content []byte) error {
 	existing, err := os.ReadFile(path)
 	if err == nil {
 		if bytes.Equal(existing, content) {
 			return nil // already up to date
 		}
-		// File exists with different content — treat as user-modified, skip.
-		slog.Warn("daemon profile resync: skipping user-modified file", "path", path)
+		// File exists with stale content — overwrite with the embedded version.
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+		slog.Info("daemon profile resync: updated file", "path", path)
 		return nil
 	}
 	if !os.IsNotExist(err) {
@@ -302,34 +309,36 @@ func writeFileIfNotModified(path string, content []byte) error {
 	if err := os.WriteFile(path, content, 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}
+	slog.Info("daemon profile resync: added file", "path", path)
 	return nil
 }
 
 // resyncProfileAssets syncs profile workflows, prompts, and scripts using
-// resync-safe semantics: files that exist with user-modified content are
-// preserved and skipped with a warning, while missing files are created.
-// This is used by the daemon on startup to apply embedded profile updates
-// without clobbering user edits.
+// profile-authoritative semantics: existing files with stale content are
+// overwritten with the embedded version, and missing files are created.
+// Files not iterated (daemon-only files absent from the composed profile)
+// are left untouched.
+// This is used by the daemon on startup and after each upgrade tick.
 func resyncProfileAssets(stateDir string, composed *profiles.ComposedProfile) error {
 	if composed == nil {
 		return fmt.Errorf("resync profile assets: composed profile is required")
 	}
 
 	for _, name := range sortedKeys(composed.Workflows) {
-		if err := writeFileIfNotModified(filepath.Join(stateDir, "workflows", name+".yaml"), composed.Workflows[name]); err != nil {
+		if err := writeFileForResync(filepath.Join(stateDir, "workflows", name+".yaml"), composed.Workflows[name]); err != nil {
 			return fmt.Errorf("resync workflow %q: %w", name, err)
 		}
 	}
 
 	for _, name := range sortedKeys(composed.Prompts) {
-		if err := writeFileIfNotModified(filepath.Join(stateDir, "prompts", filepath.FromSlash(name)+".md"), composed.Prompts[name]); err != nil {
+		if err := writeFileForResync(filepath.Join(stateDir, "prompts", filepath.FromSlash(name)+".md"), composed.Prompts[name]); err != nil {
 			return fmt.Errorf("resync prompt %q: %w", name, err)
 		}
 	}
 
 	for _, name := range sortedKeys(composed.Scripts) {
 		scriptPath := filepath.Join(stateDir, "scripts", filepath.FromSlash(name))
-		if err := writeFileIfNotModified(scriptPath, composed.Scripts[name]); err != nil {
+		if err := writeFileForResync(scriptPath, composed.Scripts[name]); err != nil {
 			return fmt.Errorf("resync script %q: %w", name, err)
 		}
 		if err := os.Chmod(scriptPath, 0o755); err != nil {

--- a/cli/cmd/xylem/init_prop_test.go
+++ b/cli/cmd/xylem/init_prop_test.go
@@ -216,6 +216,78 @@ func TestPropSyncProfileAssetsMaterializesComposedAssetsWhenForceTrue(t *testing
 	})
 }
 
+// TestPropResyncProfileAssetsMaterializesAllComposedAssets verifies that
+// resyncProfileAssets always writes every composed asset to disk, regardless
+// of whether the file already exists with different content.
+func TestPropResyncProfileAssetsMaterializesAllComposedAssets(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		stateDir, err := os.MkdirTemp("", "xylem-resync-assets-*")
+		if err != nil {
+			rt.Fatalf("MkdirTemp() error = %v", err)
+		}
+		defer os.RemoveAll(stateDir)
+
+		composed := &profiles.ComposedProfile{
+			Workflows: rapidWorkflowMap(rt, "workflow"),
+			Prompts:   rapidPromptMap(rt, "prompt"),
+		}
+
+		// Pre-populate some files with arbitrary (stale) content.
+		for _, name := range sortedKeys(composed.Workflows) {
+			if !rapid.Bool().Draw(rt, "pre-exist-workflow-"+name) {
+				continue
+			}
+			path := filepath.Join(stateDir, "workflows", name+".yaml")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				rt.Fatalf("MkdirAll(%q) error = %v", path, err)
+			}
+			stale := []byte(rapid.StringMatching(`[a-z0-9 -]{0,24}`).Draw(rt, "stale-wf-"+name))
+			if err := os.WriteFile(path, stale, 0o644); err != nil {
+				rt.Fatalf("WriteFile(%q) error = %v", path, err)
+			}
+		}
+		for _, name := range sortedKeys(composed.Prompts) {
+			if !rapid.Bool().Draw(rt, "pre-exist-prompt-"+name) {
+				continue
+			}
+			path := filepath.Join(stateDir, "prompts", filepath.FromSlash(name)+".md")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				rt.Fatalf("MkdirAll(%q) error = %v", path, err)
+			}
+			stale := []byte(rapid.StringMatching(`[a-z0-9 -]{0,24}`).Draw(rt, "stale-pr-"+name))
+			if err := os.WriteFile(path, stale, 0o644); err != nil {
+				rt.Fatalf("WriteFile(%q) error = %v", path, err)
+			}
+		}
+
+		if err := resyncProfileAssets(stateDir, composed); err != nil {
+			rt.Fatalf("resyncProfileAssets() error = %v", err)
+		}
+
+		// Every composed workflow must match the embedded content exactly.
+		for name, want := range composed.Workflows {
+			got, err := os.ReadFile(filepath.Join(stateDir, "workflows", name+".yaml"))
+			if err != nil {
+				rt.Fatalf("ReadFile(workflow %q) error = %v", name, err)
+			}
+			if string(got) != string(want) {
+				rt.Fatalf("workflow %q = %q, want %q", name, string(got), string(want))
+			}
+		}
+
+		// Every composed prompt must match the embedded content exactly.
+		for name, want := range composed.Prompts {
+			got, err := os.ReadFile(filepath.Join(stateDir, "prompts", filepath.FromSlash(name)+".md"))
+			if err != nil {
+				rt.Fatalf("ReadFile(prompt %q) error = %v", name, err)
+			}
+			if string(got) != string(want) {
+				rt.Fatalf("prompt %q = %q, want %q", name, string(got), string(want))
+			}
+		}
+	})
+}
+
 func rapidWorkflowMap(rt *rapid.T, label string) map[string][]byte {
 	count := rapid.IntRange(0, 4).Draw(rt, label+"-count")
 	assets := make(map[string][]byte, count)

--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -1325,18 +1325,18 @@ func TestInitAgentsMdForceOverwritesWhenFirstLineMatches(t *testing.T) {
 	assert.GreaterOrEqual(t, len(lines), 30, "overwritten AGENTS.md should still be the full template")
 }
 
-func TestWriteFileIfNotModified_CreatesWhenMissing(t *testing.T) {
+func TestWriteFileForResync_CreatesWhenMissing(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "subdir", "file.md")
 	content := []byte("hello world\n")
 
-	require.NoError(t, writeFileIfNotModified(path, content))
+	require.NoError(t, writeFileForResync(path, content))
 
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)
 	assert.Equal(t, content, got)
 }
 
-func TestWriteFileIfNotModified_SkipsWhenUpToDate(t *testing.T) {
+func TestWriteFileForResync_SkipsWhenUpToDate(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "file.md")
 	content := []byte("same content\n")
@@ -1345,7 +1345,7 @@ func TestWriteFileIfNotModified_SkipsWhenUpToDate(t *testing.T) {
 	info1, err := os.Stat(path)
 	require.NoError(t, err)
 
-	require.NoError(t, writeFileIfNotModified(path, content))
+	require.NoError(t, writeFileForResync(path, content))
 
 	info2, err := os.Stat(path)
 	require.NoError(t, err)
@@ -1356,19 +1356,19 @@ func TestWriteFileIfNotModified_SkipsWhenUpToDate(t *testing.T) {
 	assert.Equal(t, content, got)
 }
 
-func TestWriteFileIfNotModified_SkipsUserModifiedFile(t *testing.T) {
+func TestWriteFileForResync_OverwritesWhenDifferent(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "file.md")
-	userContent := []byte("user customisation\n")
+	staleContent := []byte("stale version\n")
 	embeddedContent := []byte("embedded version\n")
-	require.NoError(t, os.WriteFile(path, userContent, 0o644))
+	require.NoError(t, os.WriteFile(path, staleContent, 0o644))
 
-	require.NoError(t, writeFileIfNotModified(path, embeddedContent))
+	require.NoError(t, writeFileForResync(path, embeddedContent))
 
-	// User content must be preserved.
+	// Embedded content must overwrite the stale file.
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)
-	assert.Equal(t, userContent, got)
+	assert.Equal(t, embeddedContent, got)
 }
 
 func TestResyncProfileAssets_CreatesMissingFiles(t *testing.T) {
@@ -1394,14 +1394,14 @@ func TestResyncProfileAssets_CreatesMissingFiles(t *testing.T) {
 	assert.Equal(t, composed.Prompts["fix-bug/plan"], pr)
 }
 
-func TestResyncProfileAssets_PreservesUserModifiedFiles(t *testing.T) {
+func TestResyncProfileAssets_OverwritesStaleProfileFiles(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), ".xylem")
 
-	// Pre-create a user-modified prompt.
+	// Pre-create a stale prompt (e.g., from a previous binary version).
 	promptPath := filepath.Join(stateDir, "prompts", "fix-bug", "plan.md")
 	require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
-	userContent := []byte("# My custom plan prompt\nDo it my way.\n")
-	require.NoError(t, os.WriteFile(promptPath, userContent, 0o644))
+	staleContent := []byte("# Old plan prompt from v1\n")
+	require.NoError(t, os.WriteFile(promptPath, staleContent, 0o644))
 
 	embeddedPrompt := []byte("embedded plan prompt\n")
 	composed := &profiles.ComposedProfile{
@@ -1416,10 +1416,10 @@ func TestResyncProfileAssets_PreservesUserModifiedFiles(t *testing.T) {
 
 	require.NoError(t, resyncProfileAssets(stateDir, composed))
 
-	// User-modified prompt must not be overwritten.
+	// Stale profile file must be overwritten with embedded content.
 	got, err := os.ReadFile(promptPath)
 	require.NoError(t, err)
-	assert.Equal(t, userContent, got)
+	assert.Equal(t, embeddedPrompt, got)
 
 	// Missing workflow must be created.
 	wf, err := os.ReadFile(filepath.Join(stateDir, "workflows", "fix-bug.yaml"))

--- a/cli/cmd/xylem/upgrade.go
+++ b/cli/cmd/xylem/upgrade.go
@@ -19,6 +19,7 @@ var (
 	daemonExec     = func(path string, args []string, env []string) error {
 		return syscall.Exec(path, args, env)
 	}
+	daemonResyncProfileAssets = maybeResyncProfileAssets
 )
 
 type daemonUpgradeTarget struct {


### PR DESCRIPTION
## Summary

Fixes the two compounding gaps in profile asset synchronisation described in [#514](https://github.com/nicholls-inc/xylem/issues/514):

- **Gap 1 — Stale files not updated.** `resyncProfileAssets` used `writeFileIfNotModified` (create-only semantics). Files that existed with different content were silently skipped, making stale profile-owned workflows indistinguishable from user-modified files.
- **Gap 2 — No sync on binary-unchanged upgrade tick.** The periodic `upgrade` closure called only `selfUpgrade`; when `exec()` did not fire (binary hash unchanged), no profile sync ran until the next daemon restart.

## Changes

### `cli/cmd/xylem/init.go`
- Add `writeFileForResync`: profile-authoritative helper that overwrites files with different content, creates missing files, and no-ops on identical content. Logs `slog.Info` for each add/update.
- Rewrite `resyncProfileAssets` to use `writeFileForResync` (overwrite semantics). Update doc comment to reflect that profile-owned files are always brought in sync; daemon-only files not in the composed profile are untouched.

### `cli/cmd/xylem/daemon.go`
- Extract `runUpgradeTick(repoDir, executablePath, cfg)` function that calls `selfUpgrade` then conditionally calls `daemonResyncProfileAssets` when `cfg.Profiles` is non-empty.
- Upgrade closure now calls `runUpgradeTick` instead of bare `selfUpgrade`.

### `cli/cmd/xylem/upgrade.go`
- Add injectable `daemonResyncProfileAssets` var (defaults to `maybeResyncProfileAssets`) to allow test stubbing.

### `cli/cmd/xylem/init_test.go`
- Rename `TestResyncProfileAssets_PreservesUserModifiedFiles` → `TestResyncProfileAssets_OverwritesStaleProfileFiles`; invert assertion to verify overwrite behaviour.

### `cli/cmd/xylem/daemon_test.go`
- Add smoke tests S54–S58:
  - S54: stale profile workflow is overwritten on resync
  - S55: missing profile workflow is created on resync
  - S56: daemon-only workflow (not in profile) is left untouched
  - S57: `runUpgradeTick` calls `maybeResyncProfileAssets` when binary is unchanged
  - S58: resync logs added/updated files at Info level

### `cli/cmd/xylem/init_prop_test.go`
- Add `TestPropResyncProfileAssetsMaterializesAllComposedAssets`: property-based test verifying that `resyncProfileAssets` materialises all composed assets correctly regardless of pre-existing file content.

## Smoke scenarios covered

| ID | Title |
|---|---|
| S54 | ResyncOverwritesStaleProfileWorkflow |
| S55 | ResyncCreatesMissingProfileWorkflow |
| S56 | ResyncPreservesDaemonOnlyWorkflow |
| S57 | UpgradeTickCallsResyncWhenBinaryUnchanged |
| S58 | ResyncLogsAddedAndUpdatedFiles |

## Test plan

- [x] `go test ./cmd/xylem/... -run TestResync` — updated preservation test passes with overwrite semantics
- [x] `go test ./cmd/xylem/... -run TestSmoke_S5[4-8]` — all five new smoke tests pass
- [x] `go test ./cmd/xylem/... -run TestPropResync` — property test passes
- [x] `go test ./...` — full suite green (pre-existing network test failure in `gate` package is sandbox-only and unrelated to this change)
- [x] `goimports -l .` — no formatting violations
- [x] `golangci-lint run` — no lint violations (pre-commit hook passed)

Fixes #514