### PR TITLE
fix: remove stranded worktree when vessel cancelled during WorktreePath persist

### DIFF
--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -1031,6 +1031,7 @@ func (r *Runner) ensureWorktree(ctx context.Context, vessel *queue.Vessel, src s
 			vessel.WorktreePath = worktreePath
 			if updateErr := r.Queue.UpdateVessel(*vessel); updateErr != nil {
 				if r.cancelledTransition(vessel.ID, updateErr) {
+					r.removeWorktree(ctx, recreated, vessel.ID)
 					return "", false
 				}
 				log.Printf("warn: failed to persist worktree path for %s: %v", vessel.ID, updateErr)
@@ -1051,6 +1052,7 @@ func (r *Runner) ensureWorktree(ctx context.Context, vessel *queue.Vessel, src s
 	vessel.WorktreePath = created
 	if updateErr := r.Queue.UpdateVessel(*vessel); updateErr != nil {
 		if r.cancelledTransition(vessel.ID, updateErr) {
+			r.removeWorktree(ctx, created, vessel.ID)
 			return "", false
 		}
 		log.Printf("warn: failed to persist worktree path for %s: %v", vessel.ID, updateErr)

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -2395,6 +2395,84 @@ func TestEnsureWorktreeRecreatesMissingInheritedPath(t *testing.T) {
 	require.Equal(t, vessel.PhaseOutputs, stored.PhaseOutputs)
 }
 
+// TestEnsureWorktreeRemovesWorktreeOnCancelledTransition verifies that when a
+// new worktree is created but the vessel was externally cancelled before the
+// WorktreePath can be persisted, ensureWorktree removes the newly created
+// worktree rather than stranding it on disk.
+func TestEnsureWorktreeRemovesWorktreeOnCancelledTransition(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	vessel := queue.Vessel{
+		ID:        "issue-42",
+		Source:    "manual",
+		Workflow:  "fix-bug",
+		Ref:       "spec",
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	}
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	// Dequeue moves the vessel to running state.
+	dequeued, err := q.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, dequeued)
+
+	// Externally cancel the vessel while it is "running" (simulates an
+	// operator cancel racing the worktree setup path).
+	require.NoError(t, q.Update(dequeued.ID, queue.StateCancelled, "cancelled by operator"))
+
+	createdPath := filepath.Join(dir, "new-worktree")
+	wt := &mockWorktree{path: createdPath}
+	r := New(cfg, q, wt, &mockCmdRunner{})
+
+	// ensureWorktree must return (_, false) and must remove the created worktree.
+	worktreePath, ok := r.ensureWorktree(context.Background(), dequeued, &source.Manual{})
+	require.False(t, ok, "expected ensureWorktree to fail on cancelled vessel")
+	require.Empty(t, worktreePath)
+	require.True(t, wt.removeCalled, "expected Remove to be called for the stranded worktree")
+	require.Equal(t, createdPath, wt.removePath)
+}
+
+// TestEnsureWorktreeRemovesRecreatedWorktreeOnCancelledTransition verifies the
+// same cleanup guarantee for the "recreate missing worktree" path.
+func TestEnsureWorktreeRemovesRecreatedWorktreeOnCancelledTransition(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 1)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	missingPath := filepath.Join(dir, "missing-worktree") // does not exist on disk
+	vessel := queue.Vessel{
+		ID:           "issue-43",
+		Source:       "manual",
+		Workflow:     "fix-bug",
+		Ref:          "spec",
+		State:        queue.StatePending,
+		CreatedAt:    time.Now().UTC(),
+		WorktreePath: missingPath,
+	}
+	_, err := q.Enqueue(vessel)
+	require.NoError(t, err)
+
+	dequeued, err := q.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, dequeued)
+
+	require.NoError(t, q.Update(dequeued.ID, queue.StateCancelled, "cancelled by operator"))
+
+	recreatedPath := filepath.Join(dir, "recreated-worktree")
+	wt := &mockWorktree{path: recreatedPath}
+	r := New(cfg, q, wt, &mockCmdRunner{})
+
+	worktreePath, ok := r.ensureWorktree(context.Background(), dequeued, &source.Manual{})
+	require.False(t, ok, "expected ensureWorktree to fail on cancelled vessel")
+	require.Empty(t, worktreePath)
+	require.True(t, wt.removeCalled, "expected Remove to be called for the stranded recreated worktree")
+	require.Equal(t, recreatedPath, wt.removePath)
+}
+
 // TestWS6S29NilHarnessFieldsRunsNormally verifies that a runner without
 // intermediary, audit log, or tracer behaves like the pre-harness runner.
 //


### PR DESCRIPTION
## Summary

- In `ensureWorktree`, two paths create a physical worktree then call `UpdateVessel` to persist `WorktreePath`. If the vessel was externally cancelled in that narrow window, `UpdateVessel` returns `ErrInvalidTransition`, `cancelledTransition` returns `true`, and the function returned `("", false)` without cleaning up the created worktree.
- The caller's cleanup defer only fires when `worktreePath != ""`, so the physical worktree was stranded on disk.
- Fix: call `r.removeWorktree` before returning `("", false)` in the two `cancelledTransition` branches of `ensureWorktree`. Covers both the "new worktree" and "recreate missing worktree" paths.

## Test plan
- [ ] `TestEnsureWorktreeRemovesWorktreeOnCancelledTransition` — new test for the fresh-create path
- [ ] `TestEnsureWorktreeRemovesRecreatedWorktreeOnCancelledTransition` — new test for the recreate-missing path
- [ ] `go test ./internal/runner/...` passes (5.6s, 0 failures)
- [ ] `goimports -l .` clean
- [ ] CI green

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)