### PR TITLE
fix: remove harness-impl source from self-hosting overlay and fix tests

### DIFF
--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -607,9 +607,7 @@ func TestInitProfileCoreAndSelfHostingXylem(t *testing.T) {
 	cfg, err := config.Load(configPath)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"core", "self-hosting-xylem"}, cfg.Profiles)
-	if _, ok := cfg.Sources["harness-impl"]; !ok {
-		t.Fatal("expected harness-impl source from self-hosting overlay")
-	}
+	assert.NotContains(t, cfg.Sources, "harness-impl")
 }
 
 func TestInitRejectsUnknownProfile(t *testing.T) {
@@ -700,7 +698,7 @@ func TestSmoke_S5_CorePlusSelfHostingOverlayScaffoldsOverlayWorkflows(t *testing
 	cfg, err := config.Load(configPath)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"core", "self-hosting-xylem"}, cfg.Profiles)
-	assert.Contains(t, cfg.Sources, "harness-impl")
+	assert.NotContains(t, cfg.Sources, "harness-impl")
 	assert.Contains(t, cfg.Sources, "harness-pr-lifecycle")
 	assert.Contains(t, cfg.Sources, "release-cadence")
 	assert.Equal(t, []string{"ready-to-merge"}, cfg.Daemon.EffectiveAutoMergeLabels())

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -202,7 +202,6 @@ func TestComposeCoreAndSelfHostingXylemIncludesOverlayAssets(t *testing.T) {
 	assert.Contains(t, sortedKeys(composed.Prompts), "hardening-audit/rank")
 	assert.Contains(t, sortedKeys(composed.Prompts), "backlog-refinement/analyze")
 	assert.Contains(t, sortedKeys(composed.Prompts), "backlog-refinement/report")
-	assert.Contains(t, sortedKeys(composed.Sources), "harness-impl")
 	assert.Contains(t, sortedKeys(composed.Sources), "harness-pr-lifecycle")
 	assert.Contains(t, sortedKeys(composed.Sources), "continuous-improvement")
 	assert.Contains(t, sortedKeys(composed.Sources), "continuous-simplicity")

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -1,17 +1,4 @@
 sources:
-  harness-impl:
-    type: github
-    repo: "{{ .Repo }}"
-    timeout: "90m"
-    exclude: [wontfix, duplicate, in-progress, no-bot, blocked]
-    tasks:
-      implement-harness-steps:
-        labels: [harness-impl, ready-for-work]
-        workflow: implement-harness
-        status_labels:
-          running: in-progress
-          failed: xylem-failed
-          timed_out: xylem-failed
   harness-pr-lifecycle:
     type: github-pr-events
     repo: "{{ .Repo }}"
@@ -33,7 +20,7 @@ sources:
     exclude: [no-bot, pr-vessel-active]
     tasks:
       merge-ready:
-        labels: [ready-to-merge, harness-impl]
+        labels: [ready-to-merge]
         workflow: merge-pr
         status_labels:
           running: pr-vessel-active
@@ -45,7 +32,7 @@ sources:
     exclude: [no-bot, pr-vessel-active]
     tasks:
       resolve-conflicts:
-        labels: [needs-conflict-resolution, harness-impl]
+        labels: [needs-conflict-resolution]
         workflow: resolve-conflicts
         status_labels:
           running: pr-vessel-active


### PR DESCRIPTION
## Summary

- Removes the `harness-impl` source block from `xylem.overlay.yml` (was already dropped from the actual daemon config but remained in the profile template)
- Simplifies `harness-merge` task labels from `[ready-to-merge, harness-impl]` → `[ready-to-merge]`
- Simplifies `conflict-resolution` task labels from `[needs-conflict-resolution, harness-impl]` → `[needs-conflict-resolution]`
- Fixes `init_test.go` line 610–612: replaces fatal "must exist" check with `assert.NotContains(t, cfg.Sources, "harness-impl")`
- Fixes `init_test.go` line 701: flips `assert.Contains` → `assert.NotContains` for `harness-impl`
- Fixes `profiles_test.go` line 205: removes `assert.Contains(t, sortedKeys(composed.Sources), "harness-impl")`

Closes https://github.com/nicholls-inc/xylem/issues/521

## Test plan
- [x] `go test ./cmd/xylem/... ./internal/profiles/...` passes
- [x] `goimports -l .` reports no formatting issues
- [x] Pre-commit hooks (goimports, golangci-lint, go build) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)