### PR TITLE
fix: wrap validation commands in subshells to prevent cd accumulation in gate scripts

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -253,9 +253,9 @@ observability:
 
 validation:
   format: "goimports -l ."
-  lint: "cd cli && go vet ./..."
-  build: "cd cli && go build ./cmd/xylem"
-  test: "cd cli && go test ./..."
+  lint: "(cd cli && go vet ./...)"
+  build: "(cd cli && go build ./cmd/xylem)"
+  test: "(cd cli && go test ./...)"
 
 daemon:
   auto_upgrade: true

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -1416,16 +1416,16 @@ func (c *Config) validationRequiredWorkflows() []string {
 
 func (c *Config) validateValidationCommands() error {
 	if target, ok := invalidGoimportsPackagePatternTarget(c.Validation.Format); ok {
-		return fmt.Errorf(`validation.format uses goimports package pattern %q; goimports expects directories or files, use "goimports -l ." or "cd cli && goimports -l ."`, target)
+		return fmt.Errorf(`validation.format uses goimports package pattern %q; goimports expects directories or files, use "goimports -l ." or "(cd cli && goimports -l .)"`, target)
 	}
 	for _, check := range []struct {
 		name    string
 		command string
 		example string
 	}{
-		{name: "lint", command: c.Validation.Lint, example: `cd cli && go vet ./...`},
-		{name: "build", command: c.Validation.Build, example: `cd cli && go build ./cmd/xylem`},
-		{name: "test", command: c.Validation.Test, example: `cd cli && go test ./...`},
+		{name: "lint", command: c.Validation.Lint, example: `(cd cli && go vet ./...)`},
+		{name: "build", command: c.Validation.Build, example: `(cd cli && go build ./cmd/xylem)`},
+		{name: "test", command: c.Validation.Test, example: `(cd cli && go test ./...)`},
 	} {
 		if target, ok := invalidRepoRootGoCLITarget(check.command); ok {
 			return fmt.Errorf(`validation.%s runs go from repo root against %q; xylem executes validation from the worktree root, use %q`, check.name, target, check.example)

--- a/cli/internal/profiles/core/prompts/resolve-conflicts/resolve.md
+++ b/cli/internal/profiles/core/prompts/resolve-conflicts/resolve.md
@@ -34,4 +34,4 @@ For every conflicting file:
 
 After resolving all conflicts, stage the resolved files and complete the in-progress merge before validation. Because the workflow already ran `git merge ... --no-commit --no-ff`, finish that merge in place (for example, `git add <resolved-files> && git commit --no-edit` while `MERGE_HEAD` exists).
 
-Once the merge commit exists, run `cd cli && go vet ./... && go build ./cmd/xylem && go test ./...` to confirm the build and tests pass.
+Once the merge commit exists, run `(cd cli && go vet ./... && go build ./cmd/xylem && go test ./...)` to confirm the build and tests pass.

--- a/cli/internal/profiles/core/workflows/fix-pr-checks.yaml
+++ b/cli/internal/profiles/core/workflows/fix-pr-checks.yaml
@@ -11,7 +11,12 @@ phases:
     max_turns: 30
     gate:
       type: command
-      run: "true"
+      run: |
+        set -e
+        {{ if .Validation.Format }}( {{ .Validation.Format }} ){{ end }}
+        {{ if .Validation.Lint }}( {{ .Validation.Lint }} ){{ end }}
+        {{ if .Validation.Build }}( {{ .Validation.Build }} ){{ end }}
+        {{ if .Validation.Test }}( {{ .Validation.Test }} ){{ end }}
       retries: 3
   - name: push
     prompt_file: .xylem/prompts/fix-pr-checks/push.md

--- a/cli/internal/profiles/core/workflows/resolve-conflicts.yaml
+++ b/cli/internal/profiles/core/workflows/resolve-conflicts.yaml
@@ -42,7 +42,15 @@ phases:
     max_turns: 40
     gate:
       type: command
-      run: "git fetch origin main && test \"$(git branch --show-current)\" = \"$(gh pr view {{.Issue.Number}} --json headRefName --jq '.headRefName')\" && git merge-base --is-ancestor origin/main HEAD"
+      run: |
+        set -e
+        git fetch origin {{ .Repo.DefaultBranch }}
+        test "$(git branch --show-current)" = "$(gh pr view {{ .Issue.Number }} --json headRefName --jq '.headRefName')"
+        git merge-base --is-ancestor origin/{{ .Repo.DefaultBranch }} HEAD
+        {{ if .Validation.Format }}( {{ .Validation.Format }} ){{ end }}
+        {{ if .Validation.Lint }}( {{ .Validation.Lint }} ){{ end }}
+        {{ if .Validation.Build }}( {{ .Validation.Build }} ){{ end }}
+        {{ if .Validation.Test }}( {{ .Validation.Test }} ){{ end }}
       retries: 2
   - name: push
     prompt_file: .xylem/prompts/resolve-conflicts/push.md

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -719,6 +719,88 @@ func TestAllEmbeddedWorkflowsValidate(t *testing.T) {
 	}
 }
 
+func TestResolveConflictsGateUsesSubshellWrappedValidation(t *testing.T) {
+	t.Parallel()
+
+	composed, err := Compose("core")
+	require.NoError(t, err)
+
+	var wf workflowpkg.Workflow
+	require.NoError(t, yaml.Unmarshal(composed.Workflows["resolve-conflicts"], &wf))
+
+	var resolvePhase *workflowpkg.Phase
+	for i := range wf.Phases {
+		if wf.Phases[i].Name == "resolve" {
+			resolvePhase = &wf.Phases[i]
+		}
+	}
+	require.NotNil(t, resolvePhase, "resolve phase not found")
+	require.NotNil(t, resolvePhase.Gate, "resolve phase has no gate")
+
+	run := resolvePhase.Gate.Run
+	assert.Contains(t, run, "{{ if .Validation.Format }}")
+	assert.Contains(t, run, "{{ if .Validation.Lint }}")
+	assert.Contains(t, run, "{{ if .Validation.Build }}")
+	assert.Contains(t, run, "{{ if .Validation.Test }}")
+	assert.Contains(t, run, "( {{ .Validation.Format }} )")
+	assert.Contains(t, run, "( {{ .Validation.Lint }} )")
+	assert.Contains(t, run, "( {{ .Validation.Build }} )")
+	assert.Contains(t, run, "( {{ .Validation.Test }} )")
+}
+
+func TestFixPRChecksGateUsesSubshellWrappedValidation(t *testing.T) {
+	t.Parallel()
+
+	composed, err := Compose("core")
+	require.NoError(t, err)
+
+	var wf workflowpkg.Workflow
+	require.NoError(t, yaml.Unmarshal(composed.Workflows["fix-pr-checks"], &wf))
+
+	var fixPhase *workflowpkg.Phase
+	for i := range wf.Phases {
+		if wf.Phases[i].Name == "fix" {
+			fixPhase = &wf.Phases[i]
+		}
+	}
+	require.NotNil(t, fixPhase, "fix phase not found")
+	require.NotNil(t, fixPhase.Gate, "fix phase has no gate")
+
+	run := fixPhase.Gate.Run
+	assert.Contains(t, run, "{{ if .Validation.Format }}")
+	assert.Contains(t, run, "{{ if .Validation.Lint }}")
+	assert.Contains(t, run, "{{ if .Validation.Build }}")
+	assert.Contains(t, run, "{{ if .Validation.Test }}")
+	assert.Contains(t, run, "( {{ .Validation.Format }} )")
+	assert.Contains(t, run, "( {{ .Validation.Lint }} )")
+	assert.Contains(t, run, "( {{ .Validation.Build }} )")
+	assert.Contains(t, run, "( {{ .Validation.Test }} )")
+}
+
+func TestResolveConflictsGateRetainsGitChecks(t *testing.T) {
+	t.Parallel()
+
+	composed, err := Compose("core")
+	require.NoError(t, err)
+
+	var wf workflowpkg.Workflow
+	require.NoError(t, yaml.Unmarshal(composed.Workflows["resolve-conflicts"], &wf))
+
+	var resolvePhase *workflowpkg.Phase
+	for i := range wf.Phases {
+		if wf.Phases[i].Name == "resolve" {
+			resolvePhase = &wf.Phases[i]
+		}
+	}
+	require.NotNil(t, resolvePhase, "resolve phase not found")
+	require.NotNil(t, resolvePhase.Gate, "resolve phase has no gate")
+
+	run := resolvePhase.Gate.Run
+	assert.Contains(t, run, "git fetch origin")
+	assert.Contains(t, run, "git merge-base --is-ancestor")
+	assert.Equal(t, 2, resolvePhase.Gate.Retries)
+}
+
 func sortedKeys[V any](m map[string]V) []string {
 	keys := make([]string, 0, len(m))
 	for key := range m {


### PR DESCRIPTION
## Summary

Fixes https://github.com/nicholls-inc/xylem/issues/524

The `resolve-conflicts` and `fix-pr-checks` workflow gates inject validation commands from `.xylem.yml` line-by-line into a single `sh -c "cd <worktree> && <gate_script>"`. When validation commands use `cd cli && ...`, the first line changes CWD to `/worktree/cli`. Every subsequent `cd cli &&` then fails with "No such file or directory" because `cli/` doesn't exist inside `/worktree/cli/`.

The fix wraps each validation command in a subshell `( ... )` so each command's `cd` is isolated and doesn't mutate the outer shell's CWD.

**Note:** The `.xylem.yml` change (belt-and-suspenders subshell wrapping) will NOT auto-propagate to the live daemon's config on upgrade — only the workflow YAML files propagate via `maybeResyncProfileAssets`. After this PR is merged and the daemon auto-upgrades, the workflow files will be resynced automatically.

## Smoke scenarios covered

No formal smoke scenario IDs are assigned to this issue. The fix is validated by:
- Unit tests: `TestResolveConflictsGateUsesSubshellWrappedValidation`, `TestFixPRChecksGateUsesSubshellWrappedValidation`, `TestResolveConflictsGateRetainsGitChecks` (new, in `profiles_test.go`)
- All existing profile and workflow tests continue to pass

## Changes summary

### Files modified

| File | Change |
|------|--------|
| `cli/internal/profiles/core/workflows/resolve-conflicts.yaml` | Replaced single-line gate `run:` with multi-line block scalar; added `{{ .Validation.* }}` template variables wrapped in `( ... )` subshells |
| `cli/internal/profiles/core/workflows/fix-pr-checks.yaml` | Replaced `run: "true"` gate with multi-line script using `{{ .Validation.* }}` wrapped in `( ... )` subshells |
| `cli/internal/profiles/core/prompts/resolve-conflicts/resolve.md` | Updated inline guidance on line 37 to use `(cd cli && ...)` subshell syntax |
| `cli/internal/config/config.go` | Updated example strings in `validateValidationCommands` error messages to use `(cd cli && ...)` pattern |
| `.xylem.yml` | Wrapped `lint`, `build`, `test` validation commands in subshells: `(cd cli && ...)` |
| `cli/internal/profiles/profiles_test.go` | Added 3 new tests verifying gate subshell wrapping and git check retention |

### Key changes

- **`resolve-conflicts.yaml` gate**: Now emits `( {{ .Validation.Lint }} )` etc., so each validation command runs in an isolated subshell. Retains all existing `git fetch`, `git merge-base` freshness checks.
- **`fix-pr-checks.yaml` gate**: Replaces the no-op `true` gate with proper validation. When all `Validation.*` fields are empty, the script is effectively `set -e` with no commands — exits 0, preserving prior semantics.
- **Subshell isolation**: `( cmd )` means `cd cli` inside one command cannot affect the next command's CWD, regardless of how many validation commands are defined.

## Test plan

- [x] `go vet ./...` — passes
- [x] `go build ./cmd/xylem` — passes
- [x] `go test ./internal/profiles/...` — all pass including 3 new tests
- [x] `go test ./...` (excluding `runner` — pre-existing sandbox TCP bind restriction) — all pass
- [x] Pre-commit hooks: goimports, golangci-lint, go build — all passed
- [ ] Live validation: after daemon auto-upgrades, `resolve-conflicts` gate should no longer fail with "No such file" on the second `cd cli` invocation

Fixes #524