### PR TITLE
fix: github-pr source uses AND not OR for multi-label task matching

### DIFF
--- a/cli/internal/source/github_pr.go
+++ b/cli/internal/source/github_pr.go
@@ -86,88 +86,93 @@ func (g *GitHubPR) Scan(ctx context.Context) ([]queue.Vessel, error) {
 	seen := make(map[prWorkflowSeenKey]bool)
 
 	for _, task := range g.Tasks {
+		if len(task.Labels) == 0 {
+			continue
+		}
+		args := []string{
+			"pr", "list",
+			"--repo", g.Repo,
+			"--state", "open",
+		}
 		for _, label := range task.Labels {
-			args := []string{
-				"pr", "list",
-				"--repo", g.Repo,
-				"--state", "open",
-				"--label", label,
-				"--json", "number,title,body,url,labels,headRefName,mergeable",
-				"--limit", "20",
-			}
+			args = append(args, "--label", label)
+		}
+		args = append(args,
+			"--json", "number,title,body,url,labels,headRefName,mergeable",
+			"--limit", "20",
+		)
 
-			out, err := g.CmdRunner.Run(ctx, "gh", args...)
+		out, err := g.CmdRunner.Run(ctx, "gh", args...)
+		if err != nil {
+			return vessels, fmt.Errorf("gh pr list: %w", err)
+		}
+
+		var prs []ghPR
+		if err := json.Unmarshal(out, &prs); err != nil {
+			return vessels, fmt.Errorf("parse gh pr list output: %w", err)
+		}
+
+		for _, pr := range prs {
+			key := prWorkflowSeenKey{prNum: pr.Number, workflow: task.Workflow}
+			if seen[key] {
+				continue
+			}
+			fingerprint := githubSourceFingerprint(pr.Title, pr.Body, issueLabelNames(pr.Labels))
+			baseVessel := queue.Vessel{
+				ID:       fmt.Sprintf("pr-%d-%s", pr.Number, task.Workflow),
+				Source:   "github-pr",
+				Ref:      prWorkflowRef(pr.URL, task.Workflow),
+				Workflow: task.Workflow,
+				Tier:     ResolveTaskTier(task.Tier, g.DefaultTier),
+				Meta: map[string]string{
+					"pr_num":                   strconv.Itoa(pr.Number),
+					"pr_title":                 pr.Title,
+					"pr_body":                  pr.Body,
+					"pr_labels":                strings.Join(issueLabelNames(pr.Labels), ","),
+					"source_input_fingerprint": fingerprint,
+				},
+				State:     queue.StatePending,
+				CreatedAt: sourceNow(),
+			}
+			baseVessel.Meta = applyCurrentRemediationMeta(baseVessel.Meta, nil, g.currentHarnessDigest(), g.currentWorkflowDigest(task.Workflow))
+			sl := task.StatusLabels
+			if sl != nil {
+				baseVessel.Meta["status_label_queued"] = sl.Queued
+				baseVessel.Meta["status_label_running"] = sl.Running
+				baseVessel.Meta["status_label_completed"] = sl.Completed
+				baseVessel.Meta["status_label_failed"] = sl.Failed
+				baseVessel.Meta["status_label_timed_out"] = sl.TimedOut
+			}
+			lgl := task.LabelGateLabels
+			if lgl != nil {
+				baseVessel.Meta["label_gate_label_waiting"] = lgl.Waiting
+				baseVessel.Meta["label_gate_label_ready"] = lgl.Ready
+			}
+			if g.hasExcludedLabel(pr, excludeSet) {
+				continue
+			}
+			if task.Workflow == resolveConflictsWorkflow && pr.Mergeable != ghMergeableConflicting {
+				if pr.Mergeable == ghMergeableMergeable {
+					g.stripTaskLabels(ctx, pr.Number, task.Labels)
+				}
+				continue
+			}
+			retryVessel, blocked, err := g.retryCandidate(baseVessel, pr.URL, fingerprint, task.Workflow)
 			if err != nil {
-				return vessels, fmt.Errorf("gh pr list: %w", err)
+				return vessels, err
 			}
-
-			var prs []ghPR
-			if err := json.Unmarshal(out, &prs); err != nil {
-				return vessels, fmt.Errorf("parse gh pr list output: %w", err)
+			if blocked {
+				continue
 			}
-
-			for _, pr := range prs {
-				key := prWorkflowSeenKey{prNum: pr.Number, workflow: task.Workflow}
-				if seen[key] {
-					continue
-				}
-				fingerprint := githubSourceFingerprint(pr.Title, pr.Body, issueLabelNames(pr.Labels))
-				baseVessel := queue.Vessel{
-					ID:       fmt.Sprintf("pr-%d-%s", pr.Number, task.Workflow),
-					Source:   "github-pr",
-					Ref:      prWorkflowRef(pr.URL, task.Workflow),
-					Workflow: task.Workflow,
-					Tier:     ResolveTaskTier(task.Tier, g.DefaultTier),
-					Meta: map[string]string{
-						"pr_num":                   strconv.Itoa(pr.Number),
-						"pr_title":                 pr.Title,
-						"pr_body":                  pr.Body,
-						"pr_labels":                strings.Join(issueLabelNames(pr.Labels), ","),
-						"source_input_fingerprint": fingerprint,
-					},
-					State:     queue.StatePending,
-					CreatedAt: sourceNow(),
-				}
-				baseVessel.Meta = applyCurrentRemediationMeta(baseVessel.Meta, nil, g.currentHarnessDigest(), g.currentWorkflowDigest(task.Workflow))
-				sl := task.StatusLabels
-				if sl != nil {
-					baseVessel.Meta["status_label_queued"] = sl.Queued
-					baseVessel.Meta["status_label_running"] = sl.Running
-					baseVessel.Meta["status_label_completed"] = sl.Completed
-					baseVessel.Meta["status_label_failed"] = sl.Failed
-					baseVessel.Meta["status_label_timed_out"] = sl.TimedOut
-				}
-				lgl := task.LabelGateLabels
-				if lgl != nil {
-					baseVessel.Meta["label_gate_label_waiting"] = lgl.Waiting
-					baseVessel.Meta["label_gate_label_ready"] = lgl.Ready
-				}
-				if g.hasExcludedLabel(pr, excludeSet) {
-					continue
-				}
-				if task.Workflow == resolveConflictsWorkflow && pr.Mergeable != ghMergeableConflicting {
-					if pr.Mergeable == ghMergeableMergeable {
-						g.stripTaskLabels(ctx, pr.Number, task.Labels)
-					}
-					continue
-				}
-				retryVessel, blocked, err := g.retryCandidate(baseVessel, pr.URL, fingerprint, task.Workflow)
-				if err != nil {
-					return vessels, err
-				}
-				if blocked {
-					continue
-				}
-				if g.hasBranch(ctx, pr.Number) {
-					continue
-				}
-				seen[key] = true
-				if retryVessel != nil {
-					vessels = append(vessels, *retryVessel)
-					continue
-				}
-				vessels = append(vessels, baseVessel)
+			if g.hasBranch(ctx, pr.Number) {
+				continue
 			}
+			seen[key] = true
+			if retryVessel != nil {
+				vessels = append(vessels, *retryVessel)
+				continue
+			}
+			vessels = append(vessels, baseVessel)
 		}
 	}
 	return vessels, nil
@@ -182,37 +187,42 @@ func (g *GitHubPR) BacklogCount(ctx context.Context) (int, error) {
 	seen := make(map[prWorkflowSeenKey]struct{})
 	count := 0
 	for _, task := range g.Tasks {
+		if len(task.Labels) == 0 {
+			continue
+		}
+		args := []string{
+			"pr", "list",
+			"--repo", g.Repo,
+			"--state", "open",
+		}
 		for _, label := range task.Labels {
-			args := []string{
-				"pr", "list",
-				"--repo", g.Repo,
-				"--state", "open",
-				"--label", label,
-				"--json", "number,title,body,url,labels,headRefName,mergeable",
-				"--limit", "20",
-			}
+			args = append(args, "--label", label)
+		}
+		args = append(args,
+			"--json", "number,title,body,url,labels,headRefName,mergeable",
+			"--limit", "20",
+		)
 
-			out, err := g.CmdRunner.Run(ctx, "gh", args...)
-			if err != nil {
-				return 0, fmt.Errorf("gh pr list: %w", err)
-			}
+		out, err := g.CmdRunner.Run(ctx, "gh", args...)
+		if err != nil {
+			return 0, fmt.Errorf("gh pr list: %w", err)
+		}
 
-			var prs []ghPR
-			if err := json.Unmarshal(out, &prs); err != nil {
-				return 0, fmt.Errorf("parse gh pr list output: %w", err)
-			}
+		var prs []ghPR
+		if err := json.Unmarshal(out, &prs); err != nil {
+			return 0, fmt.Errorf("parse gh pr list output: %w", err)
+		}
 
-			for _, pr := range prs {
-				key := prWorkflowSeenKey{prNum: pr.Number, workflow: task.Workflow}
-				if _, ok := seen[key]; ok || g.hasExcludedLabel(pr, excludeSet) {
-					continue
-				}
-				if task.Workflow == resolveConflictsWorkflow && pr.Mergeable != ghMergeableConflicting {
-					continue
-				}
-				seen[key] = struct{}{}
-				count++
+		for _, pr := range prs {
+			key := prWorkflowSeenKey{prNum: pr.Number, workflow: task.Workflow}
+			if _, ok := seen[key]; ok || g.hasExcludedLabel(pr, excludeSet) {
+				continue
 			}
+			if task.Workflow == resolveConflictsWorkflow && pr.Mergeable != ghMergeableConflicting {
+				continue
+			}
+			seen[key] = struct{}{}
+			count++
 		}
 	}
 	return count, nil

--- a/cli/internal/source/github_pr_test.go
+++ b/cli/internal/source/github_pr_test.go
@@ -1646,7 +1646,8 @@ func TestGitHubPRScanResolveConflictsSkipsMergeablePRAndStripsLabel(t *testing.T
 				Name string `json:"name"`
 			}{{Name: "harness-impl"}, {Name: "needs-conflict-resolution"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+	// Task has two labels; Scan() issues a single AND call with both.
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--label", "harness-impl", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo: "owner/repo",
@@ -1711,7 +1712,8 @@ func TestGitHubPRScanResolveConflictsSkipsUnknownMergeablePreservingLabel(t *tes
 				Name string `json:"name"`
 			}{{Name: "harness-impl"}, {Name: "needs-conflict-resolution"}}},
 	}
-	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
+	// Task has two labels; Scan() issues a single AND call with both.
+	r.set(prJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--label", "needs-conflict-resolution", "--label", "harness-impl", "--json", "number,title,body,url,labels,headRefName,mergeable", "--limit", "20")
 
 	src := &GitHubPR{
 		Repo: "owner/repo",
@@ -1741,6 +1743,191 @@ func TestGitHubPRScanResolveConflictsSkipsUnknownMergeablePreservingLabel(t *tes
 			t.Errorf("expected NO label removal for UNKNOWN mergeable state, got call: %q", joined)
 		}
 	}
+}
+
+func countGHPRListCalls(calls [][]string) int {
+	n := 0
+	for _, c := range calls {
+		if len(c) >= 3 && c[0] == "gh" && c[1] == "pr" && c[2] == "list" {
+			n++
+		}
+	}
+	return n
+}
+
+// TestGitHubPRScanMultiLabelTaskRequiresAllLabels verifies AND semantics: a
+// task with multiple labels issues a single gh pr list call with all --label
+// flags, so GitHub's server-side AND matching applies.
+func TestGitHubPRScanMultiLabelTaskRequiresAllLabels(t *testing.T) {
+	t.Run("both labels present returns vessel", func(t *testing.T) {
+		dir := t.TempDir()
+		q := queue.New(dir + "/queue.jsonl")
+		r := newMock()
+
+		// PR carries both labels — gh would return it on a combined AND query.
+		prs := []ghPR{
+			{
+				Number: 42, Title: "merge me", URL: "https://github.com/owner/repo/pull/42", HeadRefName: "merge",
+				Labels: []struct {
+					Name string `json:"name"`
+				}{{Name: "ready-to-merge"}, {Name: "harness-impl"}},
+			},
+		}
+		// Mock key uses the combined --label flags in task.Labels order.
+		r.set(prJSON(prs), "gh", "pr", "list",
+			"--repo", "owner/repo",
+			"--state", "open",
+			"--label", "ready-to-merge",
+			"--label", "harness-impl",
+			"--json", "number,title,body,url,labels,headRefName,mergeable",
+			"--limit", "20",
+		)
+
+		src := &GitHubPR{
+			Repo: "owner/repo",
+			Tasks: map[string]GitHubTask{
+				"harness-merge": {Labels: []string{"ready-to-merge", "harness-impl"}, Workflow: "merge-pr"},
+			},
+			Queue:     q,
+			CmdRunner: r,
+		}
+
+		vessels, err := src.Scan(context.Background())
+		require.NoError(t, err)
+		require.Len(t, vessels, 1)
+		assert.Equal(t, "pr-42-merge-pr", vessels[0].ID)
+
+		// Exactly one gh pr list call, not two.
+		assert.Equal(t, 1, countGHPRListCalls(r.calls))
+	})
+
+	t.Run("only one label present returns no vessel", func(t *testing.T) {
+		dir := t.TempDir()
+		q := queue.New(dir + "/queue.jsonl")
+		r := newMock()
+
+		// PR has only harness-impl, not ready-to-merge. Pre-seed the per-label
+		// mock so that old OR-loop code (--label harness-impl alone) would find
+		// this PR and produce a vessel. The combined AND call is not seeded, so
+		// the mock default returns [] — simulating gh's server-side AND filter.
+		// This means assert.Empty is meaningful: old code produces 1 vessel, new code 0.
+		prWithOneLabel := []ghPR{
+			{
+				Number: 99, Title: "partial", URL: "https://github.com/owner/repo/pull/99", HeadRefName: "partial",
+				Labels: []struct {
+					Name string `json:"name"`
+				}{{Name: "harness-impl"}},
+			},
+		}
+		r.set(prJSON(prWithOneLabel), "gh", "pr", "list",
+			"--repo", "owner/repo",
+			"--state", "open",
+			"--label", "harness-impl",
+			"--json", "number,title,body,url,labels,headRefName,mergeable",
+			"--limit", "20",
+		)
+
+		src := &GitHubPR{
+			Repo: "owner/repo",
+			Tasks: map[string]GitHubTask{
+				"harness-merge": {Labels: []string{"ready-to-merge", "harness-impl"}, Workflow: "merge-pr"},
+			},
+			Queue:     q,
+			CmdRunner: r,
+		}
+
+		vessels, err := src.Scan(context.Background())
+		require.NoError(t, err)
+		// New AND code issues one combined call that returns [] → 0 vessels.
+		// Old per-label code would issue --label harness-impl and find pr-99 → 1 vessel.
+		assert.Empty(t, vessels)
+
+		// Exactly one call (with both labels), not two separate single-label calls.
+		assert.Equal(t, 1, countGHPRListCalls(r.calls))
+	})
+}
+
+// TestGitHubPRBacklogCountMultiLabelAndSemantics verifies that BacklogCount
+// uses the same AND-semantics fix: one call per task with all --label flags.
+func TestGitHubPRBacklogCountMultiLabelAndSemantics(t *testing.T) {
+	t.Run("both labels present counts the PR", func(t *testing.T) {
+		dir := t.TempDir()
+		q := queue.New(dir + "/queue.jsonl")
+		r := newMock()
+
+		prs := []ghPR{
+			{
+				Number: 42, Title: "merge me", URL: "https://github.com/owner/repo/pull/42", HeadRefName: "merge",
+				Labels: []struct {
+					Name string `json:"name"`
+				}{{Name: "ready-to-merge"}, {Name: "harness-impl"}},
+			},
+		}
+		r.set(prJSON(prs), "gh", "pr", "list",
+			"--repo", "owner/repo",
+			"--state", "open",
+			"--label", "ready-to-merge",
+			"--label", "harness-impl",
+			"--json", "number,title,body,url,labels,headRefName,mergeable",
+			"--limit", "20",
+		)
+
+		src := &GitHubPR{
+			Repo: "owner/repo",
+			Tasks: map[string]GitHubTask{
+				"harness-merge": {Labels: []string{"ready-to-merge", "harness-impl"}, Workflow: "merge-pr"},
+			},
+			Queue:     q,
+			CmdRunner: r,
+		}
+
+		count, err := src.BacklogCount(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+
+		assert.Equal(t, 1, countGHPRListCalls(r.calls))
+	})
+
+	t.Run("PR with only one label is not counted", func(t *testing.T) {
+		dir := t.TempDir()
+		q := queue.New(dir + "/queue.jsonl")
+		r := newMock()
+
+		// PR has only harness-impl. Pre-seed single-label response so old
+		// OR-loop code would count it. Combined AND call not seeded → default [].
+		prWithOneLabel := []ghPR{
+			{
+				Number: 99, Title: "partial", URL: "https://github.com/owner/repo/pull/99", HeadRefName: "partial",
+				Labels: []struct {
+					Name string `json:"name"`
+				}{{Name: "harness-impl"}},
+			},
+		}
+		r.set(prJSON(prWithOneLabel), "gh", "pr", "list",
+			"--repo", "owner/repo",
+			"--state", "open",
+			"--label", "harness-impl",
+			"--json", "number,title,body,url,labels,headRefName,mergeable",
+			"--limit", "20",
+		)
+
+		src := &GitHubPR{
+			Repo: "owner/repo",
+			Tasks: map[string]GitHubTask{
+				"harness-merge": {Labels: []string{"ready-to-merge", "harness-impl"}, Workflow: "merge-pr"},
+			},
+			Queue:     q,
+			CmdRunner: r,
+		}
+
+		count, err := src.BacklogCount(context.Background())
+		require.NoError(t, err)
+		// New AND code: combined call returns [] → count 0.
+		// Old OR-loop: --label harness-impl returns pr-99 → count 1.
+		assert.Equal(t, 0, count)
+
+		assert.Equal(t, 1, countGHPRListCalls(r.calls))
+	})
 }
 
 var errTest = &testError{"test error"}


### PR DESCRIPTION
## Summary

Fixes the label-matching bug in the `github-pr` source that caused no-op re-enqueue loops.

Related issue: https://github.com/nicholls-inc/xylem/issues/520

Previously, `Scan()` and `BacklogCount()` iterated over each label in a task independently, issuing one `gh pr list --label <L>` call per label and taking the union. This meant a PR carrying only _one_ of the required labels would be enqueued for tasks that require _all_ labels (e.g. `harness-merge` with `Labels: [ready-to-merge, harness-impl]` would enqueue PRs with only `harness-impl`). This produced a no-op re-enqueue loop: the merge-pr workflow would complete without merging, but on the next scan the same single-label PR would be picked up again.

The fix collapses the inner label loop into a single `gh pr list` call per task with all `--label` flags. GitHub's API already AND-matches multiple `--label` flags natively.

## Smoke scenarios covered

- **TestGitHubPRScanMultiLabelTaskRequiresAllLabels** — task with two labels issues a single combined `--label A --label B` call; PR with both labels produces 1 vessel; PR with only one label produces 0 vessels (server-side AND)
- **TestGitHubPRBacklogCountMultiLabelAndSemantics** — same AND semantics verified for `BacklogCount()`
- **TestSmoke_S1_CompletedQualifiedVesselDoesNotBlockResolveConflicts** — existing smoke test confirmed passing: completed resolve-conflicts vessel does not block re-enqueue when PR is still CONFLICTING
- **TestSmoke_S2_QualifiedCompletedVesselOverridesOlderLegacyFailedVessel** — existing smoke test confirmed passing
- **TestSmoke_S3_LegacyCompletedVesselDoesNotBlockSameWorkflow** — existing smoke test confirmed passing
- **TestGitHubPRScanResolveConflictsSkipsMergeablePRAndStripsLabel** — existing test updated: mock key now uses combined `--label needs-conflict-resolution --label harness-impl` call
- **TestGitHubPRScanResolveConflictsSkipsUnknownMergeablePreservingLabel** — same mock key update

## Changes summary

**Files modified:**

- `cli/internal/source/github_pr.go`
  - `Scan()`: removed inner `for _, label := range task.Labels` loop; replaced with a single `gh pr list` call per task appending all `--label` flags; added `len(task.Labels) == 0` guard
  - `BacklogCount()`: same structural change and guard

- `cli/internal/source/github_pr_test.go`
  - Updated mock keys for `TestGitHubPRScanResolveConflictsSkipsMergeablePRAndStripsLabel` and `TestGitHubPRScanResolveConflictsSkipsUnknownMergeablePreservingLabel` to use the combined multi-label call signature
  - Added `countGHPRListCalls()` helper to assert call count
  - Added `TestGitHubPRScanMultiLabelTaskRequiresAllLabels` (two sub-tests)
  - Added `TestGitHubPRBacklogCountMultiLabelAndSemantics` (two sub-tests)

## Test plan

- [x] `go test ./internal/source/...` — all tests pass
- [x] `go vet ./...` — clean
- [x] `go build ./cmd/xylem` — builds successfully
- [x] `goimports -l .` — no formatting issues
- [x] `golangci-lint` — passes (via pre-commit hook)
- [ ] Deploy to daemon and observe that `harness-merge` task no longer enqueues PRs carrying only `harness-impl` without `ready-to-merge`

Fixes #520