### PR TITLE
fix: increase review-pr analyze phase max_turns from 20 to 40

### DIFF
--- a/cli/internal/profiles/core/workflows/review-pr.yaml
+++ b/cli/internal/profiles/core/workflows/review-pr.yaml
@@ -3,7 +3,7 @@ description: "Review pull requests with crosscheck verification, test criticism,
 phases:
   - name: analyze
     prompt_file: .xylem/prompts/review-pr/analyze.md
-    max_turns: 20
+    max_turns: 40
   - name: verify
     prompt_file: .xylem/prompts/review-pr/verify.md
     max_turns: 60


### PR DESCRIPTION
## Summary

- Increases `max_turns` for the `analyze` phase in `review-pr` workflow from 20 to 40
- The analyze phase reads every changed file in full, which exhausts the 20-turn budget on multi-file PRs before analysis can complete
- Other phases already have higher budgets: `verify` has 60, `review` has 30 — this brings `analyze` in line with its actual workload

Fixes https://github.com/nicholls-inc/xylem/issues/512

## Test plan

- [ ] Verify `cli/internal/profiles/core/workflows/review-pr.yaml` has `max_turns: 40` for the `analyze` phase
- [ ] Confirm the next `review-pr` run on a multi-file PR completes the analyze phase without hitting the turn limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)