### PR TITLE
fix: retry unknown failures once before escalation to prevent premature human_escalation

### DIFF
--- a/cli/internal/recovery/recovery.go
+++ b/cli/internal/recovery/recovery.go
@@ -793,7 +793,7 @@ func classify(input Input) (Class, Action, float64, string) {
 	switch {
 	case input.State == queue.StateTimedOut ||
 		containsAny(combined, "timeout", "timed out", "deadline exceeded", "connection reset", "connection refused",
-			"temporarily unavailable", "temporary failure", "rate limit", "429", "502", "503", "504"):
+			"temporarily unavailable", "temporary failure", "rate limit", "signal: killed", "429", "502", "503", "504"):
 		return ClassTransient, ActionRetry, 0.92, "The failure looks transient, so retry remains the preferred recovery path."
 	case containsAny(combined, "harness", "agents.md", "protected surface", "policy blocked", "instruction", "prompt template"):
 		return ClassHarnessGap, ActionLessons, 0.9, "The failure points at missing or incorrect harness guidance and should feed institutional memory instead of repeating the same run."
@@ -804,6 +804,9 @@ func classify(input Input) (Class, Action, float64, string) {
 		"larger than one change", "separate issue"):
 		return ClassScopeGap, ActionSplitTask, 0.86, "The task exceeds the current execution scope and should be refined or split before another attempt."
 	default:
+		if input.RepeatedFailureCount == 0 {
+			return ClassUnknown, ActionRetry, 0.55, "The failure has no diagnostic signal on first attempt; attempting one retry before escalation."
+		}
 		return ClassUnknown, ActionDiagnose, 0.25, "The failure needs diagnosis before xylem can safely decide whether to retry or route follow-up work."
 	}
 }

--- a/cli/internal/recovery/recovery_test.go
+++ b/cli/internal/recovery/recovery_test.go
@@ -134,6 +134,53 @@ func TestSmoke_S5_AmbiguousFailureTriggersDiagnosisWorkflow(t *testing.T) {
 	assert.Contains(t, diagnosed.Rationale, "phases/issue-214-ambiguous/summary.json")
 }
 
+func TestClassify_FirstUnknownFailureReturnsRetry(t *testing.T) {
+	artifact := Build(Input{
+		VesselID:             "issue-508-first-failure",
+		Workflow:             "fix-bug",
+		State:                queue.StateFailed,
+		Error:                "exit status 1",
+		RepeatedFailureCount: 0,
+	})
+
+	require.NotNil(t, artifact)
+	assert.Equal(t, ClassUnknown, artifact.RecoveryClass)
+	assert.Equal(t, ActionRetry, artifact.RecoveryAction)
+	assert.GreaterOrEqual(t, artifact.Confidence, diagnosisConfidenceThreshold)
+	assert.False(t, ShouldDiagnose(artifact))
+}
+
+func TestClassify_SecondUnknownFailureReturnsDiagnose(t *testing.T) {
+	artifact := Build(Input{
+		VesselID:             "issue-508-second-failure",
+		Workflow:             "fix-bug",
+		State:                queue.StateFailed,
+		Error:                "exit status 1",
+		RepeatedFailureCount: 1,
+	})
+
+	require.NotNil(t, artifact)
+	assert.Equal(t, ClassUnknown, artifact.RecoveryClass)
+	assert.Equal(t, ActionDiagnose, artifact.RecoveryAction)
+	assert.Equal(t, 0.25, artifact.Confidence)
+	assert.True(t, ShouldDiagnose(artifact))
+}
+
+func TestClassify_SignalKilledIsTransient(t *testing.T) {
+	artifact := Build(Input{
+		VesselID:             "issue-508-killed",
+		Workflow:             "fix-bug",
+		State:                queue.StateFailed,
+		Error:                "signal: killed",
+		RepeatedFailureCount: 0,
+	})
+
+	require.NotNil(t, artifact)
+	assert.Equal(t, ClassTransient, artifact.RecoveryClass)
+	assert.Equal(t, ActionRetry, artifact.RecoveryAction)
+	assert.Equal(t, 0.92, artifact.Confidence)
+}
+
 func TestShouldDiagnoseTriggersForLowConfidenceSingleFailure(t *testing.T) {
 	artifact := &Artifact{
 		SchemaVersion:        schemaVersion,


### PR DESCRIPTION
## Summary

Fixes [#508](https://github.com/nicholls-inc/xylem/issues/508) — 5 workflows stuck in `human_escalation` with retry suppressed on first failure.

### Root cause

In `classify()`, the `default` case returned `ActionDiagnose` with confidence `0.25` for any unrecognised failure. This caused `diagnosisCandidate()` to immediately escalate to `human_escalation + RetrySuppressed=true` — even when `RepeatedFailureCount == 0` (first and only failure, never retried).

### Changes

**`cli/internal/recovery/recovery.go`**

1. **`classify()` default case** — check `RepeatedFailureCount` before escalating to diagnosis. On first failure (`count == 0`), return `ActionRetry` with confidence `0.55` (above `diagnosisConfidenceThreshold=0.5`) so `ShouldDiagnose()` returns `false` and the vessel gets one retry. On subsequent failures, fall through to the existing `ActionDiagnose` path as before.

2. **Transient patterns** — add `"signal: killed"` alongside the existing timeout/rate-limit patterns. A killed process during a xylem phase is virtually always OOM or a resource-limit hit (transient), not a deterministic application bug.

**`cli/internal/recovery/recovery_test.go`**

Three new test cases:
- `TestClassify_FirstUnknownFailureReturnsRetry` — `exit status 1` on first failure → `ActionRetry`, confidence ≥ threshold, `ShouldDiagnose=false`
- `TestClassify_SecondUnknownFailureReturnsDiagnose` — `exit status 1` on second failure → `ActionDiagnose`, confidence `0.25`, `ShouldDiagnose=true`
- `TestClassify_SignalKilledIsTransient` — `signal: killed` → `ClassTransient`, `ActionRetry`, confidence `0.92`

### Bounds

- `DefaultRetryCap=2` still caps total retries — one extra retry on first failure is within budget
- After retry fails (`RepeatedFailureCount >= 1`), diagnosis runs normally and can still escalate to `human_escalation` for genuinely ambiguous failures

Closes https://github.com/nicholls-inc/xylem/issues/508