### PR TITLE
fix: add harness-impl label to lessons PRs so conflict-resolution scanner can pick them up

### DIFF
--- a/cli/cmd/xylem/lessons.go
+++ b/cli/cmd/xylem/lessons.go
@@ -180,7 +180,7 @@ func createLessonsPullRequest(ctx context.Context, wt lessonsWorktree, runner le
 	if err := runner.RunProcess(ctx, worktreePath, "git", "push", "--set-upstream", "origin", proposal.Branch); err != nil {
 		return fmt.Errorf("create lessons pull request %q: git push: %w", proposal.Branch, err)
 	}
-	createArgs := append(repoArgs(repo), "pr", "create", "--title", proposal.Title, "--body", proposal.Body, "--head", proposal.Branch)
+	createArgs := append(repoArgs(repo), "pr", "create", "--title", proposal.Title, "--body", proposal.Body, "--head", proposal.Branch, "--label", "harness-impl")
 	out, err := runner.RunPhase(ctx, worktreePath, nil, "gh", createArgs...)
 	if err != nil {
 		return fmt.Errorf("create lessons pull request %q: gh pr create: %w", proposal.Branch, err)

--- a/cli/cmd/xylem/lessons_test.go
+++ b/cli/cmd/xylem/lessons_test.go
@@ -147,6 +147,21 @@ func TestCmdLessonsCreatesPullRequestsForGeneratedProposals(t *testing.T) {
 	if len(runner.phaseCalls) != 2 {
 		t.Fatalf("len(phaseCalls) = %d, want 2", len(runner.phaseCalls))
 	}
+	// Verify lessons PRs are created with harness-impl label so the
+	// conflict-resolution scanner task (AND-match on needs-conflict-resolution +
+	// harness-impl) can pick them up after a rebase conflict.
+	prCreateFound := false
+	for _, call := range runner.phaseCalls {
+		if strings.Contains(call, "pr create") {
+			if !strings.Contains(call, "--label harness-impl") {
+				t.Fatalf("gh pr create call missing --label harness-impl: %q", call)
+			}
+			prCreateFound = true
+		}
+	}
+	if !prCreateFound {
+		t.Fatal("no gh pr create call found in phaseCalls")
+	}
 	data, err := os.ReadFile(filepath.Join(stateDir, "reviews", "lessons.json"))
 	if err != nil {
 		t.Fatalf("ReadFile(lessons.json) error = %v", err)


### PR DESCRIPTION
## Summary

- `createLessonsPullRequest` was creating PRs with no labels
- After #526 changed the `conflict-resolution` scanner task to AND-match on both `needs-conflict-resolution` AND `harness-impl`, lessons PRs became invisible to the scanner when they hit rebase conflicts
- Fix: append `--label harness-impl` to the `gh pr create` call in `createLessonsPullRequest`
- Test: added assertion in `TestCmdLessonsCreatesPullRequestsForGeneratedProposals` that the `pr create` phase call includes `--label harness-impl`

Closes https://github.com/nicholls-inc/xylem/issues/528

## Test plan

- [x] `go build ./cmd/xylem` passes
- [x] `go test ./cmd/xylem/...` passes (new label assertion in existing test)
- [x] `goimports -l .` clean
- [x] `golangci-lint run` passes (via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)