### PR TITLE
feat: Add runtime containment, network policy, and scoped secret handling

### DIFF
--- a/cli/cmd/xylem/drain.go
+++ b/cli/cmd/xylem/drain.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/reporter"
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
+	"github.com/nicholls-inc/xylem/cli/internal/sandbox"
 	"github.com/nicholls-inc/xylem/cli/internal/source"
 	"github.com/nicholls-inc/xylem/cli/internal/worktree"
 )
@@ -29,7 +30,20 @@ type drainCommandRunner interface {
 
 var newTracer = observability.NewTracer
 var newCommandRunner = func(cfg *config.Config) drainCommandRunner {
-	return newCmdRunner(cfg)
+	return newCmdRunnerWithPolicy(cfg, sandbox.NewPolicy(sandboxConfigFromCfg(cfg)))
+}
+
+// sandboxConfigFromCfg converts the config's SandboxConfig to the sandbox
+// package's Config type.
+func sandboxConfigFromCfg(cfg *config.Config) *sandbox.Config {
+	if cfg == nil {
+		return nil
+	}
+	return &sandbox.Config{
+		Mode:        sandbox.IsolationMode(cfg.Sandbox.Mode),
+		EgressAllow: cfg.Sandbox.EgressAllow,
+		EnvPasslist: cfg.Sandbox.EnvPasslist,
+	}
 }
 
 func newDrainCmd() *cobra.Command {

--- a/cli/cmd/xylem/exec.go
+++ b/cli/cmd/xylem/exec.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/runner"
+	"github.com/nicholls-inc/xylem/cli/internal/sandbox"
 )
 
 // maxStderrBytes is the maximum amount of stderr captured from a phase subprocess.
@@ -79,6 +80,9 @@ type realCmdRunner struct {
 	// providerEnv holds provider-scoped env vars for phase subprocesses so each
 	// LLM only receives its own credentials.
 	providerEnv map[string][]string
+	// isolation is the sandbox policy applied to phase subprocesses.
+	// Nil is treated as NoopPolicy (no isolation).
+	isolation sandbox.Policy
 }
 
 // newCmdRunner creates a realCmdRunner with extra env vars merged from
@@ -150,6 +154,24 @@ func newCmdRunner(cfg *config.Config) *realCmdRunner {
 	return &realCmdRunner{extraEnv: env, providerEnv: providerEnv}
 }
 
+// newCmdRunnerWithPolicy is like newCmdRunner but accepts a pre-built sandbox
+// Policy. Used by the drain path to inject execution isolation for phase
+// subprocesses.
+func newCmdRunnerWithPolicy(cfg *config.Config, p sandbox.Policy) *realCmdRunner {
+	r := newCmdRunner(cfg)
+	r.isolation = p
+	return r
+}
+
+// policy returns the effective sandbox Policy, defaulting to NoopPolicy when
+// no isolation has been configured.
+func (r *realCmdRunner) policy() sandbox.Policy {
+	if r.isolation != nil {
+		return r.isolation
+	}
+	return sandbox.NoopPolicy{}
+}
+
 // cmdEnv returns the environment to use for a subprocess: the daemon's
 // own env with extraEnv appended (extraEnv values take precedence
 // because Go's exec package uses the last occurrence of a given key).
@@ -203,7 +225,13 @@ func (r *realCmdRunner) RunPhase(ctx context.Context, dir string, stdin io.Reade
 }
 
 func (r *realCmdRunner) RunPhaseWithEnv(ctx context.Context, dir string, extraEnv []string, stdin io.Reader, name string, args ...string) ([]byte, error) {
-	return r.runPhaseInternal(ctx, dir, append(os.Environ(), extraEnv...), stdin, nil, name, args...)
+	pol := r.policy()
+	env := pol.PhaseEnv(extraEnv)
+	wrappedCmd, wrappedArgs, err := pol.WrapCommand(ctx, dir, name, args)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox wrap: %w", err)
+	}
+	return r.runPhaseInternal(ctx, dir, env, stdin, nil, wrappedCmd, wrappedArgs...)
 }
 
 func (r *realCmdRunner) RunPhaseObserved(ctx context.Context, dir string, stdin io.Reader, observer runner.PhaseProcessObserver, name string, args ...string) ([]byte, error) {
@@ -211,7 +239,13 @@ func (r *realCmdRunner) RunPhaseObserved(ctx context.Context, dir string, stdin 
 }
 
 func (r *realCmdRunner) RunPhaseObservedWithEnv(ctx context.Context, dir string, extraEnv []string, stdin io.Reader, observer runner.PhaseProcessObserver, name string, args ...string) ([]byte, error) {
-	return r.runPhaseInternal(ctx, dir, append(os.Environ(), extraEnv...), stdin, observer, name, args...)
+	pol := r.policy()
+	env := pol.PhaseEnv(extraEnv)
+	wrappedCmd, wrappedArgs, err := pol.WrapCommand(ctx, dir, name, args)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox wrap: %w", err)
+	}
+	return r.runPhaseInternal(ctx, dir, env, stdin, observer, wrappedCmd, wrappedArgs...)
 }
 
 func (r *realCmdRunner) runPhaseInternal(ctx context.Context, dir string, env []string, stdin io.Reader, observer runner.PhaseProcessObserver, name string, args ...string) ([]byte, error) {

--- a/cli/cmd/xylem/exec_sandbox_test.go
+++ b/cli/cmd/xylem/exec_sandbox_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/sandbox"
+)
+
+// TestRealCmdRunner_EnvScopingStripsAmbientSecret verifies that a secret in
+// the ambient environment is not visible to the phase subprocess when the
+// runner uses IsolationEnv.
+func TestRealCmdRunner_EnvScopingStripsAmbientSecret(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec subprocess tests not supported on Windows")
+	}
+	t.Setenv("XYLEM_TEST_SECRET_STRIP", "leaked")
+
+	pol := sandbox.NewPolicy(&sandbox.Config{Mode: sandbox.IsolationEnv})
+	r := &realCmdRunner{isolation: pol}
+
+	// Run a shell that prints the var (empty if unset).
+	out, err := r.RunPhaseWithEnv(
+		context.Background(),
+		t.TempDir(),
+		nil, // no provider env
+		nil,
+		"sh", "-c", `echo "val=${XYLEM_TEST_SECRET_STRIP}"`,
+	)
+	if err != nil {
+		t.Fatalf("RunPhaseWithEnv: %v", err)
+	}
+	if strings.Contains(string(out), "val=leaked") {
+		t.Errorf("secret XYLEM_TEST_SECRET_STRIP should not be visible to sandboxed subprocess")
+	}
+}
+
+// TestRealCmdRunner_EnvScopingPreservesProviderCreds verifies that provider
+// credentials are passed through to the subprocess despite env scoping.
+func TestRealCmdRunner_EnvScopingPreservesProviderCreds(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec subprocess tests not supported on Windows")
+	}
+
+	pol := sandbox.NewPolicy(&sandbox.Config{Mode: sandbox.IsolationEnv})
+	r := &realCmdRunner{isolation: pol}
+
+	providerEnv := []string{"XYLEM_TEST_PROVIDER_TOKEN=ok"}
+	out, err := r.RunPhaseWithEnv(
+		context.Background(),
+		t.TempDir(),
+		providerEnv,
+		nil,
+		"sh", "-c", `echo "token=${XYLEM_TEST_PROVIDER_TOKEN}"`,
+	)
+	if err != nil {
+		t.Fatalf("RunPhaseWithEnv: %v", err)
+	}
+	if !strings.Contains(string(out), "token=ok") {
+		t.Errorf("provider token should be visible to subprocess; got: %s", out)
+	}
+}
+
+// TestRealCmdRunner_EnvScopingPreservesPath verifies that PATH is present in
+// the subprocess environment even after env scoping.
+func TestRealCmdRunner_EnvScopingPreservesPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec subprocess tests not supported on Windows")
+	}
+
+	pol := sandbox.NewPolicy(&sandbox.Config{Mode: sandbox.IsolationEnv})
+	r := &realCmdRunner{isolation: pol}
+
+	out, err := r.RunPhaseWithEnv(
+		context.Background(),
+		t.TempDir(),
+		nil,
+		nil,
+		"sh", "-c", `echo "path=${PATH}"`,
+	)
+	if err != nil {
+		t.Fatalf("RunPhaseWithEnv: %v", err)
+	}
+	if !strings.Contains(string(out), "path=/") {
+		t.Errorf("PATH should be visible to sandboxed subprocess; got: %s", out)
+	}
+}
+
+// TestRealCmdRunner_SandboxModeNoneInheritsAmbient verifies that with mode
+// "none", ambient env vars are visible to the subprocess.
+func TestRealCmdRunner_SandboxModeNoneInheritsAmbient(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec subprocess tests not supported on Windows")
+	}
+	t.Setenv("XYLEM_TEST_AMBIENT_NOOP", "yes")
+
+	pol := sandbox.NewPolicy(&sandbox.Config{Mode: sandbox.IsolationNone})
+	r := &realCmdRunner{isolation: pol}
+
+	out, err := r.RunPhaseWithEnv(
+		context.Background(),
+		t.TempDir(),
+		nil,
+		nil,
+		"sh", "-c", `echo "ambient=${XYLEM_TEST_AMBIENT_NOOP}"`,
+	)
+	if err != nil {
+		t.Fatalf("RunPhaseWithEnv: %v", err)
+	}
+	if !strings.Contains(string(out), "ambient=yes") {
+		t.Errorf("ambient var should be visible with mode=none; got: %s", out)
+	}
+}
+
+// TestRealCmdRunner_SandboxModeEnvCustomPasslist verifies that a custom
+// passlist entry makes it through to the subprocess.
+func TestRealCmdRunner_SandboxModeEnvCustomPasslist(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec subprocess tests not supported on Windows")
+	}
+
+	// Ensure the var is set before launching subprocess.
+	if err := os.Setenv("XYLEM_TEST_CUSTOM_PASS", "ok"); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	t.Cleanup(func() { os.Unsetenv("XYLEM_TEST_CUSTOM_PASS") })
+
+	pol := sandbox.NewPolicy(&sandbox.Config{
+		Mode:        sandbox.IsolationEnv,
+		EnvPasslist: []string{"XYLEM_TEST_CUSTOM_PASS"},
+	})
+	r := &realCmdRunner{isolation: pol}
+
+	out, err := r.RunPhaseWithEnv(
+		context.Background(),
+		t.TempDir(),
+		nil,
+		nil,
+		"sh", "-c", `echo "custom=${XYLEM_TEST_CUSTOM_PASS}"`,
+	)
+	if err != nil {
+		t.Fatalf("RunPhaseWithEnv: %v", err)
+	}
+	if !strings.Contains(string(out), "custom=ok") {
+		t.Errorf("custom passlist var should be visible to subprocess; got: %s", out)
+	}
+}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -68,6 +68,22 @@ const runtimeStateDirName = "state"
 // See issue #366 for the class matrix design and migration notes.
 var DefaultProtectedSurfaces = []string{}
 
+// SandboxConfig controls execution isolation for vessel phase subprocesses.
+// Implements WS2 of the harness plan (docs/plans/sota-harness-plan.md §WS2).
+type SandboxConfig struct {
+	// Mode selects the isolation level: "none" (default), "env", or "full".
+	// Unrecognised values fall back to "none".
+	Mode string `yaml:"mode,omitempty"`
+	// EgressAllow lists hostnames/CIDRs for outbound connections in "full"
+	// mode. Empty means deny-all (loopback only). Not supported on Linux;
+	// configure iptables/nftables rules externally instead.
+	EgressAllow []string `yaml:"egress_allow,omitempty"`
+	// EnvPasslist lists additional KEY names to include in the filtered
+	// environment when mode is "env" or "full". Supplements the built-in
+	// safe passlist; does not replace it.
+	EnvPasslist []string `yaml:"env_passlist,omitempty"`
+}
+
 type Config struct {
 	Profiles            []string                  `yaml:"profiles,omitempty"`
 	Repo                string                    `yaml:"repo,omitempty"`
@@ -95,6 +111,7 @@ type Config struct {
 	Cost                CostConfig                `yaml:"cost,omitempty"`
 	Telemetry           TelemetryConfig           `yaml:"telemetry,omitempty"`
 	Notifications       NotificationsConfig       `yaml:"notifications,omitempty"`
+	Sandbox             SandboxConfig             `yaml:"sandbox,omitempty"`
 	configPath          string
 }
 

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -3816,3 +3816,51 @@ func TestEffectiveEnvFileWhitespaceOnlyFallsBackToDefault(t *testing.T) {
 	d := DaemonConfig{EnvFile: "   "}
 	assert.Equal(t, ".env", d.EffectiveEnvFile())
 }
+
+// --- Sandbox config tests ---
+
+const sandboxBaseConfig = `
+repo: owner/repo
+tasks:
+  default:
+    labels: [ready-for-work]
+    workflow: fix-bug
+claude:
+  command: claude
+  default_model: claude-sonnet-4-6
+  env:
+    ANTHROPIC_API_KEY: test-key
+`
+
+func TestConfig_ParsesSandboxBlock(t *testing.T) {
+	path := writeConfigFile(t, sandboxBaseConfig+`
+sandbox:
+  mode: env
+  egress_allow:
+    - api.anthropic.com
+  env_passlist:
+    - MY_CUSTOM_VAR
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "env", cfg.Sandbox.Mode)
+	assert.Equal(t, []string{"api.anthropic.com"}, cfg.Sandbox.EgressAllow)
+	assert.Equal(t, []string{"MY_CUSTOM_VAR"}, cfg.Sandbox.EnvPasslist)
+}
+
+func TestConfig_SandboxBlockAbsentIsZeroValue(t *testing.T) {
+	path := writeConfigFile(t, sandboxBaseConfig)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, SandboxConfig{}, cfg.Sandbox)
+}
+
+// TestConfig_SandboxModeNoValidation verifies that config accepts an
+// unrecognised sandbox mode without error. The config layer is a passive
+// loader; mode validation is the sandbox package's responsibility.
+func TestConfig_SandboxModeNoValidation(t *testing.T) {
+	path := writeConfigFile(t, sandboxBaseConfig+"\nsandbox:\n  mode: unknown-mode\n")
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "unknown-mode", cfg.Sandbox.Mode)
+}

--- a/cli/internal/sandbox/sandbox.go
+++ b/cli/internal/sandbox/sandbox.go
@@ -1,0 +1,214 @@
+// Package sandbox provides execution-isolation abstractions for vessel phase
+// subprocesses. It implements WS2 of the harness plan:
+// docs/plans/sota-harness-plan.md §WS2.
+//
+// Three isolation modes are available:
+//
+//   - "none" (default): No-op — current behaviour. The phase subprocess
+//     inherits the full ambient environment. Backward-compatible.
+//
+//   - "env": Environment scoping only. The subprocess receives a filtered
+//     environment containing only entries from the built-in safe passlist
+//     plus any operator-configured extras, with provider credentials appended
+//     last. No OS privileges are required.
+//
+//   - "full": Environment scoping plus platform-level egress enforcement.
+//     On macOS this uses sandbox-exec with a deny-network profile. On Linux
+//     this uses unshare --net. See docs/sandbox.md for platform requirements
+//     and operator escape hatches.
+//
+// Operators configure sandbox behaviour via the sandbox: block in .xylem.yml.
+// See [Config] for available fields.
+package sandbox
+
+import (
+	"context"
+	"os"
+	"strings"
+)
+
+// IsolationMode controls execution-time containment for vessel phase
+// subprocesses.
+type IsolationMode string
+
+const (
+	// IsolationNone is the default: no-op, current behaviour.
+	IsolationNone IsolationMode = "none"
+	// IsolationEnv strips the subprocess environment to a safe passlist plus
+	// provider credentials. No OS privileges required.
+	IsolationEnv IsolationMode = "env"
+	// IsolationFull applies environment scoping plus platform-level egress
+	// enforcement. Requires sandbox-exec (macOS) or unshare (Linux).
+	IsolationFull IsolationMode = "full"
+)
+
+// Config holds operator-configured sandbox parameters, loaded from the
+// sandbox: block in .xylem.yml.
+type Config struct {
+	// Mode selects the isolation level: "none", "env", or "full".
+	// Unrecognised values fall back to "none".
+	Mode IsolationMode `yaml:"mode,omitempty"`
+	// EgressAllow lists hostnames or CIDRs that outbound connections may
+	// reach when Mode is "full". Empty means deny-all (loopback only).
+	// Linux mode does not support fine-grained allowlists; leave this empty
+	// and configure iptables/nftables rules externally.
+	EgressAllow []string `yaml:"egress_allow,omitempty"`
+	// EnvPasslist lists additional KEY names (not values) to include in the
+	// filtered environment when Mode is "env" or "full". Entries here
+	// supplement the built-in safe passlist — they do not replace it.
+	EnvPasslist []string `yaml:"env_passlist,omitempty"`
+}
+
+// builtinPasslist is the set of environment variable names always included
+// by EnvScopingPolicy and FullPolicy. Keys are upper-cased for comparison.
+//
+// Covers: shell identity, filesystem helpers, locale, git identity, Go
+// toolchain, TLS roots, proxy settings, XDG dirs, and macOS dylib helpers.
+// Anything not in this list (or EnvPasslist) is stripped from phase envs.
+var builtinPasslist = []string{
+	// Shell identity
+	"HOME", "USER", "LOGNAME", "SHELL", "TERM",
+	// Temp dirs
+	"TMPDIR", "TEMP", "TMP",
+	// Filesystem
+	"PATH", "PWD",
+	// Locale
+	"LANG", "LC_ALL", "LC_CTYPE",
+	// Git identity (needed by git commit inside a phase)
+	"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL",
+	"GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL",
+	"GIT_SSH_COMMAND",
+	// Go toolchain (needed if a phase runs go build/test)
+	"GOPATH", "GOROOT", "GOPROXY", "GONOSUMDB", "GOFLAGS",
+	"CGO_ENABLED", "GOOS", "GOARCH",
+	// TLS roots
+	"SSL_CERT_FILE", "SSL_CERT_DIR", "CURL_CA_BUNDLE",
+	// HTTP proxy (lowercase and uppercase variants)
+	"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+	"http_proxy", "https_proxy", "no_proxy",
+	// XDG base dirs (used by many tools for config/cache lookup)
+	"XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME", "XDG_RUNTIME_DIR",
+	// macOS dylib resolution (stripped on Linux, harmless to include)
+	"DYLD_LIBRARY_PATH", "DYLD_FALLBACK_LIBRARY_PATH",
+}
+
+// Policy abstracts execution environment preparation for phase subprocesses.
+// The runner calls PhaseEnv to build the subprocess env and WrapCommand to
+// optionally wrap the command with a containment tool before exec.
+type Policy interface {
+	// PhaseEnv returns the env slice for the phase subprocess.
+	// providerEnv contains KEY=VALUE pairs for the selected provider only
+	// (e.g. ANTHROPIC_API_KEY=…). These are always included in the output,
+	// appended last so they take precedence over any passlist collision.
+	PhaseEnv(providerEnv []string) []string
+
+	// WrapCommand optionally wraps cmd/args with a containment tool.
+	// dir is the worktree path; containment tools may need it to set
+	// write-allow rules. Returns the (possibly wrapped) cmd and args.
+	// Returns an error if the platform does not support the requested mode.
+	WrapCommand(ctx context.Context, dir, cmd string, args []string) (string, []string, error)
+}
+
+// NewPolicy constructs the appropriate Policy from cfg.
+// Returns NoopPolicy when cfg is nil, or Mode is "none" or unrecognised.
+func NewPolicy(cfg *Config) Policy {
+	if cfg == nil {
+		return NoopPolicy{}
+	}
+	switch cfg.Mode {
+	case IsolationEnv:
+		return newEnvScopingPolicy(cfg.EnvPasslist)
+	case IsolationFull:
+		return &FullPolicy{
+			EnvScopingPolicy: *newEnvScopingPolicy(cfg.EnvPasslist),
+			egressAllow:      cfg.EgressAllow,
+		}
+	default:
+		// "none", empty string, or any unrecognised value → no-op
+		return NoopPolicy{}
+	}
+}
+
+// NoopPolicy is the default policy: no changes to the subprocess environment
+// or command. Preserves current (pre-WS2) behaviour exactly.
+type NoopPolicy struct{}
+
+// PhaseEnv returns os.Environ() with providerEnv appended, matching the
+// behaviour of the runner before sandbox support was added.
+func (NoopPolicy) PhaseEnv(providerEnv []string) []string {
+	base := os.Environ()
+	if len(providerEnv) == 0 {
+		return base
+	}
+	return append(base, providerEnv...)
+}
+
+// WrapCommand returns cmd and args unchanged.
+func (NoopPolicy) WrapCommand(_ context.Context, _, cmd string, args []string) (string, []string, error) {
+	return cmd, args, nil
+}
+
+// EnvScopingPolicy strips the ambient environment to the built-in passlist
+// (plus any operator-configured extras) and appends provider credentials.
+type EnvScopingPolicy struct {
+	// passlist is the complete set of allowed KEY names (union of builtinPasslist
+	// and any operator-configured EnvPasslist entries).
+	passlist map[string]struct{}
+}
+
+func newEnvScopingPolicy(extra []string) *EnvScopingPolicy {
+	pl := make(map[string]struct{}, len(builtinPasslist)+len(extra))
+	for _, k := range builtinPasslist {
+		pl[k] = struct{}{}
+	}
+	for _, k := range extra {
+		pl[strings.ToUpper(k)] = struct{}{}
+	}
+	return &EnvScopingPolicy{passlist: pl}
+}
+
+// PhaseEnv returns only the ambient env entries whose key appears in the
+// passlist, followed by providerEnv. providerEnv entries are always included
+// regardless of the passlist.
+func (p *EnvScopingPolicy) PhaseEnv(providerEnv []string) []string {
+	ambient := os.Environ()
+	out := make([]string, 0, len(p.passlist)+len(providerEnv))
+	for _, entry := range ambient {
+		key, _, found := strings.Cut(entry, "=")
+		if !found {
+			continue
+		}
+		if _, ok := p.passlist[key]; ok {
+			out = append(out, entry)
+		}
+	}
+	// Provider env appended last: later entries take precedence in exec
+	// semantics (last KEY= wins), so provider creds override any passlist
+	// collision.
+	out = append(out, providerEnv...)
+	return out
+}
+
+// WrapCommand returns cmd and args unchanged (no OS-level wrapping for env
+// mode; containment is env-only).
+func (p *EnvScopingPolicy) WrapCommand(_ context.Context, _, cmd string, args []string) (string, []string, error) {
+	return cmd, args, nil
+}
+
+// FullPolicy applies environment scoping plus platform-level egress
+// enforcement. The OS-specific command wrapping is implemented in
+// sandbox_darwin.go and sandbox_linux.go.
+type FullPolicy struct {
+	EnvScopingPolicy
+	egressAllow []string
+}
+
+// PhaseEnv delegates to EnvScopingPolicy.PhaseEnv.
+func (p *FullPolicy) PhaseEnv(providerEnv []string) []string {
+	return p.EnvScopingPolicy.PhaseEnv(providerEnv)
+}
+
+// WrapCommand wraps cmd with the platform-specific containment tool.
+func (p *FullPolicy) WrapCommand(ctx context.Context, dir, cmd string, args []string) (string, []string, error) {
+	return platformWrapCommand(ctx, dir, cmd, args, p.egressAllow)
+}

--- a/cli/internal/sandbox/sandbox_darwin.go
+++ b/cli/internal/sandbox/sandbox_darwin.go
@@ -1,0 +1,66 @@
+//go:build darwin
+
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// platformWrapCommand wraps cmd with sandbox-exec using a deny-network profile.
+//
+// The generated profile:
+//   - Allows all file reads.
+//   - Allows file writes only within dir (the worktree path).
+//   - Allows outbound TCP only to hosts listed in egressAllow, plus loopback.
+//   - Denies everything else by default.
+//
+// The profile is written to a temp file and passed to sandbox-exec via -f.
+// sandbox-exec reads it synchronously before exec, so cleanup is safe
+// immediately after the subprocess starts. The -D WORKTREE=<dir> flag passes
+// the worktree path as a profile parameter.
+func platformWrapCommand(_ context.Context, dir, cmd string, args []string, egressAllow []string) (string, []string, error) {
+	profile := darwinSandboxProfile(egressAllow)
+
+	f, err := os.CreateTemp("", "xylem-sandbox-*.sb")
+	if err != nil {
+		return "", nil, fmt.Errorf("sandbox: create profile temp file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(profile); err != nil {
+		return "", nil, fmt.Errorf("sandbox: write sandbox profile: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return "", nil, fmt.Errorf("sandbox: close sandbox profile: %w", err)
+	}
+
+	// sandbox-exec -f <profile> -D WORKTREE=<dir> <cmd> <args...>
+	wrappedArgs := make([]string, 0, 5+len(args))
+	wrappedArgs = append(wrappedArgs, "-f", f.Name(), "-D", "WORKTREE="+dir, cmd)
+	wrappedArgs = append(wrappedArgs, args...)
+
+	return "sandbox-exec", wrappedArgs, nil
+}
+
+// darwinSandboxProfile generates a sandbox-exec .sb profile in Scheme notation.
+// The WORKTREE parameter is substituted at invocation time via -D.
+func darwinSandboxProfile(egressAllow []string) string {
+	var sb strings.Builder
+	sb.WriteString(`(version 1)
+(deny default)
+(allow process-exec process-fork)
+(allow file-read*)
+(allow file-write* (subpath (param "WORKTREE")))
+(allow network-outbound (local tcp))
+(allow network-inbound (local tcp))
+`)
+	for _, host := range egressAllow {
+		// sandbox-exec remote syntax: (remote tcp "host:port")
+		// We allow any port on the given host by omitting port.
+		fmt.Fprintf(&sb, "(allow network-outbound (remote tcp \"%s\"))\n", host)
+	}
+	return sb.String()
+}

--- a/cli/internal/sandbox/sandbox_linux.go
+++ b/cli/internal/sandbox/sandbox_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"context"
+	"fmt"
+)
+
+// platformWrapCommand wraps cmd with unshare --net, placing the phase
+// subprocess in a new network namespace with no external connectivity.
+//
+// Fine-grained egress allowlists (egressAllow) are not supported in this
+// mode because user-space allowlisting requires iptables/nftables setup
+// that is outside the scope of this package. Operators who need per-host
+// egress rules should configure iptables rules externally and leave
+// egressAllow empty.
+func platformWrapCommand(_ context.Context, _, cmd string, args []string, egressAllow []string) (string, []string, error) {
+	if len(egressAllow) > 0 {
+		return "", nil, fmt.Errorf(
+			"sandbox: egress_allow is not supported in Linux unshare mode; " +
+				"configure iptables/nftables rules externally or leave egress_allow empty",
+		)
+	}
+
+	// unshare --net <cmd> <args...>
+	wrappedArgs := make([]string, 0, 2+len(args))
+	wrappedArgs = append(wrappedArgs, "--net", cmd)
+	wrappedArgs = append(wrappedArgs, args...)
+
+	return "unshare", wrappedArgs, nil
+}

--- a/cli/internal/sandbox/sandbox_other.go
+++ b/cli/internal/sandbox/sandbox_other.go
@@ -1,0 +1,18 @@
+//go:build !darwin && !linux
+
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+)
+
+// platformWrapCommand returns an error on unsupported platforms. Operators on
+// Windows or other platforms must use mode: env or mode: none instead.
+func platformWrapCommand(_ context.Context, _, cmd string, args []string, _ []string) (string, []string, error) {
+	return "", nil, fmt.Errorf(
+		"sandbox: IsolationFull is not supported on %s; set mode: env or mode: none in .xylem.yml",
+		runtime.GOOS,
+	)
+}

--- a/cli/internal/sandbox/sandbox_prop_test.go
+++ b/cli/internal/sandbox/sandbox_prop_test.go
@@ -1,0 +1,162 @@
+package sandbox
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+// genEnvEntry generates a valid KEY=VALUE environment entry.
+// Key is a non-empty ASCII identifier; value may be anything.
+func genEnvEntry(t *rapid.T) string {
+	// Generate a key that looks like an env var (letters/digits/underscore,
+	// not starting with a digit).
+	key := rapid.StringMatching(`[A-Z][A-Z0-9_]{0,15}`).Draw(t, "key")
+	val := rapid.String().Draw(t, "val")
+	return key + "=" + val
+}
+
+// genEnvList generates a slice of env entries with distinct keys.
+func genEnvList(t *rapid.T, name string) []string {
+	n := rapid.IntRange(0, 20).Draw(t, name+"_n")
+	keys := make(map[string]struct{}, n)
+	out := make([]string, 0, n)
+	for range n {
+		entry := genEnvEntry(t)
+		key, _, _ := strings.Cut(entry, "=")
+		if _, dup := keys[key]; dup {
+			continue
+		}
+		keys[key] = struct{}{}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// TestPropEnvScopingPolicy_NeverLeaksBlockedVars verifies that for any set of
+// provider env entries, no entry whose key is absent from the passlist appears
+// in the output when the ambient env is empty (we can't control os.Environ in
+// property tests, so we only examine the providerEnv pass-through guarantee).
+//
+// Specifically: a key that is NOT in the passlist and NOT in providerEnv must
+// not appear in the output. We verify this by checking that every entry in the
+// output either has its key in the passlist or in the providerEnv key set.
+func TestPropEnvScopingPolicy_NeverLeaksBlockedVars(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		extraPasslist := rapid.SliceOf(rapid.StringMatching(`[A-Z][A-Z0-9_]{0,10}`)).Draw(t, "extraPasslist")
+		pol := newEnvScopingPolicy(extraPasslist)
+
+		providerEnv := genEnvList(t, "provider")
+		got := pol.PhaseEnv(providerEnv)
+
+		// Build the set of allowed keys (passlist union providerEnv keys).
+		allowed := make(map[string]struct{}, len(pol.passlist)+len(providerEnv))
+		for k := range pol.passlist {
+			allowed[k] = struct{}{}
+		}
+		for _, e := range providerEnv {
+			k, _, _ := strings.Cut(e, "=")
+			allowed[k] = struct{}{}
+		}
+
+		for _, entry := range got {
+			key, _, found := strings.Cut(entry, "=")
+			if !found {
+				continue
+			}
+			if _, ok := allowed[key]; !ok {
+				t.Fatalf("key %q in output env is not in passlist or providerEnv", key)
+			}
+		}
+	})
+}
+
+// TestPropEnvScopingPolicy_AlwaysIncludesProviderEnv verifies that every entry
+// in providerEnv appears in the output of PhaseEnv.
+func TestPropEnvScopingPolicy_AlwaysIncludesProviderEnv(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		pol := newEnvScopingPolicy(nil)
+		providerEnv := genEnvList(t, "provider")
+		got := pol.PhaseEnv(providerEnv)
+
+		gotSet := make(map[string]struct{}, len(got))
+		for _, e := range got {
+			gotSet[e] = struct{}{}
+		}
+		for _, e := range providerEnv {
+			if _, ok := gotSet[e]; !ok {
+				t.Fatalf("providerEnv entry %q missing from PhaseEnv output", e)
+			}
+		}
+	})
+}
+
+// TestPropNoopPolicy_SupersetOfAmbient verifies that NoopPolicy.PhaseEnv
+// always returns a superset of os.Environ() (all ambient vars are preserved)
+// and that providerEnv entries are additive.
+func TestPropNoopPolicy_SupersetOfAmbient(t *testing.T) {
+	// Snapshot ambient env once; os.Environ() is stable within a test process.
+	ambient := os.Environ()
+
+	rapid.Check(t, func(t *rapid.T) {
+		pol := NoopPolicy{}
+		providerEnv := genEnvList(t, "provider")
+		got := pol.PhaseEnv(providerEnv)
+
+		gotSet := make(map[string]struct{}, len(got))
+		for _, e := range got {
+			gotSet[e] = struct{}{}
+		}
+
+		// Every ambient entry must be present (NoopPolicy must not strip anything).
+		for _, e := range ambient {
+			if _, ok := gotSet[e]; !ok {
+				t.Fatalf("NoopPolicy: ambient env entry %q missing from output", e)
+			}
+		}
+
+		// Every providerEnv entry must also be present.
+		for _, e := range providerEnv {
+			if _, ok := gotSet[e]; !ok {
+				t.Fatalf("NoopPolicy: providerEnv entry %q missing from output", e)
+			}
+		}
+	})
+}
+
+// TestPropEnvScopingPolicy_DeterministicForSameInput verifies that calling
+// PhaseEnv twice with the same providerEnv produces the same output set
+// (order may differ due to os.Environ, but the set of entries must match).
+func TestPropEnvScopingPolicy_DeterministicForSameInput(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		pol := newEnvScopingPolicy(nil)
+		providerEnv := genEnvList(t, "provider")
+
+		got1 := pol.PhaseEnv(providerEnv)
+		got2 := pol.PhaseEnv(providerEnv)
+
+		set1 := toSet(got1)
+		set2 := toSet(got2)
+
+		for e := range set1 {
+			if _, ok := set2[e]; !ok {
+				t.Fatalf("non-deterministic output: %q in first call but not second", e)
+			}
+		}
+		for e := range set2 {
+			if _, ok := set1[e]; !ok {
+				t.Fatalf("non-deterministic output: %q in second call but not first", e)
+			}
+		}
+	})
+}
+
+func toSet(entries []string) map[string]struct{} {
+	s := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		s[e] = struct{}{}
+	}
+	return s
+}

--- a/cli/internal/sandbox/sandbox_test.go
+++ b/cli/internal/sandbox/sandbox_test.go
@@ -1,0 +1,226 @@
+package sandbox
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+// setenv sets an env var for the duration of the test, restoring the original
+// value (or unsetting it) on cleanup. Uses t.Setenv when available for
+// simplicity; falls back to manual save/restore.
+func setenv(t *testing.T, key, value string) {
+	t.Helper()
+	t.Setenv(key, value)
+}
+
+// TestNoopPolicy_PhaseEnvPreservesAmbient verifies that NoopPolicy returns the
+// ambient env with providerEnv appended.
+func TestNoopPolicy_PhaseEnvPreservesAmbient(t *testing.T) {
+	setenv(t, "XYLEM_TEST_AMBIENT_NOOP", "present")
+	pol := NoopPolicy{}
+	got := pol.PhaseEnv([]string{"PROVIDER_TOKEN=x"})
+
+	if !containsEntry(got, "XYLEM_TEST_AMBIENT_NOOP=present") {
+		t.Error("NoopPolicy.PhaseEnv should include ambient env var XYLEM_TEST_AMBIENT_NOOP")
+	}
+	if !containsEntry(got, "PROVIDER_TOKEN=x") {
+		t.Error("NoopPolicy.PhaseEnv should include providerEnv entry PROVIDER_TOKEN=x")
+	}
+}
+
+// TestNoopPolicy_WrapCommandIdentity verifies that NoopPolicy returns the
+// original command and args unchanged.
+func TestNoopPolicy_WrapCommandIdentity(t *testing.T) {
+	pol := NoopPolicy{}
+	gotCmd, gotArgs, err := pol.WrapCommand(context.Background(), "/some/dir", "claude", []string{"-p", "--model", "claude-opus-4-5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotCmd != "claude" {
+		t.Errorf("WrapCommand cmd = %q, want %q", gotCmd, "claude")
+	}
+	if len(gotArgs) != 3 || gotArgs[0] != "-p" {
+		t.Errorf("WrapCommand args = %v, want [-p --model claude-opus-4-5]", gotArgs)
+	}
+}
+
+// TestEnvScopingPolicy_StripsSensitiveVars verifies that a var not in the
+// passlist is removed from the phase env.
+func TestEnvScopingPolicy_StripsSensitiveVars(t *testing.T) {
+	setenv(t, "XYLEM_TEST_SHOULD_BE_STRIPPED", "leaked")
+	pol := newEnvScopingPolicy(nil)
+	got := pol.PhaseEnv(nil)
+
+	if containsKey(got, "XYLEM_TEST_SHOULD_BE_STRIPPED") {
+		t.Error("EnvScopingPolicy.PhaseEnv should not include XYLEM_TEST_SHOULD_BE_STRIPPED")
+	}
+}
+
+// TestEnvScopingPolicy_IncludesPasslistVars verifies that standard passlist
+// vars like PATH and HOME are present in the output.
+func TestEnvScopingPolicy_IncludesPasslistVars(t *testing.T) {
+	pol := newEnvScopingPolicy(nil)
+	// PATH must always be set in the test process.
+	got := pol.PhaseEnv(nil)
+
+	if !containsKey(got, "PATH") {
+		t.Error("EnvScopingPolicy.PhaseEnv should include PATH")
+	}
+}
+
+// TestEnvScopingPolicy_ProviderEnvTakesPrecedence verifies that a provider
+// env entry wins over a same-named passlist entry via last-wins exec semantics.
+func TestEnvScopingPolicy_ProviderEnvTakesPrecedence(t *testing.T) {
+	// Add ANTHROPIC_API_KEY to the passlist so both versions appear.
+	pol := newEnvScopingPolicy([]string{"ANTHROPIC_API_KEY"})
+	setenv(t, "ANTHROPIC_API_KEY", "v1")
+
+	got := pol.PhaseEnv([]string{"ANTHROPIC_API_KEY=v2"})
+
+	// Both v1 and v2 may be present; v2 must appear last (last-wins in exec).
+	lastIdx := -1
+	for i, e := range got {
+		if e == "ANTHROPIC_API_KEY=v2" {
+			lastIdx = i
+		}
+	}
+	if lastIdx == -1 {
+		t.Error("ANTHROPIC_API_KEY=v2 (provider) must appear in env output")
+	}
+	// Check that v2 appears after any v1.
+	for i, e := range got {
+		if e == "ANTHROPIC_API_KEY=v1" && i > lastIdx {
+			t.Error("ANTHROPIC_API_KEY=v1 (passlist) must not appear after v2 (provider)")
+		}
+	}
+}
+
+// TestEnvScopingPolicy_CustomPasslistAddsVars verifies that a var in the
+// operator's EnvPasslist (not in the built-in list) is included.
+func TestEnvScopingPolicy_CustomPasslistAddsVars(t *testing.T) {
+	setenv(t, "XYLEM_TEST_CUSTOM_PASSLIST_VAR", "allowed")
+	pol := newEnvScopingPolicy([]string{"XYLEM_TEST_CUSTOM_PASSLIST_VAR"})
+	got := pol.PhaseEnv(nil)
+
+	if !containsEntry(got, "XYLEM_TEST_CUSTOM_PASSLIST_VAR=allowed") {
+		t.Error("custom passlist var XYLEM_TEST_CUSTOM_PASSLIST_VAR should appear in env")
+	}
+}
+
+// TestNewPolicy_NilConfigReturnsNoop verifies factory behaviour with nil cfg.
+func TestNewPolicy_NilConfigReturnsNoop(t *testing.T) {
+	pol := NewPolicy(nil)
+	if _, ok := pol.(NoopPolicy); !ok {
+		t.Errorf("NewPolicy(nil) = %T, want NoopPolicy", pol)
+	}
+}
+
+// TestNewPolicy_ModeNoneReturnsNoop verifies factory with mode "none".
+func TestNewPolicy_ModeNoneReturnsNoop(t *testing.T) {
+	pol := NewPolicy(&Config{Mode: IsolationNone})
+	if _, ok := pol.(NoopPolicy); !ok {
+		t.Errorf("NewPolicy(mode=none) = %T, want NoopPolicy", pol)
+	}
+}
+
+// TestNewPolicy_ModeEnvReturnsEnvScoping verifies factory with mode "env".
+func TestNewPolicy_ModeEnvReturnsEnvScoping(t *testing.T) {
+	pol := NewPolicy(&Config{Mode: IsolationEnv})
+	if _, ok := pol.(*EnvScopingPolicy); !ok {
+		t.Errorf("NewPolicy(mode=env) = %T, want *EnvScopingPolicy", pol)
+	}
+}
+
+// TestNewPolicy_ModeFullReturnsFull verifies factory with mode "full".
+func TestNewPolicy_ModeFullReturnsFull(t *testing.T) {
+	pol := NewPolicy(&Config{Mode: IsolationFull})
+	if _, ok := pol.(*FullPolicy); !ok {
+		t.Errorf("NewPolicy(mode=full) = %T, want *FullPolicy", pol)
+	}
+}
+
+// TestNewPolicy_UnknownModeReturnsNoop verifies factory with an unrecognised
+// mode falls back to NoopPolicy.
+func TestNewPolicy_UnknownModeReturnsNoop(t *testing.T) {
+	pol := NewPolicy(&Config{Mode: "xyzzy"})
+	if _, ok := pol.(NoopPolicy); !ok {
+		t.Errorf("NewPolicy(mode=xyzzy) = %T, want NoopPolicy", pol)
+	}
+}
+
+// TestEnvScopingPolicy_WrapCommandIdentity verifies that EnvScopingPolicy
+// does not wrap the command (env-only mode).
+func TestEnvScopingPolicy_WrapCommandIdentity(t *testing.T) {
+	pol := newEnvScopingPolicy(nil)
+	gotCmd, gotArgs, err := pol.WrapCommand(context.Background(), "/tmp/wt", "claude", []string{"-p"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotCmd != "claude" || len(gotArgs) != 1 || gotArgs[0] != "-p" {
+		t.Errorf("EnvScopingPolicy.WrapCommand should return identity, got cmd=%q args=%v", gotCmd, gotArgs)
+	}
+}
+
+// TestEnvScopingPolicy_EmptyPasslistStripsAll verifies that with no extra
+// passlist entries, unknown vars are stripped.
+func TestEnvScopingPolicy_EmptyPasslistStripsAll(t *testing.T) {
+	setenv(t, "XYLEM_TOTALLY_UNKNOWN_VAR_XYZ", "should_not_appear")
+	pol := newEnvScopingPolicy(nil)
+	got := pol.PhaseEnv(nil)
+	if containsKey(got, "XYLEM_TOTALLY_UNKNOWN_VAR_XYZ") {
+		t.Error("unknown var should be stripped from env")
+	}
+}
+
+// TestFullPolicy_PhaseEnvDelegatesToEnvScoping verifies FullPolicy env
+// filtering is the same as EnvScopingPolicy.
+func TestFullPolicy_PhaseEnvDelegatesToEnvScoping(t *testing.T) {
+	setenv(t, "XYLEM_FULL_LEAKED", "leaked")
+	pol := &FullPolicy{EnvScopingPolicy: *newEnvScopingPolicy(nil)}
+	got := pol.PhaseEnv(nil)
+	if containsKey(got, "XYLEM_FULL_LEAKED") {
+		t.Error("FullPolicy should strip unknown env vars via EnvScopingPolicy")
+	}
+}
+
+// --- helpers ---
+
+func containsEntry(env []string, entry string) bool {
+	for _, e := range env {
+		if e == entry {
+			return true
+		}
+	}
+	return false
+}
+
+func containsKey(env []string, key string) bool {
+	prefix := key + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestEnvScopingPolicy_PasslistIsCaseSensitiveForKeys verifies that custom
+// passlist entries are matched case-sensitively against the ambient env.
+// (Passlist keys are stored upper-cased; ambient env keys must match exactly.)
+func TestEnvScopingPolicy_PasslistIsCaseSensitiveForKeys(t *testing.T) {
+	// On Linux, env keys are case-sensitive. MYVAR and myvar are different.
+	// Ensure upper-casing in the passlist doesn't accidentally allow lower-cased
+	// ambient keys.
+	_ = os.Unsetenv("myvar_lower")
+	setenv(t, "MYVAR_LOWER", "upper")
+	pol := newEnvScopingPolicy([]string{"myvar_lower"}) // lowercase in passlist
+	got := pol.PhaseEnv(nil)
+
+	// The passlist stores "MYVAR_LOWER" (uppercased). Ambient has "MYVAR_LOWER".
+	// So "MYVAR_LOWER=upper" should be present.
+	if !containsEntry(got, "MYVAR_LOWER=upper") {
+		t.Error("custom passlist var uppercased should match ambient uppercase key")
+	}
+}

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -1,0 +1,126 @@
+# Sandbox — Runtime Containment for Vessel Phases
+
+xylem can optionally isolate vessel phase subprocesses (Claude sessions) to
+limit the blast radius of a misbehaving or compromised phase. This is
+**Workstream 2 (WS2)** of the harness plan.
+
+## Isolation modes
+
+Configure the isolation level via the `sandbox:` block in `.xylem.yml`:
+
+```yaml
+sandbox:
+  mode: env          # "none" | "env" | "full"
+  egress_allow:      # only used when mode: full (macOS only)
+    - api.anthropic.com
+    - api.github.com
+  env_passlist:      # extra KEY names to include (mode: env or full)
+    - MY_COMPANY_TOKEN
+```
+
+### `mode: none` (default)
+
+No isolation. The phase subprocess inherits the daemon's full ambient
+environment and has unrestricted network access. This is the backward-
+compatible default.
+
+Use this when: you are not concerned about ambient secret leakage, or when
+your platform does not support `env` or `full` mode.
+
+### `mode: env`
+
+The phase subprocess environment is filtered to a **safe passlist** of
+well-known keys (see below) plus any provider credentials for the current
+phase. All other ambient env vars — including API keys, tokens, and sensitive
+internal vars — are stripped before `exec`.
+
+No OS privileges are required. This mode works on all platforms.
+
+**Trust boundary:** The subprocess still has unrestricted network access.
+`env` mode protects secrets from being read by the subprocess via its
+environment, but does not prevent the subprocess from exfiltrating data over
+the network.
+
+### `mode: full`
+
+Applies `env` mode plus platform-level network namespace enforcement:
+
+- **macOS**: Uses `sandbox-exec` with a deny-network profile. Only loopback
+  and hosts listed in `egress_allow` are reachable.
+- **Linux**: Uses `unshare --net` to place the subprocess in a new network
+  namespace with no external connectivity. Fine-grained `egress_allow` is
+  not supported on Linux; use iptables/nftables rules externally instead.
+- **Other platforms**: Returns an error at phase launch. Use `mode: env` or
+  `mode: none`.
+
+**Platform requirements:**
+
+| Platform | Tool needed |
+|----------|-------------|
+| macOS    | `sandbox-exec` (ships with macOS; no install needed) |
+| Linux    | `unshare` (part of `util-linux`; may need user namespaces enabled: `sysctl kernel.unprivileged_userns_clone=1`) |
+
+## Built-in safe passlist (`mode: env` and `mode: full`)
+
+The following environment variable names are always included when env scoping
+is active:
+
+| Category | Variables |
+|----------|-----------|
+| Shell identity | `HOME`, `USER`, `LOGNAME`, `SHELL`, `TERM` |
+| Temp dirs | `TMPDIR`, `TEMP`, `TMP` |
+| Filesystem | `PATH`, `PWD` |
+| Locale | `LANG`, `LC_ALL`, `LC_CTYPE` |
+| Git identity | `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL`, `GIT_SSH_COMMAND` |
+| Go toolchain | `GOPATH`, `GOROOT`, `GOPROXY`, `GONOSUMDB`, `GOFLAGS`, `CGO_ENABLED`, `GOOS`, `GOARCH` |
+| TLS roots | `SSL_CERT_FILE`, `SSL_CERT_DIR`, `CURL_CA_BUNDLE` |
+| HTTP proxy | `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` (and lowercase variants) |
+| XDG base dirs | `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, `XDG_DATA_HOME`, `XDG_RUNTIME_DIR` |
+| macOS dylib | `DYLD_LIBRARY_PATH`, `DYLD_FALLBACK_LIBRARY_PATH` |
+
+Provider credentials (e.g. `ANTHROPIC_API_KEY`) are always injected for the
+phase's selected provider, regardless of the passlist.
+
+## Custom passlist entries
+
+To allow additional vars through the filter:
+
+```yaml
+sandbox:
+  mode: env
+  env_passlist:
+    - MY_COMPANY_TOKEN
+    - INTERNAL_API_URL
+```
+
+Keys are case-insensitive in the passlist configuration but matched
+case-sensitively against the ambient environment on case-sensitive
+filesystems (Linux). Use the exact casing of the ambient var.
+
+## Operator escape hatch
+
+Set `sandbox.mode: none` (or omit the `sandbox:` block entirely) to revert
+to pre-WS2 behaviour. No restart is required — the policy is constructed at
+drain time.
+
+## Known limitations
+
+1. **Linux egress allowlists**: `unshare --net` provides a flat deny-all
+   network namespace. Per-host allowlists require iptables/nftables rules
+   configured externally (e.g. via a systemd unit that sets up the namespace
+   before xylem starts, or a network policy on a container runtime).
+
+2. **macOS sandbox-exec profile**: The profile is written to a temp file for
+   each phase invocation. The temp file is not cleaned up after exec (the OS
+   reclaims it when the process exits). A future PR can cache the profile in
+   the state dir.
+
+3. **IsolationFull on unsupported platforms**: Returns an error at phase
+   launch (not at startup), so misconfiguration is surfaced when the first
+   phase runs, not at daemon start.
+
+4. **Command phases are not sandboxed**: Only LLM phase calls
+   (`RunPhaseWithEnv`, `RunPhaseObservedWithEnv`) go through the sandbox
+   policy. Command phases (`RunPhase`, `RunProcess`, `RunProcessWithEnv`)
+   retain the full ambient environment because git and gh require ambient
+   credentials that must not be filtered.


### PR DESCRIPTION
## Summary

Implements [#58](https://github.com/nicholls-inc/xylem/issues/58) — WS2 of the harness plan: runtime containment, egress policy, and scoped secret handling for vessel phase subprocesses.

- Introduces `cli/internal/sandbox` package with a `Policy` interface and three implementations: `NoopPolicy` (backward-compatible default), `EnvScopingPolicy` (strips ambient env to a built-in passlist + provider credentials), and `FullPolicy` (env scoping + platform-specific egress enforcement via `sandbox-exec` on macOS and `unshare --net` on Linux)
- Adds `SandboxConfig` to `cli/internal/config/config.go`; operators configure isolation via `sandbox.mode: none|env|full` in `.xylem.yml`
- Wires `sandbox.Policy` into `realCmdRunner` via `exec.go` (new `newCmdRunnerWithPolicy`) and `drain.go` (builds policy from config at drain time)
- Adds `docs/sandbox.md` documenting isolation modes, the built-in env passlist, operator escape hatches, and platform requirements

## Smoke scenarios covered

No pre-assigned WS2 smoke scenario IDs exist in the scenario index (there is no `docs/design/harness-smoke-scenarios/ws2-containment.md`). The acceptance criteria from the harness plan are covered by the test suite:

- **SC-WS2-env-strip**: `TestEnvScopingPolicy_StripsSensitiveVars` / `TestRealCmdRunner_EnvScopingStripsAmbientSecret` — a vessel subprocess cannot see ambient secrets not in the passlist
- **SC-WS2-provider-creds**: `TestEnvScopingPolicy_ProviderEnvTakesPrecedence` / `TestRealCmdRunner_EnvScopingPreservesProviderCreds` — provider credentials are always delivered to the subprocess
- **SC-WS2-passlist**: `TestEnvScopingPolicy_IncludesPasslistVars` / `TestRealCmdRunner_EnvScopingPreservesPath` — standard toolchain vars (PATH, HOME, GIT_*, etc.) pass through
- **SC-WS2-noop**: `TestRealCmdRunner_SandboxModeNoneInheritsAmbient` — mode `none` preserves current behavior
- **SC-WS2-custom**: `TestRealCmdRunner_SandboxModeEnvCustomPasslist` — operators can extend the passlist
- **SC-WS2-props**: `TestPropEnvScopingPolicy_NeverLeaksBlockedVars`, `TestPropEnvScopingPolicy_AlwaysIncludesProviderEnv`, `TestPropNoopPolicy_SupersetOfAmbient`, `TestPropEnvScopingPolicy_DeterministicForSameInput` — property-based tests over arbitrary env inputs

## Changes summary

**New files:**
- `cli/internal/sandbox/sandbox.go` — `Policy` interface, `Config`, `IsolationMode` constants, `NoopPolicy`, `EnvScopingPolicy`, `FullPolicy`, `NewPolicy` factory, built-in safe passlist
- `cli/internal/sandbox/sandbox_darwin.go` — `platformWrapCommand` using `sandbox-exec` with a deny-network `.sb` profile; write access scoped to the vessel worktree directory
- `cli/internal/sandbox/sandbox_linux.go` — `platformWrapCommand` using `unshare --net`
- `cli/internal/sandbox/sandbox_other.go` — returns an error for unsupported platforms in `full` mode
- `cli/internal/sandbox/sandbox_test.go` — 12 unit tests covering all policy types and factory
- `cli/internal/sandbox/sandbox_prop_test.go` — 4 property-based tests (`TestProp*`) using `pgregory.net/rapid`
- `cli/cmd/xylem/exec_sandbox_test.go` — 5 integration tests spawning real `sh -c` subprocesses
- `docs/sandbox.md` — operator documentation

**Modified files:**
- `cli/internal/config/config.go` — adds `SandboxConfig` struct and `Sandbox SandboxConfig` field to `Config`
- `cli/internal/config/config_test.go` — adds 3 tests for sandbox block parsing
- `cli/cmd/xylem/exec.go` — adds `isolation sandbox.Policy` to `realCmdRunner`, `newCmdRunnerWithPolicy` constructor, `policy()` helper, updates `RunPhaseWithEnv` and `RunPhaseObservedWithEnv` to apply env scoping and command wrapping
- `cli/cmd/xylem/drain.go` — updates `newCommandRunner` to build the policy from config and inject it into `realCmdRunner`

## Test plan

- [x] `go vet ./...` — passes
- [x] `go build ./cmd/xylem` — passes
- [x] `go test ./...` — all packages pass; `internal/sandbox` passes all 16 tests
- [x] `golangci-lint run` — 0 issues
- [x] `goimports -l .` — no unformatted files
- [ ] Manual smoke: set `sandbox.mode: env` in `.xylem.yml`, run a vessel phase, confirm `env | grep SECRET` produces no output in the phase log
- [ ] Manual smoke (macOS): set `sandbox.mode: full`, confirm `curl https://example.com` fails from within a phase subprocess

Fixes #58