### PR TITLE
fix: increase fix-bug analyze and plan phase max_turns from 20 to 40

### DIFF
--- a/cli/internal/profiles/core/workflows/fix-bug.yaml
+++ b/cli/internal/profiles/core/workflows/fix-bug.yaml
@@ -3,12 +3,12 @@ description: "Diagnose and fix a bug from a GitHub issue"
 phases:
   - name: analyze
     prompt_file: .xylem/prompts/fix-bug/analyze.md
-    max_turns: 20
+    max_turns: 40
     noop:
       match: XYLEM_NOOP
   - name: plan
     prompt_file: .xylem/prompts/fix-bug/plan.md
-    max_turns: 20
+    max_turns: 40
   - name: implement
     prompt_file: .xylem/prompts/fix-bug/implement.md
     max_turns: 60

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -145,6 +145,8 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 	require.NoError(t, yaml.Unmarshal(composed.Workflows["merge-pr"], &mergePR))
 	assert.Equal(t, policy.Ops, mergePR.Class)
 	assert.Equal(t, 2, fixBug.Phases[2].Evaluator.MaxIterations)
+	assert.Equal(t, 40, fixBug.Phases[0].MaxTurns, "fix-bug analyze max_turns")
+	assert.Equal(t, 40, fixBug.Phases[1].MaxTurns, "fix-bug plan max_turns")
 
 	var implementFeature workflowpkg.Workflow
 	require.NoError(t, yaml.Unmarshal(composed.Workflows["implement-feature"], &implementFeature))


### PR DESCRIPTION
## Summary

Increases `max_turns` for the `analyze` and `plan` phases in the `fix-bug` workflow from 20 to 40, matching the value already set for the `review-pr` workflow by PR #529.

Addresses https://github.com/nicholls-inc/xylem/issues/534, which was filed after vessel `issue-522` failed at `analyze` with max_turns exhausted (20 turns insufficient for complex bug analysis).

## Changes

**Files modified:**
- `cli/internal/profiles/core/workflows/fix-bug.yaml` — `analyze` phase `max_turns: 20 → 40`; `plan` phase `max_turns: 20 → 40`
- `cli/internal/profiles/profiles_test.go` — added regression-guard assertions in `TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates`: `fixBug.Phases[0].MaxTurns == 40` (analyze) and `fixBug.Phases[1].MaxTurns == 40` (plan)

## Smoke scenarios covered

- **S2 (ComposeCoreIncludesSeededWorkflowsAndTemplates)** — existing smoke test that unmarshals the composed `fix-bug` workflow; extended with assertions that `analyze` and `plan` phases now have `MaxTurns == 40`

## Test plan

- [x] `go test ./internal/profiles/...` passes with new `MaxTurns` assertions
- [x] `go vet ./...` clean
- [x] `go build ./cmd/xylem` succeeds
- [x] Pre-commit hooks (goimports, golangci-lint, go build) all pass
- [ ] Validate live: next `fix-bug` vessel on a complex issue should complete `analyze` without hitting turn limit

Fixes #534