### PR TITLE
fix: wrap gh CLI calls with per-call timeouts to prevent daemon freeze

### DIFF
--- a/cli/cmd/xylem/automerge.go
+++ b/cli/cmd/xylem/automerge.go
@@ -9,8 +9,14 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
+)
+
+var (
+	ghReadTimeout  = 60 * time.Second  // pr list, pr view, api GET — overridden in tests
+	ghWriteTimeout = 120 * time.Second // pr merge --admin (heavier) — overridden in tests
 )
 
 type autoMergeSettings struct {
@@ -364,7 +370,9 @@ func listOpenPRs(ctx context.Context, repo string) ([]prSummary, error) {
 	if repo != "" {
 		args = append(args, "--repo", repo)
 	}
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	ghCtx, cancel := context.WithTimeout(ctx, ghReadTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ghCtx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("gh pr list: %w", err)
@@ -384,7 +392,9 @@ func getPRSummary(ctx context.Context, repo string, number int) (prSummary, erro
 	if repo != "" {
 		args = append(args, "--repo", repo)
 	}
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	ghCtx, cancel := context.WithTimeout(ctx, ghReadTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ghCtx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return prSummary{}, fmt.Errorf("gh pr view %d: %w", number, err)
@@ -417,7 +427,9 @@ func addPRLabels(ctx context.Context, repo string, number int, labels []string) 
 		fmt.Sprintf("repos/%s/issues/%d/labels", slug, number),
 		"--input", "-",
 	}
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	ghCtx, cancel := context.WithTimeout(ctx, ghReadTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ghCtx, "gh", args...)
 	cmd.Stdin = strings.NewReader(string(body))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -447,7 +459,9 @@ func requestCopilotReview(ctx context.Context, repo string, number int, reviewer
 		fmt.Sprintf("repos/%s/pulls/%d/requested_reviewers", repo, number),
 		"--input", "-",
 	}
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	ghCtx, cancel := context.WithTimeout(ctx, ghReadTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ghCtx, "gh", args...)
 	cmd.Stdin = strings.NewReader(string(body))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -462,7 +476,9 @@ func adminMergePR(ctx context.Context, repo string, number int) error {
 		args = append(args, "--repo", repo)
 	}
 	args = append(args, strconv.Itoa(number))
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	ghCtx, cancel := context.WithTimeout(ctx, ghWriteTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ghCtx, "gh", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%w: %s", err, out)

--- a/cli/cmd/xylem/automerge_test.go
+++ b/cli/cmd/xylem/automerge_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/stretchr/testify/assert"
@@ -586,6 +587,11 @@ func TestSmoke_S9_AutoAdminMergeWithinOneDaemonTick(t *testing.T) {
 		}{{Conclusion: "SUCCESS", Status: "COMPLETED"}},
 	}
 
+	// The PR has no review requests or latest reviews from the configured reviewer,
+	// so decideAutoMergeAction returns actionRequestReview (not actionAdminMerge):
+	// requestCopilotReview is called first, then adminMergePR, within one tick.
+	require.Equal(t, actionRequestReview, decideAutoMergeAction(mergeReadyPR, settings))
+
 	listOpenPRsFn = func(context.Context, string) ([]prSummary, error) {
 		return []prSummary{{
 			Number:      mergeReadyPR.Number,
@@ -626,4 +632,44 @@ func TestSmoke_S9_AutoAdminMergeWithinOneDaemonTick(t *testing.T) {
 	assert.Equal(t, 1, adminMergeCalls)
 	assert.Equal(t, 1, reviewCalls)
 	assert.Equal(t, 0, labelCalls)
+}
+
+// TestGhCallTimeoutPropagated verifies that each gh-calling function returns an
+// error when the per-call timeout fires, even with a live parent context that
+// will never cancel on its own. Without the context.WithTimeout wrapping inside
+// each function, passing context.Background() would block indefinitely if gh
+// hangs; with it, the 1ns override fires immediately and returns an error.
+func TestGhCallTimeoutPropagated(t *testing.T) {
+	origRead := ghReadTimeout
+	origWrite := ghWriteTimeout
+	t.Cleanup(func() {
+		ghReadTimeout = origRead
+		ghWriteTimeout = origWrite
+	})
+	ghReadTimeout = 1 * time.Nanosecond
+	ghWriteTimeout = 1 * time.Nanosecond
+
+	// Background context never cancels — only the per-call timeout can fail these calls.
+	ctx := context.Background()
+
+	t.Run("listOpenPRs", func(t *testing.T) {
+		_, err := listOpenPRs(ctx, "")
+		assert.Error(t, err)
+	})
+	t.Run("getPRSummary", func(t *testing.T) {
+		_, err := getPRSummary(ctx, "nicholls-inc/xylem", 1)
+		assert.Error(t, err)
+	})
+	t.Run("addPRLabels", func(t *testing.T) {
+		err := addPRLabels(ctx, "nicholls-inc/xylem", 1, []string{"ready-to-merge"})
+		assert.Error(t, err)
+	})
+	t.Run("requestCopilotReview", func(t *testing.T) {
+		err := requestCopilotReview(ctx, "nicholls-inc/xylem", 1, "copilot-pull-request-reviewer")
+		assert.Error(t, err)
+	})
+	t.Run("adminMergePR", func(t *testing.T) {
+		err := adminMergePR(ctx, "nicholls-inc/xylem", 1)
+		assert.Error(t, err)
+	})
 }


### PR DESCRIPTION
## Summary

Fixes daemon freezes caused by hung `gh` subprocess calls in the auto-merge path. Resolves https://github.com/nicholls-inc/xylem/issues/536.

Three daemon freezes were observed in 2.5 hours, all correlated with the `gh` CLI calls inside `autoMergeXylemPRs`. The root cause: all five `gh`-calling functions received the daemon lifecycle context (`ctx`), which has no deadline. If a `gh` subprocess hangs (network stall, GitHub rate-limit, slow squash-delete), `cmd.Output()` / `cmd.CombinedOutput()` blocks indefinitely — holding the main tick goroutine, preventing heartbeat writes, and making SIGTERM ineffective.

**Fix:** Each of the five `gh`-calling functions now derives a short-lived context via `context.WithTimeout` before constructing the `exec.Cmd`. Two constants control the timeouts:
- `ghReadTimeout = 60s` — for `pr list`, `pr view`, `api GET` calls
- `ghWriteTimeout = 120s` — for `pr merge --admin` (heavier squash-and-delete)

A hung call now surfaces as `context.DeadlineExceeded`, the function returns an error, the tick continues, and the next cycle retries.

## Smoke scenarios covered

No formal smoke scenario IDs are assigned to this issue (issue #536 is an operational daemon bug fix, not a harness workflow scenario). The existing `TestSmoke_S7`, `TestSmoke_S8`, and `TestSmoke_S9` tests in `automerge_test.go` continue to pass and cover the PR listing/merging code paths.

A new dedicated test `TestGhCallTimeoutPropagated` was added (see below).

## Changes summary

### `cli/cmd/xylem/automerge.go`
- Added two package-level timeout constants: `ghReadTimeout` (60s) and `ghWriteTimeout` (120s). Both are `var` (not `const`) to allow test override.
- Patched five functions to derive a per-call context with `context.WithTimeout` before passing it to `exec.CommandContext`:
  - `listOpenPRs` — uses `ghReadTimeout`
  - `getPRSummary` — uses `ghReadTimeout`
  - `addPRLabels` — uses `ghReadTimeout`
  - `requestCopilotReview` — uses `ghReadTimeout`
  - `adminMergePR` — uses `ghWriteTimeout`
- Added `"time"` to imports.

### `cli/cmd/xylem/automerge_test.go`
- Added `TestGhCallTimeoutPropagated`: overrides `ghReadTimeout` and `ghWriteTimeout` to `1ns`, then calls each real function with `context.Background()`. With a 1ns timeout, the per-call context fires immediately, and each function must return a non-nil error — proving the timeout is wired up and not bypassed.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./cmd/xylem` — clean
- [x] `go test ./cmd/xylem/...` — all pass including `TestGhCallTimeoutPropagated`
- [x] `go test ./...` — all pass except `TestRunLiveGateHTTPPassesAndPersistsEvidence` (pre-existing sandbox network restriction, unrelated to this change)
- [x] Pre-commit hooks: goimports, golangci-lint, go build — all passed

Fixes #536