### PR TITLE
feat: harness-gap-analysis: clean up stale conflict labels on mergeable PRs

### DIFF
--- a/cli/internal/review/harness_gap.go
+++ b/cli/internal/review/harness_gap.go
@@ -454,14 +454,27 @@ func detectStaleConflictLabelGap(ctx context.Context, repo string, runner issueR
 	}
 
 	evidence := make([]string, 0, len(prs))
-	count := 0
+	var stalePRs []harnessGapPullRequest
 	for _, pr := range prs {
 		if strings.EqualFold(strings.TrimSpace(pr.Mergeable), "CONFLICTING") {
 			continue
 		}
-		count++
+		stalePRs = append(stalePRs, pr)
 		evidence = append(evidence, fmt.Sprintf("#%d is `%s` but still labeled `needs-conflict-resolution`", pr.Number, strings.TrimSpace(pr.Mergeable)))
 	}
+	count := len(stalePRs)
+
+	// Strip stale labels from PRs that are no longer conflicting.
+	for _, pr := range stalePRs {
+		if _, err := runner.RunOutput(ctx, "gh", "pr", "edit",
+			strconv.Itoa(pr.Number),
+			"--repo", repo,
+			"--remove-label", "needs-conflict-resolution",
+		); err != nil {
+			return nil, fmt.Errorf("detect stale conflict-label gap: remove label from #%d: %w", pr.Number, err)
+		}
+	}
+
 	if count < harnessGapStaleConflictThreshold {
 		return nil, nil
 	}

--- a/cli/internal/review/harness_gap_test.go
+++ b/cli/internal/review/harness_gap_test.go
@@ -57,6 +57,7 @@ func TestGenerateHarnessGapAnalysisDetectsObservedSignals(t *testing.T) {
 			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--label", "needs-conflict-resolution", "--limit", "100", "--json", "number,title,url,mergeable,headRefName"): mustJSON(t, []map[string]any{
 				{"number": 11, "title": "conflict", "url": "https://example/pr/11", "mergeable": "MERGEABLE", "headRefName": "feat/issue-211-211"},
 			}),
+			commandKey("gh", "pr", "edit", "11", "--repo", "owner/repo", "--remove-label", "needs-conflict-resolution"): []byte(""),
 			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt"): mustJSON(t, []map[string]any{
 				{"number": 21, "title": "Release Please", "url": "https://example/pr/21", "headRefName": "release-please--branches--main", "createdAt": now.Add(-10 * 24 * time.Hour)},
 			}),
@@ -409,4 +410,141 @@ func valueAfterFlag(args []string, flag string) string {
 		}
 	}
 	return ""
+}
+
+func TestSmoke_S3_StaleConflictLabelStrippedAndFindingPublished(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 10, 1, 0, 0, 0, time.UTC)
+	runner := &harnessGapTestRunner{
+		responses: map[string][]byte{
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "merged", "--limit", "100", "--json", "number,title,url,headRefName,mergedAt,mergedBy,labels"):                        []byte("[]"),
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--label", "needs-conflict-resolution", "--limit", "100", "--json", "number,title,url,mergeable,headRefName"): mustJSON(t, []map[string]any{{"number": 42, "title": "old conflict", "url": "https://example/pr/42", "mergeable": "MERGEABLE", "headRefName": "feat/issue-442-442"}}),
+			commandKey("gh", "pr", "edit", "42", "--repo", "owner/repo", "--remove-label", "needs-conflict-resolution"):                                                                             []byte(""),
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt"):                                         []byte("[]"),
+			commandKey("git", "rev-list", "--left-right", "--count", "origin/main...HEAD"):                                                                                                          []byte("0\t0\n"),
+			commandKey("gh", "--repo", "owner/repo", "issue", "list", "--state", "open", "--label", "xylem-failed", "--limit", "100", "--json", "number,title,url,labels"):                          []byte("[]"),
+			commandKey("gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--limit", "100", "--json", "number,title,body"):                                                           []byte("[]"),
+		},
+	}
+
+	result, err := RunHarnessGapAnalysis(context.Background(), stateDir, "owner/repo", runner, HarnessGapOptions{
+		OutputDir: "reviews",
+		Now:       now,
+	})
+	require.NoError(t, err)
+
+	// A stale-label-patterns finding must be present.
+	var staleFinding *HarnessGapFinding
+	for i := range result.Report.Findings {
+		if result.Report.Findings[i].Category == "stale-label-patterns" {
+			staleFinding = &result.Report.Findings[i]
+			break
+		}
+	}
+	require.NotNil(t, staleFinding, "expected stale-label-patterns finding, categories: %v", func() []string {
+		cats := make([]string, len(result.Report.Findings))
+		for i, f := range result.Report.Findings {
+			cats[i] = f.Category
+		}
+		return cats
+	}())
+	assert.Equal(t, 1, staleFinding.Observed)
+	assert.Contains(t, staleFinding.Evidence[0], "#42")
+
+	// Label removal must have been called for PR 42.
+	assert.Contains(t, runner.calls,
+		[]string{"gh", "pr", "edit", "42", "--repo", "owner/repo", "--remove-label", "needs-conflict-resolution"},
+	)
+
+	// Finding must be published as a new GitHub issue.
+	var published *PublishedIssue
+	for i := range result.Published {
+		if result.Published[i].Title == staleFinding.Title {
+			published = &result.Published[i]
+			break
+		}
+	}
+	require.NotNil(t, published, "expected published issue for stale-label-patterns finding")
+	assert.True(t, published.Created)
+	assert.Equal(t, 91, published.IssueNumber)
+}
+
+func TestSmoke_S4_ConflictingPRLabelPreservedNoFinding(t *testing.T) {
+	stateDir := t.TempDir()
+	now := time.Date(2026, time.April, 10, 1, 0, 0, 0, time.UTC)
+	runner := &harnessGapTestRunner{
+		responses: map[string][]byte{
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "merged", "--limit", "100", "--json", "number,title,url,headRefName,mergedAt,mergedBy,labels"):                        []byte("[]"),
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--label", "needs-conflict-resolution", "--limit", "100", "--json", "number,title,url,mergeable,headRefName"): mustJSON(t, []map[string]any{{"number": 99, "title": "still conflicting", "url": "https://example/pr/99", "mergeable": "CONFLICTING", "headRefName": "feat/issue-499-499"}}),
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--limit", "100", "--json", "number,title,url,headRefName,createdAt"):                                         []byte("[]"),
+			commandKey("git", "rev-list", "--left-right", "--count", "origin/main...HEAD"):                                                                                                          []byte("0\t0\n"),
+			commandKey("gh", "--repo", "owner/repo", "issue", "list", "--state", "open", "--label", "xylem-failed", "--limit", "100", "--json", "number,title,url,labels"):                          []byte("[]"),
+		},
+	}
+
+	result, err := RunHarnessGapAnalysis(context.Background(), stateDir, "owner/repo", runner, HarnessGapOptions{
+		OutputDir: "reviews",
+		Now:       now,
+	})
+	require.NoError(t, err)
+
+	// No stale-label-patterns finding — the PR is genuinely CONFLICTING.
+	for _, f := range result.Report.Findings {
+		assert.NotEqual(t, "stale-label-patterns", f.Category,
+			"unexpected stale-label-patterns finding for a genuinely conflicting PR")
+	}
+
+	// No label removal command must have been issued.
+	for _, call := range runner.calls {
+		if len(call) >= 3 && call[0] == "gh" && call[1] == "pr" && call[2] == "edit" {
+			t.Fatalf("unexpected gh pr edit call for CONFLICTING PR: %v", call)
+		}
+	}
+
+	// No issues published.
+	assert.Empty(t, result.Published)
+	assert.Equal(t, 0, runner.createCount)
+}
+
+func TestDetectStaleConflictLabelGapRemovesLabelFromMergeablePRs(t *testing.T) {
+	runner := &harnessGapTestRunner{
+		responses: map[string][]byte{
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--label", "needs-conflict-resolution", "--limit", "100", "--json", "number,title,url,mergeable,headRefName"): mustJSON(t, []map[string]any{
+				{"number": 11, "title": "conflict", "url": "https://example/pr/11", "mergeable": "MERGEABLE", "headRefName": "feat/issue-211-211"},
+			}),
+			commandKey("gh", "pr", "edit", "11", "--repo", "owner/repo", "--remove-label", "needs-conflict-resolution"): []byte(""),
+		},
+	}
+
+	finding, err := detectStaleConflictLabelGap(context.Background(), "owner/repo", runner)
+	require.NoError(t, err)
+	require.NotNil(t, finding)
+
+	assert.Equal(t, "stale-label-patterns", finding.Category)
+	assert.Equal(t, 1, finding.Observed)
+
+	// Label removal was called for the stale PR.
+	assert.Contains(t, runner.calls,
+		[]string{"gh", "pr", "edit", "11", "--repo", "owner/repo", "--remove-label", "needs-conflict-resolution"},
+	)
+}
+
+func TestDetectStaleConflictLabelGapSkipsConflictingPRs(t *testing.T) {
+	runner := &harnessGapTestRunner{
+		responses: map[string][]byte{
+			commandKey("gh", "--repo", "owner/repo", "pr", "list", "--state", "open", "--label", "needs-conflict-resolution", "--limit", "100", "--json", "number,title,url,mergeable,headRefName"): mustJSON(t, []map[string]any{
+				{"number": 11, "title": "still conflicting", "url": "https://example/pr/11", "mergeable": "CONFLICTING", "headRefName": "feat/issue-211-211"},
+			}),
+		},
+	}
+
+	finding, err := detectStaleConflictLabelGap(context.Background(), "owner/repo", runner)
+	require.NoError(t, err)
+	assert.Nil(t, finding) // Below threshold — only CONFLICTING PRs, none are stale.
+
+	// Exactly one call: the gh pr list. No label removal attempted.
+	require.Len(t, runner.calls, 1, "expected only the pr list call, got: %v", runner.calls)
+	assert.Equal(t, "gh", runner.calls[0][0])
+	assert.Contains(t, runner.calls[0], "pr")
+	assert.Contains(t, runner.calls[0], "list")
 }


### PR DESCRIPTION
## Summary

Implements https://github.com/nicholls-inc/xylem/issues/532

The `detectStaleConflictLabelGap` function previously only *detected* PRs that were no longer conflicting but still carried the `needs-conflict-resolution` label — it filed a gap finding but left the stale labels in place. This change adds automatic label removal: for each PR that is no longer `CONFLICTING`, the function now calls `gh pr edit <number> --repo <repo> --remove-label needs-conflict-resolution` before returning the finding.

Key changes:
- `cli/internal/review/harness_gap.go` — added a cleanup loop in `detectStaleConflictLabelGap` that strips `needs-conflict-resolution` from all non-conflicting PRs; errors are wrapped and returned so partial cleanup is observable
- `cli/internal/review/harness_gap_test.go` — updated `TestGenerateHarnessGapAnalysisDetectsObservedSignals` with the new `gh pr edit` stub; added four new tests covering the cleanup path

## Smoke scenarios covered

- **S1** (`TestSmoke_S1_HarnessGapAnalysisFilesAutoAdminMergeIssue`) — merge-click-frequency gap is detected and published; unaffected by this change
- **S2** (`TestSmoke_S2_HarnessGapAnalysisNoopsWhenNoGapsDetected`) — no PRs with stale labels, no findings, no label removal calls
- **S3** (`TestSmoke_S3_StaleConflictLabelStrippedAndFindingPublished`) — a `MERGEABLE` PR carrying `needs-conflict-resolution` gets its label stripped AND a `stale-label-patterns` finding is published as a GitHub issue
- **S4** (`TestSmoke_S4_ConflictingPRLabelPreservedNoFinding`) — a genuinely `CONFLICTING` PR is skipped; no label removal is attempted; no finding is published

## Changes summary

**Files modified:**

- `cli/internal/review/harness_gap.go`
  - `detectStaleConflictLabelGap`: added post-filter cleanup loop calling `runner.RunOutput(ctx, "gh", "pr", "edit", strconv.Itoa(pr.Number), "--repo", repo, "--remove-label", "needs-conflict-resolution")` for each stale PR
  - No signature change; no new exported types

- `cli/internal/review/harness_gap_test.go`
  - Updated `TestGenerateHarnessGapAnalysisDetectsObservedSignals` with `gh pr edit 11` stub
  - Added `TestSmoke_S3_StaleConflictLabelStrippedAndFindingPublished`
  - Added `TestSmoke_S4_ConflictingPRLabelPreservedNoFinding`
  - Added `TestDetectStaleConflictLabelGapRemovesLabelFromMergeablePRs`
  - Added `TestDetectStaleConflictLabelGapSkipsConflictingPRs`

## Test plan

- [x] `go test ./internal/review/...` — all tests pass including four new ones
- [x] `go test ./...` — full suite green
- [x] `goimports -l .` — no formatting issues
- [x] `go vet ./...` — no issues
- [x] `go build ./cmd/xylem` — binary builds cleanly
- [x] S3 asserts label removal call appears in `runner.calls` and finding is published
- [x] S4 asserts no `gh pr edit` call is made for a genuinely CONFLICTING PR

Fixes #532