### PR TITLE
fix: worker-stall — time out running vessels with no subprocess and no phase output

### DIFF
--- a/cli/internal/runner/monitor_prop_test.go
+++ b/cli/internal/runner/monitor_prop_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
+	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 )
 
@@ -70,6 +72,67 @@ func TestProp_LatestPhaseActivityReturnsNewestOutput(t *testing.T) {
 		}
 		if !gotTime.Equal(wantTime) {
 			t.Fatalf("latestPhaseActivity(%q) time = %s, want %s", vesselID, gotTime, wantTime)
+		}
+	})
+}
+
+// TestProp_NeverRegisteredVesselTimeoutIffPastThreshold verifies that
+// CheckStalledVessels times out a never-registered running vessel if and only if
+// OrphanCheckEnabled is true AND the vessel has been running longer than the
+// configured stall threshold.
+func TestProp_NeverRegisteredVesselTimeoutIffPastThreshold(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		thresholdMin := rapid.IntRange(1, 60).Draw(rt, "threshold_min")
+		elapsedMin := rapid.IntRange(0, 120).Draw(rt, "elapsed_min")
+		orphanEnabled := rapid.Bool().Draw(rt, "orphan_enabled")
+
+		dir, err := os.MkdirTemp("", "prop-never-reg-*")
+		if err != nil {
+			rt.Fatalf("MkdirTemp: %v", err)
+		}
+		defer os.RemoveAll(dir)
+
+		cfg := makeTestConfig(dir, 1)
+		cfg.StateDir = filepath.Join(dir, ".xylem")
+		cfg.Daemon.StallMonitor.PhaseStallThreshold = fmt.Sprintf("%dm", thresholdMin)
+		cfg.Daemon.StallMonitor.OrphanCheckEnabled = orphanEnabled
+
+		q := queue.New(filepath.Join(dir, "queue.jsonl"))
+		now := time.Now().UTC()
+		_, _ = q.Enqueue(queue.Vessel{
+			ID:        "prop-1",
+			Source:    "manual",
+			State:     queue.StatePending,
+			CreatedAt: now,
+		})
+		vessel, _ := q.Dequeue()
+		require.NotNil(rt, vessel, "Dequeue returned nil")
+
+		startedAt := now.Add(-time.Duration(elapsedMin) * time.Minute)
+		vessel.StartedAt = &startedAt
+		_ = q.UpdateVessel(*vessel)
+
+		r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+		findings := r.CheckStalledVessels(context.Background())
+
+		// When elapsedMin == thresholdMin, runtimeSince returns
+		// thresholdMin + epsilon (test setup latency), which is always
+		// strictly greater than the threshold. So ">=" is the correct
+		// predicate here.
+		shouldTimeout := orphanEnabled && elapsedMin >= thresholdMin
+		if shouldTimeout {
+			if len(findings) != 1 {
+				rt.Fatalf("expected 1 finding, got %d (orphanEnabled=%v elapsed=%dm threshold=%dm)",
+					len(findings), orphanEnabled, elapsedMin, thresholdMin)
+			}
+			if findings[0].Code != "orphaned_subprocess" {
+				rt.Fatalf("expected code=orphaned_subprocess, got %q", findings[0].Code)
+			}
+		} else {
+			if len(findings) != 0 {
+				rt.Fatalf("expected 0 findings, got %d (orphanEnabled=%v elapsed=%dm threshold=%dm)",
+					len(findings), orphanEnabled, elapsedMin, thresholdMin)
+			}
 		}
 	})
 }

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -4381,6 +4381,25 @@ func (r *Runner) CheckStalledVessels(ctx context.Context) []StallFinding {
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
 				log.Printf("warn: inspect phase activity for vessel %s: %v", vessel.ID, err)
+				continue
+			}
+			// No phase output files and no tracked process.
+			// If OrphanCheckEnabled and the vessel has been running longer than
+			// the stall threshold, time it out: the worker goroutine either
+			// panicked before markProcessStarted or was never dispatched.
+			if r.Config.Daemon.StallMonitor.OrphanCheckEnabled &&
+				vessel.StartedAt != nil &&
+				r.runtimeSince(*vessel.StartedAt) > stallThreshold {
+				msg := "vessel orphaned (no subprocess registered and no phase output)"
+				log.Printf("warn: %s for vessel %s", msg, vessel.ID)
+				if r.timeoutRunningVessel(ctx, vessel, msg) {
+					findings = append(findings, StallFinding{
+						Code:     "orphaned_subprocess",
+						Level:    "critical",
+						VesselID: vessel.ID,
+						Message:  msg,
+					})
+				}
 			}
 			continue
 		}

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -9667,6 +9667,114 @@ func TestCheckStalledVesselsDoesNotTimeoutUntrackedRecentPhase(t *testing.T) {
 	assert.Equal(t, queue.StateRunning, updated.State)
 }
 
+// TestSmoke_S5_NeverRegisteredRunningVesselTimesOut verifies that a running vessel
+// with no entry in the process table and no phase output files is timed out after
+// the stall threshold has elapsed.
+func TestSmoke_S5_NeverRegisteredRunningVesselTimesOut(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "10m"
+	cfg.Daemon.StallMonitor.OrphanCheckEnabled = true
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:        "never-registered-1",
+		Source:    "manual",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	})
+	vessel, _ := q.Dequeue()
+	require.NotNil(t, vessel)
+
+	// Backdate StartedAt past the stall threshold.
+	old := now.Add(-11 * time.Minute)
+	vessel.StartedAt = &old
+	require.NoError(t, q.UpdateVessel(*vessel))
+
+	// No markProcessStarted call — process table is empty.
+	// No phase output files written — phases dir does not exist.
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	findings := r.CheckStalledVessels(context.Background())
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, "orphaned_subprocess", findings[0].Code)
+	assert.Equal(t, "never-registered-1", findings[0].VesselID)
+
+	updated, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	assert.Equal(t, queue.StateTimedOut, updated.State)
+	assert.Contains(t, updated.Error, "no subprocess registered")
+}
+
+// TestSmoke_S5_NeverRegisteredRunningVesselWithinGracePeriodIsSkipped verifies
+// that a never-registered vessel started recently (within the stall threshold) is
+// not timed out.
+func TestSmoke_S5_NeverRegisteredRunningVesselWithinGracePeriodIsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "10m"
+	cfg.Daemon.StallMonitor.OrphanCheckEnabled = true
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:        "grace-1",
+		Source:    "manual",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	})
+	vessel, _ := q.Dequeue()
+	require.NotNil(t, vessel)
+	// StartedAt set by Dequeue to approximately now — within the 10m grace period.
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	findings := r.CheckStalledVessels(context.Background())
+
+	require.Empty(t, findings)
+	updated, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	assert.Equal(t, queue.StateRunning, updated.State)
+}
+
+// TestCheckStalledVesselsSkipsNeverRegisteredWhenOrphanCheckDisabled verifies
+// that when OrphanCheckEnabled is false, a never-registered vessel past the stall
+// threshold is not timed out. This preserves existing behavior for deployments
+// that have orphan check disabled.
+func TestCheckStalledVesselsSkipsNeverRegisteredWhenOrphanCheckDisabled(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	cfg.Daemon.StallMonitor.PhaseStallThreshold = "10m"
+	cfg.Daemon.StallMonitor.OrphanCheckEnabled = false
+
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	now := time.Now().UTC()
+	_, _ = q.Enqueue(queue.Vessel{
+		ID:        "no-orphan-check-1",
+		Source:    "manual",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	})
+	vessel, _ := q.Dequeue()
+	require.NotNil(t, vessel)
+
+	old := now.Add(-11 * time.Minute)
+	vessel.StartedAt = &old
+	require.NoError(t, q.UpdateVessel(*vessel))
+
+	r := New(cfg, q, &mockWorktree{}, &mockCmdRunner{})
+	findings := r.CheckStalledVessels(context.Background())
+
+	require.Empty(t, findings)
+	updated, err := q.FindByID(vessel.ID)
+	require.NoError(t, err)
+	assert.Equal(t, queue.StateRunning, updated.State)
+}
+
 func TestSmoke_S9_NilTracerSkipsAllSpanCreationWithoutPanicking(t *testing.T) {
 	cmdRunner := &mockCmdRunner{
 		phaseOutputs: map[string][]byte{

--- a/cli/internal/runner/testdata/rapid/TestProp_NeverRegisteredVesselTimeoutIffPastThreshold/TestProp_NeverRegisteredVesselTimeoutIffPastThreshold-20260415042144-89150.fail
+++ b/cli/internal/runner/testdata/rapid/TestProp_NeverRegisteredVesselTimeoutIffPastThreshold/TestProp_NeverRegisteredVesselTimeoutIffPastThreshold-20260415042144-89150.fail
@@ -1,0 +1,13 @@
+# 2026/04/15 04:21:44.799558 [TestProp_NeverRegisteredVesselTimeoutIffPastThreshold] [rapid] draw threshold_min: 8
+# 2026/04/15 04:21:44.799561 [TestProp_NeverRegisteredVesselTimeoutIffPastThreshold] [rapid] draw elapsed_min: 8
+# 2026/04/15 04:21:44.799561 [TestProp_NeverRegisteredVesselTimeoutIffPastThreshold] [rapid] draw orphan_enabled: true
+# 2026/04/15 04:21:44.801159 [TestProp_NeverRegisteredVesselTimeoutIffPastThreshold] expected 0 findings, got 1 (orphanEnabled=true elapsed=8m threshold=8m)
+#
+v0.4.8#9841860034701767820
+0x0
+0x6b74f03291620
+0x7
+0x0
+0x9867f1f40f739
+0x8
+0x1


### PR DESCRIPTION
## Summary

Fixes the worker-stall failure mode reported in https://github.com/nicholls-inc/xylem/issues/542.

When a running vessel has no entry in the process table (`markProcessStarted` was never called) **and** no phase output files exist, `CheckStalledVessels` previously hit the `os.ErrNotExist` branch and silently `continue`d, leaving the vessel perpetually stuck in `running`. This was invisible to the heartbeat monitor because the daemon tick was still healthy — only the worker goroutine was missing.

This fix extends the `os.ErrNotExist` branch to time out vessels that are past the stall threshold with neither a tracked process nor any phase output. It uses the same `orphaned_subprocess` code path and `timeoutRunningVessel` call as the existing registered-but-exited condition, and is gated on `OrphanCheckEnabled` and the configured stall threshold so behavior is unchanged when either is unset.

Also fixes a latent correctness bug: the non-`os.ErrNotExist` error path previously fell through to the `staleFor` check with a zero `modifiedAt`, which would have produced an enormous (and incorrect) stale duration. It now `continue`s immediately after logging the warning.

## Smoke scenarios covered

| ID | Test function | Condition |
|----|--------------|----------|
| S1 | `TestSmoke_S1_UntrackedPhaseStalledVesselTimesOut` | (pre-existing) untracked + stale output → `phase_stalled` |
| S3 | `TestSmoke_S3_OrphanedRunningVesselTimesOut` | (pre-existing) registered + exited → `orphaned_subprocess` |
| S5 | `TestSmoke_S5_NeverRegisteredRunningVesselTimesOut` | **new** — never registered, no output, past threshold → `orphaned_subprocess`, state `timed_out` |
| S5-neg-a | `TestSmoke_S5_NeverRegisteredRunningVesselWithinGracePeriodIsSkipped` | **new** — never registered, within grace period → no action |
| S5-neg-b | `TestCheckStalledVesselsSkipsNeverRegisteredWhenOrphanCheckDisabled` | **new** — orphan check disabled → no action |
| Prop | `TestProp_NeverRegisteredVesselTimeoutIffPastThreshold` | **new** — property: times out iff `orphanEnabled && elapsed > threshold` (100 rapid draws + recorded regression case) |

## Changes

### `cli/internal/runner/runner.go`

- **`CheckStalledVessels`** (~line 4382): replaced the silent `continue` in the `os.ErrNotExist` branch with a guard that times out never-registered vessels past the stall threshold (`orphaned_subprocess` code, `critical` level). Added `continue` after the non-`ErrNotExist` log to fix the latent fall-through bug.

### `cli/internal/runner/runner_test.go`

- Added `TestSmoke_S5_NeverRegisteredRunningVesselTimesOut` — primary positive case.
- Added `TestSmoke_S5_NeverRegisteredRunningVesselWithinGracePeriodIsSkipped` — grace period boundary.
- Added `TestCheckStalledVesselsSkipsNeverRegisteredWhenOrphanCheckDisabled` — orphan-check-disabled gate.

### `cli/internal/runner/monitor_prop_test.go`

- Added `TestProp_NeverRegisteredVesselTimeoutIffPastThreshold` — rapid property test verifying the timeout fires if and only if `orphanEnabled && elapsed >= threshold`.

### `cli/internal/runner/testdata/rapid/TestProp_NeverRegisteredVesselTimeoutIffPastThreshold/`

- Committed recorded rapid failure for `threshold=8m, elapsed=8m, orphan=true` — serves as a pinned regression input that CI replays on every run.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./cmd/xylem` — clean
- [x] `go test ./internal/runner/... -run "TestSmoke_S5|TestCheckStalledVesselsSkipsNeverRegistered|TestProp_NeverRegistered"` — all 4 new tests pass (100 rapid draws, regression case cleared)
- [ ] Full `go test ./...` passes in CI (sandbox blocks `httptest.NewServer` locally; pre-existing skip)

Fixes #542