### PR TITLE
fix: broader gh-timeout coverage in daemon scan/check/stale-cancel hot paths

### DIFF
--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -558,7 +558,9 @@ func (r *Runner) CheckWaitingVessels(ctx context.Context) {
 			continue
 		}
 
-		found, err := gate.CheckLabel(ctx, r.Runner, repo, issueNum, vessel.WaitingFor)
+		ghCtx, ghCancel := context.WithTimeout(ctx, ghCallTimeout)
+		found, err := gate.CheckLabel(ghCtx, r.Runner, repo, issueNum, vessel.WaitingFor)
+		ghCancel()
 		if err != nil {
 			log.Printf("warn: check label for vessel %s: %v", vessel.ID, err)
 			continue

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -59,10 +59,11 @@ type mockCmdRunner struct {
 	gateOutput       []byte
 	gateErr          error
 	// Per-call gate results; when non-nil, overrides gateOutput/gateErr by call index
-	gateCallResults []gateCallResult
-	gateCallCount   int32
-	runOutputHook   func(name string, args ...string) ([]byte, error, bool)
-	runPhaseHook    func(dir, prompt, name string, args ...string) ([]byte, error, bool)
+	gateCallResults  []gateCallResult
+	gateCallCount    int32
+	runOutputHook    func(name string, args ...string) ([]byte, error, bool)
+	runOutputCtxHook func(ctx context.Context, name string, args ...string) ([]byte, error, bool)
+	runPhaseHook     func(dir, prompt, name string, args ...string) ([]byte, error, bool)
 	// Track calls for assertion
 	phaseCalls    []phaseCall
 	outputArgs    [][]string
@@ -82,7 +83,7 @@ type phaseCall struct {
 	args   []string
 }
 
-func (m *mockCmdRunner) RunOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+func (m *mockCmdRunner) RunOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
 	m.mu.Lock()
 	m.outputArgs = append(m.outputArgs, append([]string{name}, args...))
 	isIssueComment := name == "gh" && len(args) >= 3 && args[0] == "issue" && args[1] == "comment"
@@ -96,6 +97,11 @@ func (m *mockCmdRunner) RunOutput(_ context.Context, name string, args ...string
 		}
 	}
 	m.mu.Unlock()
+	if m.runOutputCtxHook != nil {
+		if out, err, handled := m.runOutputCtxHook(ctx, name, args...); handled {
+			return out, err
+		}
+	}
 	if m.runOutputHook != nil {
 		if out, err, handled := m.runOutputHook(name, args...); handled {
 			return out, err
@@ -4810,6 +4816,76 @@ func TestCheckWaitingVesselsTimeoutWritesTraceableSummary(t *testing.T) {
 	timeoutSpan := endedSpanByName(t, rec, "wait_transition:timed_out")
 	assert.Equal(t, timeoutSpan.SpanContext().TraceID().String(), summary.Trace.TraceID)
 	assert.Equal(t, timeoutSpan.SpanContext().SpanID().String(), summary.Trace.SpanID)
+}
+
+func TestCheckWaitingVessels_RespectsTimeout(t *testing.T) {
+	orig := ghCallTimeout
+	ghCallTimeout = 5 * time.Millisecond
+	t.Cleanup(func() { ghCallTimeout = orig })
+
+	dir := t.TempDir()
+	cfg := makeTestConfig(dir, 2)
+	cfg.StateDir = filepath.Join(dir, ".xylem")
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+	waitingSince := time.Now().UTC().Add(-time.Minute)
+	_, err := q.Enqueue(queue.Vessel{
+		ID:           "issue-10",
+		Source:       "github-issue",
+		Ref:          "https://github.com/owner/repo/issues/10",
+		Workflow:     "fix-bug",
+		Meta:         map[string]string{"issue_num": "10"},
+		State:        queue.StateWaiting,
+		CreatedAt:    time.Now().UTC(),
+		FailedPhase:  "plan",
+		WaitingFor:   "plan-approved",
+		WaitingSince: &waitingSince,
+		CurrentPhase: 1,
+	})
+	require.NoError(t, err)
+
+	withTestWorkingDir(t, dir)
+	writeWorkflowFile(t, dir, "fix-bug", []testPhase{
+		{
+			name: "plan", promptContent: "Create plan", maxTurns: 5,
+			gate: "      type: label\n      wait_for: \"plan-approved\"\n      timeout: \"24h\"",
+		},
+		{name: "implement", promptContent: "Implement after approval", maxTurns: 10},
+	})
+
+	// The mock blocks until the context it receives is cancelled. This simulates a
+	// hung gh process. If CheckWaitingVessels does not wrap the call with a timeout
+	// context, the goroutine below will never unblock and the time.After fires.
+	mock := &mockCmdRunner{
+		runOutputCtxHook: func(ctx context.Context, name string, args ...string) ([]byte, error, bool) {
+			if name == "gh" {
+				<-ctx.Done()
+				return nil, ctx.Err(), true
+			}
+			return nil, nil, false
+		},
+	}
+
+	r := New(cfg, q, &mockWorktree{}, mock)
+	r.Sources = map[string]source.Source{"github-issue": makeGitHubSource()}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.CheckWaitingVessels(context.Background())
+	}()
+
+	select {
+	case <-done:
+		// Returned promptly — timeout fired correctly.
+	case <-time.After(2 * time.Second):
+		t.Fatal("CheckWaitingVessels did not return within 2s — gh timeout not applied")
+	}
+
+	// Vessel must remain in waiting — a timed-out call is a warn-and-skip, not a state change.
+	v, err := q.FindByID("issue-10")
+	require.NoError(t, err)
+	assert.Equal(t, queue.StateWaiting, v.State)
 }
 
 func TestDrainVesselFails(t *testing.T) {

--- a/cli/internal/runner/stale_cancel.go
+++ b/cli/internal/runner/stale_cancel.go
@@ -8,9 +8,15 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/queue"
 )
+
+// ghCallTimeout is the maximum time allowed for a single gh CLI call in the
+// daemon's hot paths (scan tick, check tick, stale-cancel tick). Overridable
+// in tests. A hung gh process can no longer freeze the daemon indefinitely.
+var ghCallTimeout = 60 * time.Second
 
 // prRefPattern matches GitHub PR URLs and extracts the PR number.
 var prRefPattern = regexp.MustCompile(`/pull/(\d+)`)
@@ -99,7 +105,9 @@ func extractPRNumber(v queue.Vessel) int {
 // checkPRState queries the GitHub API for a PR's state.
 // Returns "OPEN", "MERGED", or "CLOSED".
 func (r *Runner) checkPRState(ctx context.Context, repo string, prNum int) (string, error) {
-	out, err := r.Runner.RunOutput(ctx, "gh", "pr", "view",
+	ghCtx, cancel := context.WithTimeout(ctx, ghCallTimeout)
+	defer cancel()
+	out, err := r.Runner.RunOutput(ghCtx, "gh", "pr", "view",
 		strconv.Itoa(prNum),
 		"--repo", repo,
 		"--json", "state",

--- a/cli/internal/runner/stale_cancel_test.go
+++ b/cli/internal/runner/stale_cancel_test.go
@@ -287,6 +287,61 @@ func TestCancelStalePRVessels_SkipsGithubMergeSource(t *testing.T) {
 	}
 }
 
+func TestCheckPRState_RespectsTimeout(t *testing.T) {
+	orig := ghCallTimeout
+	ghCallTimeout = 5 * time.Millisecond
+	t.Cleanup(func() { ghCallTimeout = orig })
+
+	dir := t.TempDir()
+	qPath := filepath.Join(dir, "queue.jsonl")
+	q := queue.New(qPath)
+
+	// The mock blocks until the context it receives is cancelled. This simulates a
+	// hung gh process. If checkPRState does not apply context.WithTimeout, the
+	// goroutine below will never unblock and the time.After fires.
+	mock := &mockCmdRunner{
+		runOutputCtxHook: func(ctx context.Context, name string, args ...string) ([]byte, error, bool) {
+			if name == "gh" {
+				<-ctx.Done()
+				return nil, ctx.Err(), true
+			}
+			return nil, nil, false
+		},
+	}
+
+	cfg := &config.Config{
+		Timeout:  "45m",
+		StateDir: dir,
+		Sources: map[string]config.SourceConfig{
+			"prs": {Type: "github-pr", Repo: "owner/repo"},
+		},
+	}
+
+	r := &Runner{
+		Config: cfg,
+		Queue:  q,
+		Runner: mock,
+		Sources: map[string]source.Source{
+			"github-pr": &source.GitHubPR{Repo: "owner/repo"},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := r.checkPRState(context.Background(), "owner/repo", 1)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error from timed-out gh call, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("checkPRState did not return within 2s — gh timeout not applied")
+	}
+}
+
 func TestExtractPRNumber(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cli/internal/source/github.go
+++ b/cli/internal/source/github.go
@@ -18,6 +18,10 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/recovery"
 )
 
+// ghCallTimeout is the maximum time allowed for a single gh CLI call in the
+// daemon's hot paths. Overridable in tests.
+var ghCallTimeout = 60 * time.Second
+
 // GitHubTask defines a label-based task for the GitHub source.
 type GitHubTask struct {
 	Labels          []string
@@ -73,7 +77,9 @@ func (g *GitHub) Scan(ctx context.Context) ([]queue.Vessel, error) {
 			args = append(args, "--label", label)
 		}
 
-		out, err := g.CmdRunner.Run(ctx, "gh", args...)
+		ghCtx, ghCancel := context.WithTimeout(ctx, ghCallTimeout)
+		out, err := g.CmdRunner.Run(ghCtx, "gh", args...)
+		ghCancel()
 		if err != nil {
 			return vessels, fmt.Errorf("gh issue list: %w", err)
 		}
@@ -141,7 +147,9 @@ func (g *GitHub) BacklogCount(ctx context.Context) (int, error) {
 			args = append(args, "--label", label)
 		}
 
-		out, err := g.CmdRunner.Run(ctx, "gh", args...)
+		ghCtx, ghCancel := context.WithTimeout(ctx, ghCallTimeout)
+		out, err := g.CmdRunner.Run(ghCtx, "gh", args...)
+		ghCancel()
 		if err != nil {
 			return 0, fmt.Errorf("gh issue list: %w", err)
 		}
@@ -552,12 +560,14 @@ func (g *GitHub) hasBranch(ctx context.Context, issueNum int) bool {
 func (g *GitHub) hasOpenPR(ctx context.Context, issueNum int) bool {
 	for _, prefix := range branchPrefixes {
 		search := fmt.Sprintf("head:%s/issue-%d-", prefix, issueNum)
-		out, err := g.CmdRunner.Run(ctx, "gh", "pr", "list",
+		ghCtx, ghCancel := context.WithTimeout(ctx, ghCallTimeout)
+		out, err := g.CmdRunner.Run(ghCtx, "gh", "pr", "list",
 			"--repo", g.Repo,
 			"--search", search,
 			"--state", "open",
 			"--json", "number,headRefName",
 			"--limit", "5")
+		ghCancel()
 		if err != nil {
 			continue
 		}
@@ -581,12 +591,14 @@ func (g *GitHub) hasOpenPR(ctx context.Context, issueNum int) bool {
 func (g *GitHub) hasMergedPR(ctx context.Context, issueNum int) bool {
 	for _, prefix := range branchPrefixes {
 		search := fmt.Sprintf("head:%s/issue-%d-", prefix, issueNum)
-		out, err := g.CmdRunner.Run(ctx, "gh", "pr", "list",
+		ghCtx, ghCancel := context.WithTimeout(ctx, ghCallTimeout)
+		out, err := g.CmdRunner.Run(ghCtx, "gh", "pr", "list",
 			"--repo", g.Repo,
 			"--search", search,
 			"--state", "merged",
 			"--json", "number,headRefName",
 			"--limit", "5")
+		ghCancel()
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## Summary

Fix for https://github.com/nicholls-inc/xylem/issues/540.

Daemon freeze #5 reproduced with `daemon.auto_merge: false`, proving the freeze was not isolated to `automerge.go`. Three `gh` CLI call sites in the daemon's hot paths (scan tick, check tick, stale-cancel tick) were passing an unbounded `ctx` — any one of them could block indefinitely on a hung `gh` process.

This PR extends the `context.WithTimeout` pattern (already established in `automerge.go` via PR #538) to all remaining `gh` call sites in the daemon hot paths:

- `runner/stale_cancel.go` — `checkPRState`: wraps `gh pr view` with a 60s timeout context
- `runner/runner.go` — `CheckWaitingVessels`: wraps `gate.CheckLabel` (which calls `gh issue view`) with a 60s timeout context
- `source/github.go` — `Scan`, `BacklogCount`, `scanBlockedByRepoState`: wraps all 4 `gh issue list` / `gh pr list` call sites with a 60s timeout context

The `ghCallTimeout` var is package-level in each package and overridable in tests (1ms for instant deadline-exceeded assertions), matching the pattern from `automerge.go`.

## Smoke scenarios covered

No harness smoke scenario IDs are assigned to issue #540. The fix is covered by the new unit tests below.

## Changes summary

**Modified files:**

- `cli/internal/runner/stale_cancel.go` — added `ghCallTimeout = 60s` package var; wrapped `r.Runner.RunOutput` in `checkPRState` with `context.WithTimeout`
- `cli/internal/runner/runner.go` — wrapped `gate.CheckLabel` call in `CheckWaitingVessels` with `context.WithTimeout(ctx, ghCallTimeout)`
- `cli/internal/source/github.go` — added `ghCallTimeout = 60s` package var; wrapped all 4 `gh` call sites in `Scan`, `BacklogCount`, and `scanBlockedByRepoState` with per-call `context.WithTimeout`
- `cli/internal/runner/stale_cancel_test.go` — added `TestCheckPRState_RespectsTimeout`: verifies that a hung `gh` call is cancelled when `ghCallTimeout` elapses
- `cli/internal/runner/runner_test.go` — added `TestCheckWaitingVessels_RespectsTimeout`: verifies that a hung `gh issue view` in the label-check path is cancelled and does not block the daemon tick

## Test plan

- [ ] `go test ./internal/runner/...` passes including new timeout tests
- [ ] `go test ./internal/source/...` passes (no new tests; source has no unit tests by design)
- [ ] `go vet ./...` clean
- [ ] `go build ./cmd/xylem` succeeds
- [ ] Daemon runs a full scan+check+stale-cancel cycle without freeze on the new binary

Fixes #540