### PR TITLE
fix: abort worktree prune when a running vessel has no persisted path

### DIFF
--- a/cli/internal/runner/worktree_prune.go
+++ b/cli/internal/runner/worktree_prune.go
@@ -2,13 +2,19 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 
+	"github.com/nicholls-inc/xylem/cli/internal/queue"
 	"github.com/nicholls-inc/xylem/cli/internal/worktree"
 )
+
+// errWorktreeSetupInProgress is returned by activeWorktreePaths when a running
+// vessel has not yet persisted its WorktreePath. Callers should defer the prune.
+var errWorktreeSetupInProgress = errors.New("worktree setup in progress, skipping prune")
 
 type xylemWorktreeLister interface {
 	ListXylem(ctx context.Context) ([]worktree.WorktreeInfo, error)
@@ -33,6 +39,10 @@ func (r *Runner) FindStaleWorktrees(ctx context.Context) ([]worktree.WorktreeInf
 
 	active, err := r.activeWorktreePaths()
 	if err != nil {
+		if errors.Is(err, errWorktreeSetupInProgress) {
+			log.Printf("warn: skipping stale worktree prune: %v", err)
+			return nil, nil
+		}
 		return nil, fmt.Errorf("list active worktrees: %w", err)
 	}
 
@@ -79,7 +89,15 @@ func (r *Runner) activeWorktreePaths() (map[string]struct{}, error) {
 
 	active := make(map[string]struct{}, len(vessels))
 	for _, vessel := range vessels {
-		if vessel.State.IsTerminal() || vessel.WorktreePath == "" {
+		if vessel.State.IsTerminal() {
+			continue
+		}
+		// A running vessel with no WorktreePath is mid-creation: the worktree
+		// exists on disk but the path has not been persisted yet. Abort prune.
+		if vessel.State == queue.StateRunning && vessel.WorktreePath == "" {
+			return nil, errWorktreeSetupInProgress
+		}
+		if vessel.WorktreePath == "" {
 			continue
 		}
 		active[r.normalizeWorktreePath(vessel.WorktreePath)] = struct{}{}

--- a/cli/internal/runner/worktree_prune_test.go
+++ b/cli/internal/runner/worktree_prune_test.go
@@ -82,6 +82,110 @@ func TestFindStaleWorktreesNormalizesRelativeActivePaths(t *testing.T) {
 	}
 }
 
+func TestFindStaleWorktrees_SkipsWhenRunningVesselHasEmptyWorktreePath(t *testing.T) {
+	repoRoot := t.TempDir()
+	q := queue.New(filepath.Join(repoRoot, "queue.jsonl"))
+	now := time.Now().UTC()
+	// Enqueue a vessel then advance it to StateRunning with no WorktreePath set.
+	if _, err := q.Enqueue(queue.Vessel{
+		ID:        "issue-99",
+		Source:    "manual",
+		Workflow:  "fix-bug",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	// Advance to running with an empty WorktreePath to simulate the race window.
+	if err := q.UpdateVessel(queue.Vessel{
+		ID:           "issue-99",
+		Source:       "manual",
+		Workflow:     "fix-bug",
+		State:        queue.StateRunning,
+		WorktreePath: "",
+		CreatedAt:    now,
+	}); err != nil {
+		t.Fatalf("UpdateVessel() error = %v", err)
+	}
+
+	// Register a worktree on disk for this vessel's branch.
+	registeredPath := filepath.Join(repoRoot, ".xylem", "worktrees", "fix", "issue-99")
+	wt := &pruningWorktree{
+		repoRoot: repoRoot,
+		list: []worktree.WorktreeInfo{
+			{Path: registeredPath, Branch: "fix/issue-99"},
+		},
+	}
+	r := New(nil, q, wt, nil)
+
+	// FindStaleWorktrees should return nil, nil — prune deferred.
+	stale, err := r.FindStaleWorktrees(context.Background())
+	if err != nil {
+		t.Fatalf("FindStaleWorktrees() error = %v", err)
+	}
+	if len(stale) != 0 {
+		t.Fatalf("len(stale) = %d, want 0 (prune should be deferred)", len(stale))
+	}
+
+	// PruneStaleWorktrees is the call that actually removes worktrees; verify
+	// that no remove is attempted even through the full prune path.
+	removed := r.PruneStaleWorktrees(context.Background())
+	if removed != 0 {
+		t.Fatalf("PruneStaleWorktrees() removed %d, want 0", removed)
+	}
+	if len(wt.removed) != 0 {
+		t.Fatalf("removed = %v, want empty (no worktrees should be removed)", wt.removed)
+	}
+}
+
+func TestFindStaleWorktrees_ProceedsWhenRunningVesselHasPath(t *testing.T) {
+	repoRoot := t.TempDir()
+	q := queue.New(filepath.Join(repoRoot, "queue.jsonl"))
+	now := time.Now().UTC()
+	vesselPath := filepath.Join(".xylem", "worktrees", "fix", "issue-100")
+	if _, err := q.Enqueue(queue.Vessel{
+		ID:        "issue-100",
+		Source:    "manual",
+		Workflow:  "fix-bug",
+		State:     queue.StatePending,
+		CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	// Advance to running WITH a WorktreePath already persisted.
+	if err := q.UpdateVessel(queue.Vessel{
+		ID:           "issue-100",
+		Source:       "manual",
+		Workflow:     "fix-bug",
+		State:        queue.StateRunning,
+		WorktreePath: vesselPath,
+		CreatedAt:    now,
+	}); err != nil {
+		t.Fatalf("UpdateVessel() error = %v", err)
+	}
+
+	orphanPath := filepath.Join(repoRoot, ".xylem", "worktrees", "fix", "orphan")
+	wt := &pruningWorktree{
+		repoRoot: repoRoot,
+		list: []worktree.WorktreeInfo{
+			{Path: filepath.Join(repoRoot, vesselPath), Branch: "fix/issue-100"},
+			{Path: orphanPath, Branch: "fix/orphan"},
+		},
+	}
+	r := New(nil, q, wt, nil)
+
+	stale, err := r.FindStaleWorktrees(context.Background())
+	if err != nil {
+		t.Fatalf("FindStaleWorktrees() error = %v", err)
+	}
+	if len(stale) != 1 {
+		t.Fatalf("len(stale) = %d, want 1", len(stale))
+	}
+	if got := stale[0].Path; got != orphanPath {
+		t.Fatalf("stale[0].Path = %q, want %q", got, orphanPath)
+	}
+}
+
 func TestPruneStaleWorktreesRemovesOnlyDetectedStalePaths(t *testing.T) {
 	repoRoot := t.TempDir()
 	q := queue.New(filepath.Join(repoRoot, "queue.jsonl"))


### PR DESCRIPTION
## Summary

Fixes the race window described in https://github.com/nicholls-inc/xylem/issues/546 — a regression of #360.

When the daemon's health tick fires `PruneStaleWorktrees` at the same moment the runner has just called `worktree.Create` but has not yet called `UpdateVessel`, the new worktree is visible on disk (registered in git) but the vessel's `WorktreePath` is still `""`. `activeWorktreePaths` skipped vessels with empty paths, so `FindStaleWorktrees` classified the freshly-created worktree as stale and removed it, stranding the vessel.

**Fix:** `activeWorktreePaths` now returns a sentinel error (`errWorktreeSetupInProgress`) when it encounters a `StateRunning` vessel with `WorktreePath == ""`. `FindStaleWorktrees` handles this by logging a warning and returning `nil, nil`, deferring the prune to the next health tick (~30 s later) by which point `UpdateVessel` will have persisted the path.

## Smoke scenarios

No smoke scenario IDs are assigned — this is a standalone unit-test-covered bug fix. The two new tests directly exercise the race scenario:

- **`TestFindStaleWorktrees_SkipsWhenRunningVesselHasEmptyWorktreePath`** — a `StateRunning` vessel with `WorktreePath == ""` causes `FindStaleWorktrees` to return `(nil, nil)` and no worktree is removed.
- **`TestFindStaleWorktrees_ProceedsWhenRunningVesselHasPath`** — a running vessel with a persisted path proceeds normally; orphan worktrees are still detected and returned as stale.

## Changes

### `cli/internal/runner/worktree_prune.go`
- Added `errWorktreeSetupInProgress` sentinel error.
- `activeWorktreePaths`: returns `errWorktreeSetupInProgress` immediately when a `StateRunning` vessel has `WorktreePath == ""`, instead of silently skipping it.
- `FindStaleWorktrees`: handles the sentinel by logging `warn: skipping stale worktree prune: ...` and returning `nil, nil`.

### `cli/internal/runner/worktree_prune_test.go`
- Added `TestFindStaleWorktrees_SkipsWhenRunningVesselHasEmptyWorktreePath`.
- Added `TestFindStaleWorktrees_ProceedsWhenRunningVesselHasPath`.

## Test plan

- [ ] `go test ./internal/runner/ -run TestFindStaleWorktrees` — all three tests pass (existing + two new).
- [ ] `go vet ./...` — clean.
- [ ] `go build ./cmd/xylem` — clean.
- [ ] Pre-existing sandbox network failures (`TestRunVesselLiveHTTPGatePersistsObservedInSituEvidence`, `TestRunLiveGateHTTPTimeoutProducesFailedStepNotSystemError`) are unrelated to this change and fail identically on `main`.

Fixes #546