### PR TITLE
fix: noop.match uses line-boundary semantics, not substring (#522)

### DIFF
--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -2593,8 +2593,31 @@ func sandboxModeFromFlags(cfg *config.Config) string {
 	return "default"
 }
 
+// phaseMatchedNoOp reports whether the phase output contains the no-op
+// sentinel. To avoid false positives when the sentinel is merely mentioned
+// inside prose or code examples (see issue #522), the sentinel must appear at
+// the start of a line (after trimming surrounding whitespace) and must be
+// followed by either end-of-line or a colon (the `SENTINEL: reason` form).
+// Any other occurrence — e.g. `the XYLEM_NOOP sentinel is used for…` — is
+// treated as prose and does not trigger the no-op.
 func phaseMatchedNoOp(p *workflow.Phase, output string) bool {
-	return p != nil && p.NoOp != nil && strings.Contains(output, p.NoOp.Match)
+	if p == nil || p.NoOp == nil {
+		return false
+	}
+	match := p.NoOp.Match
+	if match == "" {
+		return false
+	}
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == match {
+			return true
+		}
+		if strings.HasPrefix(trimmed, match) && len(trimmed) > len(match) && trimmed[len(match)] == ':' {
+			return true
+		}
+	}
+	return false
 }
 
 func buildGateClaim(p workflow.Phase, passed bool, artifactPath string, recordedAt time.Time) evidence.Claim {

--- a/cli/internal/runner/runner_test.go
+++ b/cli/internal/runner/runner_test.go
@@ -6783,7 +6783,7 @@ func TestDrainOrchestratedNoOp(t *testing.T) {
 
 	cmdRunner := &mockCmdRunner{
 		phaseOutputs: map[string][]byte{
-			"Analyze": []byte("Nothing to do XYLEM_NOOP"),
+			"Analyze": []byte("Nothing to do.\nXYLEM_NOOP\n"),
 		},
 	}
 	wt := &mockWorktree{}
@@ -10803,4 +10803,80 @@ func TestBuildTemplateData_DaemonBinaryRendersInCommand(t *testing.T) {
 	assert.NotContains(t, rendered, "{{")
 	// Verify the substitution: rendered command must begin with the actual binary path.
 	assert.True(t, strings.HasPrefix(rendered, td.DaemonBinary), "rendered command %q should start with DaemonBinary %q", rendered, td.DaemonBinary)
+}
+
+// TestPhaseMatchedNoOp_Semantics documents the line-boundary semantics of
+// the no-op sentinel match, fixed by issue #522. The sentinel must appear as
+// the start of a trimmed line, followed by either end-of-line or a colon
+// (the `SENTINEL: reason` form). Any in-prose mention — including in code
+// examples or docstrings — must NOT trigger a false no-op.
+func TestPhaseMatchedNoOp_Semantics(t *testing.T) {
+	phase := &workflow.Phase{
+		Name: "analyze",
+		NoOp: &workflow.NoOp{Match: "XYLEM_NOOP"},
+	}
+
+	cases := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "standalone line matches",
+			output: "Already fixed in main.\n\nXYLEM_NOOP\n",
+			want:   true,
+		},
+		{
+			name:   "sentinel-colon-reason form matches",
+			output: "XYLEM_NOOP: no weekly report available yet\n",
+			want:   true,
+		},
+		{
+			name:   "sentinel with leading whitespace matches",
+			output: "  XYLEM_NOOP\n",
+			want:   true,
+		},
+		// Regression for issue #522: the sentinel mentioned in prose or
+		// quoted as an example must NOT match.
+		{
+			name:   "prose mention does not match (issue #522)",
+			output: "The runner treats XYLEM_NOOP as a sentinel; we should never match it here.",
+			want:   false,
+		},
+		{
+			name:   "code-comment mention does not match",
+			output: "// Never mention XYLEM_NOOP in explanatory text.\n",
+			want:   false,
+		},
+		{
+			name:   "substring with trailing text on same line does not match",
+			output: "Nothing to do XYLEM_NOOP extra words\n",
+			want:   false,
+		},
+		{
+			name:   "empty output does not match",
+			output: "",
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := phaseMatchedNoOp(phase, tc.output)
+			if got != tc.want {
+				t.Errorf("phaseMatchedNoOp(%q) = %v, want %v", tc.output, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPhaseMatchedNoOp_NilGuards(t *testing.T) {
+	if phaseMatchedNoOp(nil, "XYLEM_NOOP") {
+		t.Error("nil phase must not match")
+	}
+	if phaseMatchedNoOp(&workflow.Phase{Name: "p"}, "XYLEM_NOOP") {
+		t.Error("phase with nil NoOp must not match")
+	}
+	if phaseMatchedNoOp(&workflow.Phase{Name: "p", NoOp: &workflow.NoOp{Match: ""}}, "XYLEM_NOOP") {
+		t.Error("empty match string must not match anything")
+	}
 }


### PR DESCRIPTION
## Summary

- Replace `strings.Contains(output, match)` in `phaseMatchedNoOp` with line-boundary semantics: sentinel must start a trimmed line and be followed by end-of-line or `:`.
- Fixes issue #522: prose mentions of the sentinel (e.g. fix-bug analyze phase explaining the `XYLEM_NOOP` mechanism while fixing a bug about it) no longer trigger false early-exit.
- All currently-deployed noop producers audited and preserved: standalone-line form (prompts, `printf '\nXYLEM_NOOP\n'`), `SENTINEL: reason` form (`echo "XYLEM_NOOP: ..."` in backlog-refinement / ci-watchdog / autonomy-review / release_cadence.go / pr-self-review).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./... -count=1` — all 45 packages pass
- [x] `go vet ./...` — clean
- [x] `goimports -l .` — clean
- [x] New `TestPhaseMatchedNoOp_Semantics` table test: 7 cases covering standalone, colon-reason, leading-whitespace, issue-#522 prose mention (`want: false`), code-comment mention, same-line trailing text, empty.
- [x] New `TestPhaseMatchedNoOp_NilGuards`: nil phase, nil NoOp, empty match.
- [x] Existing `TestDrainOrchestratedNoOp` fixture updated from `"Nothing to do XYLEM_NOOP"` to `"Nothing to do.\nXYLEM_NOOP\n"` (old form was an unintentional substring-match coincidence, never used by any real producer).

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)