### PR TITLE
fix: replace hardcoded `make test` gates in core profile workflows with template-driven commands

### DIFF
--- a/cli/internal/profiles/core/workflows/fix-bug.yaml
+++ b/cli/internal/profiles/core/workflows/fix-bug.yaml
@@ -28,14 +28,18 @@ phases:
           threshold: 0.7
     gate:
       type: command
-      run: "make test"
+      run: |
+        set -e
+        {{ if .Validation.Test }}{{ .Validation.Test }}{{ else }}echo "ERROR: validation.test not configured in .xylem.yml" >&2 && exit 1{{ end }}
       retries: 2
   - name: verify
     prompt_file: .xylem/prompts/fix-bug/verify.md
     max_turns: 60
     gate:
       type: command
-      run: "make test"
+      run: |
+        set -e
+        {{ if .Validation.Test }}{{ .Validation.Test }}{{ else }}echo "ERROR: validation.test not configured in .xylem.yml" >&2 && exit 1{{ end }}
       retries: 1
   - name: pr
     prompt_file: .xylem/prompts/fix-bug/pr.md

--- a/cli/internal/profiles/core/workflows/implement-feature.yaml
+++ b/cli/internal/profiles/core/workflows/implement-feature.yaml
@@ -28,14 +28,18 @@ phases:
           threshold: 0.7
     gate:
       type: command
-      run: "make test"
+      run: |
+        set -e
+        {{ if .Validation.Test }}{{ .Validation.Test }}{{ else }}echo "ERROR: validation.test not configured in .xylem.yml" >&2 && exit 1{{ end }}
       retries: 2
   - name: verify
     prompt_file: .xylem/prompts/implement-feature/verify.md
     max_turns: 60
     gate:
       type: command
-      run: "make test"
+      run: |
+        set -e
+        {{ if .Validation.Test }}{{ .Validation.Test }}{{ else }}echo "ERROR: validation.test not configured in .xylem.yml" >&2 && exit 1{{ end }}
       retries: 1
   - name: pr
     prompt_file: .xylem/prompts/implement-feature/pr.md

--- a/cli/internal/workflow/core_workflows_test.go
+++ b/cli/internal/workflow/core_workflows_test.go
@@ -1,0 +1,93 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func coreProfileWorkflowPath(t *testing.T, name string) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller() failed")
+
+	return filepath.Join(filepath.Dir(file), "..", "profiles", "core", "workflows", name)
+}
+
+// TestCoreWorkflowGates_UseValidationTestTemplate verifies that the command gates
+// in fix-bug and implement-feature use the {{ .Validation.Test }} template rather
+// than the hard-coded "make test" command that broke 100% of vessels (issue #562).
+func TestCoreWorkflowGates_UseValidationTestTemplate(t *testing.T) {
+	t.Parallel()
+
+	type phaseExpect struct {
+		name    string
+		retries int
+	}
+
+	cases := []struct {
+		workflow string
+		phases   []phaseExpect
+	}{
+		{
+			workflow: "fix-bug.yaml",
+			phases: []phaseExpect{
+				{name: "implement", retries: 2},
+				{name: "verify", retries: 1},
+			},
+		},
+		{
+			workflow: "implement-feature.yaml",
+			phases: []phaseExpect{
+				{name: "implement", retries: 2},
+				{name: "verify", retries: 1},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.workflow, func(t *testing.T) {
+			t.Parallel()
+
+			workflowPath := coreProfileWorkflowPath(t, tc.workflow)
+			data, err := os.ReadFile(workflowPath)
+			require.NoError(t, err, "ReadFile(%q)", workflowPath)
+
+			var wf Workflow
+			require.NoError(t, yaml.Unmarshal(data, &wf), "yaml.Unmarshal(%q)", workflowPath)
+
+			for _, pc := range tc.phases {
+				pc := pc
+				t.Run(pc.name, func(t *testing.T) {
+					t.Parallel()
+
+					phase := findPhaseByName(t, wf.Phases, pc.name)
+					require.NotNil(t, phase.Gate, "%s phase %q missing gate", tc.workflow, pc.name)
+
+					// Regression guard: must not fall back to the hard-coded make test command.
+					assert.NotContains(t, phase.Gate.Run, "make test",
+						"%s phase %q gate must not use 'make test'", tc.workflow, pc.name)
+
+					// Fix present: gate must use the per-repo Validation.Test template.
+					assert.Contains(t, phase.Gate.Run, `{{ if .Validation.Test }}`,
+						"%s phase %q gate must use .Validation.Test template", tc.workflow, pc.name)
+
+					// Fallback guard: misconfiguration must fail loudly, not silently pass.
+					assert.Contains(t, phase.Gate.Run, "exit 1",
+						"%s phase %q gate must include fallback exit 1", tc.workflow, pc.name)
+
+					// Retries: a zero value would silently disable the gate.
+					assert.Equal(t, pc.retries, phase.Gate.Retries,
+						"%s phase %q gate retries", tc.workflow, pc.name)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [nicholls-inc/xylem#562](https://github.com/nicholls-inc/xylem/issues/562) — the `fix-bug` and `implement-feature` core profile workflows had `run: "make test"` as their gate command. The xylem repo has no `Makefile`, causing 100% gate failure for all vessels dispatched through these workflows.

The template infrastructure (`{{ .Validation.Test }}`) was already fully wired end-to-end via `renderCommandTemplate` → `phase.RenderPrompt`. This PR threads it through the two affected YAML files.

## Changes summary

**Files modified:**

- `cli/internal/profiles/core/workflows/fix-bug.yaml` — replaced `run: "make test"` on the `implement` gate (retries: 2) and `verify` gate (retries: 1) with a conditional template block
- `cli/internal/profiles/core/workflows/implement-feature.yaml` — identical replacements

**Files added:**

- `cli/internal/workflow/core_workflows_test.go` — regression tests asserting that neither workflow's gates contain `make test`, that both use the `{{ if .Validation.Test }}` template, and that both include an `exit 1` fallback guard for unconfigured repos

**Key pattern (matches `fix-pr-checks.yaml` convention):**

```yaml
gate:
  type: command
  run: |
    set -e
    {{ if .Validation.Test }}{{ .Validation.Test }}{{ else }}echo "ERROR: validation.test not configured in .xylem.yml" >&2 && exit 1{{ end }}
  retries: 2
```

The `{{ else }}exit 1` guard prevents a silent phantom gate pass when `validation.test` is not configured — consistent with how `fix-pr-checks.yaml` handles missing `Format`/`Lint`/`Build` commands.

## Smoke scenarios covered

No smoke scenario IDs are assigned to this issue. The fix is validated by the new unit tests:

- `TestCoreWorkflowGates_UseValidationTestTemplate/fix-bug.yaml/implement` — asserts no `make test`, presence of `.Validation.Test` template and `exit 1` fallback, retries=2
- `TestCoreWorkflowGates_UseValidationTestTemplate/fix-bug.yaml/verify` — same, retries=1
- `TestCoreWorkflowGates_UseValidationTestTemplate/implement-feature.yaml/implement` — same, retries=2
- `TestCoreWorkflowGates_UseValidationTestTemplate/implement-feature.yaml/verify` — same, retries=1

## Test plan

- [x] `go test ./internal/workflow/...` — all 4 new subtests pass
- [x] `go vet ./...` — clean
- [x] `go build ./cmd/xylem` — clean
- [x] `goimports -l .` — no formatting issues
- [x] `golangci-lint run` — clean (pre-commit hook passed)
- [ ] End-to-end: dispatch a `fix-bug` vessel against a repo with `validation.test` configured and confirm the implement/verify gates run the configured test command instead of failing with `make: command not found`

Fixes #562