### PR TITLE
fix(source): skip scheduled scan when prior task vessel still in flight

### DIFF
--- a/cli/internal/source/scheduled.go
+++ b/cli/internal/source/scheduled.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -64,6 +65,7 @@ func (s *Scheduled) Scan(_ context.Context) ([]queue.Vessel, error) {
 	sort.Strings(taskNames)
 
 	scope := s.scope()
+	inFlightTasks := s.inFlightTasksByName()
 	vessels := make([]queue.Vessel, 0, len(taskNames))
 	for _, taskName := range taskNames {
 		if state.LastEnqueuedBuckets[taskName] >= bucket {
@@ -72,6 +74,11 @@ func (s *Scheduled) Scan(_ context.Context) ([]queue.Vessel, error) {
 		task := s.Tasks[taskName]
 		ref := fmt.Sprintf("scheduled://%s/%s@%d", scope, taskName, bucket)
 		if s.Queue != nil && s.Queue.HasRefAny(ref) {
+			continue
+		}
+		if blockingID := inFlightTasks[taskName]; blockingID != "" {
+			log.Printf("scheduled source %q: skipping task %q bucket %d — prior vessel %s still in flight",
+				s.ConfigName, taskName, bucket, blockingID)
 			continue
 		}
 
@@ -146,6 +153,41 @@ func (s *Scheduled) BranchName(vessel queue.Vessel) string {
 		taskName = "task"
 	}
 	return fmt.Sprintf("scheduled/%s-%s", taskName, sanitizeScheduledComponent(vessel.ID))
+}
+
+func (s *Scheduled) inFlightTasksByName() map[string]string {
+	result := map[string]string{}
+	if s.Queue == nil {
+		return result
+	}
+	vessels, err := s.Queue.List()
+	if err != nil {
+		log.Printf("scheduled source %q: list queue for in-flight guard: %v", s.ConfigName, err)
+		return result
+	}
+	for _, v := range vessels {
+		if v.Source != s.Name() {
+			continue
+		}
+		if v.State.IsTerminal() {
+			continue
+		}
+		if v.Meta["scheduled_config_name"] != s.ConfigName {
+			continue
+		}
+		if v.Meta["scheduled_repo"] != s.Repo {
+			continue
+		}
+		taskName := v.Meta["scheduled_task_name"]
+		if taskName == "" {
+			continue
+		}
+		if _, seen := result[taskName]; seen {
+			continue
+		}
+		result[taskName] = v.ID
+	}
+	return result
 }
 
 func parseSchedule(value string) (time.Duration, error) {

--- a/cli/internal/source/scheduled_test.go
+++ b/cli/internal/source/scheduled_test.go
@@ -52,6 +52,58 @@ func TestScheduledScanEnqueuesOnePerWindow(t *testing.T) {
 	}
 }
 
+func TestScheduledScanSkipsWhenPriorTaskVesselStillInFlight(t *testing.T) {
+	ctx := context.Background()
+	stateDir := t.TempDir()
+	q := queue.New(filepath.Join(t.TempDir(), "queue.jsonl"))
+
+	src := &Scheduled{
+		Repo:       "owner/repo",
+		StateDir:   stateDir,
+		ConfigName: "ci-watchdog",
+		Schedule:   "30m",
+		Queue:      q,
+		Tasks: map[string]ScheduledTask{
+			"monitor-main-ci": {Workflow: "ci-watchdog", Ref: "main"},
+		},
+	}
+
+	interval, err := parseSchedule("30m")
+	require.NoError(t, err)
+
+	now := sourceNow()
+	currentBucket := now.UnixNano() / interval.Nanoseconds()
+	priorBucket := currentBucket - 1
+	priorVessel := queue.Vessel{
+		ID:       fmt.Sprintf("scheduled-ci-watchdog-monitor-main-ci-%d", priorBucket),
+		Source:   "scheduled",
+		Ref:      fmt.Sprintf("scheduled://ci-watchdog/monitor-main-ci@%d", priorBucket),
+		Workflow: "ci-watchdog",
+		State:    queue.StateRunning,
+		Meta: map[string]string{
+			"scheduled_config_name": "ci-watchdog",
+			"scheduled_repo":        "owner/repo",
+			"scheduled_task_name":   "monitor-main-ci",
+			"scheduled_bucket":      fmt.Sprintf("%d", priorBucket),
+		},
+		CreatedAt: now.Add(-interval),
+	}
+	_, err = q.Enqueue(priorVessel)
+	require.NoError(t, err)
+
+	vessels, err := src.Scan(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, vessels, "in-flight guard should block while prior task vessel is still running")
+
+	priorVessel.State = queue.StateCompleted
+	require.NoError(t, q.UpdateVessel(priorVessel))
+
+	vessels, err = src.Scan(ctx)
+	require.NoError(t, err)
+	require.Len(t, vessels, 1, "guard should release once prior vessel reaches a terminal state")
+	assert.Equal(t, fmt.Sprintf("scheduled://ci-watchdog/monitor-main-ci@%d", currentBucket), vessels[0].Ref)
+}
+
 func TestParseSchedule(t *testing.T) {
 	got, err := parseSchedule("@weekly")
 	if err != nil {


### PR DESCRIPTION
## Summary
- The scheduled source created one vessel per time bucket with no check for in-flight vessels of the same task. When a workflow run approaches or exceeds its schedule interval, the next slot's vessel is enqueued before the prior finishes; once drain has capacity it dispatches multiple backlogged slots in parallel.
- Observed today: two `ci-watchdog` scheduled vessels (slots 15:30Z and 16:00Z) ran simultaneously in the `diagnose` phase after a daemon restart delayed the first dispatch past the next bucket boundary.
- Fix: in `Scan()`, list the queue once and build a per-task in-flight map (same scheduled source, config, repo; non-terminal state). Skip + log when a task already has a non-terminal vessel. `LastEnqueuedBuckets` is intentionally not updated on skip so the coalesced bucket will dispatch once the prior vessel terminates.
- Existing `HasRefAny(ref)` per-bucket guard is preserved as the first-line check.

## Test plan
- [x] `go test ./internal/source/...` passes (existing + new `TestScheduledScanSkipsWhenPriorTaskVesselStillInFlight`)
- [x] `goimports -l` clean
- [ ] After merge: daemon auto-upgrades; next ci-watchdog slot overlap should be absorbed (coalesced), verified by log line `scheduled source "ci-watchdog": skipping task "monitor-main-ci" bucket N — prior vessel ... still in flight`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)