### PR TITLE
[Lean Squad] Informal spec workflow

### DIFF
--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -27,6 +27,7 @@ var expectedCoreWorkflows = []string{
 	"fix-bug",
 	"fix-pr-checks",
 	"implement-feature",
+	"lean-squad-informal-spec",
 	"lessons",
 	"merge-pr",
 	"refine-issue",

--- a/cli/internal/profiles/core/prompts/lean-squad-informal-spec/analyze.md
+++ b/cli/internal/profiles/core/prompts/lean-squad-informal-spec/analyze.md
@@ -1,0 +1,46 @@
+You are running the `lean-squad-informal-spec` workflow (Task 2 of the Lean Squad system).
+
+See `https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md` for the upstream doctrine. The Lean Squad applies Lean 4 formal verification progressively and optimistically. You do **not** need prior formal-verification (FV) expertise — this phase writes plain English, no Lean syntax at all.
+
+## Vessel context
+
+- Vessel ID: {{.Vessel.ID}}
+- Vessel ref: `{{.Vessel.Ref}}` (expected shape: `lean-squad://<target-slug>`)
+
+## Your job in this phase
+
+Determine **which target** this vessel is scoped to and whether an informal spec already exists for it. Nothing else.
+
+### Step 1 — Parse the target slug
+
+`{{.Vessel.Ref}}` is the authoritative source. Strip the `lean-squad://` prefix; what remains is the `<target-slug>`. A slug is a short kebab-case identifier (for example `parse-uri`, `hash-map-insert`). If the ref is empty, does not begin with `lean-squad://`, or the remainder is empty, stop and emit the exact standalone line `XYLEM_NOOP` with a one-line explanation that the ref is malformed.
+
+### Step 2 — Resolve the target to a source path via `formal-verification/TARGETS.md`
+
+Read `formal-verification/TARGETS.md`. It is a table produced by the `lean-squad-orient` workflow; each row lists a target name, its source path, and a status. Find the row whose name matches `<target-slug>` (case-insensitive; tolerate minor formatting such as spaces vs. hyphens). Record the source path you found.
+
+If `formal-verification/TARGETS.md` does not exist, or no row matches the slug, emit `XYLEM_NOOP` with a one-line explanation (for example: "TARGETS.md missing — lean-squad-orient has not run yet" or "slug <x> not listed in TARGETS.md"). Do not guess a source path.
+
+### Step 3 — Check whether this target is already specified
+
+Check for an existing file at `formal-verification/specs/<target-slug>_informal.md`. If it exists and has non-trivial content (more than just a placeholder), emit the exact standalone line `XYLEM_NOOP` with a one-line explanation ("spec already exists for <target-slug>"). The tick will pick another target next run.
+
+### Step 4 — Emit a structured summary
+
+If all three steps above succeeded without emitting `XYLEM_NOOP`, produce a plain-text summary that later phases can read verbatim:
+
+```
+TARGET_SLUG: <slug>
+SOURCE_PATH: <path-from-TARGETS.md>
+TEST_PATHS:
+- <path>
+- <path>
+COMMENT_SOURCES:
+- <path-or-locator>
+NOTES:
+- <short note on where the function lives, its language, and any obvious edge cases to remember>
+```
+
+For `TEST_PATHS`, briefly search the repo for tests that exercise the source (for example, a sibling `*_test.go` file, a `tests/` directory, or a test path the TARGETS.md row hints at). It is fine to list zero or multiple entries; do not fabricate paths. For `COMMENT_SOURCES`, note any file that contains design commentary relevant to the target (docstrings, READMEs, adjacent design docs). Again, do not fabricate.
+
+Do **not** start writing the informal spec in this phase. That is the job of `implement`.

--- a/cli/internal/profiles/core/prompts/lean-squad-informal-spec/implement.md
+++ b/cli/internal/profiles/core/prompts/lean-squad-informal-spec/implement.md
@@ -1,0 +1,103 @@
+You are running the `implement` phase of `lean-squad-informal-spec` (Task 2 of the Lean Squad).
+
+See `https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md` for the upstream doctrine. The informal spec is the **first rung on the FV ladder**: a carefully worded English description of what the target is supposed to do, written so that a later phase (`lean-squad-formal-spec`) can translate it into Lean 4 without having to re-read the source from scratch. No Lean syntax appears in this file.
+
+## Vessel context
+
+- Vessel ID: {{.Vessel.ID}}
+- Vessel ref: `{{.Vessel.Ref}}`
+
+## Prior-phase output (authoritative)
+
+The `analyze` phase parsed the slug, located the source, and listed tests and comment sources. Use its output below verbatim; do not re-derive these paths.
+
+```
+{{.PreviousOutputs.analyze}}
+```
+
+From that output you have:
+- `TARGET_SLUG` — the kebab-case identifier for this target
+- `SOURCE_PATH` — the implementation file
+- `TEST_PATHS` — zero or more test files
+- `COMMENT_SOURCES` — docs or comment-bearing files
+
+## Your job in this phase
+
+Write a single file at `formal-verification/specs/<TARGET_SLUG>_informal.md`. Overwrite any placeholder that might exist. The file is **plain English mathematical prose**. No Lean, no pseudo-code blocks masquerading as Lean.
+
+### How to read the source
+
+1. Read `SOURCE_PATH` end to end first.
+2. Read each `TEST_PATHS` file. Tests are the richest source of worked examples — when a test says `f(3, 4) == 7`, that is a concrete input/output pair that belongs in the spec's "Worked examples" section.
+3. Skim the `COMMENT_SOURCES`. Pull out design constraints that are only stated there (for example, "this function must be idempotent", "callers rely on stable iteration order").
+
+If something is unclear — an edge case the source does not handle explicitly, an invariant the tests hint at but do not prove — write "Unclear — see [open question]" and add an "Open questions" subsection at the bottom. A spec with honest gaps is far more useful than a spec that guesses.
+
+### File structure (use these exact headings)
+
+```markdown
+# Informal specification: <target-slug>
+
+## Source
+
+- Implementation: `<SOURCE_PATH>`
+- Tests consulted: `<path>`, `<path>`, ...
+- Other comment sources: `<path>`, ... (or "none")
+
+## Summary
+
+One or two sentences describing, in plain English, what the function or module does. A reader with no Lean knowledge should understand this line.
+
+## Preconditions
+
+What the caller must guarantee before calling. One bullet per precondition. Be explicit about types and ranges. A precondition is a promise **about the input** that the function does not re-check.
+
+- Example: "The input list must be non-empty."
+- Example: "`capacity` is a positive integer not exceeding `2^31 - 1`."
+
+If no preconditions apply, write "None — any well-typed input is accepted."
+
+## Postconditions
+
+What the function promises to return, assuming preconditions held. A postcondition is a promise **about the output** (or side effects). One bullet each.
+
+- Example: "The returned list is a permutation of the input list."
+- Example: "No element of the returned list exceeds the maximum of the input."
+
+## Invariants
+
+Properties that hold throughout the function's execution or across successive calls. An invariant can be a data-structure invariant ("the internal buffer is never longer than `capacity`") or a temporal one ("calling `insert` twice with the same key is idempotent").
+
+If the target has no interesting invariants, write "None beyond the preconditions and postconditions above."
+
+## Edge cases
+
+A bulleted list of inputs at the boundary of the precondition space and what the function does for each. These are the scenarios where bugs hide.
+
+- Empty input, zero-valued input, maximum-sized input, duplicate input, already-sorted input, etc. — pick whatever is relevant.
+- For each bullet, state the expected behaviour concretely.
+
+## Worked examples
+
+At least two concrete input/output pairs drawn from the tests where possible. Prefer tests because they are already verified by the existing test suite. Use a simple format:
+
+- Input: `<literal>` &rarr; Output: `<literal>` — short sentence of why.
+
+If no tests exist, write examples you can verify by tracing through the source by hand, and mark them "(traced, not test-verified)".
+
+## Open questions
+
+Only include if `analyze` or your reading of the source surfaced ambiguity. Each bullet names the ambiguity in one line. Keep this short and honest.
+
+## 🔬 Disclosure
+
+This informal specification was produced by the xylem `lean-squad-informal-spec` workflow, a port of the agentics Lean Squad system (see `https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md`). It is a plain-English description intended for human review and for downstream translation into Lean 4 by `lean-squad-formal-spec`. It has not been mechanically checked; inaccuracies are possible.
+```
+
+### Reminders
+
+- **Plain prose only.** No `theorem`, no `def`, no `∀`, no backticked Lean. If you feel the urge to write Lean, resist — that is Task 3's job.
+- **Cite tests.** Every bullet in "Worked examples" should correspond to a test case where one exists.
+- **Be conservative.** If the source seems to have a bug or a surprising behaviour, describe what the source **actually does**, and flag the surprise in "Open questions". Do not silently rewrite the contract.
+- **One file only.** Write exactly `formal-verification/specs/<TARGET_SLUG>_informal.md`. Do not touch any other file — the `lean-squad-informal-spec` workflow is the sole writer of this path.
+- Do **not** commit, push, or open a PR in this phase. That is `pr`'s job.

--- a/cli/internal/profiles/core/prompts/lean-squad-informal-spec/pr.md
+++ b/cli/internal/profiles/core/prompts/lean-squad-informal-spec/pr.md
@@ -1,0 +1,68 @@
+You are running the `pr` phase of `lean-squad-informal-spec` (Task 2 of the Lean Squad).
+
+## Vessel context
+
+- Vessel ID: {{.Vessel.ID}}
+- Vessel ref: `{{.Vessel.Ref}}`
+
+## Prior-phase output
+
+```
+{{.PreviousOutputs.analyze}}
+```
+
+```
+{{.PreviousOutputs.implement}}
+```
+
+## Your job in this phase
+
+Commit the informal-spec file, push to a dedicated branch, and open a pull request.
+
+### Branch name
+
+Derive `<target-slug>` from the `analyze` output's `TARGET_SLUG` line (or, failing that, from `{{.Vessel.Ref}}` by stripping the `lean-squad://` prefix). Create the branch:
+
+```
+lean-squad-informal-spec-<target-slug>/{{.Vessel.ID}}
+```
+
+### Commit
+
+Stage only `formal-verification/specs/<target-slug>_informal.md`. Do not stage any other file. Use a commit message in Conventional Commits style, for example:
+
+```
+feat(lean-squad): informal spec for <target-slug>
+```
+
+### PR
+
+Open the PR with `gh pr create`. Title (exactly this shape):
+
+```
+[Lean Squad] Informal spec for <target-slug>
+```
+
+Body: a short markdown block containing
+1. one sentence of what the spec covers,
+2. a link to the upstream doctrine at `https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md`,
+3. the structured run marker (one line, verbatim, so the next tick can reconcile state):
+
+```
+LEAN_SQUAD_RUN: {"task":"informal-spec","target":"<target-slug>","status":"ok","artefact":"formal-verification/specs/<target-slug>_informal.md"}
+```
+
+4. the 🔬 disclosure: "Produced by xylem's `lean-squad-informal-spec` workflow; plain-English, not mechanically checked."
+
+Labels: apply `lean-squad` (and `ready-to-merge` if this repository conventionally auto-merges spec-only PRs; otherwise omit). Example:
+
+```
+gh pr create \
+  --title "[Lean Squad] Informal spec for <target-slug>" \
+  --body "<body as above>" \
+  --label "lean-squad"
+```
+
+### Idempotency
+
+If the spec file was not actually written in the `implement` phase (for example, `implement` emitted no changes), do not open an empty PR. Instead, print a short explanation and exit — `git status --porcelain formal-verification/specs/` will be empty in that case.

--- a/cli/internal/profiles/core/workflows/lean-squad-informal-spec.yaml
+++ b/cli/internal/profiles/core/workflows/lean-squad-informal-spec.yaml
@@ -1,0 +1,14 @@
+name: lean-squad-informal-spec
+description: "Lean Squad Task 2: write a plain-prose informal specification for one target"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/lean-squad-informal-spec/analyze.md
+    max_turns: 40
+    noop:
+      match: XYLEM_NOOP
+  - name: implement
+    prompt_file: .xylem/prompts/lean-squad-informal-spec/implement.md
+    max_turns: 50
+  - name: pr
+    prompt_file: .xylem/prompts/lean-squad-informal-spec/pr.md
+    max_turns: 20

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -101,6 +101,7 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 		"fix-bug",
 		"fix-pr-checks",
 		"implement-feature",
+		"lean-squad-informal-spec",
 		"lessons",
 		"merge-pr",
 		"refine-issue",


### PR DESCRIPTION
## Summary

Adds the `lean-squad-informal-spec` core-profile workflow — Unit 3 / Task 2 of the [agentics Lean Squad](https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md) port.

Reads a single target's source + tests + comments and writes a plain-English informal specification to `formal-verification/specs/<target>_informal.md`. The workflow owns this path per the state-ownership contract in the port plan.

Phases:
- **analyze** (max_turns 40, `noop: XYLEM_NOOP`) — parses `<target-slug>` from `{{.Vessel.Ref}}` (`lean-squad://<target-slug>`), resolves the source via `formal-verification/TARGETS.md`, emits `XYLEM_NOOP` if the spec already exists or inputs are missing.
- **implement** (max_turns 50) — writes the spec with sections for Preconditions, Postconditions, Invariants, Edge cases, Worked examples, Open questions, and the 🔬 disclosure. Plain prose only — no Lean syntax.
- **pr** (max_turns 20) — commits on a per-target branch, opens a PR titled `[Lean Squad] Informal spec for <target-slug>` carrying the `LEAN_SQUAD_RUN:` structured marker that the tick's `retrospect` phase reconciles.

This workflow is **orphaned** — it has no label source. The tick coordinator landed by Unit 14 will `xylem enqueue --workflow lean-squad-informal-spec --ref lean-squad://<target>`.

Doctrine: zero FV expertise required of the author. Plain prose only, conservative about ambiguity (open questions encouraged), worked examples drawn from existing tests where possible.

## Test plan

- [x] `go build ./cmd/xylem` succeeds
- [x] `go test ./...` green (includes updates to `expectedCoreWorkflows` in `cli/cmd/xylem/init_test.go` and the enumerated list in `cli/internal/profiles/profiles_test.go`)
- [x] `goimports -l .` clean
- [x] E2E: `xylem init --profile core --force` scaffolds `.xylem/workflows/lean-squad-informal-spec.yaml` and `.xylem/prompts/lean-squad-informal-spec/{analyze,implement,pr}.md` into a scratch repo
- [x] `xylem visualize -f json` lists `lean-squad-informal-spec` under `orphaned_workflows` (expected — no label trigger)

🔬 Produced by xylem's parallel-worker port of the agentics Lean Squad system; see the referenced doctrine for context.