### PR TITLE
[Lean Squad] Report workflow

### DIFF
--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -28,6 +28,7 @@ var expectedCoreWorkflows = []string{
 	"fix-pr-checks",
 	"implement-feature",
 	"lean-squad-informal-spec",
+	"lean-squad-report",
 	"lessons",
 	"merge-pr",
 	"refine-issue",

--- a/cli/internal/profiles/core/prompts/lean-squad-report/analyze.md
+++ b/cli/internal/profiles/core/prompts/lean-squad-report/analyze.md
@@ -1,0 +1,52 @@
+You are running the always-on `lean-squad-report` workflow, part of the Lean Squad formal-verification system ported from https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md.
+
+This vessel refreshes `formal-verification/REPORT.md` — the human-skimmable dashboard of progress across all Lean Squad workflows in this repo.
+
+- Vessel ID: {{.Vessel.ID}}
+- Workflow ref: {{.Vessel.Ref}}
+- Schedule source: {{index .Vessel.Meta "schedule.source_name"}}
+- Fired at: {{index .Vessel.Meta "schedule.fired_at"}}
+
+## Doctrine
+
+Lean Squad is progressive, optimistic, zero-FV-expertise. The report is the fastest way for a human with no Lean background to understand what has been attempted, what has landed, and where the squad is stuck. Keep it scannable and evidence-based — do NOT infer progress that is not reflected in committed artefacts.
+
+## Gate: recent-update no-op
+
+Check when `formal-verification/REPORT.md` was last modified on the current branch:
+
+```bash
+if [ -f formal-verification/REPORT.md ]; then
+  LAST=$(git log -1 --format=%ct -- formal-verification/REPORT.md 2>/dev/null || echo 0)
+  NOW=$(date +%s)
+  AGE=$(( NOW - LAST ))
+  if [ "$AGE" -lt 14400 ]; then
+    echo "REPORT.md updated $AGE seconds ago — within 4h window"
+  fi
+fi
+```
+
+If the last modification to `formal-verification/REPORT.md` was less than 4 hours (14400 seconds) ago, emit the exact standalone line `XYLEM_NOOP` and explain that a fresh report already exists.
+
+Also emit `XYLEM_NOOP` if `formal-verification/` does not exist (the system hasn't been bootstrapped in this repo).
+
+## Otherwise — produce analysis
+
+Survey the state the `implement` phase will need to read:
+
+1. `formal-verification/TARGETS.md` — count entries and note status markers.
+2. `formal-verification/repo-memory.json` — confirm it parses, note the `runs[]` length.
+3. `formal-verification/lean/FVSquad/**/*.lean` — count files and note top-level directory structure for the mermaid diagram.
+4. `formal-verification/specs/*_informal.md` — count informal specs present.
+5. Open `[Lean Squad]` PRs and `[Lean Squad]` / `[finding]` issues via `gh pr list` and `gh issue list` (note counts only here; full body fetch is in `implement`).
+
+Output:
+
+SUMMARY:
+- one line describing what will change in the report
+INPUTS_FOUND:
+- one bullet per input source with counts or "missing"
+GAPS:
+- one bullet per missing or malformed input (if any)
+PLAN:
+- one bullet per section of REPORT.md to refresh

--- a/cli/internal/profiles/core/prompts/lean-squad-report/implement.md
+++ b/cli/internal/profiles/core/prompts/lean-squad-report/implement.md
@@ -1,0 +1,104 @@
+Refresh `formal-verification/REPORT.md` with the sections described below.
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## You are the sole writer of `formal-verification/REPORT.md`
+
+Per the Lean Squad cross-workflow contract, only this workflow writes REPORT.md. Other workflows produce their own artefacts (TARGETS.md, RESEARCH.md, CORRESPONDENCE.md, CRITIQUE.md, specs, Lean files, issues, PRs). Your job is to aggregate those into a single dashboard.
+
+## Required sections (in this exact order)
+
+### 1. Disclosure header (top of file, verbatim)
+
+```
+> 🔬 This report is maintained by the xylem `lean-squad-report` workflow, part of the Lean Squad formal-verification system (https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md). It is regenerated on each tick; manual edits will be overwritten.
+```
+
+### 2. Architecture diagram (mermaid)
+
+Build a mermaid graph of the Lean file tree under `formal-verification/lean/FVSquad/`. Each node label encodes status by scanning that file's contents:
+
+- `specced` — file contains `theorem` or `def` declarations but bodies are `sorry`
+- `implemented` — file has non-`sorry` function bodies but theorems are still `sorry`
+- `proved` — file has non-`sorry` theorem bodies
+- `stub` — file matches the bootstrap stub shape (`Stub.lean` placeholder)
+
+Group by immediate subdirectory (e.g. `FVSquad/`, `FVSquad/Aeneas/Generated/`). Example:
+
+```mermaid
+graph TD
+  Root[FVSquad]
+  Root --> Stub["Stub.lean (stub)"]
+  Root --> FooLean["Foo.lean (proved)"]
+  Root --> BarLean["Bar.lean (specced)"]
+  Root --> Aeneas[Aeneas/Generated]
+  Aeneas --> AenBaz["Baz.lean (implemented)"]
+```
+
+If the `lean/FVSquad/` tree is empty or only contains the stub, emit a one-line placeholder diagram noting no targets yet.
+
+### 3. Target status table
+
+Read `formal-verification/TARGETS.md` and translate each target row into a single line in this table:
+
+```
+| Target | Informal spec | Formal spec | Impl extracted | Proofs | Status |
+|---|---|---|---|---|---|
+| `<name>` | ✅ / ⏳ / — | ✅ / ⏳ / — | ✅ / ⏳ / — | ✅ / ⏳ / — | <word> |
+```
+
+Column rules:
+
+- Informal spec: ✅ if `formal-verification/specs/<target>_informal.md` exists, else —.
+- Formal spec: ✅ if a `.lean` file for the target exists with non-`sorry` type/signature declarations, ⏳ if the file is present but all-`sorry`, else —.
+- Impl extracted: ✅ if the target's function bodies are non-`sorry`, ⏳ if partial, else —.
+- Proofs: ✅ if theorem bodies are non-`sorry`, ⏳ if some are, else —.
+- Status: one word — `proved` / `implemented` / `specced` / `informal` / `pending` / `blocked`.
+
+Keep to one screen. If there are more than ~20 targets, truncate and note the overflow count.
+
+### 4. Findings summary
+
+Fetch open issues labelled `[Lean Squad]` AND `[finding]` via:
+
+```bash
+gh issue list --label "Lean Squad" --label "finding" --state open --limit 50 --json number,title,labels,url
+```
+
+(Substitute `--label "[Lean Squad]"` / `--label "[finding]"` or whatever label shape this repo actually uses — try both the bracketed and unbracketed forms and pick the one that returns results; if both return empty, note "no open findings".)
+
+Group findings by classification label (e.g. `spec-incomplete`, `implementation-buggy`, `proof-technique-gap`). For each group, list issue `#N — title` on its own bullet. Keep to a single section, max ~40 lines.
+
+### 5. Run history (last 10 ticks)
+
+Read `formal-verification/repo-memory.json` and pull the final 10 entries of the `runs[]` array. Render as:
+
+```
+| Timestamp | Tasks dispatched | Targets | Vessel IDs |
+|---|---|---|---|
+| <ts> | <task1>, <task2> | <slug1>, <slug2> | <id1>, <id2> |
+```
+
+If `runs[]` has fewer than 10 entries, show everything available. If the file is missing or malformed, render a single row explaining the gap.
+
+### 6. Open Lean Squad PRs and issues
+
+Two bullet lists, one for PRs, one for issues:
+
+```bash
+gh pr list --search '"[Lean Squad]" in:title' --state open --limit 50 --json number,title,url,mergeable
+gh issue list --search '"[Lean Squad]" in:title' --state open --limit 50 --json number,title,url
+```
+
+For each PR, one line: `#N — <title> — <mergeable or checks-status>`. For each issue, one line: `#N — <title>`. Keep each list under ~30 entries; if there are more, truncate and note overflow.
+
+## Rules
+
+1. Only write `formal-verification/REPORT.md`. Do NOT edit TARGETS.md, RESEARCH.md, repo-memory.json, Lean files, or any other artefact — those are owned by sibling workflows.
+2. Evidence-based: every status claim must trace to a committed file or live `gh` query. Do not speculate about progress.
+3. Single page if possible. Truncate long lists with an explicit overflow count rather than dumping everything.
+4. If a required input is missing (e.g. `formal-verification/TARGETS.md` absent), render the section with a "no data" placeholder rather than fabricating entries.
+5. Preserve the exact disclosure header text in section 1.
+
+When you finish, summarize the counts that ended up in each section and note any inputs that were missing or malformed.

--- a/cli/internal/profiles/core/prompts/lean-squad-report/pr.md
+++ b/cli/internal/profiles/core/prompts/lean-squad-report/pr.md
@@ -1,0 +1,29 @@
+Open a pull request with the refreshed `formal-verification/REPORT.md`.
+
+## Analysis
+{{.PreviousOutputs.analyze}}
+
+## Implementation summary
+{{.PreviousOutputs.implement}}
+
+## Branch and PR
+
+- Branch: `lean-squad-report/{{.Vessel.ID}}`
+- Base: `{{.Repo.DefaultBranch}}`
+- Title: `[Lean Squad] Update report`
+- Labels: `lean-squad` (apply if the repo has this label)
+
+## PR body
+
+Include:
+
+1. A 🔬 disclosure line noting this PR was produced by the scheduled `lean-squad-report` workflow, linking to the upstream agentics doc: https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md
+2. A short summary of what changed in REPORT.md (target count, findings count, run-history length, open PR/issue counts).
+3. A note that REPORT.md is regenerated every tick and that manual edits will be overwritten by the next run.
+4. `Workflow ref: {{.Vessel.Ref}}` for traceability.
+
+## Only-this-file rule
+
+This PR must change `formal-verification/REPORT.md` only. If `git status` shows any other file modified, revert those changes before pushing.
+
+If the working tree has no changes to `formal-verification/REPORT.md` after `implement` ran (e.g. the generated content was byte-identical to the existing file), skip PR creation and explain in your final message.

--- a/cli/internal/profiles/core/workflows/lean-squad-report.yaml
+++ b/cli/internal/profiles/core/workflows/lean-squad-report.yaml
@@ -1,0 +1,15 @@
+name: lean-squad-report
+class: ops
+description: "Refresh formal-verification/REPORT.md with architecture diagram, target status, findings, run history, and open PR/issue links"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/lean-squad-report/analyze.md
+    max_turns: 40
+    noop:
+      match: XYLEM_NOOP
+  - name: implement
+    prompt_file: .xylem/prompts/lean-squad-report/implement.md
+    max_turns: 50
+  - name: pr
+    prompt_file: .xylem/prompts/lean-squad-report/pr.md
+    max_turns: 20

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -102,6 +102,7 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 		"fix-pr-checks",
 		"implement-feature",
 		"lean-squad-informal-spec",
+		"lean-squad-report",
 		"lessons",
 		"merge-pr",
 		"refine-issue",


### PR DESCRIPTION
## Summary

Unit 11 of the agentics Lean Squad port (https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md) into xylem's core profile.

Adds the always-on `lean-squad-report` workflow that refreshes `formal-verification/REPORT.md` on each tick with:

- A mermaid architecture diagram of `formal-verification/lean/FVSquad/**`, labelling each node by status (`stub` / `specced` / `implemented` / `proved`) — the diagram teaches repo structure to zero-FV-expertise reviewers.
- A target-status table derived from `TARGETS.md` (informal spec / formal spec / impl extracted / proofs / status), kept to one scannable page.
- A findings summary listing open `[Lean Squad]` + `[finding]` issues grouped by classification (`spec-incomplete` / `implementation-buggy` / `proof-technique-gap`).
- Run history: the last 10 ticks from `formal-verification/repo-memory.json` `runs[]`.
- Links to all open `[Lean Squad]` PRs and issues.

## Structure

Three phases mirroring the existing periodic-report idiom (`doc-garden.yaml`, `workflow-health-report.yaml`):

1. `analyze` (max_turns: 40, `noop: { match: XYLEM_NOOP }`) — emits NOOP if `formal-verification/REPORT.md` was updated in the last 4h, or if `formal-verification/` is absent (system not bootstrapped).
2. `implement` (max_turns: 50) — assembles the six REPORT.md sections from committed artefacts and live `gh` queries.
3. `pr` (max_turns: 20) — opens a single-file PR on branch `lean-squad-report/{{.Vessel.ID}}`, title `[Lean Squad] Update report`, with a 🔬 disclosure.

## Sole-writer discipline

Per the Lean Squad cross-workflow contract, `lean-squad-report` is the only writer of `formal-verification/REPORT.md`. The `pr.md` enforces this with an "only-this-file rule": if `git status` shows any other modified file, revert before pushing.

## Why this is safe to land alone

The workflow is orphaned — nothing in the composed config enqueues it. It becomes live only when Unit 14 adds the `lean-squad-tick` scheduled source. Until then, this PR is a no-op in the profile.

## Test plan

- [x] `cd cli && go build ./cmd/xylem && go test ./...` green (updated two hard-coded workflow-list assertions in `profiles/profiles_test.go` and `cmd/xylem/init_test.go`).
- [x] `goimports -l .` clean.
- [x] E2E recipe from the coordinator prompt: `xylem init --profile core --force` scaffolds `.xylem/workflows/lean-squad-report.yaml` and `.xylem/prompts/lean-squad-report/{analyze,implement,pr}.md`; `xylem visualize -f json` lists `lean-squad-report` in `orphaned_workflows`.