### PR TITLE
[Lean Squad] Extract-impl workflow

### DIFF
--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -28,6 +28,7 @@ var expectedCoreWorkflows = []string{
 	"fix-pr-checks",
 	"implement-feature",
 	"lean-squad-ci",
+	"lean-squad-extract-impl",
 	"lean-squad-informal-spec",
 	"lean-squad-report",
 	"lessons",

--- a/cli/internal/profiles/core/prompts/lean-squad-extract-impl/analyze.md
+++ b/cli/internal/profiles/core/prompts/lean-squad-extract-impl/analyze.md
@@ -1,0 +1,69 @@
+You are running the `lean-squad-extract-impl` workflow (Task 4 of the Lean Squad system).
+
+See `https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md` for the upstream doctrine. The Lean Squad applies Lean 4 formal verification progressively and optimistically. You do **not** need prior formal-verification (FV) expertise — this phase only reads files and decides whether the workflow should proceed.
+
+## Vessel context
+
+- Vessel ID: {{.Vessel.ID}}
+- Vessel ref: `{{.Vessel.Ref}}` (expected shape: `lean-squad://<target-slug>`)
+
+## Your job in this phase
+
+Decide whether there is work for this workflow to do for the target named in the vessel ref, and if so, collect the source paths the `implement` phase will need. Do not write Lean code in this phase.
+
+### Step 1 — Parse the target slug
+
+`{{.Vessel.Ref}}` is the authoritative source. Strip the `lean-squad://` prefix; what remains is the `<target-slug>`. A slug is a short kebab-case identifier (for example `parse-uri`, `hash-map-insert`). If the ref is empty, does not begin with `lean-squad://`, or the remainder is empty, stop and emit the exact standalone line `XYLEM_NOOP` with a one-line explanation that the ref is malformed.
+
+### Step 2 — Resolve the target to a source path via `formal-verification/TARGETS.md`
+
+Read `formal-verification/TARGETS.md`. It is a table produced by the `lean-squad-orient` workflow; each row lists a target name, its source path, and a status. Find the row whose name matches `<target-slug>` (case-insensitive; tolerate minor formatting such as spaces vs. hyphens). Record the source path.
+
+If `formal-verification/TARGETS.md` does not exist, or no row matches the slug, emit `XYLEM_NOOP` with a one-line explanation ("TARGETS.md missing — lean-squad-orient has not run yet" or "slug <x> not listed in TARGETS.md"). Do not guess a source path.
+
+### Step 3 — Check the Lean file exists
+
+The Lean file for this target lives at `formal-verification/lean/FVSquad/<CamelCaseTarget>.lean`, where `<CamelCaseTarget>` is the CamelCase form of `<target-slug>` (for example `parse-uri` -> `ParseUri`). That file is the output of `lean-squad-formal-spec` (Task 3). Read the whole file.
+
+If the Lean file does not exist, emit `XYLEM_NOOP` with a one-line explanation ("Lean file for <slug> not found — lean-squad-formal-spec has not run yet"). `lean-squad-extract-impl` is strictly downstream of `lean-squad-formal-spec` and must not fabricate a Lean scaffold.
+
+### Step 4 — Decide whether there is a sorry-stubbed function body to fill
+
+Inside the Lean file, there will typically be one or more `def` or `partial def` declarations (function bodies) and one or more `theorem` or `lemma` declarations (proof obligations). Both may currently be `sorry`-stubbed.
+
+This workflow **only** fills function bodies. Theorem `sorry`s are owned by `lean-squad-prove` (Unit 6).
+
+Scan the file and determine:
+- Does at least one `def` / `partial def` / `def ... : ... :=` have a body of `sorry` (possibly wrapped in `by sorry`)?
+- If **every** `sorry` in the file is attached to a `theorem` or `lemma` declaration (and not to a `def`), emit the exact standalone line `XYLEM_NOOP` with the one-line explanation "no sorry in function bodies — theorem sorries are owned by lean-squad-prove".
+
+A quick textual heuristic is acceptable: grep for `sorry` and inspect the surrounding declaration keyword. When in doubt, lean conservative and emit `XYLEM_NOOP`; a later tick will redispatch when truly needed.
+
+### Step 5 — Locate tests and comment sources
+
+If you passed Step 4, briefly search for:
+- Tests that exercise the source (sibling `*_test.*` file, `tests/` directory, etc.).
+- Comment-bearing files (docstrings, adjacent READMEs, design notes). Worth noting but optional.
+
+Do not fabricate paths.
+
+### Step 6 — Emit a structured summary
+
+If all prior steps succeeded without emitting `XYLEM_NOOP`, produce a plain-text summary that `implement` can read verbatim:
+
+```
+TARGET_SLUG: <slug>
+SOURCE_PATH: <path-from-TARGETS.md>
+LEAN_PATH: formal-verification/lean/FVSquad/<CamelCaseTarget>.lean
+TEST_PATHS:
+- <path>
+- <path>
+COMMENT_SOURCES:
+- <path-or-locator>
+FUNCTION_SORRIES:
+- <short identifier of each def-level sorry found, e.g. `def parseUri` line N>
+NOTES:
+- <short note on the source language and any tricky bits the translator should know>
+```
+
+Do **not** start writing Lean function bodies in this phase. That is the job of `implement`.

--- a/cli/internal/profiles/core/prompts/lean-squad-extract-impl/implement.md
+++ b/cli/internal/profiles/core/prompts/lean-squad-extract-impl/implement.md
@@ -1,0 +1,86 @@
+You are running the `implement` phase of `lean-squad-extract-impl` (Task 4 of the Lean Squad).
+
+See `https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md` for the upstream doctrine. Your job is narrow: replace `sorry` **function bodies** in one existing Lean file with faithful translations of the source code. Theorems are not your concern — leave their `sorry` alone.
+
+## Vessel context
+
+- Vessel ID: {{.Vessel.ID}}
+- Vessel ref: `{{.Vessel.Ref}}`
+
+## Prior-phase output (authoritative)
+
+The `analyze` phase parsed the slug, located the source, confirmed the Lean file exists, and confirmed at least one `def` has a `sorry` body. Use its output below verbatim; do not re-derive these paths.
+
+```
+{{.PreviousOutputs.analyze}}
+```
+
+From that output you have:
+- `TARGET_SLUG` — the kebab-case identifier for this target
+- `SOURCE_PATH` — the implementation file in the original language
+- `LEAN_PATH` — the Lean file you will edit
+- `TEST_PATHS` — zero or more test files (useful for sanity checks)
+- `COMMENT_SOURCES` — docs or comment-bearing files
+- `FUNCTION_SORRIES` — which `def`s still need bodies
+
+## Your job in this phase
+
+Edit **only** `LEAN_PATH`. Replace the `sorry` body of each listed `def` / `partial def` with a faithful translation of the corresponding construct in `SOURCE_PATH`. Preserve the existing type signatures, module header, imports, and all `theorem` / `lemma` declarations verbatim — those belong to other workflows.
+
+### What "faithful translation" means
+
+1. **Behaviour-preserving under the existing type signature.** The type in the Lean file was chosen by `lean-squad-formal-spec`. You must translate so that the function computes the same values the source would for inputs admitted by that type.
+
+2. **Idiomatic Lean 4.** Prefer pattern matching, `match`, `if ... then ... else`, and structural recursion. Avoid `do`-notation unless the source is genuinely imperative and the Lean type involves a monad already. Do not invent new types, new imports, or new auxiliary top-level declarations unless strictly necessary for the body — and if you do, place them immediately above the `def` they support.
+
+3. **Use Mathlib / core only.** Do not add third-party dependencies. If a construct in the source has no clean Lean equivalent (e.g. mutation of an in-place buffer), translate to a pure-functional equivalent and document the divergence.
+
+4. **Abstractions may be lossy — that's fine, but disclose them.** When a translation loses information relative to the source (for example, modelling `Go int` with Lean's arbitrary-precision `Int` instead of a fixed-width 64-bit integer), add a one-line comment at the body:
+
+   ```
+   -- NOTE: source uses Go's int (64-bit, two's complement); translated using Int.
+   -- Overflow / wrap-around behaviour is not modelled here.
+   ```
+
+   Use the `-- NOTE:` prefix so later phases and reviewers can grep for divergences.
+
+5. **If a source construct cannot be translated safely, leave `sorry` in place** and add a `-- NOTE: untranslated — <reason>` comment. An honest `sorry` with a reason is better than a guess.
+
+### What you must not do
+
+- Do **not** modify any `theorem` or `lemma` body. If one is `sorry`, leave it `sorry`. That belongs to `lean-squad-prove` (Unit 6).
+- Do **not** rename functions, change signatures, or restructure the module. If the signature seems wrong, leave the body `sorry` with a `-- NOTE:` explaining what you observed — `lean-squad-formal-spec` will redo the signature.
+- Do **not** write or modify any file other than `LEAN_PATH`. This workflow is the sole writer of function bodies in `formal-verification/lean/FVSquad/<CamelCaseTarget>.lean`.
+- Do **not** run `lake build` or otherwise attempt the proof. The `verify` phase runs the build.
+- Do **not** commit, push, or open a PR. The `pr` phase handles that.
+
+### Reading the source
+
+1. Read `SOURCE_PATH` end to end.
+2. Read `LEAN_PATH` end to end — note the existing imports, namespaces, and the exact signatures you must preserve.
+3. Skim `TEST_PATHS` for concrete input/output pairs that help you sanity-check your translation by hand.
+
+### Editing workflow
+
+For each `def` listed in `FUNCTION_SORRIES`:
+1. Identify the corresponding function in the source.
+2. Translate the body, keeping the signature unchanged.
+3. If the translation needs an auxiliary helper (e.g. a local `let rec`), prefer local definitions inside the `def` over new top-level declarations.
+4. Add `-- NOTE:` comments for any lossy modelling, as described above.
+
+### End-of-phase summary
+
+After editing, emit a short plain-text summary that `pr` will use:
+
+```
+LEAN_FILE: <LEAN_PATH>
+FUNCTIONS_FILLED:
+- <def name>
+- <def name>
+FUNCTIONS_LEFT_SORRY:
+- <def name> — <reason>
+DIVERGENCES:
+- <short one-liner for each -- NOTE: added>
+```
+
+If no `def` was actually filled (every one had to be left `sorry` with a NOTE, or you found none to fill after all), say so explicitly. The `pr` phase will decline to open an empty PR in that case.

--- a/cli/internal/profiles/core/prompts/lean-squad-extract-impl/pr.md
+++ b/cli/internal/profiles/core/prompts/lean-squad-extract-impl/pr.md
@@ -1,0 +1,69 @@
+You are running the `pr` phase of `lean-squad-extract-impl` (Task 4 of the Lean Squad).
+
+## Vessel context
+
+- Vessel ID: {{.Vessel.ID}}
+- Vessel ref: `{{.Vessel.Ref}}`
+
+## Prior-phase output
+
+```
+{{.PreviousOutputs.analyze}}
+```
+
+```
+{{.PreviousOutputs.implement}}
+```
+
+## Your job in this phase
+
+Commit the Lean-file changes, push to a dedicated branch, and open a pull request.
+
+### Branch name
+
+Derive `<target-slug>` from the `analyze` output's `TARGET_SLUG` line (or, failing that, from `{{.Vessel.Ref}}` by stripping the `lean-squad://` prefix). Create the branch:
+
+```
+lean-squad-extract-impl-<target-slug>/{{.Vessel.ID}}
+```
+
+### Commit
+
+Stage only the Lean file named in `implement`'s `LEAN_FILE` line (expected to be `formal-verification/lean/FVSquad/<CamelCaseTarget>.lean`). Do not stage any other file. Use a commit message in Conventional Commits style, for example:
+
+```
+feat(lean-squad): extract implementation for <target-slug>
+```
+
+### PR
+
+Open the PR with `gh pr create`. Title (exactly this shape):
+
+```
+[Lean Squad] Extract implementation for <target-slug>
+```
+
+Body: a short markdown block containing
+1. one sentence naming the target and what was filled in (for example: "Translates the `parseUri` source into Lean 4; theorem bodies remain `sorry` for `lean-squad-prove`.").
+2. a link to the upstream doctrine at `https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md`.
+3. a pointer to `formal-verification/CORRESPONDENCE.md` noting that Unit 7 (`lean-squad-correspondence`) will record the source-to-Lean mapping for this target.
+4. the structured run marker (one line, verbatim, so the next tick can reconcile state):
+
+```
+LEAN_SQUAD_RUN: {"task":"extract-impl","target":"<target-slug>","status":"ok","artefact":"<LEAN_FILE>"}
+```
+
+5. the 🔬 disclosure: "Produced by xylem's `lean-squad-extract-impl` workflow; function bodies are a best-effort translation, `lake build` green, theorems remain `sorry`."
+
+Labels: apply `lean-squad`. Do not apply `ready-to-merge` — the output contains mechanical code translations that deserve a human sanity check before merge. Example:
+
+```
+gh pr create \
+  --title "[Lean Squad] Extract implementation for <target-slug>" \
+  --body "<body as above>" \
+  --label "lean-squad"
+```
+
+### Idempotency
+
+If `implement` did not actually modify the Lean file (every `def` left `sorry`, or no diff), do not open an empty PR. Instead, print a short explanation and exit — `git status --porcelain formal-verification/lean/` will be empty in that case.

--- a/cli/internal/profiles/core/workflows/lean-squad-extract-impl.yaml
+++ b/cli/internal/profiles/core/workflows/lean-squad-extract-impl.yaml
@@ -1,0 +1,21 @@
+name: lean-squad-extract-impl
+description: "[Lean Squad] Task 4 — extract faithful Lean translations of source code into function bodies in formal-verification/lean/FVSquad/<Target>.lean (theorems remain sorry-stubbed for Unit 6)."
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/lean-squad-extract-impl/analyze.md
+    max_turns: 40
+    noop:
+      match: XYLEM_NOOP
+  - name: implement
+    prompt_file: .xylem/prompts/lean-squad-extract-impl/implement.md
+    max_turns: 50
+  - name: verify
+    type: command
+    run: |
+      set -euo pipefail
+      cd formal-verification
+      lake build 2>&1 | tee /tmp/lean-build.log
+      ! grep -q "error:" /tmp/lean-build.log
+  - name: pr
+    prompt_file: .xylem/prompts/lean-squad-extract-impl/pr.md
+    max_turns: 20

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -102,6 +102,7 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 		"fix-pr-checks",
 		"implement-feature",
 		"lean-squad-ci",
+		"lean-squad-extract-impl",
 		"lean-squad-informal-spec",
 		"lean-squad-report",
 		"lessons",


### PR DESCRIPTION
## Summary

Unit 5 of the Lean Squad port. Adds `lean-squad-extract-impl`, Task 4 of the
[agentics Lean Squad system](https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md)
into xylem's core profile.

The workflow fills `sorry`-stubbed **function bodies** in
`formal-verification/lean/FVSquad/<Target>.lean` with faithful Lean 4
translations of the source code named in the enqueued ref
`lean-squad://<target-slug>`. Theorem `sorry`s are explicitly owned by
`lean-squad-prove` (Unit 6) and remain untouched. Lossy abstractions (e.g.
Go `int` -> Lean `Int`) are disclosed via `-- NOTE:` comments so reviewers
and downstream correspondence work can grep for divergences.

Four phases:
- `analyze` (max_turns: 40, `noop: {match: XYLEM_NOOP}`) - parse slug,
  resolve source via `TARGETS.md`, emit `XYLEM_NOOP` when the Lean file is
  missing or every `sorry` is on a theorem.
- `implement` (max_turns: 50) - translate function bodies, preserve
  signatures and theorem `sorry`s, add `-- NOTE:` for divergences.
- `verify` (command) - `lake build` in `formal-verification/` must succeed
  with no `error:` in the output.
- `pr` (max_turns: 20) - commit on
  `lean-squad-extract-impl-<target-slug>/<vessel-id>`, open PR with
  `LEAN_SQUAD_RUN` marker for state reconciliation, `lean-squad` label
  (no auto-merge, mechanical translations warrant human sanity check).

Sole writer of function bodies inside `FVSquad/<Target>.lean` per the
state-ownership contract in the squad plan.

## Test plan

- [x] `cd cli && go build ./cmd/xylem`
- [x] `go test ./...` - all packages green
- [x] `goimports -l .` - clean
- [x] `go vet ./...` - clean
- [x] `go test -v ./internal/workflow -run TestLoad` - YAML parses, noop
      semantics verified
- [x] `go test -v ./cmd/xylem -run TestInit` - workflow appears in
      scaffolded output
- [x] `go test -v ./internal/profiles -run TestSmoke_S2` - composition
      includes `lean-squad-extract-impl`

## 🔬 Disclosure

Produced by xylem's self-improvement loop (autonomous unit worker, 14-way
parallel port of the Lean Squad system). Pattern matches the already-landed
`lean-squad-informal-spec` (Unit 3).