### PR TITLE
[Lean Squad] Status dashboard workflow

### DIFF
--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -36,6 +36,7 @@ var expectedCoreWorkflows = []string{
 	"lean-squad-orient",
 	"lean-squad-prove",
 	"lean-squad-report",
+	"lean-squad-status",
 	"lessons",
 	"merge-pr",
 	"refine-issue",

--- a/cli/internal/profiles/core/prompts/lean-squad-status/analyze.md
+++ b/cli/internal/profiles/core/prompts/lean-squad-status/analyze.md
@@ -1,0 +1,35 @@
+🔬 *Lean Squad — `lean-squad-status` / `analyze` phase.*
+
+This phase is `type: command`, so the logic lives inline in
+`.xylem/workflows/lean-squad-status.yaml`. This file is a human-readable companion: it
+documents what the shell step does and why, so a new contributor can read the scaffolded
+workflow directory and understand the dashboard without tracing bash.
+
+## Purpose
+
+Locate (or create) the single rolling GitHub issue titled
+`[Lean Squad] Formal Verification Status`. Subsequent runs of the `update` phase replace
+its body with the current dashboard. This is the only source of truth for a human who
+wants to click one link and see the state of formal verification in the repo.
+
+## Behaviour
+
+1. Search for an existing issue by exact title match, preferring the OPEN instance if
+   more than one exists (sorted highest-numbered first as a tiebreak).
+2. If none exists, create it with the `lean-squad` and `lean-squad-status` labels and a
+   placeholder body carrying the 🔬 disclosure and a "Getting started" opt-in footer.
+3. Emit a single line `ISSUE: <number>` on stdout. The `update` phase reads this from
+   the captured analyze output at `.xylem/phases/<vessel-id>/analyze.output`.
+
+## Teaching notes
+
+New contributors: the 🔬 emoji is a consistent Lean Squad convention — every artefact
+the system maintains carries it, so you can tell at a glance that a file, issue, or PR
+is machine-maintained and will be overwritten on the next run. Do not edit by hand.
+
+## Error handling
+
+The step uses `set -euo pipefail`. `gh issue list` failures are tolerated by defaulting
+to an empty JSON array — the step falls through to creation. A hard `gh issue create`
+failure (e.g. missing repo permissions, network outage) propagates and fails the phase;
+the vessel will retry on the next scheduled run.

--- a/cli/internal/profiles/core/prompts/lean-squad-status/update.md
+++ b/cli/internal/profiles/core/prompts/lean-squad-status/update.md
@@ -1,0 +1,49 @@
+🔬 *Lean Squad — `lean-squad-status` / `update` phase.*
+
+This phase is `type: command`, so the logic lives inline in
+`.xylem/workflows/lean-squad-status.yaml`. This file is a human-readable companion.
+
+## Purpose
+
+Replace the body of the dashboard issue identified by the `analyze` phase with a
+compact, up-to-date snapshot of formal-verification state in this repo.
+
+## Dashboard contents
+
+- **Targets** — top portion of `formal-verification/TARGETS.md` (sole writer:
+  `lean-squad-orient`). If the file is absent, a hint points contributors at
+  `lean-squad-orient`.
+- **Open [Lean Squad] PRs** — `gh pr list --label lean-squad --state open`, rendered
+  as a markdown table with issue number, title, and updated-at timestamp.
+- **Open [finding] issues** — `gh issue list --label lean-squad --label finding
+  --state open`, same table shape. These are the counterexamples and spec gaps
+  surfaced by `lean-squad-prove`.
+- **Latest report excerpt** — first ~40 lines of `formal-verification/REPORT.md` (sole
+  writer: `lean-squad-report`) if it exists.
+- **Next run** — a pointer at the tick coordinator schedule in
+  `docs/workflows/lean-squad.md`.
+- **Getting started** — the opt-in triad (`formal-verification/` dir,
+  `.github/lean-squad.yml`, or `lean-squad-opt-in` label).
+
+## Teaching notes
+
+The dashboard is itself a teaching artefact. New contributors click it, see the table
+of open PRs and findings, and learn the vocabulary (targets, findings, specs) by
+reading the linked items. Keep the layout stable — outside consumers (other docs, the
+`lean-squad-report` run history) link into specific sections.
+
+## Sole-writer guarantee
+
+This workflow is the sole writer of the dashboard issue body. Every other lean-squad
+workflow is read-only with respect to it. If two `lean-squad-status` vessels somehow
+run concurrently, the last `gh issue edit` wins — acceptable because both computed the
+body from the same upstream sources.
+
+## Error handling
+
+- A missing `ISSUE: <number>` marker in the `analyze` output is a hard error (the
+  phase fails so the vessel can be retried).
+- Missing `TARGETS.md` / `REPORT.md` is treated as a valid, empty state and rendered
+  as an encouragement for the relevant task to run.
+- `gh pr list` / `gh issue list` failures fall through to empty arrays so the
+  dashboard degrades gracefully instead of failing the whole run.

--- a/cli/internal/profiles/core/workflows/lean-squad-status.yaml
+++ b/cli/internal/profiles/core/workflows/lean-squad-status.yaml
@@ -1,0 +1,133 @@
+name: lean-squad-status
+class: ops
+description: "Maintain the rolling [Lean Squad] Formal Verification Status dashboard issue"
+phases:
+  - name: analyze
+    type: command
+    allowed_tools: "Bash"
+    run: |
+      set -euo pipefail
+      TITLE="[Lean Squad] Formal Verification Status"
+      EXISTING=$(gh issue list \
+        --search "${TITLE} in:title" \
+        --state all \
+        --json number,state,title \
+        --limit 3 2>/dev/null || echo "[]")
+      NUM=$(printf '%s' "$EXISTING" | jq -r \
+        --arg t "$TITLE" \
+        'map(select(.title == $t)) | sort_by(if .state == "OPEN" then 0 else 1 end, -.number) | .[0].number // empty')
+      if [ -z "$NUM" ]; then
+        INITIAL_BODY=$(cat <<'EOF'
+      🔬 *Lean Squad status dashboard — this issue is maintained automatically by the `lean-squad-status` workflow. Do not edit by hand; changes will be overwritten on the next run.*
+
+      Initialising… the first run will replace this body with the current state of formal-verification targets, findings, and recent PRs.
+
+      ### Getting started
+      To opt in, add any one of:
+      - a `formal-verification/` directory at the repo root
+      - a `.github/lean-squad.yml` config file
+      - the `lean-squad-opt-in` label on any open issue
+      EOF
+      )
+        NUM=$(gh issue create \
+          --title "$TITLE" \
+          --label lean-squad \
+          --label lean-squad-status \
+          --body "$INITIAL_BODY" \
+          | awk -F/ '{print $NF}')
+      fi
+      echo "ISSUE: ${NUM}"
+  - name: update
+    type: command
+    allowed_tools: "Bash"
+    run: |
+      set -euo pipefail
+      TITLE="[Lean Squad] Formal Verification Status"
+      ANALYZE_OUT=".xylem/phases/{{.Vessel.ID}}/analyze.output"
+      NUM=$(grep -E '^ISSUE: ' "$ANALYZE_OUT" 2>/dev/null | tail -1 | awk '{print $2}')
+      if [ -z "${NUM:-}" ]; then
+        echo "dashboard issue number not found in analyze output" >&2
+        exit 1
+      fi
+
+      BODY="${TMPDIR:-/tmp}/lean-squad-status-body.md"
+      NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+      PRS_JSON=$(gh pr list \
+        --label lean-squad \
+        --state open \
+        --limit 25 \
+        --json number,title,url,updatedAt 2>/dev/null || echo "[]")
+      FINDINGS_JSON=$(gh issue list \
+        --label lean-squad \
+        --label finding \
+        --state open \
+        --limit 25 \
+        --json number,title,url,updatedAt 2>/dev/null || echo "[]")
+      TARGETS_SECTION=""
+      if [ -f formal-verification/TARGETS.md ]; then
+        TARGETS_SECTION=$(awk '/^##/ {n++} n<3 {print}' formal-verification/TARGETS.md)
+      fi
+      REPORT_HEAD=""
+      if [ -f formal-verification/REPORT.md ]; then
+        REPORT_HEAD=$(awk 'NR<=40' formal-verification/REPORT.md)
+      fi
+
+      {
+        echo "🔬 *Lean Squad status dashboard — maintained automatically by the \`lean-squad-status\` workflow. Do not edit by hand; changes will be overwritten on the next run.*"
+        echo
+        echo "_Last updated: ${NOW}_"
+        echo
+        echo "### Targets"
+        if [ -n "$TARGETS_SECTION" ]; then
+          echo
+          printf '%s\n' "$TARGETS_SECTION"
+        else
+          echo
+          echo "_No \`formal-verification/TARGETS.md\` yet. Run \`lean-squad-orient\` to propose targets._"
+        fi
+        echo
+        echo "### Open [Lean Squad] PRs"
+        PR_COUNT=$(printf '%s' "$PRS_JSON" | jq 'length')
+        if [ "$PR_COUNT" -gt 0 ]; then
+          echo
+          echo "| # | Title | Updated |"
+          echo "|---|---|---|"
+          printf '%s' "$PRS_JSON" | jq -r '.[] | "| [#\(.number)](\(.url)) | \(.title) | \(.updatedAt) |"'
+        else
+          echo
+          echo "_None open._"
+        fi
+        echo
+        echo "### Open [finding] issues"
+        FINDING_COUNT=$(printf '%s' "$FINDINGS_JSON" | jq 'length')
+        if [ "$FINDING_COUNT" -gt 0 ]; then
+          echo
+          echo "| # | Title | Updated |"
+          echo "|---|---|---|"
+          printf '%s' "$FINDINGS_JSON" | jq -r '.[] | "| [#\(.number)](\(.url)) | \(.title) | \(.updatedAt) |"'
+        else
+          echo
+          echo "_None open._"
+        fi
+        if [ -n "$REPORT_HEAD" ]; then
+          echo
+          echo "### Latest report excerpt"
+          echo
+          printf '%s\n' "$REPORT_HEAD"
+        fi
+        echo
+        echo "### Next run"
+        echo
+        echo "The tick coordinator (\`lean-squad\`) re-enqueues this workflow every run. See \`docs/workflows/lean-squad.md\` for the schedule."
+        echo
+        echo "### Getting started"
+        echo
+        echo "To opt in, add any one of:"
+        echo "- a \`formal-verification/\` directory at the repo root"
+        echo "- a \`.github/lean-squad.yml\` config file"
+        echo "- the \`lean-squad-opt-in\` label on any open issue"
+      } > "$BODY"
+
+      gh issue edit "$NUM" --body-file "$BODY"
+      echo "DASHBOARD: https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/issues/${NUM}"

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -110,6 +110,7 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 		"lean-squad-orient",
 		"lean-squad-prove",
 		"lean-squad-report",
+		"lean-squad-status",
 		"lessons",
 		"merge-pr",
 		"refine-issue",


### PR DESCRIPTION
## Summary

Adds the `lean-squad-status` workflow to the core profile. This workflow maintains a single rolling GitHub issue titled **[Lean Squad] Formal Verification Status** as the dashboard for formal-verification state in the repo.

- Both phases are `type: command` (`Bash`-only, no LLM cost).
- `analyze` locates (or creates) the dashboard issue and emits `ISSUE: <number>`. New issues are created with labels `lean-squad` + `lean-squad-status` and a placeholder body carrying the machine-maintained disclosure and a "Getting started" opt-in footer.
- `update` reads the issue number from the analyze output, then regenerates the body from:
  - top of `formal-verification/TARGETS.md` (sole writer: `lean-squad-orient`)
  - open `[Lean Squad]` PRs
  - open `[finding]` issues
  - head of `formal-verification/REPORT.md` (sole writer: `lean-squad-report`)
  It then writes the body via `gh issue edit --body-file` and emits `DASHBOARD: <url>`.
- Companion prompt files under `cli/internal/profiles/core/prompts/lean-squad-status/` document what each command phase does so contributors scaffolding the workflow can read the behaviour without tracing bash.

The workflow is intentionally orphaned (no label triggers); the `lean-squad` tick coordinator (separate unit) re-enqueues it on every tick. `xylem visualize -f json` lists it under `orphaned_workflows`.

## Test plan

- [x] `go build ./cmd/xylem` green
- [x] `go test ./cmd/xylem ./internal/profiles` green (includes the two hardcoded workflow-list tests)
- [x] `goimports -l .` clean
- [x] `go vet ./...` clean
- [x] E2E: `xylem init --profile core --force` into a scratch repo — workflow YAML and prompts dir scaffold correctly
- [x] `xylem visualize -f json` reports `lean-squad-status` under `orphaned_workflows`

## Cross-unit notes

This is Unit 12 of the 14-parallel-worker Lean Squad port. As expected, this PR edits two files that every sibling unit also edits (`cli/internal/profiles/profiles_test.go` and `cli/cmd/xylem/init_test.go`) to keep the hardcoded expected-workflow-list in alphabetical order. These edits will produce trivial merge conflicts against sibling unit PRs — resolve by re-sorting the combined list.

Reference: agentics lean-squad port plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)