### PR TITLE
[Lean Squad] Focus dispatcher workflow

### DIFF
--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -32,6 +32,7 @@ var expectedCoreWorkflows = []string{
 	"lean-squad-ci",
 	"lean-squad-correspondence",
 	"lean-squad-extract-impl",
+	"lean-squad-focus",
 	"lean-squad-formal-spec",
 	"lean-squad-informal-spec",
 	"lean-squad-orient",

--- a/cli/internal/profiles/core/prompts/lean-squad-focus/analyze.md
+++ b/cli/internal/profiles/core/prompts/lean-squad-focus/analyze.md
@@ -1,0 +1,101 @@
+You are the Lean Squad **focus dispatcher**. Someone added the `lean-squad-focus` label
+to a GitHub issue and wrote instructions in the body. Your job is to parse those
+instructions into a concrete plan of task vessels to enqueue, without doing the work
+yourself. A later dispatch phase will run `xylem enqueue` for each line you emit.
+
+No Lean 4 or formal-verification expertise is required — you are a router, not a prover.
+
+## Issue to parse
+
+- Title: {{.Issue.Title}}
+- URL: {{.Issue.URL}}
+- Number: {{.Issue.Number}}
+- Labels: {{.Issue.Labels}}
+
+Body:
+
+```
+{{.Issue.Body}}
+```
+
+## Valid task names
+
+The Lean Squad exposes eleven tasks. Each one is a standalone workflow. Recognise any of
+these names (case-insensitive) in the issue body:
+
+| Task | Workflow name | One-line purpose |
+|---|---|---|
+| `orient` | `lean-squad-orient` | Survey repo, propose FV-tractable targets, update `TARGETS.md` |
+| `informal-spec` | `lean-squad-informal-spec` | Write plain-prose pre/postconditions for a target |
+| `formal-spec` | `lean-squad-formal-spec` | Translate informal spec to Lean 4 type + theorem declarations (with `sorry`) |
+| `extract-impl` | `lean-squad-extract-impl` | Replace `sorry` bodies with faithful Lean translations of source code |
+| `prove` | `lean-squad-prove` | Attempt one proof; file an issue on failure with classification |
+| `correspondence` | `lean-squad-correspondence` | Maintain source-to-Lean mapping table in `CORRESPONDENCE.md` |
+| `critique` | `lean-squad-critique` | Honest assessment of proved properties and coverage gaps |
+| `aeneas` | `lean-squad-aeneas` | Rust-only: auto-generate Lean from Rust via Charon+Aeneas |
+| `ci` | `lean-squad-ci` | Create/maintain the `lean-ci.yml` GitHub Action gate |
+| `report` | `lean-squad-report` | Update `REPORT.md` architecture diagram + run history |
+| `status` | `lean-squad-status` | Maintain the single rolling "Formal Verification Status" dashboard issue |
+
+Accept common aliases: `research`/`target-identification` → `orient`, `informal` →
+`informal-spec`, `formal` → `formal-spec`, `extract` → `extract-impl`, `proof`/`proofs` →
+`prove`. Collapse a trailing `s` silently (`proves` → `prove`).
+
+## Target resolution
+
+Targets are the source elements each task operates on (typically a function, type, or
+module name, but sometimes a path). Look for them, in priority order:
+
+1. Explicit `target: <slug>` or `target=<slug>` phrases in the issue body.
+2. Back-ticked identifiers alongside a task word, e.g. ``prove `ParseInt` ``.
+3. A `TARGETS.md` table listed in the body.
+4. `formal-verification/TARGETS.md` in the repo (read-only — if it exists, use its
+   top-priority pending target).
+5. If none can be determined for a task, use the literal string `ALL` as the target slug —
+   the downstream workflow reads its own `TARGETS.md` to pick one.
+
+Slug rules: alphanumerics, underscore, hyphen, dot, and slash allowed. Replace whitespace
+with a single hyphen. Preserve case.
+
+## Output format
+
+Emit one `PLAN:` line per task-and-target pair you are confident about:
+
+```
+PLAN: task=<task-name> target=<target-slug>
+```
+
+Example:
+
+```
+PLAN: task=prove target=ParseInt
+PLAN: task=informal-spec target=validateJSON
+PLAN: task=report target=ALL
+```
+
+For anything the user asked for but you could not map to the eleven tasks, emit an
+`UNKNOWN:` line verbatim (preserving their original phrasing):
+
+```
+UNKNOWN: Task 99 on Foo
+UNKNOWN: "audit the proofs" (unclear which task)
+```
+
+Emit `XYLEM_NOOP` on its own line (and nothing else) if any of the following hold:
+- The issue body is empty or contains no instructions.
+- No sentence in the body mentions any of the eleven task names or their aliases.
+- The body appears to be automated boilerplate with no request.
+
+### Rules
+
+- Cap yourself at **four** `PLAN:` lines — the dispatch phase will also cap, but keeping
+  your output short reduces chance of the cap cutting off a more-important request.
+- No prose narration in your output. `PLAN:`, `UNKNOWN:`, or `XYLEM_NOOP` lines only.
+- Do not modify any files. Do not run any shell commands. Read-only analysis.
+- If the user asked for the same task on the same target twice, emit it once.
+- If the user asked for multiple targets for one task, emit one `PLAN:` line per target.
+
+## Transparency
+
+The dispatch phase posts a summary comment on the issue prefixed with :microscope: —
+keeping with the Lean Squad convention that every artefact discloses its AI origin.

--- a/cli/internal/profiles/core/prompts/lean-squad-focus/dispatch.md
+++ b/cli/internal/profiles/core/prompts/lean-squad-focus/dispatch.md
@@ -1,0 +1,39 @@
+# `dispatch` phase (reference)
+
+The `dispatch` phase of the `lean-squad-focus` workflow is a `type: command` phase whose
+shell body lives inline in `lean-squad-focus.yaml`. This file is a human-readable
+reference — the runner does **not** load it at execution time.
+
+## What the shell does
+
+1. Reads `.xylem/phases/<vessel-id>/analyze.output` (written by the preceding prompt
+   phase).
+2. Extracts lines starting with `PLAN: task=<name> target=<slug>` (capped at 4) and
+   `UNKNOWN: <raw>` (unlimited, for transparency in the summary comment).
+3. For each valid PLAN line, runs:
+
+   ```bash
+   xylem enqueue \
+     --workflow lean-squad-<task> \
+     --ref lean-squad://<target> \
+     --id lean-squad-<task>-<slug>-focus-<unix-ts>-<index>
+   ```
+
+4. Posts a summary comment on the issue via `gh issue comment` listing dispatched
+   vessels and any unrecognised requests, prefixed with :microscope:.
+5. Removes the `lean-squad-focus` label with `gh issue edit`.
+
+## Error tolerance
+
+- If no PLAN lines are present, dispatches zero vessels and still removes the label plus
+  posts the summary comment (the run was a no-op, the label should not re-trigger).
+- If a PLAN line is malformed (missing `task=` or `target=`), it is silently skipped —
+  the analyze prompt is responsible for well-formed output.
+- If `xylem enqueue` rejects a workflow name because the sibling workflow is not
+  present in the composed config, the shell halts via `set -eu` and the vessel is
+  retried. Keep sibling workflows landed before relying on focus dispatch.
+
+## Cap rationale
+
+The 4-vessel cap prevents a single issue body from spawning a runaway batch. Operators
+wanting more vessels can invoke the label multiple times with distinct bodies.

--- a/cli/internal/profiles/core/workflows/lean-squad-focus.yaml
+++ b/cli/internal/profiles/core/workflows/lean-squad-focus.yaml
@@ -1,0 +1,60 @@
+name: lean-squad-focus
+description: "Parse a lean-squad-focus issue body and enqueue the requested Lean Squad task vessels"
+phases:
+  - name: analyze
+    prompt_file: .xylem/prompts/lean-squad-focus/analyze.md
+    max_turns: 40
+    allowed_tools: Read
+    noop:
+      match: XYLEM_NOOP
+  - name: dispatch
+    type: command
+    run: |
+      set -eu
+      OUT=".xylem/phases/{{.Vessel.ID}}/analyze.output"
+      test -s "$OUT"
+
+      TMPDIR_LS="${TMPDIR:-/tmp}"
+      PLANS_FILE="$TMPDIR_LS/lean-squad-focus-plans.$$"
+      UNKNOWNS_FILE="$TMPDIR_LS/lean-squad-focus-unknowns.$$"
+      trap 'rm -f "$PLANS_FILE" "$UNKNOWNS_FILE"' EXIT
+
+      grep -E '^[[:space:]]*PLAN:[[:space:]]+task=' "$OUT" 2>/dev/null | head -n 4 > "$PLANS_FILE" || true
+      grep -E '^[[:space:]]*UNKNOWN:' "$OUT" 2>/dev/null > "$UNKNOWNS_FILE" || true
+
+      TS=$(date +%s)
+      DISPATCHED=0
+      DISPATCHED_LINES=""
+
+      while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        TASK=$(printf '%s' "$line" | sed -n 's/.*task=\([A-Za-z0-9_-]\{1,\}\).*/\1/p')
+        TARGET=$(printf '%s' "$line" | sed -n 's/.*target=\([A-Za-z0-9_./-]\{1,\}\).*/\1/p')
+        [ -z "$TASK" ] && continue
+        [ -z "$TARGET" ] && continue
+        SLUG=$(printf '%s' "$TARGET" | tr '/.' '--')
+        VID="lean-squad-${TASK}-${SLUG}-focus-${TS}-${DISPATCHED}"
+        xylem enqueue \
+          --workflow "lean-squad-${TASK}" \
+          --ref "lean-squad://${TARGET}" \
+          --id "$VID"
+        DISPATCHED=$((DISPATCHED + 1))
+        DISPATCHED_LINES="${DISPATCHED_LINES}- \`${TASK}\` on \`${TARGET}\` (vessel \`${VID}\`)
+      "
+      done < "$PLANS_FILE"
+
+      {
+        printf ':microscope: Lean Squad focus dispatched: %d vessel(s) queued.\n' "$DISPATCHED"
+        if [ -n "$DISPATCHED_LINES" ]; then
+          printf '\n%s' "$DISPATCHED_LINES"
+        fi
+        if [ -s "$UNKNOWNS_FILE" ]; then
+          printf '\nUnrecognised requests (ignored):\n```\n'
+          cat "$UNKNOWNS_FILE"
+          printf '```\n'
+        fi
+      } | gh issue comment {{.Issue.Number}} --body-file -
+
+      gh issue edit {{.Issue.Number}} --remove-label lean-squad-focus
+
+      echo "DISPATCHED: ${DISPATCHED}"

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -106,6 +106,7 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 		"lean-squad-ci",
 		"lean-squad-correspondence",
 		"lean-squad-extract-impl",
+		"lean-squad-focus",
 		"lean-squad-formal-spec",
 		"lean-squad-informal-spec",
 		"lean-squad-orient",


### PR DESCRIPTION
## Summary

Unit 13 of 14 in the Lean Squad port. Adds one new workflow, `lean-squad-focus`, the xylem-native analog of agentics' `/lean-squad <instructions>` slash command. When a `lean-squad-focus` label is applied to an issue, the workflow:

1. **analyze** (prompt phase, Read-only, `XYLEM_NOOP` aware) — parses the issue body against the 11 Lean Squad tasks and emits `PLAN: task=<name> target=<slug>` lines (capped at 4) plus `UNKNOWN:` lines for unrecognised requests. The LLM is instructed as a router — no Lean/FV expertise required.
2. **dispatch** (command phase) — reads the analyze output, runs `xylem enqueue --workflow lean-squad-<task> --ref lean-squad://<target>` per PLAN line, posts a `:microscope:` summary comment to the issue, and removes the label.

Full 4-vessel cap is enforced both in the prompt and in the `dispatch` shell (`head -n 4`). POSIX `sh -c` compatible (no bash-isms), variables survive the parse loop (tempfile-driven, not piped subshell).

## Test-file changes

`cli/cmd/xylem/init_test.go` and `cli/internal/profiles/profiles_test.go` both contain pinned alphabetical slices of expected core workflows (used by `TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates`, `TestSmoke_S4_CoreInitScaffoldsTrackedControlPlane`, `TestSmoke_S5_CorePlusSelfHostingOverlayScaffoldsOverlayWorkflows`). I inserted `"lean-squad-focus"` between `"implement-feature"` and `"lessons"` — purely mechanical.

## Orphan-until-Unit-14 status

The workflow has no source trigger yet — Unit 14 wires the `lean-squad-focus` label source as a separate change. `xylem visualize -f json` lists it under `orphaned_workflows` until then. This is the deterministic gate preventing dispatch from firing against xylem's own daemon before the 11 sibling `lean-squad-<task>` workflows land.

## Test plan

- [x] `go build ./cmd/xylem` clean
- [x] `go test ./...` — all green
- [x] `goimports -l .` clean
- [x] `go vet ./...` clean
- [x] E2E: `xylem init --profile core` scaffolds `.xylem/workflows/lean-squad-focus.yaml` and `.xylem/prompts/lean-squad-focus/`
- [x] `xylem visualize -f json` registers the workflow under `orphaned_workflows` (expected)
- [x] pre-commit hooks (goimports, golangci-lint, go build, yaml, trailing whitespace) all pass

## Cross-unit contract

- Siblings (`lean-squad-orient`, `lean-squad-prove`, etc.): Units 2–12 land the 11 task workflows that this dispatcher enqueues.
- Unit 14: lands the label source and coordinator that triggers this workflow.
- Until both sides are merged, dispatching this workflow will fail at runtime against missing sibling workflow names — which is why the source side is held until the 13 workflow PRs are in.