### PR TITLE
[Lean Squad] Tick coordinator + wiring (MERGE LAST)

### DIFF
--- a/cli/cmd/xylem/init_test.go
+++ b/cli/cmd/xylem/init_test.go
@@ -27,6 +27,7 @@ var expectedCoreWorkflows = []string{
 	"fix-bug",
 	"fix-pr-checks",
 	"implement-feature",
+	"lean-squad",
 	"lean-squad-aeneas",
 	"lean-squad-bootstrap",
 	"lean-squad-ci",

--- a/cli/internal/profiles/core/AGENTS.md.tmpl
+++ b/cli/internal/profiles/core/AGENTS.md.tmpl
@@ -34,6 +34,8 @@ Issues labelled with these trigger xylem workflows automatically:
 |---|---|
 | `xylem:fix-bug` | Analyse → implement → verify → PR |
 | `xylem:implement-feature` | Plan → implement → verify → PR |
+| `lean-squad-opt-in` | Opt in to the Lean Squad 8h tick (Lean 4 formal verification); see [docs](https://github.com/nicholls-inc/xylem/blob/main/docs/workflows/lean-squad.md) |
+| `lean-squad-focus` | Run a specific lean-squad task now (details in issue body) |
 
 ## Further reading
 

--- a/cli/internal/profiles/core/prompts/lean-squad/assess_state.md
+++ b/cli/internal/profiles/core/prompts/lean-squad/assess_state.md
@@ -1,0 +1,90 @@
+You are running the `assess_state` phase of the `lean-squad` tick coordinator.
+
+🔬 **Lean Squad.** A progressive, optimistic application of Lean 4 formal verification to this repo.
+Your job in this phase is to pick the **two highest-value next tasks** to dispatch this tick.
+Zero formal-verification expertise is assumed — the prompts for each sub-workflow teach the
+concepts. Think of this system as a coordinated fleet of agents that collectively build a Lean
+model of this codebase over weeks. Build failures mid-proof are progress, not errors: failing
+theorems get filed as GitHub issues (real spec/impl bugs), and `sorry`-guarded stubs are valid
+interim output.
+
+- Vessel ID: {{.Vessel.ID}}
+- Tick ref: {{.Vessel.Ref}}
+- Fired at: {{index .Vessel.Meta "schedule.fired_at"}}
+- Gate output (opt-in signal): {{.PreviousOutputs.gate}}
+- Bootstrap status: {{.PreviousOutputs.bootstrap_if_missing}}
+- Merge log: {{.PreviousOutputs.merge_open_prs}}
+
+## The task cluster
+
+These 12 task workflows exist (13 if you count the focus/dispatch entrypoint); you pick any two:
+
+| Task slug | Purpose | Prerequisites |
+|---|---|---|
+| `orient` | Survey the repo; write/update `formal-verification/{RESEARCH,TARGETS}.md` with 3-5 prioritised targets. | bootstrap done |
+| `informal-spec` | Pick one target from TARGETS.md; write `formal-verification/specs/<target>_informal.md` in prose (pre/post-conditions, invariants, edge cases). | one target with status `[ ] pending` |
+| `formal-spec` | Translate one informal spec into Lean 4 skeleton (`lean/FVSquad/<Target>.lean`, type defs + theorem decls with `sorry` bodies). | informal spec exists |
+| `extract-impl` | Replace `sorry` function bodies with faithful Lean translations of the source code. | formal spec exists |
+| `prove` | Try to prove one theorem. On failure, file a `[finding]` issue with a minimal counterexample. | extract-impl done for that target |
+| `correspondence` | Maintain `formal-verification/CORRESPONDENCE.md` — source-function → Lean-definition map with divergence notes. | any target with formal spec |
+| `critique` | Maintain `formal-verification/CRITIQUE.md` — honest assessment of what the proved properties actually guard. | any target with proofs attempted |
+| `aeneas` | Rust-only. Auto-generate Lean from Rust via Charon+Aeneas. NOOPs on non-Rust repos. | Cargo.toml at repo root |
+| `ci` | Create/maintain `.github/workflows/lean-ci.yml` (elan + mathlib cache + `lake build` on Lean-touching PRs). | formal-verification/lean/ exists |
+| `report` | Update `formal-verification/REPORT.md` (always-on; dispatched unconditionally by this tick). | — |
+| `status` | Maintain the rolling dashboard issue titled `[Lean Squad] Formal Verification Status` (always-on; dispatched unconditionally). | — |
+
+`report` and `status` are dispatched unconditionally by the next phase (`dispatch`). **You pick the
+other two**, and they are what drive real progress.
+
+## How to pick
+
+1. **Read `formal-verification/repo-memory.json`** if it exists. The `phase` field hints at which
+   stage the system is in (`orient` | `specify` | `prove` | `mature`). The `runs` array lists
+   recent ticks' choices — avoid picking a task that was picked in the last 1-2 ticks unless
+   artefact state demands it.
+2. **Count artefacts on disk** to understand actual progress:
+   - `ls formal-verification/specs/ 2>/dev/null | wc -l` → informal specs
+   - `ls formal-verification/lean/FVSquad/*.lean 2>/dev/null | wc -l` → formal specs
+   - `grep -l 'sorry' formal-verification/lean/FVSquad/*.lean 2>/dev/null | wc -l` → unproven
+   - `gh pr list --label lean-squad --state open --json number --jq 'length'` → in-flight work
+3. **Apply phase-aware weighting.** Early ticks (empty `formal-verification/lean/`) favour
+   `orient` and `informal-spec`. Once targets exist, shift toward `formal-spec`→`extract-impl`→
+   `prove`. Once proofs accumulate, `correspondence` and `critique` become valuable. `ci` is a
+   one-shot: pick it once, not repeatedly. `aeneas` is Rust-only.
+4. **Distinct target slugs.** The two tasks you pick MUST target **different files** in
+   `formal-verification/lean/FVSquad/<Target>.lean`. This is a hard constraint — two parallel
+   vessels writing the same Lean file will conflict-merge. If you pick two spec/impl/prove
+   tasks, they must have different `target_slug` values. Tasks that don't touch a specific
+   target (e.g. `orient`, `correspondence`, `critique`, `ci`) can use the literal target slug
+   `_global` (distinct by virtue of the slug itself).
+
+## Handling bootstrap-pending state
+
+If `bootstrap_if_missing` emitted `BOOTSTRAP-PENDING:`, the project is mid-bootstrap. Pick only
+workflows that don't need `formal-verification/` yet: you may still pick `orient` (it's
+idempotent and will no-op if `TARGETS.md` is already present). If nothing else is safe, emit
+two `PLAN:` lines both naming `orient` on distinct pseudo-target slugs `_warmup-a` and
+`_warmup-b` — the dispatch phase will de-dupe and the always-on `report`+`status` pair still
+fire.
+
+## Output format
+
+Emit **exactly** this, in this order:
+
+```
+REASONING:
+<1-3 sentences explaining why these two tasks this tick, referencing repo-memory.json state
+ or artefact counts you observed>
+
+PLAN: <task-slug> <target-slug>
+PLAN: <task-slug> <target-slug>
+```
+
+- `<task-slug>` is one of: `orient`, `informal-spec`, `formal-spec`, `extract-impl`, `prove`,
+  `correspondence`, `critique`, `aeneas`, `ci`.
+- `<target-slug>` is a short filesystem-safe identifier (kebab-case, no spaces). Use the stem
+  of the Lean file (e.g. `binary-search`, `parse-url`). Use `_global` for whole-repo tasks.
+- The two PLAN: lines MUST have distinct `<target-slug>` values.
+- DO NOT emit `PLAN: report` or `PLAN: status` — those are dispatched unconditionally.
+
+End after the second `PLAN:` line. No other text after it.

--- a/cli/internal/profiles/core/prompts/lean-squad/retrospect.md
+++ b/cli/internal/profiles/core/prompts/lean-squad/retrospect.md
@@ -1,0 +1,76 @@
+You are running the `retrospect` phase of the `lean-squad` tick coordinator.
+
+🔬 **Lean Squad tick retrospective.** This is the last phase of an 8-hour tick. You record what
+this tick did so future ticks can make better decisions.
+
+- Vessel ID: {{.Vessel.ID}}
+- Tick ref: {{.Vessel.Ref}}
+- Fired at: {{index .Vessel.Meta "schedule.fired_at"}}
+- Dispatch log: {{.PreviousOutputs.dispatch}}
+- Assess-state output: {{.PreviousOutputs.assess_state}}
+- Repository: {{.Repo}}
+
+## What you do, concretely
+
+1. **Ensure `formal-verification/repo-memory.json` exists.** If the file is missing (this should
+   only happen when bootstrap is pending), create it with a seed:
+   ```json
+   {"phase": "orient", "targets": [], "runs": []}
+   ```
+2. **Append a new entry to `runs[]`.** Parse the `PLAN:` lines from the `assess_state` output
+   above and the `DISPATCHED:` lines from the `dispatch` output above. Build one entry:
+   ```json
+   {
+     "timestamp": "<iso-8601 UTC from schedule.fired_at>",
+     "vessel_id": "<this vessel id>",
+     "gate_signal": "<short description of which opt-in triggered>",
+     "bootstrap_pending": <true|false, derived from previous outputs>,
+     "plan": [
+       {"task": "<task-slug>", "target": "<target-slug>"},
+       {"task": "<task-slug>", "target": "<target-slug>"}
+     ],
+     "dispatched": [
+       {"workflow": "lean-squad-<task>", "target": "<slug>", "vessel_id": "<id>"},
+       ...
+     ],
+     "notes": "<optional 1-sentence summary>"
+   }
+   ```
+   Include the always-on `report` and `status` dispatches in `dispatched[]`.
+3. **Update `runs[]` in-place.** Read the existing JSON, append this new entry to the end of
+   `runs[]`, write the file back with `jq` or a short Python snippet. Keep the rest of the file
+   untouched. Do not edit `targets[]` or `phase` — other workflows own those fields.
+4. **Open a PR.** Create a branch, commit the memory update, push, and open a PR:
+   - Branch name: `lean-squad/tick-<bucket>` where `<bucket>` is the UTC hour bucket used by
+     the dispatch phase (format `YYYYMMDD-HH`, e.g. `20260416-18`). Derive it from the fired_at
+     time or run `date -u +%Y%m%d-%H` if that matches closely enough.
+   - Commit message: `chore(lean-squad): tick retrospective <bucket>`
+   - PR title: `[Lean Squad] Tick <bucket>`
+   - PR body: list the two selected tasks, any bootstrap state, and the full dispatch log
+     quoted in a collapsible `<details>` block. Tag with 🔬 at the top.
+   - PR labels: `lean-squad`
+   - If the branch already exists from an earlier tick in the same hour bucket (very unlikely
+     at 8h cadence, but possible if a retry fires), append a `-retry<N>` suffix.
+
+## Safety rules
+
+- Do **NOT** edit `formal-verification/TARGETS.md`, `RESEARCH.md`, `CORRESPONDENCE.md`,
+  `CRITIQUE.md`, `REPORT.md`, or any file under `formal-verification/lean/` or
+  `formal-verification/specs/`. Other workflows are the sole writers of those files.
+- Do **NOT** merge PRs in this phase. Merges happen in `merge_open_prs` earlier in the tick.
+- If JSON parsing of `repo-memory.json` fails, DO NOT overwrite the file. Log the error with a
+  clear message and exit the phase gracefully — a subsequent tick will retry.
+
+## Deliverable
+
+Output the git operations you ran, the resulting PR URL, and end with a single line:
+
+```
+RESULT: <pr-url>
+```
+
+If you can't open a PR (e.g. no changes to commit because memory update was a no-op), end with:
+
+```
+RESULT: none — <reason>
+```

--- a/cli/internal/profiles/core/workflows/lean-squad.yaml
+++ b/cli/internal/profiles/core/workflows/lean-squad.yaml
@@ -1,0 +1,139 @@
+name: lean-squad
+class: ops
+description: "Tick coordinator for the Lean Squad formal-verification system. Every 8h, deterministically checks opt-in signals, merges open Lean-Squad PRs, asks an LLM to select the two highest-value next tasks (state-weighted), and dispatches them as vessels. On non-opted-in repos the first phase short-circuits via XYLEM_NOOP — the whole tick costs one tiny shell call."
+phases:
+  # Phase 1: deterministic opt-in gate.
+  # Plain shell test, NOT an LLM call — the only defence against the 8h tick
+  # firing on non-FV repos. Any of three signals wins; absence NOOPs the tick.
+  - name: gate
+    type: command
+    noop:
+      match: XYLEM_NOOP
+    run: |
+      set -euo pipefail
+      if [ -d formal-verification ]; then
+        echo "OPT-IN: formal-verification/ directory present"
+        exit 0
+      fi
+      if [ -f .github/lean-squad.yml ]; then
+        echo "OPT-IN: .github/lean-squad.yml present"
+        exit 0
+      fi
+      if gh issue list --label lean-squad-opt-in --state open --limit 1 --json number \
+           --jq 'length' 2>/dev/null | grep -q '^[1-9]'; then
+        echo "OPT-IN: lean-squad-opt-in issue label"
+        exit 0
+      fi
+      echo "XYLEM_NOOP: no lean-squad opt-in signal detected"
+
+  # Phase 2: bootstrap_if_missing.
+  # Dedup via stable --ref: queue.Enqueue silently no-ops if a vessel with the
+  # same ref is already pending/running/waiting. We cd to the daemon repo root
+  # (owner of --git-common-dir) because xylem enqueue resolves state_dir from
+  # CWD, and phase commands run inside the worktree's .xylem/ scaffold.
+  - name: bootstrap_if_missing
+    type: command
+    run: |
+      set -euo pipefail
+      if [ -d formal-verification ]; then
+        echo "BOOTSTRAP-SKIP: formal-verification/ already exists"
+        exit 0
+      fi
+      REPO_ROOT="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+      (cd "$REPO_ROOT" && xylem enqueue \
+        --workflow lean-squad-bootstrap \
+        --ref "lean-squad-bootstrap" \
+        --source "lean-squad-tick")
+      echo "BOOTSTRAP-PENDING: enqueued lean-squad-bootstrap; assess_state will skip tasks 3-10"
+
+  # Phase 3: merge ready lean-squad PRs.
+  # MERGEABLE + CLEAN, lean-squad-labelled, not do-not-merge.
+  - name: merge_open_prs
+    type: command
+    run: |
+      set -euo pipefail
+      PRS=$(gh pr list \
+        --label lean-squad \
+        --state open \
+        --json number,mergeable,mergeStateStatus,labels \
+        --jq '.[] | select((.labels | map(.name) | index("do-not-merge") | not) and .mergeable == "MERGEABLE" and .mergeStateStatus == "CLEAN") | .number' 2>/dev/null || true)
+      if [ -z "$PRS" ]; then
+        echo "MERGE-SKIP: no ready lean-squad PRs"
+        exit 0
+      fi
+      for N in $PRS; do
+        echo "MERGE: #$N"
+        gh pr merge "$N" --squash --delete-branch --admin || echo "MERGE-WARN: #$N failed to merge"
+      done
+
+  # Phase 4: state-weighted task selection (LLM).
+  # Reads repo-memory.json + artefact tree, emits exactly two PLAN: lines with
+  # distinct target slugs. Distinct targets prevent parallel vessels racing
+  # on the same lean/FVSquad/<Target>.lean file.
+  - name: assess_state
+    prompt_file: .xylem/prompts/lean-squad/assess_state.md
+    max_turns: 30
+    allowed_tools: "Bash, Read, Grep, Glob"
+    gate:
+      type: command
+      run: |
+        set -eu
+        out=".xylem/phases/{{.Vessel.ID}}/assess_state.output"
+        test -s "$out"
+        # Require at least two PLAN: lines with task+target fields.
+        PLAN_COUNT=$(grep -c '^PLAN: ' "$out" || true)
+        if [ "$PLAN_COUNT" -lt 2 ]; then
+          echo "ERROR: assess_state emitted $PLAN_COUNT PLAN: lines, expected exactly 2" >&2
+          exit 1
+        fi
+
+  # Phase 5: dispatch.
+  # Parses PLAN: lines from assess_state, de-dupes by target slug, enqueues
+  # each task plus the always-on lean-squad-{report,status} pair. Cap of 4
+  # total enqueues so a runaway prompt cannot fan out.
+  - name: dispatch
+    type: command
+    run: |
+      set -euo pipefail
+      REPO_ROOT="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+      OUT=".xylem/phases/{{.Vessel.ID}}/assess_state.output"
+      BUCKET="$(date -u +%Y%m%d-%H)"
+      ENQUEUED=0
+      CAP=4
+      SEEN_TARGETS=""
+      enqueue_once() {
+        local task="$1" target="$2"
+        if [ "$ENQUEUED" -ge "$CAP" ]; then
+          echo "DISPATCH-SKIP: cap $CAP reached, not enqueueing $task for $target"
+          return 0
+        fi
+        (cd "$REPO_ROOT" && xylem enqueue \
+          --workflow "lean-squad-${task}" \
+          --ref "lean-squad://${target}" \
+          --id "lean-squad-${task}-${target}-${BUCKET}" \
+          --source "lean-squad-tick")
+        ENQUEUED=$((ENQUEUED + 1))
+        echo "DISPATCHED: lean-squad-${task} target=${target}"
+      }
+      while read -r marker task target _rest; do
+        [ "$marker" = "PLAN:" ] || continue
+        [ -n "$task" ] && [ -n "$target" ] || continue
+        case "$SEEN_TARGETS" in
+          *"|${target}|"*)
+            echo "DISPATCH-SKIP: duplicate target $target"
+            continue
+            ;;
+        esac
+        SEEN_TARGETS="${SEEN_TARGETS}|${target}|"
+        enqueue_once "$task" "$target"
+      done < "$OUT"
+      enqueue_once "report" "_tick-${BUCKET}"
+      enqueue_once "status" "_tick-${BUCKET}"
+      echo "DISPATCH-DONE: enqueued ${ENQUEUED}/${CAP}"
+
+  # Phase 6: retrospect.
+  # Append a run entry to formal-verification/repo-memory.json, open a PR.
+  - name: retrospect
+    prompt_file: .xylem/prompts/lean-squad/retrospect.md
+    max_turns: 40
+    allowed_tools: "Bash, Read, Write, Edit, Grep, Glob"

--- a/cli/internal/profiles/core/xylem.yml.tmpl
+++ b/cli/internal/profiles/core/xylem.yml.tmpl
@@ -78,6 +78,14 @@ sources:
       resolve:
         labels: [needs-conflict-resolution]
         workflow: resolve-conflicts
+  lean-squad-focus:
+    type: github
+    repo: "{{ .Repo }}"
+    exclude: [no-bot]
+    tasks:
+      focus:
+        labels: [lean-squad-focus]
+        workflow: lean-squad-focus
   lessons-hygiene:
     type: schedule
     cadence: "@daily"
@@ -102,6 +110,10 @@ sources:
     type: schedule
     cadence: "@weekly"
     workflow: field-report
+  lean-squad-tick:
+    type: schedule
+    cadence: "8h"
+    workflow: lean-squad
 
 concurrency: 2
 max_turns: 50

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -101,6 +101,7 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 		"fix-bug",
 		"fix-pr-checks",
 		"implement-feature",
+		"lean-squad",
 		"lean-squad-aeneas",
 		"lean-squad-bootstrap",
 		"lean-squad-ci",

--- a/docs/workflows/lean-squad.md
+++ b/docs/workflows/lean-squad.md
@@ -1,0 +1,146 @@
+# Lean Squad: progressive formal verification for any xylem repo
+
+> 🔬 Inspired by [agentics' lean-squad](https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md). Ported into xylem's `core` profile as a cluster of ~14 workflows that apply [Lean 4](https://lean-lang.org/) formal verification (FV) to a codebase progressively, optimistically, and without assuming prior FV expertise from the humans or agents involved.
+
+## What it does
+
+Every 8 hours, on any xylem-managed repo that uses the `core` profile, a **tick** fires. The tick first runs a **deterministic opt-in gate** — three plain shell checks that cost essentially nothing. On the vast majority of repos, the gate sees no signal and the tick terminates immediately via `XYLEM_NOOP`.
+
+On a repo that **has opted in**, the tick does five things:
+
+1. **Bootstrap** the Lean toolchain and `formal-verification/` scaffold if missing.
+2. **Merge** any ready `lean-squad`-labelled PRs from earlier ticks.
+3. **Assess** the current state of the FV artefact tree (what specs exist, what's proved, what's still `sorry`-guarded) and pick the **two highest-value next tasks** for this tick.
+4. **Dispatch** those two tasks as independent vessels, plus two always-on observability workflows (`lean-squad-report` updates the status Markdown, `lean-squad-status` maintains a rolling GitHub dashboard issue).
+5. **Retrospect** — record what this tick dispatched into `formal-verification/repo-memory.json` so future ticks can make better decisions.
+
+Over weeks, the system progressively builds a Lean model of your codebase: proved theorems about pure functions, `sorry`-guarded specifications for the tricky bits, honest `CRITIQUE.md` about what the model does and doesn't capture, and filed GitHub issues when a proof fails in a way that signals a real spec or implementation bug.
+
+## How to opt in
+
+Any **one** of these signals enables Lean Squad on a repo:
+
+1. A `formal-verification/` directory exists at the repo root (typically created by the first run of `lean-squad-bootstrap`).
+2. A `.github/lean-squad.yml` file exists (created by a human who wants to opt in without bootstrapping yet).
+3. Any open GitHub issue carries the `lean-squad-opt-in` label.
+
+The simplest way to kick things off on a new repo:
+
+```bash
+gh issue create \
+  --title "Enable Lean Squad formal verification" \
+  --body "Bootstrap lean-squad on this repository." \
+  --label lean-squad-opt-in
+```
+
+The next 8h tick will detect the label, enqueue `lean-squad-bootstrap`, and start building a `formal-verification/` scaffold. Subsequent ticks run the full cycle.
+
+## How to opt out / stop
+
+- Remove the three signals above (delete `formal-verification/`, delete `.github/lean-squad.yml`, close or unlabel the `lean-squad-opt-in` issues). The next tick emits `XYLEM_NOOP` and stops.
+- Or: add the `no-bot` label to a specific issue to exclude just that issue from triggering `lean-squad-focus`.
+
+## Running a focused task by slash-command analogue
+
+To ask the system to work on a specific target right now (instead of waiting 8h), open an issue with the `lean-squad-focus` label:
+
+```
+Title: Formalise the parse_url function
+Body:
+Task: formal-spec
+Target: parse-url
+Notes: focus on the query-string extraction path; skip the fragment handling for now
+Labels: lean-squad-focus
+```
+
+The `lean-squad-focus` workflow reads the issue body, parses the task+target, and enqueues the corresponding `lean-squad-<task>` workflow with that target pinned. Removes the label when done.
+
+## The 12 sub-workflows (plus the tick)
+
+| Workflow | Trigger | Output | Writes to |
+|---|---|---|---|
+| `lean-squad` (this tick) | Scheduled, 8h | Enqueues 2 tasks + report + status | `formal-verification/repo-memory.json` (runs[] only) |
+| `lean-squad-bootstrap` | Enqueued by tick | Installs elan/Lean, writes scaffold, opens PR | `formal-verification/{README,RESEARCH,TARGETS,CORRESPONDENCE,CRITIQUE,REPORT}.md`, `lakefile.toml`, `lean-toolchain`, `lean/FVSquad/Stub.lean`, `repo-memory.json` (seed only) |
+| `lean-squad-orient` | Enqueued by tick | Surveys repo, proposes 3-5 targets | `formal-verification/{RESEARCH,TARGETS}.md` |
+| `lean-squad-informal-spec` | Enqueued by tick | Writes plain-prose spec for one target | `formal-verification/specs/<target>_informal.md` |
+| `lean-squad-formal-spec` | Enqueued by tick | Writes Lean 4 skeleton with `sorry` bodies | `formal-verification/lean/FVSquad/<Target>.lean` |
+| `lean-squad-extract-impl` | Enqueued by tick | Replaces `sorry` function bodies with Lean | same file (target-pinned) |
+| `lean-squad-prove` | Enqueued by tick | Proves a theorem OR files an issue | same file, plus `[finding]`-labelled issues |
+| `lean-squad-correspondence` | Enqueued by tick | Maintains source-to-Lean mapping table | `formal-verification/CORRESPONDENCE.md` |
+| `lean-squad-critique` | Enqueued by tick | Honest assessment of coverage gaps | `formal-verification/CRITIQUE.md` |
+| `lean-squad-aeneas` | Enqueued by tick | Rust-only: auto-generate Lean from Rust | `formal-verification/lean/FVSquad/Aeneas/Generated/*.lean` |
+| `lean-squad-ci` | Enqueued by tick | Creates `.github/workflows/lean-ci.yml` | that file only |
+| `lean-squad-report` | Enqueued by tick (always-on) | Updates status Markdown with mermaid diagram | `formal-verification/REPORT.md` |
+| `lean-squad-status` | Enqueued by tick (always-on) | Maintains rolling GitHub dashboard issue | `[Lean Squad] Formal Verification Status` issue body |
+| `lean-squad-focus` | `lean-squad-focus` label | Parses issue body, enqueues a specific task | — |
+
+## State ownership (prevents parallel-vessel write conflicts)
+
+Multiple `lean-squad-*` vessels can run concurrently. Each artefact below has exactly one **writer** workflow; all others are read-only. The tick's `assess_state` phase enforces that the two tasks it dispatches per tick target **distinct** `<target-slug>` values, preventing two vessels from racing on the same `lean/FVSquad/<Target>.lean` file.
+
+| File / artefact | Sole writer |
+|---|---|
+| `formal-verification/repo-memory.json` | `lean-squad` (this tick's `retrospect` phase) |
+| `formal-verification/REPORT.md` | `lean-squad-report` |
+| `formal-verification/{RESEARCH,TARGETS}.md` | `lean-squad-orient` |
+| `formal-verification/CORRESPONDENCE.md` | `lean-squad-correspondence` |
+| `formal-verification/CRITIQUE.md` | `lean-squad-critique` |
+| `formal-verification/specs/<target>_informal.md` | `lean-squad-informal-spec` (pinned to `<target>`) |
+| `formal-verification/lean/FVSquad/<Target>.lean` | pinned per tick by `assess_state` |
+| `formal-verification/lean/FVSquad/Aeneas/Generated/*.lean` | `lean-squad-aeneas` |
+| `.github/workflows/lean-ci.yml` | `lean-squad-ci` |
+| Dashboard issue body | `lean-squad-status` |
+
+Task vessels emit a structured marker in their PR body so the next tick's `retrospect` phase can reconcile state cheaply:
+
+```
+LEAN_SQUAD_RUN: {"task":"<name>","target":"<slug>","status":"<ok|partial|blocked>","artefact":"<path>"}
+```
+
+## Configuration surface
+
+Two sources are added to the core profile `xylem.yml` template by Unit 14:
+
+```yaml
+lean-squad-tick:
+  type: schedule
+  cadence: "8h"
+  workflow: lean-squad
+
+lean-squad-focus:
+  type: github
+  repo: "{{ .Repo }}"
+  exclude: [no-bot]
+  tasks:
+    focus:
+      labels: [lean-squad-focus]
+      workflow: lean-squad-focus
+```
+
+There is deliberately **no config knob to disable** the tick short of removing the source from `.xylem.yml`. The deterministic opt-in gate makes an "off" knob unnecessary — on non-opted-in repos the tick costs one tiny shell call every 8h.
+
+## Costs and guardrails
+
+- **On non-opted-in repos:** ~1 short shell call every 8h. No LLM tokens, no GitHub API calls beyond `gh issue list --label lean-squad-opt-in` (one cheap call per tick).
+- **On opted-in repos:** 1 LLM call for `assess_state` + 1 LLM call for `retrospect` + the dispatched 4 vessels (2 selected tasks + report + status). The `dispatch` phase hard-caps total enqueues per tick at 4, so no prompt hallucination can fan out an unbounded number of vessels.
+- **Merge safety:** the tick's `merge_open_prs` phase merges only `MERGEABLE` + `CLEAN` PRs labelled `lean-squad` that do **NOT** have the `do-not-merge` label. Hold any PR indefinitely by adding `do-not-merge`.
+- **Toolchain failures:** if `lake build` fails during bootstrap, the system emits a `TOOLING-GAP` marker and subsequent ticks skip tasks that require a working toolchain (`formal-spec`, `extract-impl`, `prove`, `aeneas`) until the gap is fixed.
+
+## Adding this to a repo
+
+`xylem init --profile core --force` scaffolds the workflows into `.xylem/workflows/` and the prompts into `.xylem/prompts/`. No other code change is required. The first tick that detects an opt-in signal will kick off `lean-squad-bootstrap`.
+
+## Debugging a stuck tick
+
+1. **Check the gate.** Look at `.xylem/phases/lean-squad-*/gate.output` — it should say either `OPT-IN: ...` or `XYLEM_NOOP: ...`.
+2. **Check the dispatch.** `.xylem/phases/lean-squad-*/dispatch.output` lists what was enqueued. If the cap was hit, you'll see `DISPATCH-SKIP: cap 4 reached`.
+3. **Check the daemon queue.** `xylem queue list` shows pending/running/waiting vessels. A stuck `lean-squad-bootstrap` usually means elan/Lean installation is asking for an interactive sudo password — the bootstrap prompt is supposed to use the non-interactive installer; file an issue if it doesn't.
+4. **Check `repo-memory.json`.** If it's missing or malformed, `retrospect` will refuse to overwrite it. Manually restore from git history or delete and let bootstrap re-seed.
+
+## Further reading
+
+- [agentics lean-squad source](https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md) — the original system this port is modelled on.
+- [Lean 4 reference](https://lean-lang.org/lean4/doc/) — the formal-verification language.
+- [mathlib4](https://github.com/leanprover-community/mathlib4) — the community library pulled in by bootstrap.
+- [Aeneas](https://github.com/AeneasVerif/aeneas) — the Rust-to-Lean translator used by the `lean-squad-aeneas` workflow.
+- `.xylem/workflows/lean-squad.yaml` in any opted-in repo — the exact phases you see running.


### PR DESCRIPTION
## MERGE LAST (blocked on sibling units 1-13)

This is **Unit 14 of 14** in the Lean Squad port. It is the ONLY unit that edits shared files (`xylem.yml.tmpl`, `AGENTS.md.tmpl`, test fixtures) and must merge **last**, after every sibling unit has landed. The tick coordinator dispatches to 12 sub-workflows (`lean-squad-bootstrap`, `lean-squad-report`, `lean-squad-status`, `lean-squad-proof-attempt`, etc.) that are authored by Units 1-13. Merging this PR before those land will enqueue vessels for workflows that do not exist.

Keep the `do-not-merge` label until **all 13 sibling PRs are merged**. Then strip the label and land this one.

## Summary

- 6-phase tick coordinator at `cli/internal/profiles/core/workflows/lean-squad.yaml`:
  1. **gate** (command, noop-emitting) — deterministic opt-in probe: `formal-verification/` directory, `.github/lean-squad.yml` file, or `lean-squad-opt-in` issue label. Non-FV repos short-circuit here for ~1 shell call of cost.
  2. **bootstrap_if_missing** (command) — enqueues `lean-squad-bootstrap` once (stable `--ref` dedup) if `formal-verification/` is absent.
  3. **merge_open_prs** (command) — squash-merges lean-squad PRs that are `MERGEABLE` + `CLEAN` and not `do-not-merge`.
  4. **assess_state** (prompt, max_turns:30, gate requires >=2 `PLAN:` lines) — LLM reads `repo-memory.json` + artefact tree, emits exactly two distinct-target task picks.
  5. **dispatch** (command) — parses `PLAN:` lines, de-dupes by target slug, enqueues each + always-on `report`/`status` pair, cap 4 total.
  6. **retrospect** (prompt, max_turns:40) — appends a run entry to `repo-memory.json` and opens a PR.
- Prompt templates under `cli/internal/profiles/core/prompts/lean-squad/`: `assess_state.md` + `retrospect.md`. Both written for zero-FV-expertise operators (Lean concepts taught inline).
- Sources wired in `cli/internal/profiles/core/xylem.yml.tmpl`:
  - `lean-squad-tick` (type: schedule, cadence 8h, workflow lean-squad)
  - `lean-squad-focus` (type: github, label `lean-squad-focus`, workflow lean-squad-focus)
- `AGENTS.md.tmpl`: two label rows added to the workflow-labels table with inline docs-link (section compressed — see note below).
- Test fixture updates: `cli/cmd/xylem/init_test.go` and `cli/internal/profiles/profiles_test.go` add `lean-squad` to the alphabetical expected-workflow lists.
- User-facing docs at `docs/workflows/lean-squad.md`.

## Key design choices

- **State-dir CWD trap**: `xylem enqueue` resolves `state_dir` relative to CWD, and phase commands run inside the worktree `.xylem/` scaffold. `bootstrap_if_missing` and `dispatch` `cd "$REPO_ROOT"` (discovered via `git rev-parse --path-format=absolute --git-common-dir`) before enqueueing so vessels land in the daemon's queue, not the worktree's.
- **Stable-ref dedup**: `bootstrap_if_missing` uses `--ref "lean-squad-bootstrap"` — `queue.Enqueue` silently no-ops if a vessel with the same Ref is pending/running/waiting, so parallel ticks don't spawn duplicates. Completed vessels don't block, so retry is automatic if bootstrap fails.
- **Cap 4 enqueues**: prevents a runaway LLM PLAN block from fanning out the queue.
- **do-not-merge filter in merge_open_prs**: explicitly excludes PRs holding the label, so a human can freeze a lean-squad PR without daemon interference.

## Expected E2E warning (not a bug)

`xylem visualize -f json` on this branch alone warns `missing workflow "lean-squad-focus"` — the `lean-squad-focus` workflow file is authored by Unit 13. The warning will resolve once that sibling merges. The `lean-squad` workflow itself is registered cleanly; the `lean-squad-tick` source fires against a present workflow.

## Spec deviation: AGENTS.md section compression

The Unit 14 spec asked for a full "Formal verification" section in `AGENTS.md.tmpl`. The template's existing tests enforce a 50-line ceiling (`TestInitEmitsAgentsMd`), and a full section pushed it to 60 lines. Compromise: I compressed the section into two rows of the existing workflow-labels table (label + one-line description) + a docs link, and moved the full content to `docs/workflows/lean-squad.md`. Same information, zero test-suite breakage, still surfaces to agents reading AGENTS.md.

## Test plan

- [x] `go build ./cmd/xylem`
- [x] `go test ./...` (full suite, race-free)
- [x] `goimports -l .` clean
- [x] `xylem visualize -f json` registers `lean-squad` workflow and both new sources (missing `lean-squad-focus` workflow warning is expected — Unit 13)
- [ ] Post-merge of all 13 siblings: re-run E2E; `lean-squad-focus` warning should clear
- [ ] Post-merge on an opted-in repo: verify 8h tick fires, gate emits OPT-IN, subsequent phases execute
- [ ] Post-merge on a non-opted-in repo: verify gate emits XYLEM_NOOP, tick short-circuits for ~1 shell call of cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)