### PR TITLE
feat(lean-squad): opt in xylem to Lean Squad formal verification

### DIFF
--- a/.github/lean-squad.yml
+++ b/.github/lean-squad.yml
@@ -1,0 +1,17 @@
+# Lean Squad opt-in for this repository.
+#
+# This file's presence is the opt-in signal for the 8-hour `lean-squad-tick`
+# workflow (see cli/internal/profiles/core/workflows/lean-squad.yaml gate phase).
+# Once the tick detects this file, `bootstrap_if_missing` will enqueue
+# `lean-squad-bootstrap` to install the Lean 4 toolchain (via elan) and scaffold
+# `formal-verification/` with placeholder RESEARCH/TARGETS/CORRESPONDENCE/CRITIQUE/REPORT
+# markdown files, a mathlib-dep'd `lakefile.toml`, and a `repo-memory.json`.
+#
+# Subsequent ticks pick 2 weighted tasks per run across the 10-task Lean Squad
+# (orient, informal-spec, formal-spec, extract-impl, prove, correspondence,
+# critique, aeneas, ci, report) plus the always-on status dashboard issue.
+#
+# System reference: https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md
+# Local docs:      docs/workflows/lean-squad.md
+
+enabled: true


### PR DESCRIPTION
## Summary

Creates `.github/lean-squad.yml` — the opt-in signal that activates the 8-hour `lean-squad-tick` workflow on this repo.

Without this file, the tick's deterministic gate emits `XYLEM_NOOP` on every run (by design — safe default for any repo inheriting the core profile). With this file, the gate emits `OPT-IN: .github/lean-squad.yml present` and the `bootstrap_if_missing` phase enqueues `lean-squad-bootstrap` to install the Lean 4 toolchain via `elan` and scaffold `formal-verification/` with placeholder RESEARCH/TARGETS/CORRESPONDENCE/CRITIQUE/REPORT markdown, a mathlib-dep'd `lakefile.toml`, and `repo-memory.json`.

Subsequent ticks select 2 weighted tasks per run across the 10-task Lean Squad (orient, informal-spec, formal-spec, extract-impl, prove, correspondence, critique, aeneas, ci, report), plus always-on status dashboard issue.

## What happens after merge

1. Next `lean-squad-tick` firing (every 8h, cadence in `cli/internal/profiles/core/xylem.yml.tmpl`).
2. Gate phase: detects `.github/lean-squad.yml`, exits with `OPT-IN: ...`.
3. `bootstrap_if_missing`: no `formal-verification/` yet, enqueues `lean-squad-bootstrap`.
4. Bootstrap installs elan + Lean toolchain, scaffolds `formal-verification/`, opens PR titled `[Lean Squad] Bootstrap formal-verification/ scaffolding`.
5. Tick after that: `assess_state` computes weights, enqueues 2 tasks + always-on report + status dashboard.

## References

- Upstream system: https://github.com/githubnext/agentics/blob/main/docs/lean-squad.md
- Local docs: `docs/workflows/lean-squad.md`
- Tick coordinator: `cli/internal/profiles/core/workflows/lean-squad.yaml`

## Test plan

- [x] Gate logic simulation confirms the file triggers opt-in (verified locally)
- [ ] Next `lean-squad-tick` firing observably dispatches `lean-squad-bootstrap`
- [ ] Bootstrap PR appears with `formal-verification/` scaffolding

🤖 Generated with [Claude Code](https://claude.com/claude-code)