### PR TITLE
feat(.xylem.yml): materialize lean-squad-tick source (#555 workaround)

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -144,6 +144,10 @@ sources:
     type: schedule
     cadence: "@weekly"
     workflow: field-report
+  lean-squad-tick:
+    type: schedule
+    cadence: "8h"
+    workflow: lean-squad
 
   # --- Sources from self-hosting-xylem overlay ---
   pr-self-review:


### PR DESCRIPTION
## Summary

- Adds the `lean-squad-tick` scheduled source (cadence `8h`, workflow `lean-squad`) to the materialized sources block in `.xylem.yml`.
- The source is already defined in the core profile at `cli/internal/profiles/core/xylem.yml.tmpl` (merged via PR #589, Unit 14 of the Lean Squad port), but issue #555 (profile composition producing empty sources at runtime) prevents it from reaching the runtime config.
- Matches the existing emergency-materialization pattern already acknowledged at the top of `.xylem.yml`:
  > EMERGENCY: sources block materialized from profiles to work around #555 ... Remove this block once #555 lands.

## Why this lands now

PR #590 enabled opt-in signal #2 (`.github/lean-squad.yml`). The gate phase in `lean-squad.yaml` will emit `OPT-IN: .github/lean-squad.yml present` — but the tick itself cannot fire until the scheduler actually schedules it, which requires the source to exist in the runtime config.

## Risk

Near-zero. The tick's first phase is a shell-only deterministic gate; it runs exactly once every 8h regardless of xylem vessel state and no-ops quickly on repos that haven't opted in. This repo *has* opted in, so the tick will proceed to `bootstrap_if_missing` which enqueues `lean-squad-bootstrap` to install the Lean 4 toolchain and scaffold `formal-verification/`.

## Test plan

- [x] `.xylem.yml` diff is additive and minimal (one source block, 4 lines).
- [ ] Post-merge: daemon auto-upgrade picks up the change, scheduler registers `lean-squad-tick`, tick fires within 8h.
- [ ] Optional: force dispatch via `xylem enqueue --workflow lean-squad --ref lean-squad-tick://manual --id lean-squad-tick-manual-<ts>` to verify the gate/bootstrap pathway end-to-end.

## Cleanup

Remove this materialized source once #555 lands and the core profile's sources are composed into the runtime config automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)