### PR TITLE
feat(config): set concurrency to 3

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -380,6 +380,7 @@ validation:
   build: "(cd cli && go build ./cmd/xylem)"
   test: "(cd cli && go test ./...)"
 
+concurrency: 3
 max_turns: 100
 timeout: "45m"
 state_dir: ".xylem"


### PR DESCRIPTION
## Summary
- Sets `concurrency: 3` in `.xylem.yml`, up from the default of 1
- Allows up to 3 vessels to run in parallel (one high-tier Claude + one med-tier Copilot + one low-tier Copilot simultaneously)
- No per-class caps needed at this level — global limit is sufficient

## Test plan
- [ ] Config parses without error (`xylem doctor`)
- [ ] Daemon picks up new concurrency on auto-upgrade restart
- [ ] Three vessels observed running concurrently in daemon logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)