### PR TITLE
fix(queue): reject duplicate vessel IDs in Enqueue (I9)

### DIFF
--- a/cli/cmd/xylem/scan_test.go
+++ b/cli/cmd/xylem/scan_test.go
@@ -279,22 +279,24 @@ func TestScanReenqueuesCompletedIssue(t *testing.T) {
 		}
 	})
 
-	if !strings.Contains(out, "Added 1") {
-		t.Fatalf("expected completed issue to be re-enqueued, got: %s", out)
+	// Spec I9 (docs/invariants/queue.md) forbids duplicate IDs. The scanner's
+	// completed-issue re-enqueue path currently reuses the original ID, which
+	// the queue now rejects; the scanner logs the collision and skips. The
+	// scanner-side fix (route re-enqueue through a RetryID-style new ID) is
+	// tracked as a separate gap.
+	if !strings.Contains(out, "skipped 1") {
+		t.Fatalf("expected duplicate-ID re-enqueue to be skipped, got: %s", out)
+	}
+	if !strings.Contains(out, "Added 0") {
+		t.Fatalf("expected no new vessel added, got: %s", out)
 	}
 
 	vessels, err := q.List()
 	if err != nil {
 		t.Fatalf("list queue: %v", err)
 	}
-	if len(vessels) != 2 {
-		t.Fatalf("expected original and re-enqueued vessels, got %d", len(vessels))
-	}
-	if vessels[1].ID != "issue-3" {
-		t.Fatalf("expected re-enqueued vessel to reuse issue id, got %s", vessels[1].ID)
-	}
-	if vessels[1].State != queue.StatePending {
-		t.Fatalf("expected re-enqueued vessel to be pending, got %s", vessels[1].State)
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 queue entry (duplicate rejected), got %d", len(vessels))
 	}
 }
 

--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -59,6 +59,11 @@ var validTransitions = map[VesselState]map[VesselState]bool{
 // ErrInvalidTransition is returned when a state transition is not allowed.
 var ErrInvalidTransition = errors.New("invalid state transition")
 
+// ErrDuplicateID is returned by Enqueue when the vessel's ID collides with any
+// existing vessel in the queue. ID is the primary key (invariant I9); callers
+// must supply unique IDs. Distinct from Ref collision, which is a silent no-op.
+var ErrDuplicateID = errors.New("duplicate vessel ID")
+
 // IsTerminal reports whether s is a terminal vessel state.
 func (s VesselState) IsTerminal() bool {
 	return s == StateCompleted || s == StateFailed || s == StateCancelled || s == StateTimedOut
@@ -141,6 +146,12 @@ func (q *Queue) Enqueue(vessel Vessel) (bool, error) {
 						return nil // already active, skip silently
 					}
 				}
+			}
+		}
+
+		for _, v := range vessels {
+			if v.ID == vessel.ID {
+				return ErrDuplicateID
 			}
 		}
 

--- a/cli/internal/queue/queue_invariants_prop_test.go
+++ b/cli/internal/queue/queue_invariants_prop_test.go
@@ -553,7 +553,6 @@ func TestPropQueueInvariant_I8_FileWellFormedness(t *testing.T) {
 
 // Invariant I9: Unique vessel IDs.
 func TestPropQueueInvariant_I9_UniqueIDs(t *testing.T) {
-	t.Skip("known violation: row I9 in docs/invariants/queue.md gap analysis; Enqueue checks only Ref, not ID, so two vessels can share an ID. Remove this Skip when Enqueue rejects duplicate IDs.")
 	rapid.Check(t, func(t *rapid.T) {
 		q, _, cleanup := newPropQueueWithDir(t, "queue-i9-prop")
 		defer cleanup()

--- a/cli/internal/queue/queue_test.go
+++ b/cli/internal/queue/queue_test.go
@@ -1820,8 +1820,12 @@ func helperFailVessel(t *testing.T, q *Queue, id string) {
 }
 
 // helperEnqueueFailThenReenqueue creates a queue with two records for the
-// same vessel ID: the first failed, the second pending (failed vessels allow
-// re-enqueue; completed vessels do not).
+// same vessel ID: the first failed, the second pending. Since I9 forbids
+// duplicate IDs via Enqueue, the duplicate is installed via ReplaceAll, which
+// is the privileged path where the caller is responsible for preserving
+// queue invariants (spec I7/I9 ⚠). This exercises the last-write-wins
+// semantics of Update/FindByID/Cancel/UpdateVessel when a caller has
+// deliberately produced a duplicate.
 func helperEnqueueFailThenReenqueue(t *testing.T) (*Queue, Vessel) {
 	t.Helper()
 	q, _ := newTestQueue(t)
@@ -1830,8 +1834,12 @@ func helperEnqueueFailThenReenqueue(t *testing.T) (*Queue, Vessel) {
 		t.Fatalf("enqueue: %v", err)
 	}
 	helperFailVessel(t, q, vessel.ID)
-	if _, err := q.Enqueue(testVessel(42)); err != nil {
-		t.Fatalf("re-enqueue: %v", err)
+	existing, err := q.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if err := q.ReplaceAll(append(existing, testVessel(42))); err != nil {
+		t.Fatalf("replace-all with duplicate ID: %v", err)
 	}
 	return q, vessel
 }
@@ -1970,21 +1978,23 @@ func TestCompact(t *testing.T) {
 	t.Run("removes stale terminal records", func(t *testing.T) {
 		q, path := newTestQueue(t)
 
-		// Enqueue 3 vessels, fail 2, then re-enqueue them.
+		// Enqueue 3 vessels, fail 2, then install duplicate pending records for
+		// them via ReplaceAll. Direct Enqueue would collide on I9; ReplaceAll is
+		// the privileged path whose caller carries that obligation (spec I7/I9).
 		for _, id := range []int{1, 2, 3} {
 			if _, err := q.Enqueue(testVessel(id)); err != nil {
 				t.Fatalf("enqueue: %v", err)
 			}
 		}
-		// Fail vessel 1 and 2 (failed vessels allow re-enqueue).
 		for _, id := range []int{1, 2} {
 			helperFailVessel(t, q, fmt.Sprintf("issue-%d", id))
 		}
-		// Re-enqueue vessel 1 and 2.
-		for _, id := range []int{1, 2} {
-			if _, err := q.Enqueue(testVessel(id)); err != nil {
-				t.Fatalf("re-enqueue: %v", err)
-			}
+		existing, err := q.List()
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if err := q.ReplaceAll(append(existing, testVessel(1), testVessel(2))); err != nil {
+			t.Fatalf("replace-all: %v", err)
 		}
 
 		// Before compaction: 5 records (failed-1, failed-2, pending-3, pending-1, pending-2).
@@ -2046,15 +2056,19 @@ func TestCompact(t *testing.T) {
 	t.Run("retains latest terminal record per ID", func(t *testing.T) {
 		q, _ := newTestQueue(t)
 
-		// Enqueue a vessel, fail it, re-enqueue, fail again.
+		// Enqueue, fail, then install a second pending record via ReplaceAll
+		// (Enqueue rejects duplicate IDs under I9), then fail it too.
 		if _, err := q.Enqueue(testVessel(20)); err != nil {
 			t.Fatalf("enqueue: %v", err)
 		}
 		helperFailVessel(t, q, "issue-20")
-		if _, err := q.Enqueue(testVessel(20)); err != nil {
-			t.Fatalf("re-enqueue: %v", err)
+		existing, err := q.List()
+		if err != nil {
+			t.Fatalf("list: %v", err)
 		}
-		// Dequeue and fail the re-enqueued vessel.
+		if err := q.ReplaceAll(append(existing, testVessel(20))); err != nil {
+			t.Fatalf("replace-all: %v", err)
+		}
 		if _, err := q.Dequeue(); err != nil {
 			t.Fatalf("dequeue: %v", err)
 		}
@@ -2132,13 +2146,18 @@ func TestCompact(t *testing.T) {
 func TestCompactDryRun(t *testing.T) {
 	q, path := newTestQueue(t)
 
-	// Enqueue, fail, and re-enqueue a vessel (failed vessels allow re-enqueue).
+	// Enqueue, fail, then install a duplicate pending record via ReplaceAll
+	// (Enqueue rejects duplicate IDs under I9).
 	if _, err := q.Enqueue(testVessel(1)); err != nil {
 		t.Fatalf("enqueue: %v", err)
 	}
 	helperFailVessel(t, q, "issue-1")
-	if _, err := q.Enqueue(testVessel(1)); err != nil {
-		t.Fatalf("re-enqueue: %v", err)
+	existing, err := q.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if err := q.ReplaceAll(append(existing, testVessel(1))); err != nil {
+		t.Fatalf("replace-all: %v", err)
 	}
 
 	linesBefore := readNonEmptyLines(t, path)

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"context"
+	"errors"
 	"log"
 	"os"
 	"time"
@@ -93,6 +94,15 @@ func (s *Scanner) Scan(ctx context.Context) (ScanResult, error) {
 			}
 
 			enqueued, err := s.Queue.Enqueue(vessel)
+			if errors.Is(err, queue.ErrDuplicateID) {
+				// Changed-fingerprint retry path currently reuses the original
+				// ID, which collides with the failed record (I9). Skip rather
+				// than crash the scan; the correct fix (route through Update
+				// or use RetryID for a new-ID retry) is scanner-side.
+				log.Printf("warn: scanner: duplicate vessel ID %q, skipping", vessel.ID)
+				result.Skipped++
+				continue
+			}
 			if err != nil {
 				return result, err
 			}

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -554,18 +554,23 @@ func TestScanReenqueuesChangedFailedIssue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.Added != 1 {
-		t.Fatalf("expected changed failed issue to be re-enqueued, added=%d", result.Added)
+	// Spec I9 (docs/invariants/queue.md) forbids duplicate IDs. The
+	// changed-fingerprint path currently reuses the original ID, which the
+	// queue now rejects; the scanner logs the collision and skips. The
+	// scanner-side fix (route changed-fingerprint retries through Update or
+	// a RetryID-style new ID) is tracked as a separate gap.
+	if result.Added != 0 {
+		t.Fatalf("expected duplicate-ID re-enqueue to be skipped, added=%d", result.Added)
+	}
+	if result.Skipped != 1 {
+		t.Fatalf("expected duplicate-ID re-enqueue to be counted as skipped, skipped=%d", result.Skipped)
 	}
 	vessels, err := q.List()
 	if err != nil {
 		t.Fatalf("list queue: %v", err)
 	}
-	if len(vessels) != 2 {
-		t.Fatalf("expected 2 queue entries, got %d", len(vessels))
-	}
-	if vessels[1].Meta["source_input_fingerprint"] == oldFingerprint {
-		t.Fatal("expected updated fingerprint for changed issue input")
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 queue entry (duplicate rejected), got %d", len(vessels))
 	}
 }
 


### PR DESCRIPTION
## Summary

Enforces invariant **I9** from `docs/invariants/queue.md` (gap-analysis row I9):
> `∀ v1, v2 ∈ List(). v1.ID = v2.ID ⟹ v1 = v2`. ID is a primary key across the queue.

Before this PR, `Enqueue` checked only `Ref` collisions, not `ID`. Two vessels with the same `ID` was a silent divergence; `FindByID` returned the last match, and every downstream state-machine claim implicitly assumed uniqueness.

## What changed

- New exported sentinel `ErrDuplicateID`.
- `Enqueue` scans for an ID collision after the existing Ref-collision scan and before the append. Ordering preserves I1a (Ref no-op still returns `(false, nil)`); genuine duplicate-ID callers get `(false, ErrDuplicateID)`.
- Scanner's changed-fingerprint retry path now skips + logs on `ErrDuplicateID` (the scanner-side fix to use `RetryID`/`Update` is a separate gap, not in scope here).
- `helperEnqueueFailThenReenqueue` and the two affected `TestCompact*` subtests migrated to `ReplaceAll` (privileged path, per spec I7/I9 ⚠) so they can continue to exercise last-write-wins behavior on deliberately duplicated IDs.
- Removes the unsanctioned `t.Skip` on `TestPropQueueInvariant_I9_UniqueIDs` (PR #591 kept it green but Governance §4 only sanctioned the I5b skip).

Verified by `crosscheck:byfuglien` — HIGH confidence.

## Test plan

- [x] `go test -race ./internal/queue ./internal/runner ./internal/scanner` (passes)
- [x] `TestPropQueueInvariant_I9_UniqueIDs` now unskipped and passing
- [x] Pre-commit hooks (goimports, golangci-lint, go build)
- [ ] CI green

Pre-existing failures in `internal/workflow` (`TestSmoke_S{5,6,7}*` max_turns 30 vs 50) are unrelated to this PR and exist on `main`.