### PR TITLE
fix(queue): enforce terminal-field immutability in UpdateVessel (I2)

### DIFF
--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -73,9 +73,71 @@ var ErrInvalidTransition = errors.New("invalid state transition")
 // must supply unique IDs. Distinct from Ref collision, which is a silent no-op.
 var ErrDuplicateID = errors.New("duplicate vessel ID")
 
+// ErrTerminalImmutable is returned when a caller attempts to mutate a protected
+// field on a sealed terminal vessel (completed, cancelled, timed_out). See
+// docs/invariants/queue.md invariant I2.
+var ErrTerminalImmutable = errors.New("terminal vessel is immutable")
+
 // IsTerminal reports whether s is a terminal vessel state.
 func (s VesselState) IsTerminal() bool {
 	return s == StateCompleted || s == StateFailed || s == StateCancelled || s == StateTimedOut
+}
+
+// isSealedTerminal reports whether s is a terminal state with no legal
+// outgoing transitions (i.e. excluding StateFailed, which permits retry via
+// failed→pending; governed by I3).
+func isSealedTerminal(s VesselState) bool {
+	return s == StateCompleted || s == StateCancelled || s == StateTimedOut
+}
+
+// protectedFieldsEqual returns true when the 19 I2-protected fields on a and b
+// are equal. Meta is intentionally excluded — runner recovery-metadata paths
+// legitimately mutate Meta on terminal vessels. Kept as explicit field-by-field
+// comparison (not reflection) so adding a new protected field is a compile-time
+// decision.
+func protectedFieldsEqual(a, b Vessel) bool {
+	if a.State != b.State ||
+		a.Ref != b.Ref ||
+		a.Source != b.Source ||
+		a.Workflow != b.Workflow ||
+		a.WorkflowDigest != b.WorkflowDigest ||
+		a.WorkflowClass != b.WorkflowClass ||
+		a.Tier != b.Tier ||
+		a.RetryOf != b.RetryOf ||
+		a.Error != b.Error ||
+		a.CurrentPhase != b.CurrentPhase ||
+		a.GateRetries != b.GateRetries ||
+		a.WaitingFor != b.WaitingFor ||
+		a.WorktreePath != b.WorktreePath ||
+		a.FailedPhase != b.FailedPhase ||
+		a.GateOutput != b.GateOutput {
+		return false
+	}
+	if !timePtrEqual(a.StartedAt, b.StartedAt) ||
+		!timePtrEqual(a.EndedAt, b.EndedAt) ||
+		!timePtrEqual(a.WaitingSince, b.WaitingSince) {
+		return false
+	}
+	return stringMapEqual(a.PhaseOutputs, b.PhaseOutputs)
+}
+
+func timePtrEqual(a, b *time.Time) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Equal(*b)
+}
+
+func stringMapEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || bv != v {
+			return false
+		}
+	}
+	return true
 }
 
 type Vessel struct {
@@ -407,6 +469,8 @@ func (q *Queue) UpdateVessel(vessel Vessel) error {
 				if !allowed[vessel.State] {
 					return fmt.Errorf("%w: cannot move vessel %s from %s to %s", ErrInvalidTransition, vessel.ID, previous.State, vessel.State)
 				}
+			} else if isSealedTerminal(previous.State) && !protectedFieldsEqual(previous, vessel) {
+				return fmt.Errorf("%w: cannot mutate protected fields on terminal vessel %s", ErrTerminalImmutable, vessel.ID)
 			}
 			vessels[i] = vessel
 			if err := q.writeAllVessels(vessels); err != nil {

--- a/cli/internal/queue/queue_invariants_prop_test.go
+++ b/cli/internal/queue/queue_invariants_prop_test.go
@@ -268,7 +268,6 @@ func TestPropQueueInvariant_I1a_EnqueueActiveRefIsNoop(t *testing.T) {
 
 // Invariant I2: Terminal records are immutable in place (except failed→pending retry).
 func TestPropQueueInvariant_I2_TerminalImmutability(t *testing.T) {
-	t.Skip("known violation: row I2 in docs/invariants/queue.md gap analysis; UpdateVessel skips transition validation when State unchanged, so terminal vessels can have Error/PhaseOutputs/etc. mutated freely. Remove this Skip when the UpdateVessel guard lands.")
 	rapid.Check(t, func(t *rapid.T) {
 		q, _, cleanup := newPropQueueWithDir(t, "queue-i2-prop")
 		defer cleanup()


### PR DESCRIPTION
## Summary

Enforces invariant **I2** from `docs/invariants/queue.md` (gap-analysis row I2):
> Once `v.State ∈ {completed, cancelled, timed_out}`, no operation may mutate any of the 19 protected fields.

Before this PR, `UpdateVessel` skipped transition validation when `previous.State == vessel.State`, so terminal vessels could have `Error`, `PhaseOutputs`, etc. mutated freely. Silent mutation of terminal records corrupts the audit trail and the compaction dedup key.

## What changed

- New exported sentinel `ErrTerminalImmutable`.
- `UpdateVessel` now rejects same-state mutations on sealed-terminal vessels (`completed`/`cancelled`/`timed_out`) when any protected field differs.
- `Meta` is explicitly excluded — the runner's recovery-metadata persistence path (runner.go:1349, 1363) legitimately mutates `Meta` on terminal vessels and must keep working.
- `failed` remains exempt; I3 governs the `failed → pending` retry path.
- Comparison is explicit field-by-field (no reflection), so adding a new protected field is a compile-time decision.
- Removes the unsanctioned `t.Skip` on `TestPropQueueInvariant_I2_TerminalImmutability`.

Verified by `crosscheck:byfuglien` — HIGH confidence, all four pre/post conditions hold.

## Test plan

- [x] `go test -race ./internal/queue ./internal/runner ./internal/scanner` (passes)
- [x] `TestPropQueueInvariant_I2_TerminalImmutability` now unskipped and passing
- [x] Existing runner recovery-metadata path (Meta-only mutation on terminal) still works
- [ ] CI green

Pre-existing `internal/workflow` max_turns failures unrelated to this PR.