### PR TITLE
fix(queue): retry resets to indistinguishable-from-fresh (I3)

### DIFF
--- a/cli/cmd/xylem/daemon_test.go
+++ b/cli/cmd/xylem/daemon_test.go
@@ -1475,11 +1475,15 @@ func TestReconcileStaleVessels(t *testing.T) {
 		if updated.StartedAt != nil {
 			t.Fatal("expected StartedAt to be cleared")
 		}
-		if updated.CurrentPhase != 2 {
-			t.Fatalf("updated.CurrentPhase = %d, want 2", updated.CurrentPhase)
+		// Spec I3 (docs/invariants/queue.md) extended: running→pending
+		// (orphan reconcile) must reset CurrentPhase/PhaseOutputs/WorktreePath
+		// so the requeued vessel restarts fresh at phase 0 without inheriting
+		// a stale worktree path (loop 202 chdir cascade).
+		if updated.CurrentPhase != 0 {
+			t.Fatalf("updated.CurrentPhase = %d, want 0 (reset on orphan reconcile)", updated.CurrentPhase)
 		}
-		if updated.PhaseOutputs["plan"] != "done" {
-			t.Fatalf("updated.PhaseOutputs[plan] = %q, want done", updated.PhaseOutputs["plan"])
+		if len(updated.PhaseOutputs) != 0 {
+			t.Fatalf("updated.PhaseOutputs = %v, want empty (reset on orphan reconcile)", updated.PhaseOutputs)
 		}
 		if updated.WorktreePath != "" {
 			t.Fatalf("updated.WorktreePath = %q, want empty", updated.WorktreePath)

--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -274,8 +274,17 @@ func resetPendingState(vessel *Vessel, previousState VesselState) {
 	vessel.WaitingFor = ""
 	vessel.FailedPhase = ""
 	vessel.GateOutput = ""
-	if previousState == StateRunning {
+	switch previousState {
+	case StateFailed, StateRunning:
+		// Retry (failed→pending) and orphan reconcile (running→pending) must
+		// restart the workflow from phase 0 with no inherited worktree.
+		// Partial resumes caused the loop-202 chdir cascade.
+		vessel.CurrentPhase = 0
+		vessel.PhaseOutputs = nil
 		vessel.WorktreePath = ""
+	case StateWaiting:
+		// Label-gate resume keeps CurrentPhase, PhaseOutputs, WorktreePath —
+		// same workflow instance continues after the label appears.
 	}
 }
 

--- a/cli/internal/queue/queue_invariants_prop_test.go
+++ b/cli/internal/queue/queue_invariants_prop_test.go
@@ -312,7 +312,6 @@ func TestPropQueueInvariant_I2_TerminalImmutability(t *testing.T) {
 
 // Invariant I3: Retry resets to indistinguishable-from-fresh.
 func TestPropQueueInvariant_I3_RetryResetsCleanly(t *testing.T) {
-	t.Skip("known violation: row I3 in docs/invariants/queue.md gap analysis; resetPendingState does not reset CurrentPhase or PhaseOutputs. Remove this Skip when the reset is extended.")
 	rapid.Check(t, func(t *rapid.T) {
 		q, _, cleanup := newPropQueueWithDir(t, "queue-i3-prop")
 		defer cleanup()

--- a/cli/internal/queue/queue_test.go
+++ b/cli/internal/queue/queue_test.go
@@ -933,14 +933,15 @@ func TestUpdateValidTransitionFailedToPending(t *testing.T) {
 	if got.State != StatePending {
 		t.Fatalf("expected pending after retry, got %q", got.State)
 	}
-	if got.WorktreePath != "/tmp/wt-14" {
-		t.Fatalf("expected WorktreePath preserved, got %q", got.WorktreePath)
+	// Per I3: failed→pending resets to indistinguishable-from-fresh.
+	if got.WorktreePath != "" {
+		t.Fatalf("expected WorktreePath cleared, got %q", got.WorktreePath)
 	}
-	if got.CurrentPhase != 2 {
-		t.Fatalf("expected CurrentPhase preserved, got %d", got.CurrentPhase)
+	if got.CurrentPhase != 0 {
+		t.Fatalf("expected CurrentPhase reset, got %d", got.CurrentPhase)
 	}
-	if got.PhaseOutputs["plan"] != "done" {
-		t.Fatalf("expected PhaseOutputs[plan]=done, got %q", got.PhaseOutputs["plan"])
+	if got.PhaseOutputs != nil {
+		t.Fatalf("expected PhaseOutputs reset, got %v", got.PhaseOutputs)
 	}
 }
 
@@ -990,11 +991,13 @@ func TestUpdateValidTransitionRunningToPending(t *testing.T) {
 	if got.GateOutput != "" {
 		t.Fatalf("expected GateOutput cleared, got %q", got.GateOutput)
 	}
-	if got.CurrentPhase != 2 {
-		t.Fatalf("expected CurrentPhase preserved, got %d", got.CurrentPhase)
+	// Per I3 (policy extension): running→pending (orphan reconcile) must also
+	// reset phase pointer and outputs — partial resume caused loop-202 chdir cascade.
+	if got.CurrentPhase != 0 {
+		t.Fatalf("expected CurrentPhase reset, got %d", got.CurrentPhase)
 	}
-	if got.PhaseOutputs["plan"] != "done" {
-		t.Fatalf("expected PhaseOutputs[plan]=done, got %q", got.PhaseOutputs["plan"])
+	if got.PhaseOutputs != nil {
+		t.Fatalf("expected PhaseOutputs reset, got %v", got.PhaseOutputs)
 	}
 	if got.WorktreePath != "" {
 		t.Fatalf("expected WorktreePath cleared, got %q", got.WorktreePath)


### PR DESCRIPTION
## Summary

Enforces invariant **I3** from `docs/invariants/queue.md` (gap-analysis row I3):
> A vessel transitioned `failed → pending` must have the 11 listed lifecycle fields cleared to zero — partial state leaks cause mid-workflow resumption bugs (loop 202 chdir cascade).

Before this PR, `resetPendingState` cleared 8 of the 11, leaking `CurrentPhase`, `PhaseOutputs`, and sometimes `WorktreePath`. The runner then resumed retries at the non-zero phase pointer, corrupting the retry semantically.

## What changed

`resetPendingState` now uses a switch on `previousState`:

- `StateFailed` and `StateRunning`: clear `CurrentPhase`/`PhaseOutputs`/`WorktreePath` in addition to the existing 8 fields. `StateRunning` is a policy extension for orphan reconcile (loop 202 chdir cascade prevention).
- `StateWaiting`: preserve `CurrentPhase`/`PhaseOutputs`/`WorktreePath`. Label-gate resume (runner.go:574) is a mid-workflow continuation, not a retry, and requires the phase pointer intact.
- Updated `TestUpdateValidTransitionFailedToPending` and `TestUpdateValidTransitionRunningToPending` to match the now-correct semantics.
- Removes the unsanctioned `t.Skip` on `TestPropQueueInvariant_I3_RetryResetsCleanly`.

Verified by `crosscheck:byfuglien` — HIGH confidence, all five I3 clauses hold.

## Test plan

- [x] `go test -race ./internal/queue ./internal/runner ./internal/scanner` (passes)
- [x] `TestPropQueueInvariant_I3_RetryResetsCleanly` now unskipped and passing
- [x] Label-gate resume path (`waiting → pending`) continues to preserve phase state
- [ ] CI green

Pre-existing `internal/workflow` max_turns failures unrelated.