### PR TITLE
fix(workflow): raise implement-harness max_turns to 50 for analyze/plan/test_critic/pr_draft

### DIFF
--- a/.xylem/workflows/implement-harness.yaml
+++ b/.xylem/workflows/implement-harness.yaml
@@ -3,13 +3,13 @@ description: "Implement a harness spec step with verification, testing, and smok
 phases:
   - name: analyze
     prompt_file: .xylem/prompts/implement-harness/analyze.md
-    max_turns: 30
+    max_turns: 50
     tier: high
     noop:
       match: XYLEM_NOOP
   - name: plan
     prompt_file: .xylem/prompts/implement-harness/plan.md
-    max_turns: 30
+    max_turns: 50
     tier: high
   - name: implement
     prompt_file: .xylem/prompts/implement-harness/implement.md
@@ -28,7 +28,7 @@ phases:
       retries: 2
   - name: test_critic
     prompt_file: .xylem/prompts/implement-harness/test_critic.md
-    max_turns: 30
+    max_turns: 50
     tier: med
     gate:
       type: command
@@ -44,7 +44,7 @@ phases:
       retries: 2
   - name: pr_draft
     prompt_file: .xylem/prompts/implement-harness/pr_draft.md
-    max_turns: 30
+    max_turns: 50
     tier: med
     gate:
       type: command


### PR DESCRIPTION
## Summary

- Raises `max_turns` from 30 → 50 for the `analyze`, `plan`, `test_critic`, and `pr_draft` phases of `.xylem/workflows/implement-harness.yaml`
- Fixes three failing CI smoke tests: `TestSmoke_S5_AnalyzePhaseMaxTurnsIs50`, `TestSmoke_S6_PlanPhaseMaxTurnsIs50`, `TestSmoke_S7_OtherPhaseMaxTurnsAreUnchanged`

## Test plan

- [ ] `go test ./internal/workflow/ -run "TestSmoke_S[567]_"` passes (verified locally)
- [ ] Full CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)