### PR TITLE
feat: widen ci-watchdog schedule from 30m to 1h to prevent overlapping runs

### DIFF
--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -928,7 +928,7 @@ func TestSmoke_S11_SelfHostingOverlayContainsCIWatchdogSourceAndWorkflow(t *test
 	var src profileSourceConfig
 	require.NoError(t, yaml.Unmarshal(composed.Sources["ci-watchdog"], &src))
 	assert.Equal(t, "scheduled", src.Type)
-	assert.Equal(t, "30m", src.Schedule)
+	assert.Equal(t, "1h", src.Schedule)
 	assert.Equal(t, "30m", src.Timeout)
 	require.Contains(t, src.Tasks, "monitor-main-ci")
 	assert.Equal(t, "ci-watchdog", src.Tasks["monitor-main-ci"].Workflow)

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -184,7 +184,7 @@ sources:
   ci-watchdog:
     type: scheduled
     repo: "{{ .Repo }}"
-    schedule: "30m"
+    schedule: "1h"
     timeout: "30m"
     tasks:
       monitor-main-ci:


### PR DESCRIPTION
## Summary

Fixes the ci-watchdog schedule/timeout parity bug described in https://github.com/nicholls-inc/xylem/issues/572.

The ci-watchdog scheduled source had `schedule: "30m"` and `timeout: "30m"`, meaning any run that used its full 30-minute budget would still be in-flight when the next scheduled slot fired. The scanner's in-flight guard would then emit "skipping task monitor-main-ci — prior vessel still in flight" on every tick, and if the guard ever failed to catch it, two ci-watchdog vessels could run simultaneously.

This changes the schedule to `"1h"`, giving a 30-minute buffer between the timeout expiry and the next scheduled dispatch.

## Changes

| File | Change |
|------|--------|
| `cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml` | `schedule: "30m"` → `schedule: "1h"` |
| `cli/internal/profiles/profiles_test.go` | Updated `TestSmoke_S11` assertion to expect `"1h"` |

## Smoke scenarios

No formal smoke scenario IDs are assigned to this issue. The existing `TestSmoke_S11_SelfHostingOverlayContainsCIWatchdogSourceAndWorkflow` test validates that the composed profile contains the correct schedule, timeout, workflow, and ref values.

## Test plan

- [x] `go test ./internal/profiles -run TestSmoke_S11` passes with updated assertion
- [x] `go vet ./...` clean
- [x] `go build ./cmd/xylem` succeeds
- [x] `goimports -l .` clean (verified by pre-commit hook)
- [ ] Post-deploy: confirm scanner no longer emits "skipping task monitor-main-ci" on every tick
- [ ] Post-deploy: confirm no two ci-watchdog vessels with `running` state simultaneously for 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #572