### PR TITLE
[lessons] backlog-refinement-report institutional memory updates

### DIFF
--- a/.xylem/HARNESS.md
+++ b/.xylem/HARNESS.md
@@ -127,3 +127,10 @@ Separately, the checked-in self-hosting `merge-pr` workflow remains scoped to
   - `scheduled-release-cadence-label-mature-release-pr-123327` (2026-04-11T12:37:39Z) — `phases/scheduled-release-cadence-label-mature-release-pr-123327/label_ready.output`
   - `scheduled-release-cadence-label-mature-release-pr-123328` (2026-04-11T16:03:34Z) — `phases/scheduled-release-cadence-label-mature-release-pr-123328/label_ready.output`
   - `scheduled-release-cadence-label-mature-release-pr-123329` (2026-04-11T20:01:05Z) — `phases/scheduled-release-cadence-label-mature-release-pr-123329/label_ready.output`
+
+### Do not finish `backlog-refinement` work with phase `report` still failing due to `exit status`. <!-- xylem-lesson:lesson-dc676cf4dc9a -->
+- Rationale: This failure pattern recurred in 2 failed vessels for `backlog-refinement` and should be encoded as institutional memory instead of rediscovered in later runs.
+- Example symptom: exit status 1
+- Evidence:
+  - `scheduled-backlog-refinement-daily-backlog-refinement-246696` (2026-04-15T01:43:22Z) — `phases/scheduled-backlog-refinement-daily-backlog-refinement-246696/report.output`
+  - `scheduled-backlog-refinement-daily-backlog-refinement-246698` (2026-04-15T04:43:34Z) — `phases/scheduled-backlog-refinement-daily-backlog-refinement-246698/report.output`


### PR DESCRIPTION
## Institutional memory updates for backlog-refinement-report

This PR proposes evidence-backed `Do Not` guidance derived from recurring failed vessels.

- `lesson-dc676cf4dc9a` (2 samples, class=unknown, action=human_escalation)

### Proposed HARNESS.md additions

### Do not finish `backlog-refinement` work with phase `report` still failing due to `exit status`. <!-- xylem-lesson:lesson-dc676cf4dc9a -->
- Rationale: This failure pattern recurred in 2 failed vessels for `backlog-refinement` and should be encoded as institutional memory instead of rediscovered in later runs.
- Example symptom: exit status 1
- Evidence:
  - `scheduled-backlog-refinement-daily-backlog-refinement-246696` (2026-04-15T01:43:22Z) — `phases/scheduled-backlog-refinement-daily-backlog-refinement-246696/report.output`
  - `scheduled-backlog-refinement-daily-backlog-refinement-246698` (2026-04-15T04:43:34Z) — `phases/scheduled-backlog-refinement-daily-backlog-refinement-246698/report.output`