### PR TITLE
[lessons] pr-self-review-review institutional memory updates

### DIFF
--- a/.xylem/HARNESS.md
+++ b/.xylem/HARNESS.md
@@ -127,3 +127,10 @@ Separately, the checked-in self-hosting `merge-pr` workflow remains scoped to
   - `scheduled-release-cadence-label-mature-release-pr-123327` (2026-04-11T12:37:39Z) — `phases/scheduled-release-cadence-label-mature-release-pr-123327/label_ready.output`
   - `scheduled-release-cadence-label-mature-release-pr-123328` (2026-04-11T16:03:34Z) — `phases/scheduled-release-cadence-label-mature-release-pr-123328/label_ready.output`
   - `scheduled-release-cadence-label-mature-release-pr-123329` (2026-04-11T20:01:05Z) — `phases/scheduled-release-cadence-label-mature-release-pr-123329/label_ready.output`
+
+### Do not finish `pr-self-review` work with phase `review` still failing due to `exit status`. <!-- xylem-lesson:lesson-f3017bef90ba -->
+- Rationale: This failure pattern recurred in 2 failed vessels for `pr-self-review` and should be encoded as institutional memory instead of rediscovered in later runs.
+- Example symptom: exit status 1
+- Evidence:
+  - `pr-485-pr-self-review` (2026-04-14T18:26:06Z) — `phases/pr-485-pr-self-review/review.output`
+  - `pr-565-pr-self-review` (2026-04-16T11:53:19Z) — `phases/pr-565-pr-self-review/review.output`


### PR DESCRIPTION
## Institutional memory updates for pr-self-review-review

This PR proposes evidence-backed `Do Not` guidance derived from recurring failed vessels.

- `lesson-f3017bef90ba` (2 samples, class=unknown, action=human_escalation)

### Proposed HARNESS.md additions

### Do not finish `pr-self-review` work with phase `review` still failing due to `exit status`. <!-- xylem-lesson:lesson-f3017bef90ba -->
- Rationale: This failure pattern recurred in 2 failed vessels for `pr-self-review` and should be encoded as institutional memory instead of rediscovered in later runs.
- Example symptom: exit status 1
- Evidence:
  - `pr-485-pr-self-review` (2026-04-14T18:26:06Z) — `phases/pr-485-pr-self-review/review.output`
  - `pr-565-pr-self-review` (2026-04-16T11:53:19Z) — `phases/pr-565-pr-self-review/review.output`