### PR TITLE
[lessons] review-pr-analyze institutional memory updates

### DIFF
--- a/.xylem/HARNESS.md
+++ b/.xylem/HARNESS.md
@@ -127,3 +127,12 @@ Separately, the checked-in self-hosting `merge-pr` workflow remains scoped to
   - `scheduled-release-cadence-label-mature-release-pr-123327` (2026-04-11T12:37:39Z) — `phases/scheduled-release-cadence-label-mature-release-pr-123327/label_ready.output`
   - `scheduled-release-cadence-label-mature-release-pr-123328` (2026-04-11T16:03:34Z) — `phases/scheduled-release-cadence-label-mature-release-pr-123328/label_ready.output`
   - `scheduled-release-cadence-label-mature-release-pr-123329` (2026-04-11T20:01:05Z) — `phases/scheduled-release-cadence-label-mature-release-pr-123329/label_ready.output`
+
+### Do not finish `review-pr` work with phase `analyze` still failing due to `exit status`. <!-- xylem-lesson:lesson-a5a8b20d0d3e -->
+- Rationale: This failure pattern recurred in 4 failed vessels for `review-pr` and should be encoded as institutional memory instead of rediscovered in later runs.
+- Example symptom: exit status 1
+- Evidence:
+  - `pr-563-pr-opened` (2026-04-16T11:43:59Z) — `phases/pr-563-pr-opened/analyze.output`
+  - `pr-563-head-9040c84c` (2026-04-16T12:24:05Z) — `phases/pr-563-head-9040c84c/analyze.output`
+  - `pr-563-head-bca47873` (2026-04-16T12:34:34Z) — `phases/pr-563-head-bca47873/analyze.output`
+  - `pr-567-head-46751401` (2026-04-16T13:23:07Z) — `phases/pr-567-head-46751401/analyze.output`


### PR DESCRIPTION
## Institutional memory updates for review-pr-analyze

This PR proposes evidence-backed `Do Not` guidance derived from recurring failed vessels.

- `lesson-a5a8b20d0d3e` (4 samples, class=unknown, action=human_escalation)

### Proposed HARNESS.md additions

### Do not finish `review-pr` work with phase `analyze` still failing due to `exit status`. <!-- xylem-lesson:lesson-a5a8b20d0d3e -->
- Rationale: This failure pattern recurred in 4 failed vessels for `review-pr` and should be encoded as institutional memory instead of rediscovered in later runs.
- Example symptom: exit status 1
- Evidence:
  - `pr-563-pr-opened` (2026-04-16T11:43:59Z) — `phases/pr-563-pr-opened/analyze.output`
  - `pr-563-head-9040c84c` (2026-04-16T12:24:05Z) — `phases/pr-563-head-9040c84c/analyze.output`
  - `pr-563-head-bca47873` (2026-04-16T12:34:34Z) — `phases/pr-563-head-bca47873/analyze.output`
  - `pr-567-head-46751401` (2026-04-16T13:23:07Z) — `phases/pr-567-head-46751401/analyze.output`