### PR TITLE
fix(runner): cancel stale PR vessels in waiting state

### DIFF
--- a/cli/internal/runner/stale_cancel.go
+++ b/cli/internal/runner/stale_cancel.go
@@ -30,12 +30,13 @@ var prSources = map[string]bool{
 	"github-pr-events": true,
 }
 
-// CancelStalePRVessels checks pending vessels that reference pull requests and
-// cancels those whose PRs are already merged or closed. This prevents wasting
-// concurrency slots on work that can never succeed (e.g., merging an already-
-// merged PR, resolving conflicts on a closed PR). Vessels from the
-// github-merge source are excluded because a merged PR is their trigger, not
-// an obsolescence signal.
+// CancelStalePRVessels checks pending and waiting vessels that reference pull
+// requests and cancels those whose PRs are already merged or closed. This
+// prevents wasting concurrency slots on work that can never succeed (e.g.,
+// merging an already-merged PR, resolving conflicts on a closed PR) and
+// releases waiting vessels that are polling for a label on a PR that will
+// never receive it. Vessels from the github-merge source are excluded because
+// a merged PR is their trigger, not an obsolescence signal.
 //
 // Returns the number of vessels cancelled.
 func (r *Runner) CancelStalePRVessels(ctx context.Context) int {
@@ -44,9 +45,18 @@ func (r *Runner) CancelStalePRVessels(ctx context.Context) int {
 		log.Printf("warn: cancel stale PR vessels: list pending: %v", err)
 		return 0
 	}
+	waiting, err := r.Queue.ListByState(queue.StateWaiting)
+	if err != nil {
+		log.Printf("warn: cancel stale PR vessels: list waiting: %v", err)
+		return 0
+	}
+
+	candidates := make([]queue.Vessel, 0, len(pending)+len(waiting))
+	candidates = append(candidates, pending...)
+	candidates = append(candidates, waiting...)
 
 	cancelled := 0
-	for _, vessel := range pending {
+	for _, vessel := range candidates {
 		if !prSources[vessel.Source] {
 			continue
 		}

--- a/cli/internal/runner/stale_cancel_test.go
+++ b/cli/internal/runner/stale_cancel_test.go
@@ -342,6 +342,136 @@ func TestCheckPRState_RespectsTimeout(t *testing.T) {
 	}
 }
 
+func TestCancelStalePRVessels_CancelsWaitingMerged(t *testing.T) {
+	dir := t.TempDir()
+	qPath := filepath.Join(dir, "queue.jsonl")
+	q := queue.New(qPath)
+
+	v := queue.Vessel{
+		ID:        "merge-pr-60",
+		Source:    "github-pr",
+		Ref:       "https://github.com/owner/repo/pull/60",
+		Workflow:  "merge-pr",
+		State:     queue.StatePending,
+		CreatedAt: time.Now(),
+		Meta:      map[string]string{"pr_num": "60", "config_source": "prs"},
+	}
+	if _, err := q.Enqueue(v); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Update(v.ID, queue.StateRunning, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Update(v.ID, queue.StateWaiting, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _ := json.Marshal(map[string]string{"state": "MERGED"})
+	mock := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name == "gh" && len(args) >= 2 && args[0] == "pr" && args[1] == "view" {
+				return resp, nil, true
+			}
+			return nil, nil, false
+		},
+	}
+
+	cfg := &config.Config{
+		Timeout:  "45m",
+		StateDir: dir,
+		Sources: map[string]config.SourceConfig{
+			"prs": {Type: "github-pr", Repo: "owner/repo"},
+		},
+	}
+
+	r := &Runner{
+		Config: cfg,
+		Queue:  q,
+		Runner: mock,
+		Sources: map[string]source.Source{
+			"github-pr": &source.GitHubPR{Repo: "owner/repo"},
+		},
+	}
+
+	cancelled := r.CancelStalePRVessels(context.Background())
+	if cancelled != 1 {
+		t.Errorf("expected 1 cancelled, got %d", cancelled)
+	}
+
+	vessel, err := q.FindByID("merge-pr-60")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vessel.State != queue.StateCancelled {
+		t.Errorf("expected cancelled, got %s", vessel.State)
+	}
+}
+
+func TestCancelStalePRVessels_KeepsWaitingOpen(t *testing.T) {
+	dir := t.TempDir()
+	qPath := filepath.Join(dir, "queue.jsonl")
+	q := queue.New(qPath)
+
+	v := queue.Vessel{
+		ID:        "merge-pr-61",
+		Source:    "github-pr",
+		Ref:       "https://github.com/owner/repo/pull/61",
+		Workflow:  "merge-pr",
+		State:     queue.StatePending,
+		CreatedAt: time.Now(),
+		Meta:      map[string]string{"pr_num": "61", "config_source": "prs"},
+	}
+	if _, err := q.Enqueue(v); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Update(v.ID, queue.StateRunning, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Update(v.ID, queue.StateWaiting, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _ := json.Marshal(map[string]string{"state": "OPEN"})
+	mock := &mockCmdRunner{
+		runOutputHook: func(name string, args ...string) ([]byte, error, bool) {
+			if name == "gh" {
+				return resp, nil, true
+			}
+			return nil, nil, false
+		},
+	}
+
+	cfg := &config.Config{
+		Timeout:  "45m",
+		StateDir: dir,
+		Sources: map[string]config.SourceConfig{
+			"prs": {Type: "github-pr", Repo: "owner/repo"},
+		},
+	}
+
+	r := &Runner{
+		Config: cfg,
+		Queue:  q,
+		Runner: mock,
+		Sources: map[string]source.Source{
+			"github-pr": &source.GitHubPR{Repo: "owner/repo"},
+		},
+	}
+
+	cancelled := r.CancelStalePRVessels(context.Background())
+	if cancelled != 0 {
+		t.Errorf("expected 0 cancelled, got %d", cancelled)
+	}
+
+	vessel, err := q.FindByID("merge-pr-61")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vessel.State != queue.StateWaiting {
+		t.Errorf("expected waiting, got %s", vessel.State)
+	}
+}
+
 func TestExtractPRNumber(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- `CancelStalePRVessels` now queries both `pending` and `waiting` vessels, cancelling any whose PR is already merged or closed
- Previously, vessels suspended by a label gate (`waiting` state) for a merged/closed PR would remain stuck indefinitely, consuming queue capacity and never reaching a terminal state
- Adds two new tests: `TestCancelStalePRVessels_CancelsWaitingMerged` and `TestCancelStalePRVessels_KeepsWaitingOpen`

## Test plan
- [x] All 7 existing + new stale cancel tests pass
- [x] Full runner test suite passes (110s)
- [x] `go vet`, `golangci-lint`, `goimports` clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)