### PR TITLE
fix(merge-pr): replace invalid REST reviewThreads with GraphQL query

### DIFF
--- a/cli/internal/profiles/core/workflows/merge-pr.yaml
+++ b/cli/internal/profiles/core/workflows/merge-pr.yaml
@@ -39,13 +39,24 @@ phases:
       fi
 
       # 3. Review: no CHANGES_REQUESTED decision, all review threads resolved.
-      REVIEW=$(gh pr view "$PR" --repo "$REPO" --json reviewDecision,reviewThreads)
-      DECISION=$(echo "$REVIEW" | jq -r '.reviewDecision')
+      #    reviewThreads is GraphQL-only (not available via gh pr view --json REST).
+      OWNER="${REPO%%/*}"
+      NAME="${REPO##*/}"
+      REVIEW=$(gh api graphql -F owner="$OWNER" -F name="$NAME" -F pr="$PR" -f query='
+        query($owner: String!, $name: String!, $pr: Int!) {
+          repository(owner: $owner, name: $name) {
+            pullRequest(number: $pr) {
+              reviewDecision
+              reviewThreads(first: 100) { nodes { isResolved } }
+            }
+          }
+        }')
+      DECISION=$(echo "$REVIEW" | jq -r '.data.repository.pullRequest.reviewDecision')
       if [ "$DECISION" = "CHANGES_REQUESTED" ]; then
         echo "XYLEM_NOOP: reviewDecision=CHANGES_REQUESTED"
         exit 0
       fi
-      UNRESOLVED=$(echo "$REVIEW" | jq '[.reviewThreads[] | select(.isResolved == false)] | length')
+      UNRESOLVED=$(echo "$REVIEW" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
       if [ "$UNRESOLVED" -gt 0 ]; then
         echo "XYLEM_NOOP: $UNRESOLVED unresolved review thread(s)"
         exit 0

--- a/cli/internal/profiles/profiles_test.go
+++ b/cli/internal/profiles/profiles_test.go
@@ -158,6 +158,12 @@ func TestSmoke_S2_ComposeCoreIncludesSeededWorkflowsAndTemplates(t *testing.T) {
 	var mergePR workflowpkg.Workflow
 	require.NoError(t, yaml.Unmarshal(composed.Workflows["merge-pr"], &mergePR))
 	assert.Equal(t, policy.Ops, mergePR.Class)
+	require.GreaterOrEqual(t, len(mergePR.Phases), 1, "merge-pr must have at least 1 phase")
+	assert.Equal(t, "check", mergePR.Phases[0].Name)
+	assert.NotContains(t, mergePR.Phases[0].Run, "--json reviewDecision,reviewThreads",
+		"check phase must not use gh pr view --json reviewThreads (GraphQL-only field)")
+	assert.Contains(t, mergePR.Phases[0].Run, "gh api graphql",
+		"check phase must use gh api graphql for reviewThreads")
 	assert.Equal(t, 2, fixBug.Phases[2].Evaluator.MaxIterations)
 	assert.Equal(t, 40, fixBug.Phases[0].MaxTurns, "fix-bug analyze max_turns")
 	assert.Equal(t, 40, fixBug.Phases[1].MaxTurns, "fix-bug plan max_turns")


### PR DESCRIPTION
## Summary

Fixes the merge-pr workflow's `check` phase which used `gh pr view --json reviewDecision,reviewThreads` — but `reviewThreads` is a GraphQL-only field not available via the REST-backed `gh pr view --json`. This caused `exit 1` on every invocation, blocking auto-admin-merge for all harness-impl PRs.

Replaces the broken REST call with `gh api graphql` to query `reviewDecision` and `reviewThreads` correctly.

Ref: https://github.com/nicholls-inc/xylem/issues/574

## Changes

### Modified files

- **`cli/internal/profiles/core/workflows/merge-pr.yaml`** — Step 3 (review check) now uses `gh api graphql` with a proper GraphQL query instead of `gh pr view --json reviewDecision,reviewThreads`. Extracts owner/name from `REPO` slug, passes `PR` as Int, and reads results from the nested `.data.repository.pullRequest` path.
- **`cli/internal/profiles/profiles_test.go`** — Added regression assertions in `TestSmoke_S2` verifying the check phase uses `gh api graphql` and does not contain the broken `--json reviewDecision,reviewThreads` field combination.

## Smoke scenarios covered

- **S2-merge-pr-graphql**: `TestSmoke_S2` asserts check phase contains `gh api graphql` (positive)
- **S2-merge-pr-no-rest-reviewThreads**: `TestSmoke_S2` asserts check phase does NOT contain `--json reviewDecision,reviewThreads` (negative regression guard)
- **S7-merge-phase-unchanged**: Existing `TestSmoke_S7_MergePRWorkflowUsesRepoSlugAndAdminFlag` confirms merge phase unaffected by check-phase changes

## Test plan

- [x] `go vet ./...` passes
- [x] `go build ./cmd/xylem` succeeds
- [x] `go test ./...` all packages pass
- [x] `goimports -l .` reports no formatting issues
- [x] Pre-commit hooks pass (foxguard, golangci-lint, yaml check)
- [ ] Daemon picks up updated workflow via auto-upgrade and successfully merges a harness-impl PR through the check phase without `exit 1`

## Out of scope

- DTU shim (`cli/internal/dtushim/shim.go`) accepts `reviewThreads` in its `gh pr view --json` mock — fixing the shim's superset behavior is a separate concern
- Runtime copy at `.xylem/workflows/merge-pr.yaml` is a protected control surface; fix propagates via profile scaffold/auto-upgrade

Fixes #574