### PR TITLE
test(invariants): enforce non-empty bodies on all invariant test functions

### DIFF
--- a/cli/internal/invariants/contract_test.go
+++ b/cli/internal/invariants/contract_test.go
@@ -1,0 +1,44 @@
+package invariants_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInvariantTestBodiesNotEmpty enforces that every Test* function in every
+// *_invariants_prop_test.go file has at least one executable statement.
+// Comment-only or blank bodies are not acceptable — use t.Skip("reason") for
+// aspirational or known-violation tests.
+func TestInvariantTestBodiesNotEmpty(t *testing.T) {
+	files, err := filepath.Glob(filepath.Join("..", "*", "*_invariants_prop_test.go"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no *_invariants_prop_test.go files found — check that the package is in cli/internal/")
+	}
+
+	fset := token.NewFileSet()
+	for _, file := range files {
+		f, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Errorf("parse %s: %v", file, err)
+			continue
+		}
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || !strings.HasPrefix(fn.Name.Name, "Test") {
+				continue
+			}
+			if len(fn.Body.List) == 0 {
+				pos := fset.Position(fn.Pos())
+				t.Errorf("%s: %s has an empty body — add t.Skip(\"reason\") or implement the test",
+					pos, fn.Name.Name)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `cli/internal/invariants/contract_test.go` — a meta-test that uses `go/ast` to parse every `*_invariants_prop_test.go` file and fail if any `Test*` function has zero statements in its body
- Comment-only bodies don't appear in `ast.FuncDecl.Body.List`, so the check is exact — immune to string literals, block comments, and other Go syntax edge cases
- Runs under the existing `go test ./...` CI step; no new job, workflow trigger, or external dependency required
- Aspirational or known-violation tests must use `t.Skip("reason")` — which counts as one statement and passes the check

## Motivation

`TestInvariant_I13` previously had a comment-only body (no executable statements). Go's test runner passes empty tests silently, providing zero enforcement. The fix on main (PR #636) landed a full `rapid.Check` implementation for I13; this PR ensures no future invariant test can regress to a silent empty stub.

## Test plan

- [ ] `cd cli && go test ./internal/invariants/` — passes
- [ ] `cd cli && go test ./...` — no regression in other packages
- [ ] Verify the check would have caught the original empty I13: introduce a temporary empty body and confirm the test fails with a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)