### PR TITLE
feat(source): require_labels gate + github-merge exclude filtering

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -79,11 +79,13 @@ sources:
         tier: high
         on:
           pr_opened: true
+          require_labels: [ready-to-merge]
       review-updated:
         workflow: review-pr
         tier: high
         on:
           pr_head_updated: true
+          require_labels: [ready-to-merge]
       respond-to-review:
         workflow: respond-to-pr-review
         tier: high
@@ -194,6 +196,7 @@ sources:
   harness-post-merge:
     type: github-merge
     repo: "nicholls-inc/xylem"
+    exclude: ["autorelease: tagged", no-bot]
     tasks:
       unblock-deps:
         workflow: unblock-wave

--- a/cli/cmd/xylem/daemon_reload_test.go
+++ b/cli/cmd/xylem/daemon_reload_test.go
@@ -276,7 +276,7 @@ func TestSmoke_S5_DaemonReloadPreservesFrozenWorkflowSnapshot(t *testing.T) {
 	require.NoError(t, os.WriteFile(workflowPath, mutatedWorkflow, 0o644))
 
 	cmdRunner.set([]byte(`[{"number":42,"title":"reload control plane","url":"https://github.com/owner/name/pull/42","mergeCommit":{"oid":"abcdef1234567890"},"headRefName":"control-plane"}]`),
-		"gh", "pr", "list", "--repo", "owner/name", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+		"gh", "pr", "list", "--repo", "owner/name", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName,labels", "--limit", "20")
 	cmdRunner.set([]byte(`{"files":[{"path":".xylem.yml"},{"path":".xylem/workflows/fix-bug.yaml"}]}`),
 		"gh", "pr", "view", "42", "--repo", "owner/name", "--json", "files")
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -182,6 +182,11 @@ type PREventsConfig struct {
 	// never create vessels. AuthorDeny takes precedence over AuthorAllow.
 	AuthorDeny []string `yaml:"author_deny,omitempty"`
 	Debounce   string   `yaml:"debounce,omitempty"`
+	// RequireLabels gates all event-based triggers (pr_opened, pr_head_updated,
+	// checks_failed, review_submitted, commented): a vessel is only created if
+	// the PR carries at least one of the listed labels. Label triggers (the
+	// separate "labels:" field) are not affected by this gate.
+	RequireLabels []string `yaml:"require_labels,omitempty"`
 }
 
 // ActionsConfig filters which GitHub Actions workflow runs trigger a task.

--- a/cli/internal/profiles/core/xylem.yml.tmpl
+++ b/cli/internal/profiles/core/xylem.yml.tmpl
@@ -48,10 +48,12 @@ sources:
         workflow: review-pr
         on:
           pr_opened: true
+          require_labels: [ready-to-merge]
       review-updated:
         workflow: review-pr
         on:
           pr_head_updated: true
+          require_labels: [ready-to-merge]
       respond-to-review:
         workflow: respond-to-pr-review
         on:

--- a/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
+++ b/cli/internal/profiles/self-hosting-xylem/xylem.overlay.yml
@@ -157,6 +157,7 @@ sources:
   harness-post-merge:
     type: github-merge
     repo: "{{ .Repo }}"
+    exclude: ["autorelease: tagged", no-bot]
     tasks:
       unblock-deps:
         workflow: unblock-wave

--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -225,6 +225,7 @@ func (s *Scanner) buildSources() []sourceEntry {
 			entries = append(entries, sourceEntry{
 				src: &source.GitHubMerge{
 					Repo:                srcCfg.Repo,
+					Exclude:             srcCfg.Exclude,
 					Tasks:               mergeTasks,
 					DefaultTier:         s.Config.LLMRouting.DefaultTier,
 					Queue:               s.Queue,
@@ -302,6 +303,7 @@ func convertPREventsTasks(cfgTasks map[string]config.Task) map[string]source.PRE
 			task.PRHeadUpdated = t.On.PRHeadUpdated
 			task.AuthorAllow = t.On.AuthorAllow
 			task.AuthorDeny = t.On.AuthorDeny
+			task.RequireLabels = t.On.RequireLabels
 			task.Debounce = source.UnsetPREventsDebounce
 			if t.On.Debounce != "" {
 				task.Debounce, _ = time.ParseDuration(t.On.Debounce)

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -1381,7 +1381,7 @@ func TestScanMerge(t *testing.T) {
 			HeadRefName: "feature-x",
 		},
 	}
-	r.set(mergedPRJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+	r.set(mergedPRJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName,labels", "--limit", "20")
 
 	s := New(cfg, q, r)
 	result, err := s.Scan(context.Background())

--- a/cli/internal/source/github_merge.go
+++ b/cli/internal/source/github_merge.go
@@ -19,6 +19,7 @@ type MergeTask struct {
 // GitHubMerge scans for merged PRs and produces vessels.
 type GitHubMerge struct {
 	Repo                string
+	Exclude             []string
 	Tasks               map[string]MergeTask
 	DefaultTier         string
 	Queue               *queue.Queue
@@ -30,12 +31,17 @@ type ghMergeCommit struct {
 	OID string `json:"oid"`
 }
 
+type ghMergedPRLabel struct {
+	Name string `json:"name"`
+}
+
 type ghMergedPR struct {
-	Number      int           `json:"number"`
-	Title       string        `json:"title"`
-	URL         string        `json:"url"`
-	MergeCommit ghMergeCommit `json:"mergeCommit"`
-	HeadRefName string        `json:"headRefName"`
+	Number      int               `json:"number"`
+	Title       string            `json:"title"`
+	URL         string            `json:"url"`
+	MergeCommit ghMergeCommit     `json:"mergeCommit"`
+	HeadRefName string            `json:"headRefName"`
+	Labels      []ghMergedPRLabel `json:"labels"`
 }
 
 type ControlPlaneMergeEvent struct {
@@ -47,11 +53,16 @@ type ControlPlaneMergeEvent struct {
 func (g *GitHubMerge) Name() string { return "github-merge" }
 
 func (g *GitHubMerge) Scan(ctx context.Context) ([]queue.Vessel, error) {
+	excludeSet := make(map[string]bool, len(g.Exclude))
+	for _, ex := range g.Exclude {
+		excludeSet[ex] = true
+	}
+
 	args := []string{
 		"pr", "list",
 		"--repo", g.Repo,
 		"--state", "merged",
-		"--json", "number,title,url,mergeCommit,headRefName",
+		"--json", "number,title,url,mergeCommit,headRefName,labels",
 		"--limit", "20",
 	}
 	out, err := g.CmdRunner.Run(ctx, "gh", args...)
@@ -67,6 +78,9 @@ func (g *GitHubMerge) Scan(ctx context.Context) ([]queue.Vessel, error) {
 	var vessels []queue.Vessel
 
 	for _, pr := range prs {
+		if g.hasExcludedLabel(pr, excludeSet) {
+			continue
+		}
 		oid := strings.TrimSpace(pr.MergeCommit.OID)
 		if oid == "" {
 			continue
@@ -108,6 +122,15 @@ func (g *GitHubMerge) Scan(ctx context.Context) ([]queue.Vessel, error) {
 	}
 
 	return vessels, nil
+}
+
+func (g *GitHubMerge) hasExcludedLabel(pr ghMergedPR, excludeSet map[string]bool) bool {
+	for _, l := range pr.Labels {
+		if excludeSet[l.Name] {
+			return true
+		}
+	}
+	return false
 }
 
 func (g *GitHubMerge) listFiles(ctx context.Context, number int) ([]string, error) {

--- a/cli/internal/source/github_merge_test.go
+++ b/cli/internal/source/github_merge_test.go
@@ -34,7 +34,7 @@ func TestMergeScan(t *testing.T) {
 		},
 	}
 	prBytes, _ := json.Marshal(prs)
-	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName,labels", "--limit", "20")
 
 	g := &GitHubMerge{
 		Repo: "owner/repo",
@@ -88,7 +88,7 @@ func TestMergeScanControlPlaneCallback(t *testing.T) {
 		},
 	}
 	prBytes, _ := json.Marshal(prs)
-	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName,labels", "--limit", "20")
 	r.set([]byte(`{"files":[{"path":".xylem/workflows/fix-bug.yaml"},{"path":"README.md"}]}`),
 		"gh", "pr", "view", "20", "--repo", "owner/repo", "--json", "files")
 
@@ -134,7 +134,7 @@ func TestMergeScanControlPlaneCallbackIgnoresNonControlPlaneChanges(t *testing.T
 		},
 	}
 	prBytes, _ := json.Marshal(prs)
-	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName,labels", "--limit", "20")
 	r.set([]byte(`{"files":[{"path":"README.md"},{"path":"docs/guide.md"}]}`),
 		"gh", "pr", "view", "20", "--repo", "owner/repo", "--json", "files")
 
@@ -175,7 +175,7 @@ func TestMergeScanControlPlaneCallbackSkipsDuplicates(t *testing.T) {
 		},
 	}
 	prBytes, _ := json.Marshal(prs)
-	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName,labels", "--limit", "20")
 
 	_, _ = q.Enqueue(queue.Vessel{
 		ID:     "merge-pr-20-abcdef12",
@@ -215,7 +215,7 @@ func TestMergeScanDedup(t *testing.T) {
 		{Number: 20, Title: "merged PR", URL: "https://github.com/owner/repo/pull/20", MergeCommit: ghMergeCommit{OID: "abcdef1234567890"}, HeadRefName: "feature-x"},
 	}
 	prBytes, _ := json.Marshal(prs)
-	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName,labels", "--limit", "20")
 
 	// Pre-enqueue the same merge ref
 	_, _ = q.Enqueue(queue.Vessel{
@@ -249,7 +249,7 @@ func TestMergeScanDedupCompleted(t *testing.T) {
 		{Number: 20, Title: "merged PR", URL: "https://github.com/owner/repo/pull/20", MergeCommit: ghMergeCommit{OID: "abcdef1234567890"}, HeadRefName: "feature-x"},
 	}
 	prBytes, _ := json.Marshal(prs)
-	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName,labels", "--limit", "20")
 
 	// Pre-enqueue and complete the same merge ref
 	_, _ = q.Enqueue(queue.Vessel{
@@ -327,7 +327,7 @@ func TestMergeScanGHError(t *testing.T) {
 	q := queue.New(filepath.Join(dir, "queue.jsonl"))
 	r := newMock()
 
-	r.setErr(fmt.Errorf("network error"), "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+	r.setErr(fmt.Errorf("network error"), "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName,labels", "--limit", "20")
 
 	g := &GitHubMerge{
 		Repo:      "owner/repo",
@@ -354,7 +354,7 @@ func TestMergeScanEmptyOIDSkipped(t *testing.T) {
 		{Number: 30, Title: "no OID", URL: "https://github.com/owner/repo/pull/30", MergeCommit: ghMergeCommit{OID: ""}, HeadRefName: "branch-30"},
 	}
 	prBytes, _ := json.Marshal(prs)
-	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName", "--limit", "20")
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName,labels", "--limit", "20")
 
 	g := &GitHubMerge{
 		Repo:      "owner/repo",
@@ -369,5 +369,73 @@ func TestMergeScanEmptyOIDSkipped(t *testing.T) {
 	}
 	if len(vessels) != 0 {
 		t.Fatalf("expected 0 vessels (empty OID), got %d", len(vessels))
+	}
+}
+
+func TestMergeScanExclude(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghMergedPR{
+		{
+			Number:      40,
+			Title:       "autorelease PR",
+			URL:         "https://github.com/owner/repo/pull/40",
+			MergeCommit: ghMergeCommit{OID: "aabbccdd11223344"},
+			HeadRefName: "release-branch",
+			Labels:      []ghMergedPRLabel{{Name: "autorelease: tagged"}},
+		},
+	}
+	prBytes, _ := json.Marshal(prs)
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName,labels", "--limit", "20")
+
+	g := &GitHubMerge{
+		Repo:    "owner/repo",
+		Exclude: []string{"autorelease: tagged"},
+		Tasks:   map[string]MergeTask{"unblock": {Workflow: "unblock-wave"}},
+		Queue:   q, CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels (excluded label), got %d", len(vessels))
+	}
+}
+
+func TestMergeScanExcludeNotApplied(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghMergedPR{
+		{
+			Number:      41,
+			Title:       "normal PR",
+			URL:         "https://github.com/owner/repo/pull/41",
+			MergeCommit: ghMergeCommit{OID: "1122334455667788"},
+			HeadRefName: "fix-branch",
+			Labels:      []ghMergedPRLabel{{Name: "bug"}},
+		},
+	}
+	prBytes, _ := json.Marshal(prs)
+	r.set(prBytes, "gh", "pr", "list", "--repo", "owner/repo", "--state", "merged", "--json", "number,title,url,mergeCommit,headRefName,labels", "--limit", "20")
+
+	g := &GitHubMerge{
+		Repo:    "owner/repo",
+		Exclude: []string{"autorelease: tagged"},
+		Tasks:   map[string]MergeTask{"unblock": {Workflow: "unblock-wave"}},
+		Queue:   q, CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel, got %d", len(vessels))
 	}
 }

--- a/cli/internal/source/github_pr_events.go
+++ b/cli/internal/source/github_pr_events.go
@@ -29,6 +29,11 @@ type PREventsTask struct {
 	// AuthorDeny takes precedence over AuthorAllow.
 	AuthorDeny []string
 	Debounce   time.Duration
+	// RequireLabels gates all event-based triggers (PROpened, PRHeadUpdated,
+	// ChecksFailed, ReviewSubmitted, Commented): a vessel is only created if
+	// the PR carries at least one of the listed labels. Label triggers are
+	// not affected.
+	RequireLabels []string
 }
 
 // GitHubPREvents scans GitHub PRs for specific events and produces vessels.
@@ -198,6 +203,24 @@ func (g *GitHubPREvents) Scan(ctx context.Context) ([]queue.Vessel, error) {
 							})
 						}
 					}
+				}
+			}
+
+			// Event-based triggers: skip if PR doesn't carry a required label.
+			if len(task.RequireLabels) > 0 {
+				prLabels := make(map[string]bool, len(pr.Labels))
+				for _, l := range pr.Labels {
+					prLabels[l.Name] = true
+				}
+				hasRequired := false
+				for _, rl := range task.RequireLabels {
+					if prLabels[rl] {
+						hasRequired = true
+						break
+					}
+				}
+				if !hasRequired {
+					continue
 				}
 			}
 

--- a/cli/internal/source/github_pr_events_test.go
+++ b/cli/internal/source/github_pr_events_test.go
@@ -1287,3 +1287,87 @@ func TestShouldSkipAuthoredEvent(t *testing.T) {
 		})
 	}
 }
+
+func TestPREventsScanRequireLabelsBlocks(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{
+			Number: 50, Title: "PR without required label",
+			URL:         "https://github.com/owner/repo/pull/50",
+			HeadRefName: "branch-50",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "in-progress"}},
+		},
+	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review-opened": {
+				Workflow:      "review-pr",
+				PROpened:      true,
+				RequireLabels: []string{"ready-to-merge"},
+			},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 0 {
+		t.Fatalf("expected 0 vessels (require_labels not met), got %d", len(vessels))
+	}
+}
+
+func TestPREventsScanRequireLabelsAllows(t *testing.T) {
+	dir := t.TempDir()
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	prs := []ghPR{
+		{
+			Number: 51, Title: "PR with required label",
+			URL:         "https://github.com/owner/repo/pull/51",
+			HeadRefName: "branch-51",
+			Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "ready-to-merge"}},
+		},
+	}
+	r.set(prEventsListJSON(prs), "gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,url,labels,headRefName", "--limit", "50")
+	// scanPROpened reads the PR's creation timestamp
+	r.set([]byte(`[{"createdAt":"2024-01-01T00:00:00Z","headRefOid":"abc123"}]`),
+		"gh", "pr", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,createdAt,headRefOid", "--limit", "50")
+
+	g := &GitHubPREvents{
+		Repo: "owner/repo",
+		Tasks: map[string]PREventsTask{
+			"review-opened": {
+				Workflow:      "review-pr",
+				PROpened:      true,
+				RequireLabels: []string{"ready-to-merge"},
+			},
+		},
+		Queue:     q,
+		CmdRunner: r,
+	}
+
+	vessels, err := g.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Fatalf("expected 1 vessel (require_labels met), got %d", len(vessels))
+	}
+	if vessels[0].Workflow != "review-pr" {
+		t.Errorf("Workflow = %q, want review-pr", vessels[0].Workflow)
+	}
+}


### PR DESCRIPTION
## Summary

- **`review-pr` gap**: `pr-lifecycle` fired on every opened/updated PR (including `autorelease: pending` bot PRs and unlabelled WIP PRs). Fixed by adding `require_labels: [ready-to-merge]` to the `review-opened` and `review-updated` tasks.
- **`unblock-wave` gap**: `github-merge` source had no label-filtering infrastructure — no `Exclude` field, no label fetching. Fixed by adding full exclude support matching the pattern already used by `github-pr` and `github-pr-events`.

## Changes

**Code:**
- `config/config.go`: `RequireLabels []string` added to `PREventsConfig` (`require_labels:` in YAML)
- `source/github_pr_events.go`: `RequireLabels` on `PREventsTask`; gate in `Scan()` skips all event-based triggers if PR lacks a required label (label triggers unaffected)
- `source/github_merge.go`: `Exclude []string` on `GitHubMerge`, `Labels` field on `ghMergedPR`, `hasExcludedLabel()` method, exclude check before vessel creation
- `scanner/scanner.go`: Wires `Exclude` into `GitHubMerge` and `RequireLabels` into `convertPREventsTasks`

**Config (canonical + live materialized):**
- `profiles/core/xylem.yml.tmpl`: `review-opened`/`review-updated` require `ready-to-merge`
- `profiles/self-hosting-xylem/xylem.overlay.yml`: `harness-post-merge` excludes `autorelease: tagged` and `no-bot`
- `.xylem.yml`: Mirrored (EMERGENCY materialized block, live until #555 lands)

## Test plan

- [ ] `TestPREventsScanRequireLabelsBlocks` — `pr_opened` with `require_labels: [ready-to-merge]`, PR has no matching label → 0 vessels
- [ ] `TestPREventsScanRequireLabelsAllows` — same task, PR has `ready-to-merge` → 1 vessel
- [ ] `TestMergeScanExclude` — PR with `autorelease: tagged` in exclude set → 0 vessels
- [ ] `TestMergeScanExcludeNotApplied` — PR with unrelated label → 1 vessel
- [ ] All existing `github_merge_test.go`, `github_pr_events_test.go`, `scanner_test.go`, `daemon_reload_test.go` tests still pass (mock JSON fields updated to include `labels`)
- [ ] `go build ./cmd/xylem`, `go vet ./...`, `goimports -l .` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)