### PR TITLE
docs(assurance): 14-item deterministic-assurance roadmap

### DIFF
--- a/docs/assurance/ROADMAP.md
+++ b/docs/assurance/ROADMAP.md
@@ -1,0 +1,84 @@
+# Xylem Assurance Roadmap
+
+## Purpose
+
+This directory tracks the execution of the **6-layer assurance hierarchy** (see `docs/research/assurance-hierarchy.md` and `docs/research/literature-review.md`) as applied pragmatically to xylem. It exists so the plan survives across long timeframes without depending on conversation context or ephemeral plan files.
+
+Each numbered item below has its own standalone doc under `immediate/`, `next/`, `medium-term/`, or `aspirational/`. That doc is the source of truth for scope, acceptance criteria, and kill criteria — not any issue, PR, or plan file elsewhere.
+
+## Strategic context
+
+The long-term goal is **deterministic AI-driven software development**: formally verified kernels for critical pure logic, contract graphs for integration boundaries, and spec-intent alignment checks for everything else. The full hierarchy lives in `docs/research/assurance-hierarchy.md`.
+
+xylem's current pragmatic projection of that hierarchy:
+
+| Layer | Hierarchy reach | Xylem reach today |
+|-------|-----------------|-------------------|
+| 1: Formally verified pure code | Dafny / Lean 4 | Sequential pure kernels only (queue state machine, retry-DAG, budget gate). Concurrent code stays in Go + property tests. |
+| 2: Compilation correctness | Verified compilation (CompCert) | **No Go CompCert exists.** Trusted Go toolchain. Not addressable. |
+| 3: Contract graph verification | End-to-end subgraph verification | Pairwise contracts near-term. End-to-end subgraph verification is aspirational (item #13). |
+| 4: Implementation–spec alignment | Deterministic (Dafny accepts/rejects) | Delivered by Dafny-verified kernels as they land (#06, #09). |
+| 5: Spec–intent alignment | Probabilistic (claimcheck, ~96%) | `intent-check` workflow phase (#07). |
+| 6: Spec completeness | Best-effort | `spec-adversary` workflow phase (#14), acceptance-oracle (#11). |
+
+## Roadmap
+
+### Immediate (start now)
+
+| # | Item | Cost | Doc |
+|---|------|------|-----|
+| 1 | Enforce `// Invariant IN:` test coverage mapping in CI | 1 day | [immediate/01-invariant-test-coverage-ci.md](immediate/01-invariant-test-coverage-ci.md) |
+| 2 | Fix Queue I9 tautology and enforce ID uniqueness | 1 hour | [immediate/02-fix-queue-i9-tautology.md](immediate/02-fix-queue-i9-tautology.md) |
+| 3 | Naive-reference differential test for queue | 2 days | [immediate/03-naive-reference-differential-test.md](immediate/03-naive-reference-differential-test.md) |
+| 4 | Close 14 partial-coverage gaps in runner property tests | 1–2 weeks | [immediate/04-close-partial-coverage-gaps.md](immediate/04-close-partial-coverage-gaps.md) |
+| 5 | Amend assurance-hierarchy.md with xylem projection section | 2 hours | [immediate/05-hierarchy-xylem-projection.md](immediate/05-hierarchy-xylem-projection.md) |
+
+### Next (4–8 weeks)
+
+| # | Item | Cost | Doc |
+|---|------|------|-----|
+| 6 | Queue state machine Dafny-verified kernel | 1–2 weeks | [next/06-queue-dafny-kernel.md](next/06-queue-dafny-kernel.md) |
+| 7 | `intent-check` workflow phase (claimcheck-analog) | 1 week | [next/07-intent-check-phase.md](next/07-intent-check-phase.md) |
+| 8 | `verify-kernel` workflow phase | 2 days | [next/08-verify-kernel-phase.md](next/08-verify-kernel-phase.md) |
+| 9 | Retry-DAG acyclicity Dafny-verified kernel | 3 days | [next/09-retry-dag-dafny-kernel.md](next/09-retry-dag-dafny-kernel.md) |
+
+### Medium-term (2–3 months)
+
+| # | Item | Cost | Doc |
+|---|------|------|-----|
+| 10 | Gobra concurrency-safety specs for queue | 3–4 weeks | [medium-term/10-gobra-queue.md](medium-term/10-gobra-queue.md) |
+| 11 | `acceptance-oracle` workflow phase | 2 weeks | [medium-term/11-acceptance-oracle-phase.md](medium-term/11-acceptance-oracle-phase.md) |
+| 12 | Naive-reference implementations for gate and source | 1 week | [medium-term/12-gate-source-reference-impls.md](medium-term/12-gate-source-reference-impls.md) |
+
+### Aspirational (scope and commit later)
+
+| # | Item | Cost | Doc |
+|---|------|------|-----|
+| 13 | Go-native contract-graph-verifier (extend existing Rust+Lean PoC) | 2–3 months | [aspirational/13-go-native-cgv.md](aspirational/13-go-native-cgv.md) |
+| 14 | `spec-adversary` workflow phase (Layer 6) | 2 weeks | [aspirational/14-spec-adversary-phase.md](aspirational/14-spec-adversary-phase.md) |
+
+## How to use this directory
+
+**To check status of a roadmap item** — open the item's doc. Each doc carries a `Status` field at the top: `Not started`, `In progress`, `Blocked`, or `Done`. When a PR lands for an item, update the doc's Status and cross-reference the PR number.
+
+**To execute a roadmap item** — the doc is the spec. File a GitHub issue referencing the doc path and apply the appropriate label (`bug` / `enhancement` / `harness-impl`). The xylem daemon drains the issue through its isolated SDLC phases. Do not paste the full doc into the issue body; link to it.
+
+**To propose a new item** — add a new file under the correct horizon directory, add a row to the roadmap table above, and open a PR. The strategic context section above constrains what belongs in this directory: items that move a layer of the assurance hierarchy, not general engineering work.
+
+**To kill or defer an item** — do not delete the doc. Mark `Status: Deferred` with a `Reason:` line and, if applicable, a link to the item that supersedes it. The goal of this directory is that no decision disappears, including negative ones.
+
+## Roadmap-level kill criteria
+
+Stop and re-plan the entire roadmap if any of the following becomes true:
+
+- **Dafny pipeline fails the first kernel (#06).** If crosscheck extraction produces unusable Go after 3 weeks, the whole "verified kernels in Go" thesis is invalidated — rescope before committing to #07–#09.
+- **`intent-check` false-positive rate > 30% (#07).** claimcheck's reported 96.3% was on a curated benchmark. If real-PR FP rate is above 30% after 2 weeks, the Layer 5 strategy needs a different approach.
+- **No Immediate item lands in 4 weeks.** If items #01–#05 are not all merged within 4 weeks of start, the problem is process-level (daemon reliability, model quality, review capacity) — fix that before continuing.
+
+## References
+
+- `docs/research/assurance-hierarchy.md` — the 6-layer hierarchy this roadmap operationalizes
+- `docs/research/literature-review.md` — prior art (GS AI, Kleppmann, Midspiral, Axiom, Harmonic, de Moura, Skomarovsky)
+- `docs/invariants/queue.md`, `scanner.md`, `runner.md` — load-bearing module invariant specs
+- `.claude/rules/protected-surfaces.md` — governance for invariant docs and property tests
+- `CLAUDE.md` — xylem architecture and testing patterns

--- a/docs/assurance/aspirational/13-go-native-cgv.md
+++ b/docs/assurance/aspirational/13-go-native-cgv.md
@@ -1,0 +1,84 @@
+# 13: Go-Native Contract-Graph-Verifier (Extend Existing PoC)
+
+**Horizon:** Aspirational (2–3 months engineering time; scope and commit after #06–#09 validate broader thesis)
+**Status:** Not started
+**Estimated cost:** 2–3 months engineering time
+**Depends on:** #06–#09 (Dafny track must prove the broader thesis before investing in CGV)
+**Unblocks:** Layer 3 end-to-end subgraph verification
+
+## Context
+
+A Rust+Lean contract-graph-verifier proof-of-concept exists at `~/repos/contract-graph-verifier/`. It has:
+
+- A Rust extractor (`src/`) — ruff-based Python AST extraction, Django ORM edge discovery, SQLite-backed contract storage.
+- A Lean checker (`prover/`) — `Types.lean`, `BehaviorModel.lean`, `DependentExpr.lean`, `Translation.lean`, `Checker.lean`, `Composition.lean` — including machine-checked soundness theorems (`checkEdge_sound`, `checkPath_sound`).
+
+The Django-specific bits (Python extractor, `BehaviorModel.lean`) do not port to xylem. The **Lean machinery does**. Specifically: `Types.lean`, `Checker.lean`, `Composition.lean`, and the soundness theorems are contract-level abstractions independent of Django.
+
+Extending the PoC for xylem means:
+- Swap the ruff-based Python extractor for a `go/ast`-based Go extractor.
+- Replace `BehaviorModel.lean` with a Go-specific behavior model (smaller than the Django version — no ORM, no field precision rules; just interface contracts and invariant references).
+- Target the `scanner → queue → runner` 3-node graph.
+
+**Important framing:** this is not a greenfield research project. The Lean soundness work is done and proven. This item is an engineering extension of existing work.
+
+## Scope
+
+**In scope:**
+- `go/ast`-based extractor replacing the Python extractor.
+- Go behavior model replacing `BehaviorModel.lean`.
+- End-to-end verification on the 3-node graph (scanner → queue → runner).
+
+**Out of scope:**
+- New Lean theorems (`checkEdge_sound` and `checkPath_sound` are already proven).
+- Full-repo verification (3 nodes is the target scope).
+- Replacing Dafny kernels (#06, #09) — CGV targets composition boundaries, not leaf kernels.
+
+## Deliverables
+
+Work happens in an external repo (fork of `contract-graph-verifier` — name TBD, e.g. `cgv-xylem`):
+
+1. Rust extractor rewrite targeting `go/ast`.
+2. `prover/GoBehaviorModel.lean` replacing `BehaviorModel.lean`.
+3. End-to-end verification run produces sound-or-counterexample output on the 3-node graph.
+4. Integration with xylem — a `verify-graph` workflow phase invoking the CGV, gating merges on Layer 3 contract compliance.
+
+## Acceptance criteria
+
+- Lean checker returns sound-or-counterexample output on `scanner → queue → runner`.
+- A deliberately introduced contract violation (e.g. `scanner` writing a state `queue` does not accept) is caught.
+- CGV integrates as a workflow phase without exceeding reasonable latency budgets.
+
+## Files to touch
+
+External repo:
+- `src/` — Rust extractor (rewritten).
+- `prover/GoBehaviorModel.lean` — new.
+- `prover/Checker.lean`, `Composition.lean` — reused, unchanged.
+
+Xylem repo (only at the final integration step):
+- New `.xylem/prompts/verify-graph/*.md` and workflow YAML updates.
+
+## Risks
+
+- **Multi-week scope.** Commit to this item only after #06–#09 prove the broader deterministic-assurance thesis.
+- **Impedance mismatch between Go types and Lean types.** Needs careful translation in `GoBehaviorModel.lean`.
+- **Maintenance burden of a separate repo.** Keep extractor output stable; only the behavior model evolves with xylem.
+
+## Kill criteria
+
+- If #06–#09 fail or are abandoned, re-assess whether CGV is worth the investment.
+- If after 6 weeks the Go extractor cannot produce a usable graph, back out.
+
+## Execution notes
+
+**Same-LLM review concern:** Lean work is out of scope for any LLM-assisted track. Rust extractor rewrite is in scope but must be human-reviewed given the soundness-of-extraction implications.
+
+**Protected surfaces:** Eventual workflow YAML integration would require governance notes; the majority of work happens in the external repo.
+
+## References
+
+- `~/repos/contract-graph-verifier/README.md` (the PoC)
+- `~/repos/contract-graph-verifier/prover/Composition.lean` (reusable soundness theorems)
+- `docs/research/assurance-hierarchy.md` §Layer 3
+- `docs/research/literature-review.md` §de Moura (Veil as precedent for protocol-level graph verification)

--- a/docs/assurance/aspirational/14-spec-adversary-phase.md
+++ b/docs/assurance/aspirational/14-spec-adversary-phase.md
@@ -1,0 +1,67 @@
+# 14: `spec-adversary` Workflow Phase (Layer 6)
+
+**Horizon:** Aspirational
+**Status:** Not started
+**Estimated cost:** 2 weeks (implementation) + ongoing iteration
+**Depends on:** #07 (intent-check plumbing reused)
+**Unblocks:** nothing — Layer 6 is open-ended
+
+## Context
+
+Layer 6 of the assurance hierarchy — spec completeness — has no production tool that works well today. Kleppmann and de Moura both frame it as the unresolved frontier. The idea in the literature-review companion work: an adversarial LLM proposes candidate invariants the current spec lacks; a human reviews; ratified invariants become new entries in `docs/invariants/*.md`.
+
+This is explicitly an iterative practice, not a deterministic tool. The phase exists to lower the cost of discovering "properties we should have specified but did not." Success is not "zero missed properties" — success is "the adversary proposes at least one non-obvious candidate on each meaningful change."
+
+## Scope
+
+**In scope:**
+- New workflow phase `spec-adversary` run during `analyze` for protected-surface changes (or as a standalone workflow triggered by a `needs-adversary-review` label).
+- Adversary prompt — gets the touched module's invariant doc and current code; asked to propose properties that could hold but are not documented.
+- PR comment format — proposed properties listed with "accept / reject / defer" radio buttons the human fills in during review.
+
+**Out of scope:**
+- Automated promotion into invariant docs — always requires human review and governance note.
+- Adversary proposals on green-path PRs — only runs when protected surfaces are touched.
+- Replacing `intent-check`. `intent-check` verifies the spec matches the code. `spec-adversary` asks what the spec is missing. Complementary.
+
+## Deliverables
+
+1. `.xylem/prompts/spec-adversary/propose.md`.
+2. Phase integration in the core profile (likely as a post-implement sub-phase or a standalone workflow).
+3. PR comment template.
+4. Acceptance criterion tracker — log of proposals, acceptance rate, signal-to-noise ratio.
+
+## Acceptance criteria
+
+- Seeded-gap test case: given a module with a known missing invariant, adversary proposes it (or something close).
+- Real-PR signal-to-noise ratio ≥ 1:5 after 4 weeks of operation. Kill otherwise.
+- At least one ratified new invariant promoted into `docs/invariants/*.md` via the adversary within the first 8 weeks.
+
+## Files to touch
+
+- **New:** `.xylem/prompts/spec-adversary/*.md`
+- **Modified:** workflow YAMLs (**PROTECTED**).
+- **Modified over time:** `docs/invariants/*.md` as ratified proposals land (**PROTECTED** — each requires governance note).
+
+## Risks
+
+- **Low signal-to-noise.** Likely. Kill criterion is strict.
+- **Promotion bypass.** If a ratified proposal is promoted without sufficient review, the invariant doc is polluted. Mitigate by requiring `pr-self-review` (claude-opus) AND human review for every new invariant entry.
+- **Reviewer fatigue.** If adversary proposes 20 properties per PR, humans will rubber-stamp. Cap adversary output at 3 proposals per PR.
+
+## Kill criteria
+
+- Signal-to-noise < 1:5 after 4 weeks.
+- No ratified proposals land within 8 weeks.
+
+## Execution notes
+
+**Protected surfaces:** Invariant docs and workflow YAMLs. Multiple governance notes required.
+
+**Same-LLM review concern:** This phase *is* a form of adversarial review. Its output must still be reviewed by a claude-opus `pr-self-review` or a human, not accepted blindly.
+
+## References
+
+- `docs/research/literature-review.md` §closing paragraphs on Layer 6 and spec completeness
+- `docs/research/assurance-hierarchy.md` §Layer 6
+- `docs/assurance/next/07-intent-check-phase.md` (plumbing precedent)

--- a/docs/assurance/immediate/01-invariant-test-coverage-ci.md
+++ b/docs/assurance/immediate/01-invariant-test-coverage-ci.md
@@ -1,0 +1,73 @@
+# 01: Enforce Invariant↔Test Coverage Mapping in CI
+
+**Horizon:** Immediate
+**Status:** Not started
+**Estimated cost:** 1 day
+**Depends on:** nothing
+**Unblocks:** #02, #03, #04 (coverage gate catches regressions for all subsequent invariant work)
+
+## Context
+
+`docs/invariants/queue.md` §Governance.2 already requires every property test to carry a `// Invariant IN: <Name>` comment linking it to the spec entry. There is no CI check that enforces this. The scanner, runner, and queue invariant docs all have the same governance rule, and it is silently unenforced across all three.
+
+This is the cheapest intervention that structurally closes the "silent test drop" failure mode: if an invariant exists in the doc but has no corresponding `// Invariant IN:` comment in a property test, the AI can claim coverage that does not exist. A mechanical check removes that possibility.
+
+## Scope
+
+**In scope:**
+- A script (Go tool under `cli/cmd/` or Python script under `scripts/`) that parses all invariant IDs from `docs/invariants/*.md` and verifies each ID is referenced by at least one `// Invariant IN: <ID>` comment in a `*_invariants_prop_test.go` file.
+- The script must also fail if a property test comment references an invariant ID that does not exist in any invariant doc.
+- Pre-commit hook that runs the script on `docs/invariants/*` or `*_invariants_prop_test.go` changes.
+- CI workflow step that runs the script on every PR.
+
+**Out of scope:**
+- Fixing missing coverage — that is item #04 for runner, and will be identified per-module as the check surfaces gaps.
+- Changing the `// Invariant IN:` comment format.
+- Running the property tests themselves — unit test execution stays as-is.
+
+## Deliverables
+
+1. New file `scripts/check_invariant_coverage.py` (or Go equivalent under `cli/cmd/xylem-check-invariants/main.go`). Prefer Go if the existing toolchain makes it easy to expose as a `go run` target.
+2. Pre-commit hook entry under `.pre-commit-config.yaml` (if one exists) or `.git/hooks/pre-commit` invocation via whatever mechanism this repo uses.
+3. CI workflow addition in `.github/workflows/*.yml` — a step that calls the script.
+4. Documentation update in `docs/invariants/queue.md` (or a new `docs/invariants/README.md`) pointing to the enforcement mechanism so the governance rule is no longer stating an unenforced requirement.
+
+## Acceptance criteria
+
+- CI fails on a PR that adds a new invariant to any doc without a covering test comment.
+- CI fails on a PR that deletes or renames a `// Invariant IN:` comment while the invariant still exists in the doc.
+- CI fails on a PR that adds a `// Invariant IN: IX` comment where `IX` is not in any doc.
+- Script runs in under 10 seconds across all three modules.
+- The invariant docs no longer state a governance rule that is not mechanically enforced.
+
+## Files to touch
+
+- **New:** `scripts/check_invariant_coverage.py` or `cli/cmd/xylem-check-invariants/main.go`
+- **New:** CI workflow step (likely in `.github/workflows/go-checks.yml` or similar)
+- **Modified:** pre-commit hook config if one exists
+- **Modified (minor, doc-only):** `docs/invariants/queue.md` §Governance.2 (pointer to mechanical check)
+- **Read-only (input):** `docs/invariants/*.md`, `cli/internal/*/invariants_prop_test.go`, `cli/internal/*/*_invariants_prop_test.go`
+
+## Risks
+
+- **False positives on comment format variations.** Mitigate with a strict regex and documented format. Reject variations like `// Invariant: IN` or `// IN:` — the format must be exactly `// Invariant IN: <Name>`.
+- **Invariant IDs with sub-labels (e.g. `I1a`, `I5b`) may confuse naive parsing.** Mitigate by parsing header lines in the docs strictly — anything matching `^### I\d+[a-z]?: .+` is an invariant header.
+- **New invariants that are intentionally not-yet-covered (e.g. aspirational) will fail CI.** Mitigate by supporting an opt-out marker in the doc (e.g. `<!-- aspirational -->` on the header line) and documenting it.
+
+## Kill criteria
+
+Stop and re-plan if:
+- After 4 weeks, the check produces more noise than signal (false positives, flakiness, slow builds).
+- The script takes more than 2 days to build, indicating the problem is more complex than assumed and needs different tooling.
+
+## Execution notes
+
+**Same-LLM review concern:** This item is low-risk — the script is mechanical. A gpt-5-mini implementation followed by claude-opus `pr-self-review` is sufficient separation for this scope. No need for human review of the generated script if the acceptance criteria (which are mechanical) all pass.
+
+**Protected surfaces:** None. Only adds new files and non-invasive CI steps. `.claude/rules/protected-surfaces.md` is not touched.
+
+## References
+
+- `docs/invariants/queue.md` §Governance.2 (source of the enforcement requirement)
+- `docs/invariants/scanner.md`, `docs/invariants/runner.md` (parallel docs with same rule)
+- `.claude/rules/protected-surfaces.md` (classifies invariant docs and property tests as protected)

--- a/docs/assurance/immediate/02-fix-queue-i9-tautology.md
+++ b/docs/assurance/immediate/02-fix-queue-i9-tautology.md
@@ -1,0 +1,77 @@
+# 02: Fix Queue I9 Tautology and Enforce ID Uniqueness
+
+**Horizon:** Immediate
+**Status:** Not started
+**Estimated cost:** 1 hour
+**Depends on:** nothing
+**Unblocks:** nothing, but provides a live example of the adversarial-test pattern for #04
+
+## Context
+
+`docs/invariants/queue.md` defines I9 as "Unique IDs — no two vessels in the queue share the same `ID`." The invariant doc explicitly notes that this is **not enforced in code today**: `Enqueue` checks only `Ref`, not `ID`.
+
+The corresponding property test `TestPropQueueInvariant_I9_UniqueIDs` (in `cli/internal/queue/queue_invariants_prop_test.go`, around lines 700–760) passes — but it passes **vacuously**. It draws mutating ops via `drawMutatingOp`, which already relies on `Ref`-based dedup. The test never constructs the scenario it claims to cover (two vessels with same ID + different Ref). This is textbook test theatre: the test executes without failing, the coverage looks green, and the invariant is not actually checked.
+
+This is the canonical concrete example of the concern that motivated the full roadmap. Fixing it is a one-hour change that also seeds the adversarial-test pattern for #04.
+
+## Scope
+
+**In scope:**
+- Rewrite `TestPropQueueInvariant_I9_UniqueIDs` to **explicitly** construct a scenario that would violate I9 if the invariant were not enforced: enqueue two vessels with the same `ID` and different `Ref`, and assert that the second enqueue is rejected (or that `List()` still contains only one).
+- Add ID-uniqueness enforcement to `queue.Enqueue` (one-line guard): if a vessel with the same `ID` already exists in the queue, return an error.
+- Update `docs/invariants/queue.md` to remove the "not enforced in code" note on I9.
+
+**Out of scope:**
+- Re-auditing other invariants for similar tautologies. Item #04 covers runner audits; a follow-up could cover queue/scanner.
+- Changing the `Enqueue` signature or semantics beyond adding the ID-uniqueness check.
+
+## Deliverables
+
+1. Modified `cli/internal/queue/queue_invariants_prop_test.go`: rewritten I9 test that is **RED** against the current `queue.Enqueue` implementation.
+2. Modified `cli/internal/queue/queue.go`: one-line ID-uniqueness guard in `Enqueue`.
+3. Modified `docs/invariants/queue.md`: remove the "not enforced in code" annotation on I9.
+
+## Acceptance criteria
+
+- With the test change alone (no `queue.go` change): `go test ./cli/internal/queue -run TestPropQueueInvariant_I9_UniqueIDs` fails deterministically.
+- After the `queue.Enqueue` fix lands: the test passes.
+- After merge: the invariant doc no longer states I9 is unenforced.
+
+## Files to touch
+
+- `cli/internal/queue/queue_invariants_prop_test.go` (**PROTECTED** — see note below)
+- `cli/internal/queue/queue.go`
+- `docs/invariants/queue.md` (**PROTECTED** — see note below)
+
+## Protected-surface note
+
+`.claude/rules/protected-surfaces.md` protects both `docs/invariants/queue.md` and `cli/internal/queue/queue_invariants_prop_test.go` against modifications that **relax** an invariant to make a failing test pass. This change is the opposite: **strengthening** a tautological test to actually verify the invariant, plus strengthening the invariant's enforcement in code to match the doc's intent.
+
+The PR description must explicitly state:
+1. The test is being strengthened, not relaxed.
+2. The invariant doc update removes a note about unenforced behavior — it does not weaken any claim.
+3. The code change (`queue.Enqueue` guard) aligns behavior with the invariant doc, not the other way around.
+
+Include the queue.md §Governance heading in the PR body so reviewers confirm compliance.
+
+## Risks
+
+- **Existing callers may rely on `Enqueue` silently accepting duplicate IDs** (unlikely given the invariant-doc claim, but possible). Mitigate by grepping for `Enqueue` call sites and confirming none depend on duplicate-ID behavior.
+- **Rapid generators for other I tests may now fail** if they relied on duplicate IDs being acceptable. Mitigate by running the full property-test suite after the `Enqueue` fix.
+
+## Kill criteria
+
+None — the change is small enough that risk is bounded. If the code fix causes unrelated failures, revert the code change and ship the test change alone (with the test marked RED and a TODO linking here).
+
+## Execution notes
+
+**Same-LLM review concern:** Because this touches a protected surface, `pr-self-review` (claude-opus) must explicitly verify that the test is stronger, not weaker, than before. The review prompt should cross-check the new test structure against §Governance.2 of queue.md.
+
+**Manual-review override:** If the xylem workflow surfaces any doubt about the protected-surface check, route to human review before merge rather than merging on `pr-self-review` approval alone.
+
+## References
+
+- `docs/invariants/queue.md` §I9 (the invariant)
+- `cli/internal/queue/queue_invariants_prop_test.go` `TestPropQueueInvariant_I9_UniqueIDs` (the test to fix)
+- `cli/internal/queue/queue.go` `Enqueue` (the code to update)
+- `.claude/rules/protected-surfaces.md` (governance classification)

--- a/docs/assurance/immediate/03-naive-reference-differential-test.md
+++ b/docs/assurance/immediate/03-naive-reference-differential-test.md
@@ -1,0 +1,75 @@
+# 03: Naive-Reference Differential Test for Queue
+
+**Horizon:** Immediate
+**Status:** Not started
+**Estimated cost:** 2 days
+**Depends on:** nothing (independent of #01–#02, though benefits from #01 landing first)
+**Unblocks:** #12 (same pattern applied to gate and source)
+
+## Context
+
+de Moura's observation — *"an inefficient program that is obviously correct can serve as its own specification"* — gives xylem a Layer-1-adjacent assurance step that requires **zero new tooling**. Write a stupid O(n), single-file, in-memory reference queue that models every documented invariant naively, and differential-test the real queue against it under `rapid`-generated op sequences. Any divergence in observable state (`List()` output, `Dequeue` result, `Stats()` counters) indicates either a real-queue bug or a reference-queue bug, and the naive reference is easy enough to eyeball-verify that the burden falls on the real queue.
+
+This is the single highest-value, lowest-cost intervention in the whole roadmap. It does not require Dafny, Gobra, claimcheck, or any new workflow phase. It catches everything the partial-coverage property tests miss — because the reference encodes the full specification, not a hand-picked set of invariants.
+
+## Scope
+
+**In scope:**
+- A new package `cli/internal/queue/reference/` with a single-file, in-memory, O(n) correct-by-construction reference queue.
+- The reference must implement the same public interface as `cli/internal/queue/queue.go` (or a strict subset: `Enqueue`, `Dequeue`, `List`, `UpdateState`, `UpdatePhase`, `Cancel`, plus whatever else is needed to mirror the real queue's externally observable behavior).
+- A differential test `cli/internal/queue/reference/differential_test.go` using `pgregory.net/rapid` that:
+  - Generates a sequence of mutating ops.
+  - Applies each op to both the real queue (under a temp dir) and the reference.
+  - Compares `List()` output (and any other accessors touched) after every mutation.
+  - Fails if outputs diverge.
+
+**Out of scope:**
+- Applying the pattern to other modules (gate, source) — that is #12.
+- Replacing the existing invariant property tests — this is additive.
+- Modeling concurrency — the reference is single-threaded. Differential test serializes ops.
+
+## Deliverables
+
+1. `cli/internal/queue/reference/reference.go` — naive implementation. No optimizations. Clarity dominates performance.
+2. `cli/internal/queue/reference/differential_test.go` — `TestProp_DifferentialAgainstReal` using rapid.
+3. `cli/internal/queue/reference/README.md` — explains why the reference exists (de Moura pattern), what it does NOT model (concurrency, durability, crash recovery), and when to update it.
+
+## Acceptance criteria
+
+- Rapid finds no divergence across 10,000+ iterations (`rapid.Check` default) with a non-trivial op mix.
+- The reference implementation is under 200 lines of Go (if larger, it is not naive enough).
+- The differential test runs in under 30 seconds in CI.
+- A deliberately introduced bug in `cli/internal/queue/queue.go` (e.g. swapping the order of two operations in `UpdateState`) is caught by the differential test.
+
+## Files to touch
+
+- **New:** `cli/internal/queue/reference/reference.go`
+- **New:** `cli/internal/queue/reference/differential_test.go`
+- **New:** `cli/internal/queue/reference/README.md`
+- **Read-only (input):** `cli/internal/queue/queue.go` (the interface to mirror)
+- **Read-only (input):** `docs/invariants/queue.md` (the invariants the reference must honor)
+
+## Risks
+
+- **The reference itself has bugs.** This is the main risk. Mitigate by (a) keeping it absurdly simple and short, (b) requiring code review focused specifically on reference correctness (not the differential test), (c) cross-checking reference behavior against the invariant doc line-by-line in the review.
+- **Interface drift between real queue and reference.** Mitigate by defining a small test-only interface in the reference package that both types satisfy, and asserting at compile time.
+- **Concurrency surface not modeled.** This is documented as out of scope. The reference cannot catch race conditions — those remain covered by `go test -race` and the real queue's property tests. Call this out explicitly in `README.md`.
+- **Mutating-op generator (`drawMutatingOp`) may already have tautological shortcuts** (see I9 for a concrete example). Use a fresh generator inside `differential_test.go` that does **not** short-circuit via the real queue's dedup.
+
+## Kill criteria
+
+- If after 3 days the differential test still cannot be made deterministic (for reasons other than finding real bugs), re-scope to a smaller interface subset or drop the item.
+- If more than 200 lines of reference code are required to cover the interface honestly, the real queue's interface is too wide — split first, then reference.
+
+## Execution notes
+
+**Same-LLM review concern:** This is the most sensitive Immediate item from a review-model standpoint. The whole point is that the reference is "obviously correct" — but *to whom?* If gpt-5-mini writes the reference and claude-opus reviews it, we are relying on the review catching any subtle errors. For this item specifically, surface the reference code in the PR body and recommend a human eyeball-check before merge rather than relying solely on `pr-self-review`.
+
+**Protected surfaces:** None directly. The reference is new code and does not touch the existing property tests.
+
+## References
+
+- `docs/research/assurance-hierarchy.md` §Layer 1 (formally-verified pure code)
+- `docs/research/literature-review.md` §de Moura (2026) — source of the "obviously correct is its own spec" pattern
+- `cli/internal/queue/queue.go` (the system under test)
+- `cli/internal/queue/queue_invariants_prop_test.go` (existing property tests the differential test complements)

--- a/docs/assurance/immediate/04-close-partial-coverage-gaps.md
+++ b/docs/assurance/immediate/04-close-partial-coverage-gaps.md
@@ -1,0 +1,93 @@
+# 04: Close Partial-Coverage Gaps in Runner Property Tests
+
+**Horizon:** Immediate
+**Status:** Not started
+**Estimated cost:** 1–2 weeks (6 small PRs)
+**Depends on:** #01 (coverage CI helps catch regression after each PR lands)
+**Unblocks:** #10 (Gobra needs a clean invariant-test baseline first)
+
+## Context
+
+An audit of `cli/internal/runner/runner_invariants_prop_test.go` (conducted during the research phase that produced this roadmap) found 14 partial-coverage gaps. "Partial" here means the property test exists and references the invariant via `// Invariant IN:` comment, but the test's generator or assertion does not exercise the full behavior the invariant describes.
+
+The six highest-impact gaps, selected because each one is small enough to fit in a single PR, each corresponds to one invariant, and each is independently mergeable:
+
+| Gap | Invariant | Symptom |
+|-----|-----------|---------|
+| A | Runner I1 (per-class concurrency) | Test exercises global concurrency cap but not per-class slot accounting. |
+| B | Runner I3 (mid-phase cancellation) | Test cancels only at phase boundaries; cancel during phase execution is not covered. |
+| C | Runner I6 (label gate waiting) | Test asserts `waiting` state transition but does not sample the label poll interval. |
+| D | Runner I8 (mid-run sampling) | Test asserts pre/post state but does not sample state during a long-running vessel. |
+| E | Runner I11 (`CheckStalledVessels`) | Test asserts output but never traverses the full stalled-vessel path that `CheckStalledVessels` guards. |
+| F | Runner I14 (rehydration after restart) | Test does not exercise the rehydration code path — it asserts on state that would be reconstructed but was never dehydrated. |
+
+## Scope
+
+**In scope:**
+- One PR per gap (A–F). Each PR:
+  - Strengthens the corresponding property test so it actually exercises the invariant's full behavior.
+  - Must be **RED** against the current `runner` code if the invariant is not enforced, or **GREEN** if the code is correct and only the test was too weak.
+  - Must land independently — no cross-PR dependencies.
+
+**Out of scope:**
+- Queue invariant audit (I9 is #02; a broader queue audit is a follow-up item not yet scoped).
+- Scanner invariant audit (S1–S8 are all covered per the initial audit; S4/S5 are correctly `t.Skip`'d against known code violations).
+- Runner invariants I4, I7, I9 — these are correctly `t.Skip`'d against documented-pending code work. Do not re-enable them here.
+
+## Deliverables
+
+Six merged PRs, one per gap. Each PR must include:
+1. The strengthened property test (touching `cli/internal/runner/runner_invariants_prop_test.go` — **PROTECTED**).
+2. If the test reveals a code bug: the minimal fix in `cli/internal/runner/`.
+3. If the test reveals only a gap in the test itself (no code bug): the PR description must explicitly state that no code change was required and why the weaker test was not catching the full invariant.
+4. A reference to `docs/invariants/runner.md` § for the invariant in question, confirming the strengthened test now exercises the full scope.
+
+## Acceptance criteria
+
+Per PR:
+- `go test ./cli/internal/runner -run <TestName>` against the test change alone (no code change) either: (a) fails RED because the invariant is not enforced, then passes GREEN after the code fix; or (b) passes because the invariant is already correctly enforced and the original test was too weak.
+- The PR cannot be "passed by making the test trivially true." This is explicitly checked by `pr-self-review` in the governance-note section of the PR description.
+
+Across all six:
+- All six PRs merged within 2 weeks of start.
+- No regressions in non-runner test suites.
+- Coverage CI (#01, if landed) does not flag new uncovered invariants.
+
+## Files to touch
+
+- `cli/internal/runner/runner_invariants_prop_test.go` (**PROTECTED** — strengthening only, not relaxing)
+- `cli/internal/runner/runner.go` and supporting files (as needed per gap)
+- No doc changes expected unless an invariant's §"current limitations" section needs updating after a code fix lands.
+
+## Protected-surface note
+
+Each PR touches a protected property-test file. Same rules as #02:
+- PR description must explicitly state the test is being strengthened.
+- Must cite `docs/invariants/runner.md` §Governance.
+- `pr-self-review` prompt must verify strengthening, not relaxation.
+
+If `pr-self-review` (claude-opus) cannot confidently certify strengthening, the PR routes to human review.
+
+## Risks
+
+- **Gap B (mid-phase cancellation) may require runner-harness changes** to make mid-phase cancel observable. If so, factor out the harness change as a separate preparatory PR.
+- **Gap F (rehydration after restart) is state-machine-heavy** and could overlap with #10 (Gobra). Keep it isolated — ship the property test as a rapid test, do not jump to formal specs in this item.
+- **One PR may block another if they touch the same test-helper function.** Order by dependency: A → E → others (A is pure generator change; E touches the stalled-vessel helper; others are independent).
+
+## Kill criteria
+
+- If after 2 weeks fewer than 4 of the 6 PRs are merged, stop and re-plan — the remaining gaps may not be "partial" but actually "deferred by design."
+- If any gap reveals an invariant that is not implementable without a significant refactor, close the gap as a separate feature issue and mark the roadmap item's status `Partially done — N/6`.
+
+## Execution notes
+
+**Parallelizable within xylem:** Each gap can be filed as its own GitHub issue with the `bug` label (the gap is a test bug — or a code bug if the strengthened test fails). The xylem daemon will pick them up in parallel via `fix-bug` workflow.
+
+**Same-LLM review concern:** Runner code is more complex than queue; PRs that only strengthen tests are low-risk, but PRs that fix code bugs discovered by the strengthened test must go through `pr-self-review` AND a human eyeball on the code fix before merge.
+
+## References
+
+- `docs/invariants/runner.md` §I1, I3, I6, I8, I11, I14 (invariant definitions)
+- `cli/internal/runner/runner_invariants_prop_test.go` (tests to strengthen)
+- `.claude/rules/protected-surfaces.md` (governance)
+- `docs/invariants/runner.md` §Governance (strengthening rules)

--- a/docs/assurance/immediate/05-hierarchy-xylem-projection.md
+++ b/docs/assurance/immediate/05-hierarchy-xylem-projection.md
@@ -1,0 +1,101 @@
+# 05: Amend Assurance Hierarchy With Xylem Projection Section
+
+**Horizon:** Immediate
+**Status:** Not started
+**Estimated cost:** 2 hours
+**Depends on:** nothing
+**Unblocks:** everything that cites the hierarchy as its north star
+
+## Context
+
+`docs/research/assurance-hierarchy.md` describes the 6-layer hierarchy as a research framework. It deliberately does not tie itself to any specific ecosystem, so it does not state the current concrete tooling reach for xylem.
+
+Without a xylem-specific projection, every downstream decision on this roadmap (and any future roadmap in this repo) has to re-derive the gap between the hierarchy's ambition and xylem's current Go-ecosystem reality. That derivation drifts quickly: new readers assume Layer 2 is in scope (it is not — there is no Go CompCert), or assume Layer 3 end-to-end subgraph verification is available near-term (it is not — #13 is aspirational).
+
+The fix is to add a single **"Xylem projection"** section to the hierarchy doc that states the current reach per layer and explicitly names the tooling limits. This is a doc amendment, not a new doc.
+
+## Scope
+
+**In scope:**
+- Add a new section titled "Xylem projection" to `docs/research/assurance-hierarchy.md`, placed after the hierarchy definition and before the "Supporting Workflow Elements" section.
+- Each of the six layers gets one paragraph (or bullet) stating:
+  - Current xylem reach.
+  - Explicit tooling limit (e.g. "no Go CompCert exists; Layer 2 is trusted toolchain").
+  - Cross-reference to the relevant roadmap items in `docs/assurance/`.
+
+**Out of scope:**
+- Changing the hierarchy definition itself.
+- Changing the literature review.
+- Adding new layers or removing existing ones.
+
+## Deliverables
+
+A single PR adding a "Xylem projection" section to `docs/research/assurance-hierarchy.md` with content approximately like:
+
+```markdown
+## Xylem projection
+
+This section states the current concrete reach of each layer within the xylem
+codebase (Go, concurrent daemon, no verified Go compiler available). It is
+maintained alongside `docs/assurance/ROADMAP.md` and should be updated whenever
+a roadmap item changes a layer's reach.
+
+**Layer 1 (formally verified pure code).** Restricted to sequential pure logic
+— queue state machine (I7), retry-DAG acyclicity (I10), budget-gate arithmetic,
+class-slot accounting, dedup-key hashing. Tooling: Dafny via the `crosscheck`
+plugin, compiled to Go via `crosscheck:extract-code`. See `docs/assurance/next/06-queue-dafny-kernel.md` and `09-retry-dag-dafny-kernel.md`.
+
+**Layer 2 (compilation correctness).** No Go equivalent of CompCert exists. The
+Go toolchain is part of the trusted computing base. This layer is **not
+addressable** in the near term.
+
+**Layer 3 (contract graph verification).** Pairwise contracts via Gobra are
+near-term (item #10 — queue only). End-to-end subgraph verification (scanner →
+queue → runner) is aspirational (item #13 — Go-native extension of the existing
+Rust+Lean contract-graph-verifier PoC).
+
+**Layer 4 (implementation-spec alignment).** Delivered by Dafny-verified
+kernels as they land. `verify-kernel` workflow phase (#08) gates merges on
+`dafny_verify` of any touched `.dfy` files.
+
+**Layer 5 (spec-intent alignment).** `intent-check` workflow phase (#07) —
+claimcheck-analog using two-LLM back-translation. Probabilistic; expect
+~96% accuracy on curated benchmarks and unknown real-PR performance until
+item #07 is operating.
+
+**Layer 6 (spec completeness).** Best-effort. `acceptance-oracle` workflow
+phase (#11) gives observable user-behavior assurance; `spec-adversary` phase
+(#14) explores adversarial property discovery. No theorem proves spec
+completeness; these are both iterative practices.
+```
+
+## Acceptance criteria
+
+- Section is added to `docs/research/assurance-hierarchy.md`.
+- Each layer paragraph names at least one tooling limit or cross-references a roadmap item.
+- The section is discoverable from `docs/assurance/ROADMAP.md` (the ROADMAP already links to the hierarchy doc).
+
+## Files to touch
+
+- `docs/research/assurance-hierarchy.md` (additive section)
+- `docs/assurance/ROADMAP.md` (minor cross-reference update if the section introduces new anchors worth linking to)
+
+## Risks
+
+None material. This is a doc amendment. The only risk is drift: if the section becomes stale, it misleads future readers. Mitigate with a single sentence at the top of the section naming its refresh trigger ("updated whenever a roadmap item changes a layer's reach").
+
+## Kill criteria
+
+None.
+
+## Execution notes
+
+**Same-LLM review concern:** Doc-only change. `pr-self-review` (claude-opus) is sufficient. No human review required unless the projection introduces a factual error (e.g. misstating what Dafny can verify).
+
+**Protected surfaces:** `docs/research/assurance-hierarchy.md` is **not** in the protected list. It is a research document. Edits are permitted without governance note.
+
+## References
+
+- `docs/research/assurance-hierarchy.md` (the doc to amend)
+- `docs/research/literature-review.md` (source of the tooling-reach facts)
+- `docs/assurance/ROADMAP.md` (the cross-reference target)

--- a/docs/assurance/medium-term/10-gobra-queue.md
+++ b/docs/assurance/medium-term/10-gobra-queue.md
@@ -1,0 +1,67 @@
+# 10: Gobra Concurrency-Safety Specs for Queue
+
+**Horizon:** Medium-term (2–3 months)
+**Status:** Not started
+**Estimated cost:** 3–4 weeks
+**Depends on:** #06 (Dafny pipeline proven), #09 (retry-DAG verified)
+**Unblocks:** nothing — this is the first real concurrency proof; future items depend on its success or failure.
+
+## Context
+
+Dafny cannot model concurrency. Queue is xylem's most concurrency-sensitive pure module: file lock on `state/daemon.pid`, in-memory mutex, JSONL append-and-fsync semantics, atomic rename. A real concurrency-safety proof requires a Go-native verifier. **Gobra** (ETH/Viper) is the only production-ish candidate — still prototype-grade, with the WireGuard case study having to strip concurrency-heavy features to prove memory safety.
+
+Queue is a narrower surface than WireGuard. Lock order is simple: file lock ⟹ mutex. Critical sections are short. The hypothesis worth testing: Gobra can prove lock-order compliance, absence of data races on the in-memory structures, and atomicity of JSONL appends for this specific module.
+
+## Scope
+
+**In scope:**
+- `.gobra` specs covering:
+  - Lock-order invariant: file lock acquired before mutex; released in reverse.
+  - Data-race freedom for all shared mutable fields on the `Queue` struct.
+  - Atomicity of every JSONL append operation.
+- CI integration — Gobra runs on every PR touching `cli/internal/queue/*`.
+
+**Out of scope:**
+- Runner concurrency. Scanner concurrency. Any other module.
+- Proving crash recovery (durability across fsync and reboot) — Gobra does not model crash semantics.
+
+## Deliverables
+
+1. `cli/internal/queue/queue.gobra` (or Gobra annotations embedded in queue.go via comments — follow whichever convention Gobra tooling requires).
+2. CI workflow step that invokes Gobra verify.
+3. `docs/assurance/medium-term/10-gobra-queue-findings.md` — record of what Gobra proved, what it could not prove, and why (for honest scoping of future items).
+
+## Acceptance criteria
+
+- `gobra verify ./cli/internal/queue/...` returns clean in CI.
+- Documented findings: every property Gobra could not prove is written down with a reason (typically "Gobra does not model X"), plus a pointer to the property test that compensates.
+
+## Files to touch
+
+- **New/Modified:** `cli/internal/queue/*.gobra` or embedded annotations.
+- **Modified:** `.github/workflows/*.yml` (Gobra step).
+- **New:** `docs/assurance/medium-term/10-gobra-queue-findings.md`.
+- **Read-only:** `docs/invariants/queue.md` (target invariants).
+
+## Risks
+
+- **Gobra is prototype.** Expect tooling rough edges. Follow WireGuard precedent: if a feature of the Go code blocks verification, consider whether the feature can be refactored out or whether Gobra's limitation is acceptable and documented.
+- **Mixing Dafny kernels (#06, #09) with Gobra verification in the same package.** Gobra may not understand the Dafny-generated `interface{}` types. Mitigate by keeping Dafny kernels as leaf functions called from (but not structurally embedded in) the queue's concurrent body.
+- **CI latency.** Gobra verification is slow. Budget 2–5 minutes per run; if higher, move to a separate CI job that runs only on relevant path changes.
+
+## Kill criteria
+
+- If after 6 weeks no non-toy specs verify, shelve and classify as aspirational.
+- If verification requires structural changes to queue.go that break property tests, back out.
+
+## Execution notes
+
+**Same-LLM review concern:** Gobra specs are formal and should be human-reviewed. `pr-self-review` cannot meaningfully audit a Viper-level specification.
+
+**Protected surfaces:** None directly, though updates to `docs/invariants/queue.md` to reference Gobra-verified properties would require governance notes.
+
+## References
+
+- Gobra: https://github.com/viperproject/gobra
+- WireGuard case study (the reference for what Gobra can realistically prove).
+- `docs/research/literature-review.md` §closing paragraph on spec-completeness.

--- a/docs/assurance/medium-term/11-acceptance-oracle-phase.md
+++ b/docs/assurance/medium-term/11-acceptance-oracle-phase.md
@@ -1,0 +1,70 @@
+# 11: `acceptance-oracle` Workflow Phase
+
+**Horizon:** Medium-term (2–3 months)
+**Status:** Not started
+**Estimated cost:** 2 weeks
+**Depends on:** #07 (intent-check pattern established — acceptance-oracle reuses the phase-plumbing)
+**Unblocks:** nothing — Layer 6 proxy
+
+## Context
+
+The assurance-hierarchy doc describes an **external acceptance oracle** as a practice that sits alongside the hierarchy: deterministic user-perspective verification steps written before development starts and stored outside the coding-agent-accessible repo. Its purpose is to measure whether the software works *from a user's perspective*, not from the author's. It complements formal verification: formal tools prove the spec is satisfied; the oracle measures whether the spec was the right spec.
+
+xylem already has a DTU smoke environment (see `docs/dtu-manual-smoke-tests.md`, `docs/dtu-fixture-regression-tests.md`). The `acceptance-oracle` workflow phase wires the DTU environment into the core profile so that every PR touching observable user behavior runs against scenarios the coding agent cannot modify.
+
+## Scope
+
+**In scope:**
+- New workflow phase `acceptance-oracle` run after `pr_draft` and before merge.
+- External oracle harness — scenarios live in a separate directory or repo that the coding agent does not have write access to.
+- Coverage of the top-10 user-observable flows (CLI commands, daemon behaviors, GitHub-integration flows).
+- Gate failure blocks merge.
+
+**Out of scope:**
+- Unit-level acceptance tests — those are within-repo and covered by existing property tests.
+- Subjective criteria ("the UX feels good") — oracle scenarios must be **mechanically verifiable**. Anything subjective is quantified or rejected.
+- Writing new DTU fixtures — item reuses existing fixtures plus any gaps identified during scoping.
+
+## Deliverables
+
+1. External oracle harness — scenarios as JSON or YAML files, plus a runner script.
+2. `.xylem/prompts/acceptance-oracle/run.md` — phase prompt (may just be a command gate).
+3. Phase block in `fix-bug`, `implement-feature`, `implement-harness`.
+4. Top-10 flows scoped and documented in `docs/assurance/medium-term/11-acceptance-oracle-scenarios.md`.
+
+## Acceptance criteria
+
+- Phase runs on every `implement-feature` vessel; failures block merge.
+- At least 3 scenarios active within 4 weeks (kill criterion), 10 within 12 weeks.
+- A deliberately introduced regression in a CLI command triggers the gate.
+
+## Files to touch
+
+- **New:** external oracle directory (location TBD — could be a sibling directory outside the main working tree, or a separate repo).
+- **New:** `.xylem/prompts/acceptance-oracle/*.md`
+- **Modified:** three workflow YAMLs (**PROTECTED**).
+- **New:** `docs/assurance/medium-term/11-acceptance-oracle-scenarios.md`.
+
+## Risks
+
+- **Oracle drift.** Scenarios go stale as features evolve. Mitigate with quarterly review and a clear ownership model.
+- **External harness access.** The coding agent must NOT be able to modify the oracle scenarios. Enforce via filesystem permissions or separate repo — not via convention.
+- **Phase latency.** If scenarios run for more than a few minutes, PRs stall. Budget accordingly; parallelize where possible.
+
+## Kill criteria
+
+- If fewer than 3 scenarios are active after 4 weeks of implementation work, re-scope — the top-10 list was wrong.
+- If the oracle flags more than 30% false positives, the scenarios are too brittle; simplify.
+
+## Execution notes
+
+**Protected surfaces:** Workflow YAMLs. Requires governance note.
+
+**Same-LLM review concern:** Oracle scenarios are authored by humans (or designed by humans and filled in by LLM), not by the coding agent. This is the whole point — external to the write/review loop.
+
+## References
+
+- `docs/research/assurance-hierarchy.md` §Supporting Workflow Elements (External Acceptance Oracle)
+- `docs/dtu-manual-smoke-tests.md`
+- `docs/dtu-fixture-regression-tests.md`
+- `docs/assurance/next/07-intent-check-phase.md` (plumbing precedent)

--- a/docs/assurance/medium-term/12-gate-source-reference-impls.md
+++ b/docs/assurance/medium-term/12-gate-source-reference-impls.md
@@ -1,0 +1,72 @@
+# 12: Naive-Reference Implementations for Gate and Source
+
+**Horizon:** Medium-term (2–3 months)
+**Status:** Not started
+**Estimated cost:** 1 week
+**Depends on:** #03 (pattern established on queue)
+**Unblocks:** nothing — incremental Layer-1-adjacent assurance spread across more modules
+
+## Context
+
+Item #03 applies de Moura's "inefficient program as its own spec" pattern to queue. Once that pattern is proven, applying it to two more modules — `gate` and `source` (specifically the dedup-key computation) — is mechanical. Both are pure, sequential, and small. Both are under-tested today relative to their criticality: `gate.BudgetGate.Check` gates every cost-sensitive operation; `source` dedup-key logic gates every scheduled dispatch.
+
+Runner is **explicitly excluded**. Runner's concurrency surface is large enough that a naive single-threaded reference would model only a small subset of its behavior, giving a false sense of assurance. Runner stays with property tests + `go test -race` + acceptance oracle (#11).
+
+## Scope
+
+**In scope:**
+- `cli/internal/gate/reference/` — naive reference for `BudgetGate.Check` (pure decision against remaining USD + per-class limits).
+- `cli/internal/source/reference/` — naive reference for dedup-key computation.
+- Differential tests against real implementations under rapid.
+
+**Out of scope:**
+- Runner.
+- Scanner (dedup is part of source; runner logic is concurrent).
+- Workflow loader (deeply tied to YAML parsing — not a good reference target).
+
+## Deliverables
+
+Two PRs, one per module, each mirroring #03's structure:
+
+1. **gate:**
+   - `cli/internal/gate/reference/reference.go`
+   - `cli/internal/gate/reference/differential_test.go`
+   - README linking to #03.
+
+2. **source:**
+   - `cli/internal/source/reference/reference.go` (dedup-key only)
+   - `cli/internal/source/reference/differential_test.go`
+   - README explaining per-source-type variations.
+
+## Acceptance criteria
+
+- Rapid finds no divergence across 10k+ iterations per module.
+- Each reference under 200 lines.
+- Deliberately introduced bug in real implementation caught by differential test.
+
+## Files to touch
+
+- **New:** `cli/internal/gate/reference/*`
+- **New:** `cli/internal/source/reference/*`
+- **Read-only:** `cli/internal/gate/gate.go`, `cli/internal/source/*.go`
+
+## Risks
+
+- **Source has multiple source types** (github, github-pr, scheduled, etc.). Dedup logic may vary per type. Mitigate by scoping reference to the common `dedupKey` computation and noting per-type variations.
+- **Gate has external dependencies** (real USD tracking, time). Mitigate by making reference depend only on pure inputs — pass time and budget as arguments.
+
+## Kill criteria
+
+- If source dedup logic cannot be modeled cleanly in < 200 lines, ship gate-only.
+
+## Execution notes
+
+**Same-LLM review concern:** Same as #03 — reference correctness is the main risk. Human eyeball recommended for each PR.
+
+**Protected surfaces:** None.
+
+## References
+
+- `docs/assurance/immediate/03-naive-reference-differential-test.md` (the precedent)
+- `docs/research/literature-review.md` §de Moura
+- `cli/internal/gate/gate.go`, `cli/internal/source/*.go`

--- a/docs/assurance/next/06-queue-dafny-kernel.md
+++ b/docs/assurance/next/06-queue-dafny-kernel.md
@@ -1,0 +1,99 @@
+# 06: Queue State Machine Dafny-Verified Kernel
+
+**Horizon:** Next (4–8 weeks)
+**Status:** Not started
+**Estimated cost:** 1–2 weeks
+**Depends on:** #01 (coverage CI), #02 (I9 fix), #03 (naive reference — gives a property-test oracle against which the extracted Go can be validated)
+**Unblocks:** #07 (intent-check has a concrete Dafny artifact to reason about), #08 (verify-kernel gate has something to verify), #09 (retry-DAG follows same pipeline)
+
+## Context
+
+The first real Dafny→Go extraction on xylem code. Its purpose is to prove the whole **spec-iterate → generate-verified → extract-code → wire into Go** pipeline end-to-end on production code before committing to items #07–#09. Success proves the thesis; failure invalidates the entire Dafny track and forces a fallback to "trusted-Go + stronger property tests."
+
+The target is the narrowest, most contained kernel in xylem: the queue state machine. Specifically:
+- `validTransitions` — the pure enum-to-enum mapping that says which `VesselState` can transition to which.
+- `IsTerminal` — a pure structural predicate.
+- `protectedFieldsEqual` (backing I2 — terminal-record immutability) — a pure structural comparison.
+
+All three are sequential, pure, and small. They are the **best possible first target**: if Dafny cannot verify these, nothing else in xylem is verifiable via Dafny.
+
+## Scope
+
+**In scope:**
+- A new Dafny source file `cli/internal/queue/verified/state_machine.dfy` specifying:
+  - The `VesselState` datatype (mirroring the Go enum).
+  - `validTransitions(from, to)` as a total function with a post-condition asserting a table-driven semantics.
+  - `IsTerminal(state)` as a total function.
+  - `protectedFieldsEqual(old, new)` as a structural comparison over the subset of fields I2 considers immutable.
+- A generated Go file `cli/internal/queue/verified/state_machine.go` extracted via `crosscheck:extract-code`.
+- Rewiring in `cli/internal/queue/queue.go` so existing callers invoke the verified implementations instead of the original Go.
+- A README in `cli/internal/queue/verified/` explaining what Dafny is, which files are hand-written vs generated, and how to regenerate.
+
+**Out of scope:**
+- Concurrency properties. Dafny has no concurrency model.
+- I/O durability (fsync, atomic rename). Dafny hard wall.
+- Retry-DAG acyclicity (that is #09).
+- `Enqueue`/`Dequeue`/`List` — too stateful and too wide an interface for a first kernel.
+
+## Deliverables
+
+1. `cli/internal/queue/verified/state_machine.dfy` — hand-written Dafny, committed as source of truth.
+2. `cli/internal/queue/verified/state_machine.go` — machine-generated Go, committed alongside.
+3. Updated `cli/internal/queue/queue.go` — calls the generated kernel.
+4. `cli/internal/queue/verified/README.md` — pipeline instructions.
+5. Updated `docs/invariants/queue.md` — reference the verified kernel in the relevant invariant entries (I2, I7).
+
+## Pipeline steps
+
+Executed by a human operator (not the xylem daemon — first kernel requires manual oversight):
+
+1. Write the `.dfy` spec by hand, iteratively, using `crosscheck:spec-iterate` until it is well-formed and the intended post-conditions are stated.
+2. Run `crosscheck:generate-verified` to produce a verified Dafny body.
+3. Run `mcp__plugin_crosscheck_dafny__dafny_verify` to confirm no verification errors.
+4. Run `crosscheck:extract-code` to compile to Go.
+5. Inspect the generated Go. If larger than 200 lines or non-idiomatic, simplify the spec before re-extracting. (Plugin's own docs recommend human review at that size.)
+6. Commit all three files (`.dfy`, `.go`, `README.md`) in one PR.
+7. Rewire `queue.go` callers in a **separate** PR so the rewiring is reviewable independently of the verification work.
+
+## Acceptance criteria
+
+- `mcp__plugin_crosscheck_dafny__dafny_verify` returns clean on `state_machine.dfy`.
+- Extracted `state_machine.go` compiles and passes all existing queue property tests.
+- The naive-reference differential test (#03) continues to pass after rewiring.
+- The PR adding the kernel is **not** merged by `pr-self-review` alone — human review is required for the first kernel because it establishes the pattern.
+
+## Files to touch
+
+- **New:** `cli/internal/queue/verified/state_machine.dfy`
+- **New:** `cli/internal/queue/verified/state_machine.go` (generated)
+- **New:** `cli/internal/queue/verified/README.md`
+- **Modified:** `cli/internal/queue/queue.go` (rewiring — in a follow-up PR)
+- **Modified:** `docs/invariants/queue.md` (reference the kernel — **PROTECTED**, governance note required)
+
+## Risks
+
+- **Dafny→Go extraction uses `interface{}` type erasure.** Callers may need type assertions. Mitigate by keeping the verified API small (a handful of pure functions with simple inputs).
+- **Dafny `real` → `BigRational`, not `float64`.** Not an issue for queue state machine (no numeric logic). Worth noting for future kernels that touch budgets.
+- **Generated Go may not be idiomatic.** Plugin docs say ≥200 lines warrants review. Simpler spec → simpler output.
+- **First kernel sets the pattern for all future kernels.** Over-engineering or under-engineering this one propagates. Err on the side of simple.
+
+## Kill criteria
+
+- If the spec cannot be made to verify cleanly within 3 days of dedicated work, re-scope the target (perhaps only `IsTerminal` first).
+- If the extracted Go breaks existing callers in ways that require more than a day of rewiring, the interface is wrong — re-spec.
+- If this item takes more than 3 weeks end-to-end (not elapsed time — actual engineering days), fall back to "trusted Go + property tests" and mark items #07–#09 as blocked pending a re-assessment of the Dafny track.
+
+## Execution notes
+
+**Same-LLM review concern:** Must be human-reviewed. `pr-self-review` can catch style issues but cannot validate that a Dafny spec correctly captures a Go implementation's intended semantics. The first kernel is a governance moment, not a merge-automation moment.
+
+**Protected surfaces:** `docs/invariants/queue.md` update requires governance note per `.claude/rules/protected-surfaces.md`. The kernel files themselves are new and unprotected.
+
+## References
+
+- `docs/research/assurance-hierarchy.md` §Layer 1
+- `docs/research/literature-review.md` §Axiom, §Harmonic, §Midspiral (prior art on Dafny/Lean extraction)
+- Crosscheck plugin at `~/.claude/plugins/cache/nicholls/crosscheck/2.1.0/`
+- Dafny Go compilation docs: https://dafny.org/latest/Compilation/Go
+- `cli/internal/queue/queue.go` (the code being replaced)
+- `docs/invariants/queue.md` §I2, §I7 (the invariants being verified)

--- a/docs/assurance/next/07-intent-check-phase.md
+++ b/docs/assurance/next/07-intent-check-phase.md
@@ -1,0 +1,76 @@
+# 07: `intent-check` Workflow Phase (claimcheck-analog)
+
+**Horizon:** Next (4–8 weeks)
+**Status:** Not started
+**Estimated cost:** 1 week
+**Depends on:** nothing hard — can run in parallel with #06/#08/#09; benefits from #06 landing first (concrete artifact to reason about)
+**Unblocks:** #14 (spec-adversary reuses the same two-LLM plumbing)
+
+## Context
+
+Midspiral's `claimcheck` addresses Layer 5 (spec-intent alignment) using **round-trip informalization**: send the formal artifact to one LLM that is blind to the original intent, ask it to describe the guarantee in plain English, then send both the original intent and the back-translation to a second LLM that checks for semantic match. In Midspiral's testing this caught planted errors and unexpected gaps that a single-model review missed, reporting ~96.3% accuracy on a curated benchmark.
+
+The pattern is language-agnostic. For xylem, the "formal artifact" is an invariant-doc entry plus its property test plus any relevant code. The "original intent" is the invariant doc's prose description. The two-LLM separation gives structural adversariality that single-model review cannot.
+
+This item addresses the concern that motivated the whole roadmap: *the same LLM writes both the invariant doc and its covering property test.* `intent-check` forces a different LLM, blind to the original prose, to describe what the test actually guarantees — and a third model to diff those descriptions.
+
+## Scope
+
+**In scope:**
+- New workflow phase `intent-check` defined in `.xylem/workflows/phases/intent-check.md` (prompt template).
+- Integration into the three core-profile workflows (`fix-bug`, `implement-feature`, `implement-harness`).
+- The phase runs **after** `implement` and **before** `pr_draft`. It reads the invariant doc(s) touched by the change, reads the covering property test(s) and code changes, asks the blind back-translator to describe the guarantees, and asks a second model to diff the back-translation against the original invariant prose.
+- If the diff flags a mismatch above a configurable threshold, the phase fails the gate — the PR does not proceed to `pr_draft`.
+- The back-translator and the diff-checker must use **different models** from both the original writer (implement phase) and from each other. Concretely: implement on `med` tier (gpt-5-mini), back-translator on `high` tier (claude-opus), diff-checker on a third provider if available — or the same tier but with an adversarial prompt if not.
+
+**Out of scope:**
+- Layer 6 (spec completeness). This phase only checks *if the spec captures the intent*, not *if the intent covers all relevant properties*. That is #14.
+- Replacing `test_critic`. `test_critic` catches test theatre at the code level; `intent-check` catches drift at the prose-vs-code level. They are complementary.
+- Running `intent-check` on every PR unconditionally. It runs only when the change touches a file listed under `.claude/rules/protected-surfaces.md` (invariant docs or property tests), where spec-intent drift is most dangerous.
+
+## Deliverables
+
+1. `.xylem/prompts/intent-check/back_translate.md` — prompt for the blind back-translator (sees code and test only, never the invariant doc prose).
+2. `.xylem/prompts/intent-check/diff.md` — prompt for the diff-checker (sees both the original invariant prose and the back-translation).
+3. Phase block added to `.xylem/workflows/fix-bug.yaml`, `.xylem/workflows/implement-feature.yaml`, `.xylem/workflows/implement-harness.yaml`.
+4. Gate logic (probably via a new `type: intent_check` gate, or a command gate that runs a Go helper under `cli/cmd/xylem-intent-check/main.go`).
+5. Documentation in `docs/workflows.md` describing the phase and when it runs.
+
+## Acceptance criteria
+
+- **Seeded mismatch test case.** Construct a test fixture where the invariant doc prose and the code/test diverge in a way claimcheck's paper documented (e.g. "adding a ballot cannot decrease the tally" — lemma proves only non-negativity). The phase must flag this mismatch. This is the minimum proof that the plumbing works.
+- **Real-PR false-positive rate < 30%** after 2 weeks of live operation. Track with a simple CSV of every phase run: invariant touched, phase verdict, eventual human verdict.
+- **No false negatives on the seeded case.** Missing the planted mismatch kills the item.
+
+## Files to touch
+
+- **New:** `.xylem/prompts/intent-check/*.md`
+- **Modified:** three workflow YAMLs (**PROTECTED** per `.claude/rules/protected-surfaces.md` — requires human-authored amendment)
+- **New:** `cli/cmd/xylem-intent-check/main.go` (or equivalent gate helper)
+- **Modified:** `docs/workflows.md`
+
+## Risks
+
+- **False-positive rate.** Claimcheck's 96.3% was on a curated benchmark; real-world operation on xylem's invariant docs will be noisier. Enforce the kill criterion strictly.
+- **Latency.** A two-LLM pipeline adds two extra model calls per PR that touches a protected surface. Keep the back-translator prompt tight (< 1k tokens context) to bound latency.
+- **Model separation may be illusory.** If both models are Claude Opus from Anthropic, a shared bias may pass them both. Mitigate by running the back-translator on claude-opus and the diff-checker on a different provider (or a different Claude model if no suitable alternative is configured).
+- **Gate failure mode.** If the phase errors out (model unavailable, parse failure), it must not silently pass. Explicit fail-open vs fail-closed decision required — **default to fail-closed** for protected-surface PRs.
+
+## Kill criteria
+
+- FP rate > 30% after 2 weeks of real-PR runs.
+- FN on the seeded mismatch fixture (fundamental plumbing failure).
+- Latency > 10 minutes per invocation after tuning.
+
+## Execution notes
+
+**Protected surfaces:** The three workflow YAMLs are in the protected list. Amendments require human-authored changes with a governance note. Plan for two PRs: one for the Go helper + prompts (not protected); one for the workflow YAML integration (protected).
+
+**Same-LLM review concern:** This *is* the solution to the same-LLM-review concern for protected-surface PRs. Meta-risk: if `intent-check` is written by gpt-5-mini and reviewed by claude-opus `pr-self-review`, the review is checking the tool that checks review separation. Human review recommended for the first PR introducing this phase.
+
+## References
+
+- `docs/research/literature-review.md` §Midspiral / claimcheck
+- Midspiral claimcheck blog: https://midspiral.com/blog/claimcheck-narrowing-the-gap-between-proof-and-intent/
+- `docs/research/assurance-hierarchy.md` §Layer 5
+- `.claude/rules/protected-surfaces.md` (list of files that trigger intent-check)

--- a/docs/assurance/next/08-verify-kernel-phase.md
+++ b/docs/assurance/next/08-verify-kernel-phase.md
@@ -1,0 +1,70 @@
+# 08: `verify-kernel` Workflow Phase
+
+**Horizon:** Next (4–8 weeks)
+**Status:** Not started
+**Estimated cost:** 2 days
+**Depends on:** #06 (something to verify)
+**Unblocks:** #09 (retry-DAG kernel integrates cleanly into an existing gate)
+
+## Context
+
+Once the Dafny kernel pattern is established (#06), every subsequent PR that touches `.dfy` files needs a gate that runs `dafny_verify` and fails on verification failure. This prevents accidental regression of verified properties — without it, a well-intentioned change to a `.dfy` spec could introduce a verification gap that ships silently, defeating the whole point of the kernel.
+
+This is a thin phase. It only runs when a PR touches `.dfy` files. It invokes the Crosscheck plugin's `dafny_verify` MCP tool (Docker-isolated, 120s timeout per the plugin docs) and fails the gate if verification fails.
+
+## Scope
+
+**In scope:**
+- New workflow phase `verify-kernel` defined in `.xylem/workflows/phases/verify-kernel.md`.
+- Integration into `fix-bug`, `implement-feature`, `implement-harness` — placed **after** `implement` and **before** `test_critic` (or `verify` if no `test_critic`).
+- The phase detects `.dfy` file changes vs `origin/main` and runs `dafny_verify` on each.
+- If `dafny_verify` fails on any touched `.dfy`, the gate fails; the vessel does not proceed.
+
+**Out of scope:**
+- Creating new kernels (that is #06 and #09).
+- Running Dafny on a whole-repo basis — only on changed files, because full-repo Dafny verification is too slow for a per-PR gate.
+- Dafny-to-Go extraction — that remains manual per #06's pipeline.
+
+## Deliverables
+
+1. `.xylem/prompts/verify-kernel/verify.md` (prompt if needed — may be a command gate instead).
+2. Phase block in three workflow YAMLs.
+3. Gate logic — likely a command gate invoking a Go helper or shell script that detects changed `.dfy` files and calls the Dafny verifier.
+4. Documentation in `docs/workflows.md`.
+
+## Acceptance criteria
+
+- Intentionally introduce a broken `.dfy` spec (e.g. a false post-condition). Gate fails.
+- Restore the spec. Gate passes.
+- On a PR that does not touch `.dfy` files, the gate exits cleanly (no-op) in under 1 second.
+- The gate respects the plugin's 120s timeout and reports a meaningful failure message if it exceeds.
+
+## Files to touch
+
+- **New:** `.xylem/prompts/verify-kernel/verify.md` (or a shell script under `scripts/`)
+- **Modified:** three workflow YAMLs (**PROTECTED**)
+- **Modified:** `docs/workflows.md`
+
+## Risks
+
+- **Dafny toolchain in CI may be flaky or unavailable.** The Crosscheck plugin uses Docker-isolated Dafny; requires Docker in the CI environment. If unavailable, fall back to pre-commit-only enforcement (still valuable, just less thorough).
+- **False positives from brittle specs.** A tight spec may fail verification after an unrelated refactor. Mitigate with stable module boundaries and small kernels per #06 kill criterion.
+- **Latency.** 120s per `.dfy` file. If many files are touched, gate becomes slow. Mitigate by keeping kernels small and few.
+
+## Kill criteria
+
+- If Dafny fails intermittently in CI more than 10% of runs after 2 weeks of operation, fall back to pre-commit-only enforcement and document the CI gap.
+- If any kernel requires more than 120s to verify, split it into smaller specs.
+
+## Execution notes
+
+**Protected surfaces:** Workflow YAML amendments require governance note.
+
+**Same-LLM review concern:** Gate logic is mechanical. `pr-self-review` is sufficient.
+
+## References
+
+- Crosscheck plugin: `~/.claude/plugins/cache/nicholls/crosscheck/2.1.0/`
+- MCP tools: `mcp__plugin_crosscheck_dafny__dafny_verify`, `dafny_compile`, `dafny_cleanup`
+- Dafny Go compilation: https://dafny.org/latest/Compilation/Go
+- `docs/assurance/next/06-queue-dafny-kernel.md` (the dependency)

--- a/docs/assurance/next/09-retry-dag-dafny-kernel.md
+++ b/docs/assurance/next/09-retry-dag-dafny-kernel.md
@@ -1,0 +1,80 @@
+# 09: Retry-DAG Acyclicity Dafny-Verified Kernel
+
+**Horizon:** Next (4–8 weeks)
+**Status:** Not started
+**Estimated cost:** 3 days
+**Depends on:** #06 (pipeline pattern established), #08 (verify-kernel gate catches regressions)
+**Unblocks:** nothing — this is a terminal item in the Next phase
+
+## Context
+
+`docs/invariants/queue.md` §I10 documents that retry-DAG acyclicity is **caller-responsibility**: the invariant doc explicitly warns that the queue itself does not check for cycles in the retry graph. A cycle would cause a vessel to retry itself indefinitely.
+
+With the Dafny pipeline proven by #06, replacing caller-responsibility with a **verified checker** at the queue boundary is a 3-day item. The kernel is pure graph-algorithm code (DFS with termination measure), entirely sequential, and the post-condition ("if the function returns true, the graph is acyclic") is trivial to state.
+
+## Scope
+
+**In scope:**
+- New Dafny source `cli/internal/queue/verified/retry_dag.dfy`:
+  - A graph datatype (adjacency list over vessel IDs).
+  - An `IsAcyclic(graph)` function with termination measure and post-condition.
+- Generated Go file `cli/internal/queue/verified/retry_dag.go` extracted via `crosscheck:extract-code`.
+- Wiring: call the verified checker at every queue entry point that accepts a retry reference (`Enqueue`, `UpdatePhase`, anywhere else that introduces a parent→child retry edge).
+
+**Out of scope:**
+- Other queue invariants (they are #06 or deferred).
+- Runner-side retry logic — that stays Go.
+
+## Deliverables
+
+1. `cli/internal/queue/verified/retry_dag.dfy` — spec.
+2. `cli/internal/queue/verified/retry_dag.go` — generated.
+3. `cli/internal/queue/queue.go` — wiring at retry-edge entry points.
+4. Updated `docs/invariants/queue.md` §I10 — remove the "caller responsibility" annotation.
+5. Strengthened `TestPropQueueInvariant_I10_RetryDagAcyclic` — must exercise the verified checker's error path.
+
+## Pipeline steps
+
+Same as #06:
+1. `crosscheck:spec-iterate` on `retry_dag.dfy`.
+2. `crosscheck:generate-verified`.
+3. `mcp__plugin_crosscheck_dafny__dafny_verify`.
+4. `crosscheck:extract-code`.
+5. Commit spec, generated Go, and wiring in **one** PR (smaller than #06 so bundling is OK).
+
+## Acceptance criteria
+
+- `dafny_verify` returns clean.
+- Extracted Go passes property tests, including the strengthened I10 test.
+- A deliberately cyclic retry reference inserted via test scaffolding is rejected.
+- Invariant doc no longer calls I10 caller-responsibility.
+
+## Files to touch
+
+- **New:** `cli/internal/queue/verified/retry_dag.dfy`
+- **New:** `cli/internal/queue/verified/retry_dag.go`
+- **Modified:** `cli/internal/queue/queue.go`
+- **Modified:** `docs/invariants/queue.md` (**PROTECTED** — governance note)
+- **Modified:** `cli/internal/queue/queue_invariants_prop_test.go` (**PROTECTED** — strengthening)
+
+## Risks
+
+- **Graph datatype in Dafny requires a termination measure for DFS.** If the measure is not obvious, the spec will not verify. Standard technique: measure is the number of unvisited nodes; decrements on each recursive call.
+- **Wiring at Enqueue may reject vessels that were previously accepted.** Audit existing queue data for any vessel that (after the fix) would be rejected. Likely none given the invariant is already documented, but verify.
+- **Performance.** Per-Enqueue graph check is O(V + E) of the retry chain. Bounded by max retry depth, which is small. Not a concern.
+
+## Kill criteria
+
+- If Dafny termination measure is intractable after 2 days, fall back to a Go implementation with a property-test proof of correctness and file the Dafny version as a future aspirational item.
+
+## Execution notes
+
+**Protected surfaces:** Two — `queue.md` and the property test file. Both strengthening, both requiring governance notes.
+
+**Same-LLM review concern:** Same as #06 — first time the pipeline runs on a different module member, so human review for the initial PR, then `pr-self-review` is sufficient for follow-ups.
+
+## References
+
+- `docs/invariants/queue.md` §I10
+- `cli/internal/queue/queue.go` (Enqueue and retry-edge entry points)
+- `docs/assurance/next/06-queue-dafny-kernel.md` (pipeline precedent)

--- a/docs/research/assurance-hierarchy.md
+++ b/docs/research/assurance-hierarchy.md
@@ -1,0 +1,82 @@
+# A Six-Layer Assurance Hierarchy for AI-Assisted Software Development
+
+## Scope
+
+This hierarchy addresses the question: **given a specification, can we be confident the implementation is correct?** It explicitly excludes whether the specification solves the right problem — that is a product discovery concern, not an engineering assurance concern.
+
+## The Hierarchy
+
+### Layer 1: Formally Verified Pure, Functional Code
+
+Business logic and core algorithms are written in a formally verifiable language such as Dafny, which compiles to target languages including JavaScript and TypeScript. The formal verification toolchain (Dafny's verifier, or Lean 4 via tools like Axiom or Harmonic's Aristotle) provides mathematical proof that the code satisfies its specification for all possible inputs — not just tested inputs.
+
+This is deterministic assurance: the proof either passes or it doesn't.
+
+### Layer 2: Compilation Correctness
+
+Formal verification proves properties of source code, but the deployed system runs compiled output. If the compiler has a bug, the emitted code may not preserve the properties proven in the source language. This layer provides assurance that the compilation or transpilation step preserves verified properties.
+
+Approaches include verified compilation (e.g., CompCert for C), translation validation (verifying each specific compilation output against its source), or proof-carrying code where proofs travel with the compiled artifact.
+
+Without this layer, a formally verified Dafny program and its compiled JavaScript output are connected only by trust in the compiler — an unverified link in an otherwise verified chain.
+
+### Layer 3: Contract Graph Verification
+
+Individual verified units must compose correctly. The contract graph verifier checks interface contracts at integration boundaries — between verified units and between verified code and third-party libraries. Critically, this verification operates end-to-end across subgraphs, not just at pairwise boundaries.
+
+This distinction matters because two units can each satisfy their boundary contracts while producing emergent behavior that neither unit's specification anticipated — ordering dependencies, resource contention, or feedback loops that only manifest in the full assembly. End-to-end subgraph verification catches these composition failures.
+
+This layer targets the approximately 75% of code surface area that sits at integration boundaries, which resists formal proof of individual units and is where the majority of production bugs originate.
+
+### Layer 4: Implementation–Specification Alignment
+
+Layers 1–3 prove that code satisfies a specification. This layer asks: does the specification actually describe the implementation's behavior? Tools like Midspiral's lemmafit integrate Dafny verification into the development workflow, where code that cannot be proven correct against the specification does not compile.
+
+This is still deterministic — the verifier accepts or rejects.
+
+### Layer 5: Specification–Intent Alignment
+
+A verified proof guarantees the code is correct relative to a specification, but does the specification capture what was actually intended? This is the gap between "verified" and "intended."
+
+Midspiral's claimcheck addresses this via round-trip informalization: translate the formal specification back into plain English without seeing the original requirement, then compare the back-translation against the original intent. In testing, this caught both planted errors and unexpected gaps — for example, a requirement stating "adding a ballot can't decrease a tally" where the lemma merely proved counts are non-negative, a tautology masquerading as a monotonicity guarantee.
+
+This layer is probabilistic. Claimcheck reports approximately 96.3% accuracy using structural separation (two models, with the informalizer blind to the original requirement), though this is acknowledged as a development benchmark rather than a formal evaluation.
+
+### Layer 6: Specification Completeness
+
+Even if every specified property is correctly implemented and aligned with intent, the specification itself may be incomplete — it may fail to enumerate properties that matter. Traditional user stories test the happy path and some error cases, getting nowhere near the exhaustive coverage that formal verification provides.
+
+The concept of formally verified user stories addresses this: rather than writing a handful of test cases from a user story, an LLM systematically enumerates candidate formal properties — invariants, pre/post conditions, boundary behaviors, commutativity, monotonicity, conservation laws. A human reviews the property list, each property is formally verified, and claimcheck validates intent alignment.
+
+This layer is best-effort. There is no theorem that can prove a specification is complete — the question "have I missed any important properties?" is inherently a human judgment call. However, adversarial property discovery — where one agent proposes properties and another agent tries to find scenarios the property set doesn't cover — could make this search significantly more structured than the status quo.
+
+## Two Chains, One Gradient
+
+The hierarchy contains two distinct chains with different failure modes and verification methods:
+
+**The Implementation Chain (Layers 1–3):** Is the code correct and do the pieces fit together? This chain is deterministically verifiable via formal proofs and contract checks.
+
+**The Specification Chain (Layers 4–6):** Does the spec match the code, the intent, and the full problem surface? This chain degrades from deterministic (Layer 4) to probabilistic (Layer 5, ~96%) to best-effort (Layer 6).
+
+Residual risk concentrates at the top of the specification chain — Layer 6 — which is where the research opportunity lies.
+
+## Supporting Workflow Elements
+
+Two additional practices sit alongside the hierarchy rather than within it:
+
+**External Acceptance Oracle.** Deterministic verification steps written from the perspective of a user, exercising the feature to determine if the user story is satisfied. These exist outside the repository so the coding agent cannot write code to pass them, and are written before development starts to force upfront intent specification. Requirements must be mechanically verifiable — subjective criteria like "the page feels responsive" must be quantified. The oracle provides empirical, user-perspective assurance that the service works, complementing the exhaustive assurance of formal verification.
+
+**Test Theatre Detection.** Critical review of automated tests to eliminate tests that look productive but verify nothing meaningful. This runs after the implementation has stabilized — not as a sequential pipeline step during development, but as a quality gate once there is confidence the code has stopped changing.
+
+## References
+
+- Axiom. AXLE - Axiom Lean Engine. https://axle.axiommath.ai/
+- Axiom. https://axiommath.ai/
+- Harmonic. Aristotle API. https://aristotle.harmonic.fun/
+- Harmonic. "Aristotle: IMO-level Automated Theorem Proving." arXiv, March 2026. https://arxiv.org/html/2510.01346v1
+- Midspiral. https://midspiral.com/
+- Midspiral. "lemmafit: Make agents prove that their code is correct." GitHub. https://github.com/midspiral/lemmafit
+- Midspiral. "claimcheck: Narrowing the Gap between Proof and Intent." https://midspiral.com/blog/claimcheck-narrowing-the-gap-between-proof-and-intent/
+- Midspiral. "From Intent to Proof: Dafny Verification for Web Apps." https://midspiral.com/blog/from-intent-to-proof-dafny-verification-for-web-apps/
+- Kleppmann, M. "Prediction: AI will make formal verification go mainstream." December 2025. https://martin.kleppmann.com/2025/12/08/ai-formal-verification.html
+- de Moura, L. "When AI Writes the World's Software, Who Verifies It?" February 2026. https://leodemoura.github.io/blog/2026/02/28/when-ai-writes-the-worlds-software.html

--- a/docs/research/literature-review.md
+++ b/docs/research/literature-review.md
@@ -1,0 +1,93 @@
+# Brief Literature Review: Formal Verification Hierarchies and AI-Assisted Code Assurance
+
+## Purpose
+
+This review was conducted to assess whether the six-layer assurance hierarchy described in the companion report ("A Six-Layer Assurance Hierarchy for AI-Assisted Software Development") has precedent in existing literature. The review is preliminary — conducted over the course of a single conversation, not a systematic literature search — and should be treated as a starting point for a proper review, not a definitive novelty claim.
+
+## Existing Work
+
+### Guaranteed Safe AI (Dalrymple et al., 2024)
+
+The closest structural analog identified. This paper proposes a verification hierarchy spanning from no guarantees (Level 0) through increasingly sophisticated empirical testing methods (Levels 1–5), probabilistic inference with convergence guarantees (Levels 6–8), to formal proofs establishing definitive safety bounds (Levels 9–10). The framework is organized around three core components: a world model (mathematical description of how the AI system affects the outside world), a safety specification (mathematical description of acceptable effects), and a verifier (auditable proof certificate).
+
+The paper also notes that AI capabilities could accelerate creation of good safety specifications — for example, AI systems could suggest new specifications, critique proposed ones, or generate examples of cases where two candidate specifications differ.
+
+**Relevance:** This is the most important prior work to engage with. The confidence gradient (deterministic → probabilistic → best-effort) and the structural decomposition into distinct verification concerns are shared features. The key divergences are: (1) GS AI targets AI system safety broadly, not developer workflows specifically; (2) it does not distinguish an implementation chain from a specification chain; (3) it does not address compilation correctness, contract graph verification at integration boundaries, or the spec-intent alignment problem as distinct layers.
+
+### Kleppmann (2025)
+
+Martin Kleppmann's blog post argues that formal verification is about to become mainstream due to three converging factors: formal verification is becoming vastly cheaper, AI-generated code needs formal verification so human review can be skipped, and the precision of formal verification counteracts the imprecise nature of LLMs. He identifies the specification problem clearly: as verification becomes automated, the challenge moves to correctly defining the specification — knowing that the properties proven are the right ones.
+
+**Relevance:** Kleppmann names the spec completeness problem but does not propose a layered hierarchy or structured approach to addressing it. The observation that "it doesn't matter if [LLMs] hallucinate nonsense, because the proof checker will reject any invalid proof" is foundational context for why LLM-assisted formal verification is viable.
+
+### Midspiral: lemmafit and claimcheck
+
+Midspiral builds open-source tools for what they call "the correctness layer for AI-generated software." Two tools are directly relevant:
+
+**lemmafit** integrates Dafny formal verification into the Claude Code development workflow. Business logic is written in Dafny, mathematically verified, then auto-compiled to TypeScript for use in React applications. A verification daemon watches .dfy files, runs `dafny verify`, and on success compiles to JavaScript/TypeScript. Code that cannot be proven correct does not compile.
+
+**claimcheck** addresses the gap between "verified" and "intended" using round-trip informalization. The technique sends a Dafny lemma to one LLM (blind to the original requirement) to describe what it guarantees in plain English, then sends both the original requirement and the back-translation to a second LLM to assess semantic match. In testing against an election tally system, claimcheck caught both a planted error (a tautology masquerading as a monotonicity guarantee) and an unexpected gap (a lemma proving one specific reordering rather than arbitrary permutation). Structural separation (two different models, informalizer blind to the requirement) outperformed single-model approaches by 10 points. Reported accuracy is 96.3%, acknowledged as a development benchmark rather than a formal evaluation.
+
+**Relevance:** Midspiral addresses spec-intent alignment (Layer 5 of the hierarchy) as a specific tool, and frames it as "one layer in an ongoing attempt to map natural language requirements to formal guarantees." They do not propose a broader hierarchy. Their blog post "From Intent to Proof" notes that a more transparent workflow would surface generated domain obligations back to the user in human-readable form before proof generation begins, allowing iteration on intent before committing to proof search — which aligns with the specification chain concept but is not formalized as such.
+
+### Axiom
+
+Axiom trains AI systems to generate formally verified outputs in Lean. The system uses deterministic proof verifiers to detect incorrect outputs, providing mathematical certainty that code functions return the correct answer for every input. Axiom also verifies that code does not introduce hidden vulnerabilities. The company raised $200M in Series A funding (March 2026) at a $1.6B valuation, and has released AXLE (Axiom Lean Engine) as a public API providing proof verification and manipulation primitives.
+
+Axiom's approach involves a "verified data flywheel" — orders of magnitude more formally verified data than all previously available human-produced sources — which feeds back into training. Because this data is checked by deterministic proof verifiers, it avoids the data pollution and model collapse problems associated with unverified AI-generated training data.
+
+**Relevance:** Axiom provides the tooling substrate for Layer 1 (formally verified code) via Lean. Their focus is on making formal verification cheap and automated, not on defining an assurance hierarchy. The recursive self-improvement loop (verified data improving the model that generates verified data) is relevant infrastructure but does not address the specification chain.
+
+### Harmonic: Aristotle
+
+Harmonic's Aristotle system combines formal verification with informal reasoning, achieving gold-medal-equivalent performance on the 2025 International Mathematical Olympiad with formally verified solutions in Lean 4. The system can autonomously prove and formalize for up to 24 hours without human intervention and leads ProofBench rankings. Harmonic's roadmap includes expansion from mathematics into software verification, targeting safety-critical industries.
+
+The system works by requiring models to produce reasoning as code in Lean 4, which is then checked by an algorithmic process independent of the AI. Every solution is verified down to foundational axioms using the Lean 4 proof assistant.
+
+**Relevance:** Like Axiom, Aristotle provides tooling for Layer 1. Harmonic's stated roadmap into software verification and code correctness suggests these tools will become directly applicable to the assurance hierarchy's implementation chain. The key architectural insight — that the verifier is outside the loop and does not negotiate — aligns with the hierarchy's principle that each layer provides independent assurance.
+
+### de Moura (2026)
+
+Leonardo de Moura's blog post surveys the Lean ecosystem and argues that verification will be a decisive advantage in software development. He notes that AI agents are already building their own proof strategies on top of the Lean platform, and highlights Veil, a distributed protocol verifier built on Lean that combines model checking with full formal proof. Veil generates concrete counterexamples when properties fail and full formal proofs when they hold. During verification of the Rabia consensus protocol, the Veil team discovered an inconsistency in a prior formal verification that had gone undetected across two separate tools.
+
+De Moura also raises the specification problem as not purely technical: specifications for medical devices, voting systems, or AI safety monitors encode values, not just logic. He suggests AI can bridge the accessibility gap by explaining specifications in plain language.
+
+**Relevance:** The Veil work is directly relevant to Layer 3 (contract graph verification), specifically for distributed systems where composition verification is hardest. The observation about specifications encoding values connects to the boundary the hierarchy draws between Layer 6 (spec completeness) and the explicitly excluded "right solution for the right problem" domain.
+
+### Skomarovsky (2026)
+
+A practitioner-oriented post proposing five independent structural dimensions that determine whether AI-generated code is amenable to formal verification. The framework classifies code artifacts by tractability rather than defining layers of assurance.
+
+**Relevance:** Complementary but structurally different. Skomarovsky's framework answers "can we verify this?" while the assurance hierarchy answers "given that we can, what layers of confidence do we have?"
+
+## Assessment of Novelty
+
+The individual concepts in the hierarchy exist separately in the literature:
+
+- **Confidence gradients** in verification are present in the GS AI paper
+- **Spec-intent alignment** is addressed by Midspiral's claimcheck
+- **Spec completeness** as the limiting problem is named by Kleppmann and Midspiral
+- **Contract verification at composition boundaries** is well-studied, particularly in hardware verification and distributed systems (Veil)
+- **Compilation correctness** is a known concern (CompCert, translation validation)
+- **Formally verified code via LLM-assisted tools** is actively developed by Axiom, Harmonic, and Midspiral
+
+What was not found in this review is a single framework assembling these into a unified hierarchy with the specific structure proposed: the split into an implementation chain (Layers 1–3, deterministic) and a specification chain (Layers 4–6, degrading from deterministic through probabilistic to best-effort), with explicit identification of where residual risk concentrates.
+
+**Caveat:** This review was conducted in a single conversation session, not as a systematic literature search. "Not found" is weaker than "does not exist." A proper literature review — particularly engaging deeply with the GS AI paper, the formal methods in AI-generated code space, and the DO-178C / safety-critical systems literature — would be required before making any novelty claims in publication.
+
+## References
+
+- Dalrymple, D. et al. "Towards Guaranteed Safe AI: A Framework for Ensuring Robust and Reliable AI Systems." 2024. https://arxiv.org/html/2405.06624v1
+- Kleppmann, M. "Prediction: AI will make formal verification go mainstream." December 2025. https://martin.kleppmann.com/2025/12/08/ai-formal-verification.html
+- Midspiral. "claimcheck: Narrowing the Gap between Proof and Intent." https://midspiral.com/blog/claimcheck-narrowing-the-gap-between-proof-and-intent/
+- Midspiral. "From Intent to Proof: Dafny Verification for Web Apps." https://midspiral.com/blog/from-intent-to-proof-dafny-verification-for-web-apps/
+- Midspiral. "lemmafit: Make agents prove that their code is correct." GitHub. https://github.com/midspiral/lemmafit
+- Axiom. https://axiommath.ai/
+- Axiom. AXLE - Axiom Lean Engine. https://axle.axiommath.ai/
+- SiliconANGLE. "Verifiable AI startup Axiom raises $200M to prove AI-generated code is safe to use." March 2026. https://siliconangle.com/2026/03/12/verifiable-ai-startup-axiom-raises-200m-prove-ai-generated-code-safe-use/
+- Menlo Ventures. "AI Will Write All the Code. Mathematics Will Prove It Works." March 2026. https://menlovc.com/perspective/ai-will-write-all-the-code-mathematics-will-prove-it-works/
+- Harmonic. "Aristotle: IMO-level Automated Theorem Proving." arXiv, March 2026. https://arxiv.org/html/2510.01346v1
+- Harmonic. News. https://harmonic.fun/news
+- de Moura, L. "When AI Writes the World's Software, Who Verifies It?" February 2026. https://leodemoura.github.io/blog/2026/02/28/when-ai-writes-the-worlds-software.html
+- Lean FRO. https://lean-lang.org/fro/about/
+- Skomarovsky. "Your AI Just Wrote 500 Lines of Code. Can You Prove Any of It Works?" April 2026. https://skomarovsky.github.io/verification/verification_framework.html


### PR DESCRIPTION
## Summary

- Establishes `docs/assurance/` as a time-sliced index for the deterministic-assurance initiative — 14 self-contained items across `immediate/`, `next/`, `medium-term/`, `aspirational/`
- Lands `docs/research/assurance-hierarchy.md` and `docs/research/literature-review.md` (the strategic basis these roadmap items project onto xylem)
- No code changes; all files new

## Why

The roadmap needs to survive a multi-quarter timeframe without context drift. Each doc is self-contained (scope, deliverables, acceptance criteria, risks, kill criteria) so a single item can be picked up and executed months later without re-deriving the strategy.

The 5 Immediate items will be filed as GitHub issues after this lands (referenced by path from `docs/assurance/immediate/*.md`).

## Test plan

- [x] `docs/assurance/ROADMAP.md` renders as a navigable index
- [x] Each item has the consistent template (Context, Scope, Deliverables, Acceptance, Risks, Kill, Execution, References)
- [x] No protected surfaces modified; pre-commit passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)