### PR TITLE
chore(config): route med tier to gpt-4.1 by dropping --effort medium

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -285,12 +285,12 @@ providers:
   copilot:
     kind: copilot
     command: "copilot"
-    flags: "--yolo --autopilot --effort medium"
+    flags: "--yolo --autopilot"
     env:
       COPILOT_GITHUB_TOKEN: "${COPILOT_GITHUB_TOKEN}"
     tiers:
       low: "gpt-5-mini"   # active: light structured tasks (0x premium)
-      med: "gpt-5-mini"   # STOPGAP loop238 — gpt-4.1 rejects --effort medium (#569); revert once #569 fix lands
+      med: "gpt-4.1"      # active: implementation, fix-checks, conflict resolution (0x premium, more capable than gpt-5-mini)
       high: "gpt-4.1"     # unused — high routes to claude
 
 llm_routing:


### PR DESCRIPTION
## Summary

- Drop `--effort medium` from `copilot.flags` — the flag is rejected by `gpt-4.1` (see #569)
- Revert med tier `gpt-5-mini` → `gpt-4.1` (which was reverted as a stopgap in loop238)
- Net effect: med tier runs on gpt-4.1 (more capable, same 0x premium cost)

## Why

Without this, the med tier (implement, fix-checks, conflict-resolution phases) runs on `gpt-5-mini` as a workaround for #569. gpt-4.1 is the intended model and outperforms gpt-5-mini on implementation tasks.

This is also a **prerequisite for the deterministic-assurance roadmap** (`docs/assurance/ROADMAP.md`, landing in #643). The companion PR escalates the `test_critic` phase to tier: high (claude-opus) so the critic is on a different vendor from the implementation — which requires the med tier to be stable first.

## Governance

`.xylem.yml` is a protected control surface (`.claude/rules/protected-surfaces.md`). This edit is a **strengthening** change — it restores the originally-intended med-tier model after a temporary workaround is no longer needed — not a relaxation. The change is explicitly authorised by the roadmap intake review.

## Test plan

- [x] `copilot --help | grep -- --effort` to confirm the flag is still supported for whichever tier wants it later (it's still valid; we just stopped passing it globally)
- [ ] After merge + auto-upgrade: confirm next med-tier vessel (implement phase) runs on `gpt-4.1` by checking the phase output's model-identifier header
- [ ] After merge + auto-upgrade: confirm low-tier vessels still work on `gpt-5-mini` (scheduled metrics tasks should dispatch normally)

## Related

- #569 (the original --effort medium rejection bug that forced the stopgap)
- #643 (deterministic-assurance roadmap docs)
- Companion PR: test_critic tier escalation (follows this one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)