### PR TITLE
chore(workflow): escalate test_critic phase to tier: high

### DIFF
--- a/.xylem/workflows/implement-harness.yaml
+++ b/.xylem/workflows/implement-harness.yaml
@@ -29,7 +29,7 @@ phases:
   - name: test_critic
     prompt_file: .xylem/prompts/implement-harness/test_critic.md
     max_turns: 50
-    tier: med
+    tier: high
     gate:
       type: command
       run: "cd cli && go test ./..."


### PR DESCRIPTION
## Summary

- Change `test_critic` phase in `.xylem/workflows/implement-harness.yaml` from `tier: med` → `tier: high`
- Net effect: the test-theatre critic now runs on claude-opus-4-6 (Anthropic) instead of gpt-4.1 (GitHub/OpenAI) — a distinct model and distinct vendor from the implementation phase that wrote the tests

## Why

`test_critic` is explicitly chartered to detect test theatre in the implementation phase's output. With both phases on the same tier (med/gpt-4.1), the critic was the same model reviewing its own work — which is exactly the failure mode the deterministic-assurance roadmap (`docs/assurance/ROADMAP.md`, #643) is trying to close.

Running the critic on a different vendor means a flaw in one vendor's output pattern is much less likely to be invisible to the critic.

## Scope

- Only `implement-harness.yaml` has a dedicated `test_critic` phase. `fix-bug.yaml` and `implement-feature.yaml` have a `verify` phase that runs tests and reports — not a critic phase. Those are scoped out deliberately to keep this PR minimal. If those workflows grow a critic phase later, the same rule applies.

## Governance

`.xylem/workflows/*.yaml` is a protected control surface (`.claude/rules/protected-surfaces.md`). This is a **strengthening** change — it routes the critic to a more capable and distinct model. No phase logic, prompt file, gate command, or retry count is altered.

## Test plan

- [x] Diff is a single line change on a phase that already exists
- [ ] After merge + auto-upgrade: next `implement-harness` vessel's `test_critic` phase should show claude-opus-4-6 in the model-identifier header in `.xylem/phases/<id>/test_critic/stdout.log`
- [ ] Confirm the phase still completes within its `max_turns: 50` budget (opus is more expensive but the critic prompt is short-lived)

## Related

- #643 (deterministic-assurance roadmap docs)
- #644 (companion prerequisite: med tier → gpt-4.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)