### PR TITLE
test(queue): strengthen I9 property test + sync spec status

### DIFF
--- a/cli/internal/queue/queue_invariants_prop_test.go
+++ b/cli/internal/queue/queue_invariants_prop_test.go
@@ -5,14 +5,14 @@ package queue
 // of the spec). The file is a protected surface: modifications require a
 // human-signed commit (see .claude/rules/protected-surfaces.md).
 //
-// Four tests are t.Skip'd because they would fail against the current code
+// Two tests are t.Skip'd because they would fail against the current code
 // (see the spec's Gap analysis). Removing a skip is a one-line action once
 // the corresponding fix lands:
 //   - I2: UpdateVessel skips validation on same-state mutations.
 //   - I3: resetPendingState does not reset CurrentPhase / PhaseOutputs.
-//   - I9: Enqueue does not reject duplicate IDs.
-// I2, I3, and I9 are skipped by the "keep CI green until the code fix lands"
+// I2 and I3 are skipped by the "keep CI green until the code fix lands"
 // principle with explicit gap-row references in the skip message.
+// I9 is no longer skipped — the Enqueue duplicate-ID guard landed in PR #594.
 //
 // I5b (crash durability) was originally the one sanctioned skip per the
 // spec's Governance §4; it now runs against the atomic writeAllVessels fix
@@ -21,6 +21,7 @@ package queue
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -709,21 +710,47 @@ func TestPropQueueInvariant_I8_FileWellFormedness(t *testing.T) {
 }
 
 // Invariant I9: Unique vessel IDs.
+//
+// Directly exercises the Enqueue duplicate-ID rejection landed in PR #594.
+// A second Enqueue that shares the first vessel's ID but carries a distinct
+// Ref must fail with ErrDuplicateID and the queue must still contain exactly
+// one vessel. The distinct Ref is required to keep us past the Ref-dedup
+// short-circuit (Enqueue silently no-ops a matching-Ref active vessel before
+// reaching the ID check).
 func TestPropQueueInvariant_I9_UniqueIDs(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		q, _, cleanup := newPropQueueWithDir(t, "queue-i9-prop")
 		defer cleanup()
-		n := rapid.IntRange(1, 20).Draw(t, "n")
-		for i := 0; i < n; i++ {
-			op := drawMutatingOp(t, false)
-			applyOp(q, op)
-			seen := map[string]bool{}
-			for _, v := range mustList(t, q) {
-				if seen[v.ID] {
-					t.Fatalf("I9: duplicate ID %q in queue after op %d (%v)", v.ID, i, op.kind)
-				}
-				seen[v.ID] = true
-			}
+
+		v1 := drawFreshVessel(t)
+		if v1.Ref == "" {
+			v1.Ref = "https://github.com/example/repo/issues/1"
+		}
+		if _, err := q.Enqueue(v1); err != nil {
+			t.Fatalf("I9: initial Enqueue failed: %v", err)
+		}
+
+		v2 := drawFreshVessel(t)
+		v2.ID = v1.ID                                                        // force the ID collision
+		v2.Ref = fmt.Sprintf("https://github.com/example/repo/issues/%d", 9) // distinct from drawRef's pool
+		if v2.Ref == v1.Ref {
+			t.Fatalf("test setup: v2.Ref must differ from v1.Ref, both %q", v1.Ref)
+		}
+
+		_, err := q.Enqueue(v2)
+		if !errors.Is(err, ErrDuplicateID) {
+			t.Fatalf("I9: duplicate-ID Enqueue returned %v, want ErrDuplicateID", err)
+		}
+
+		vessels := mustList(t, q)
+		if len(vessels) != 1 {
+			t.Fatalf("I9: queue has %d vessels after rejected duplicate, want 1", len(vessels))
+		}
+		if vessels[0].ID != v1.ID {
+			t.Fatalf("I9: surviving vessel ID is %q, want %q", vessels[0].ID, v1.ID)
+		}
+		if vessels[0].Ref != v1.Ref {
+			t.Fatalf("I9: surviving vessel Ref is %q, want %q (second Enqueue must be fully rejected)", vessels[0].Ref, v1.Ref)
 		}
 	})
 }

--- a/docs/invariants/queue.md
+++ b/docs/invariants/queue.md
@@ -147,12 +147,15 @@ error that stops further queue use, or (b) never be produced.
 **I9. Unique vessel IDs.**
 `∀ v1, v2 ∈ List(). v1.ID = v2.ID ⟹ v1 = v2`. `ID` is a primary key across
 the queue.
-- *Why:* `FindByID` currently returns the last match (queue.go:311) and
-  `Enqueue` checks only `Ref` collisions, not `ID`. Two vessels sharing an
-  `ID` is a silent divergence; every downstream state-machine claim implicitly
-  assumes this invariant.
-- *Test:* rapid ops; after every mutation, assert `ID` set has no duplicates.
-- *Status:* **not enforced in code.** `Enqueue` must reject duplicate `ID`.
+- *Why:* `FindByID` returns the last match (queue.go:311); without ID
+  uniqueness, every downstream state-machine claim would silently diverge
+  when two vessels shared an `ID`.
+- *Test:* explicit two-vessel construction — enqueue a vessel, then enqueue
+  a second vessel sharing the first's `ID` but with a distinct `Ref` (to
+  bypass the Ref-dedup short-circuit); assert `ErrDuplicateID` and
+  `len(List()) == 1`.
+- *Status:* **enforced.** `Enqueue` rejects duplicate `ID` with
+  `ErrDuplicateID` (PR #594, queue.go:223–227).
 
 **I10. `RetryOf` forms a DAG rooted at fresh vessels.**
 If `v.RetryOf ≠ ""`, then (a) there exists `w ∈ List() ∪ compacted_history`
@@ -229,17 +232,18 @@ fix is merged.
 | I7 | ✓ | `Update` (queue.go:219), `Cancel` (queue.go:409) | Transition validated before mutation. |
 | I7 | ✓ | `UpdateVessel` (queue.go:373) | Validates only on state-change, which is correct for I7 (but see I2 gap above). |
 | I8 | ✗ | `readAllVessels` (queue.go:629) | Silently skips malformed lines with a `log.Printf` warning. Fix: fail-closed (return error and stop using queue) OR make writes atomic so malformed lines cannot appear. Prerequisite for honest I5b. |
-| I9 | ✗ | `Enqueue` (queue.go:127) | Checks only `Ref`, not `ID`. Two vessels with the same `ID` is a silent bug. Fix: reject duplicate-`ID` enqueue. |
+| I9 | ✓ | `Enqueue` (queue.go:223–227) | Rejects duplicate-`ID` enqueue with `ErrDuplicateID` (PR #594). Ref-dedup at queue.go:212–221 short-circuits before the ID check when both `Ref` and `ID` collide; property test uses a distinct `Ref` to exercise the ID path. |
 | I10 | ⚠ | no enforcement | `RetryOf` is set by callers and never validated. Acceptable if callers are disciplined; property test must assert DAG over all observed queue states. |
 | I11 | ✓ | `compactVessels` (queue.go:467) | Removes only when `IsTerminal()`. Property test pins the current guarantee against future regressions. |
 
-**Summary:** 4 outright violations (I2, I3, I5b, I8, I9), 3 warnings (I1/I4/I10
-partial coverage). Fix order recommended:
+**Summary:** 3 outright violations (I2, I3, I5b, I8), 3 warnings (I1/I4/I10
+partial coverage). I9 landed in PR #594 and is pinned by
+`TestPropQueueInvariant_I9_UniqueIDs`. Fix order recommended for the
+remaining items:
 
-1. **I9** (duplicate `ID`) — one-line `Enqueue` guard; cheapest.
-2. **I2** (terminal-field mutation) — one-branch `UpdateVessel` guard.
-3. **I3** (`CurrentPhase`/`PhaseOutputs` reset) — needs policy sign-off on runner-side consequences before the reset is added.
-4. **I8 + I5b** (atomic writes + fail-closed reads) — paired change; correct order is I8 first (loud), then I5b (quiet, builds on I8).
+1. **I2** (terminal-field mutation) — one-branch `UpdateVessel` guard.
+2. **I3** (`CurrentPhase`/`PhaseOutputs` reset) — needs policy sign-off on runner-side consequences before the reset is added.
+3. **I8 + I5b** (atomic writes + fail-closed reads) — paired change; correct order is I8 first (loud), then I5b (quiet, builds on I8).
 
 ---
 


### PR DESCRIPTION
## Summary

- Rewrite `TestPropQueueInvariant_I9_UniqueIDs` from a tautological loop-of-random-ops into an explicit two-vessel construction that directly exercises the `Enqueue` duplicate-ID rejection path.
- Sync `docs/invariants/queue.md` I9 Status/Test/Gap fields with the code state that landed in PR #594 (commit 33a331a).
- Authorized by [docs/assurance/ROADMAP.md](https://github.com/nicholls-inc/xylem/blob/main/docs/assurance/ROADMAP.md) immediate item **#02** — [02-fix-queue-i9-tautology.md](https://github.com/nicholls-inc/xylem/blob/main/docs/assurance/immediate/02-fix-queue-i9-tautology.md).

## Why the old test was tautological

`drawMutatingOp` → `opEnqueue` → `drawFreshVessel` picks IDs from an 8-slot pool via `drawID(t)`. `applyOp` swallows the `ErrDuplicateID` error from `Enqueue` (landed in PR #594). The loop then asserts "no duplicate IDs visible in `List()`" — a property that holds trivially because the guard silently prevents duplicates from landing. Removing the I9 guard from `queue.go` would not have flipped this test RED.

## New test shape

```go
v1 := drawFreshVessel(t) // with non-empty Ref
q.Enqueue(v1)

v2 := drawFreshVessel(t)
v2.ID = v1.ID                                  // force ID collision
v2.Ref = "https://github.com/example/repo/issues/9" // distinct Ref
q.Enqueue(v2)

assert errors.Is(err, ErrDuplicateID)
assert len(List()) == 1
assert List()[0] == v1 (ID + Ref unchanged)
```

The distinct `Ref` is required to keep us past the Ref-dedup short-circuit at `queue.go:212–221`, which returns `(false, nil)` on a matching-Ref active vessel **before** reaching the ID check. Reproduced as test failure on first run when randomly picked refs collided — now pinned with a guard assertion.

## Doc updates

- `docs/invariants/queue.md` §I9: Status line changed from *"not enforced in code. `Enqueue` must reject duplicate `ID`"* → *"enforced. `Enqueue` rejects duplicate `ID` with `ErrDuplicateID` (PR #594, queue.go:223–227)"*.
- §I9 *Test* clause rewritten to describe the two-vessel construction.
- Gap-analysis row for I9: `✗ → ✓` with a note on the Ref-dedup short-circuit.
- Summary section: I9 removed from the remaining fix backlog (3 violations, not 4).

## Governance

This is **not** an invariant relaxation (§Amendment procedure). The invariant statement is unchanged:

> `∀ v1, v2 ∈ List(). v1.ID = v2.ID ⟹ v1 = v2`

Only the Status/Test/Gap fields are synced with reality post-#594. The property test is strengthened (stricter contract assertion), not weakened. Work falls under §1 Spec location's "explicit human direction" clause via the merged ROADMAP (commit `868672c`).

## Test plan

- [x] `cd cli && go test ./internal/queue/... -run TestPropQueueInvariant_I9 -v` — GREEN (100 rapid iterations)
- [x] `cd cli && go test ./internal/queue/...` — GREEN (full queue suite, 49s)
- [x] `cd cli && go vet ./...` — clean
- [x] `cd cli && go build ./cmd/xylem` — clean
- [x] Pre-commit hooks (goimports, golangci-lint, foxguard) — all passed

Fixes #648