### PR TITLE
fix(merge-pr): use GraphQL for reviewThreads; gh pr view field is REST-invalid

### DIFF
--- a/cli/internal/profiles/core/workflows/merge-pr.yaml
+++ b/cli/internal/profiles/core/workflows/merge-pr.yaml
@@ -39,13 +39,19 @@ phases:
       fi
 
       # 3. Review: no CHANGES_REQUESTED decision, all review threads resolved.
-      REVIEW=$(gh pr view "$PR" --repo "$REPO" --json reviewDecision,reviewThreads)
-      DECISION=$(echo "$REVIEW" | jq -r '.reviewDecision')
+      # reviewDecision is exposed via `gh pr view --json`, but reviewThreads is
+      # only accessible via GraphQL (see #574). Query each source separately.
+      DECISION=$(gh pr view "$PR" --repo "$REPO" --json reviewDecision --jq '.reviewDecision')
       if [ "$DECISION" = "CHANGES_REQUESTED" ]; then
         echo "XYLEM_NOOP: reviewDecision=CHANGES_REQUESTED"
         exit 0
       fi
-      UNRESOLVED=$(echo "$REVIEW" | jq '[.reviewThreads[] | select(.isResolved == false)] | length')
+      OWNER=$(echo "$REPO" | cut -d/ -f1)
+      NAME=$(echo "$REPO" | cut -d/ -f2)
+      UNRESOLVED=$(gh api graphql \
+        -f query='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$num){reviewThreads(first:100){nodes{isResolved}}}}}' \
+        -F owner="$OWNER" -F repo="$NAME" -F num="$PR" \
+        --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
       if [ "$UNRESOLVED" -gt 0 ]; then
         echo "XYLEM_NOOP: $UNRESOLVED unresolved review thread(s)"
         exit 0


### PR DESCRIPTION
## Summary

Fixes #574. The `merge-pr` workflow's `check` phase queries
`gh pr view --json reviewDecision,reviewThreads` to gate auto-admin-merge.
`reviewThreads` is **not a valid REST field** on `gh pr view --json` — it only
exists on the GraphQL `PullRequest` type. As a result every invocation exited 1
and the daemon's auto-admin-merge has been broken across the fleet since PR#570.

Split the query so each field comes from the right API:
- `reviewDecision` → `gh pr view --json reviewDecision --jq '.reviewDecision'`
- `reviewThreads` → `gh api graphql` with the documented
  `PullRequest.reviewThreads` connection (`first:100`, filter on `isResolved`)

## Verification

Reproduced the bug on PR#571:

```
gh pr view 571 --json reviewDecision,reviewThreads
  -> Unknown JSON field: "reviewThreads"  (exit 1)
```

Confirmed the GraphQL query works:

```
gh api graphql -f query='query($owner:String!,$repo:String!,$num:Int!){
  repository(owner:$owner,name:$repo){
    pullRequest(number:$num){
      reviewDecision
      reviewThreads(first:100){nodes{isResolved}}
    }
  }
}' -F owner=nicholls-inc -F repo=xylem -F num=571
  -> {"data":{"repository":{"pullRequest":{
       "reviewDecision":null,
       "reviewThreads":{"nodes":[{"isResolved":false}]}}}}}
```

## Test plan

- [x] `go build ./cmd/xylem` — clean
- [x] `go vet ./internal/profiles/...` — clean
- [x] `go test ./internal/profiles/` — pass
- [x] `go test ./...` — pass
- [x] `goimports -l .` — clean
- [x] pre-commit foxguard — pass
- [ ] After merge: confirm next `merge-pr-*` vessel on a `harness-impl` + `ready-to-merge` PR reaches the `merge` phase (check phase exits 0, not 1)

## Why this is critical

Auto-admin-merge is the final step that turns a green, reviewed harness PR into a merged commit. It has been silently broken since PR#570 — every `check` phase failure shows as an `unblock-wave` vessel `run failed; phase "check_deps" failed` (see #574, #605, #633). Unblocks the whole harness auto-merge loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)