### PR TITLE
fix(merge-pr): use -f for owner/repo to avoid gh numeric-coercion (#656)

### DIFF
--- a/cli/internal/profiles/core/workflows/merge-pr.yaml
+++ b/cli/internal/profiles/core/workflows/merge-pr.yaml
@@ -48,9 +48,11 @@ phases:
       fi
       OWNER=$(echo "$REPO" | cut -d/ -f1)
       NAME=$(echo "$REPO" | cut -d/ -f2)
+      # Use -f for owner/repo (GraphQL String!) to avoid `gh api -F` auto-coercing
+      # all-numeric org/repo names to Int and violating the schema (#656).
       UNRESOLVED=$(gh api graphql \
         -f query='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$num){reviewThreads(first:100){nodes{isResolved}}}}}' \
-        -F owner="$OWNER" -F repo="$NAME" -F num="$PR" \
+        -f owner="$OWNER" -f repo="$NAME" -F num="$PR" \
         --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
       if [ "$UNRESOLVED" -gt 0 ]; then
         echo "XYLEM_NOOP: $UNRESOLVED unresolved review thread(s)"

--- a/cli/internal/profiles/implement_harness_guard_test.go
+++ b/cli/internal/profiles/implement_harness_guard_test.go
@@ -2,6 +2,8 @@ package profiles_test
 
 import (
 	"io/fs"
+	"regexp"
+	"strings"
 	"testing"
 
 	. "github.com/nicholls-inc/xylem/cli/internal/profiles"
@@ -69,4 +71,51 @@ func TestImplementHarnessEmbeddedHonoursPRFixes(t *testing.T) {
 	require.Equalf(t, "high", criticTier,
 		"implement-harness test_critic phase tier=%q — PR #645 requires 'high' for cross-vendor critique",
 		criticTier)
+}
+
+// TestMergePRReviewThreadsUsesStringFields guards against the regression in
+// issue #656: `gh api -F` auto-coerces all-numeric strings to Int, so binding
+// `owner` / `repo` (GraphQL `String!`) with `-F` would break for any org or
+// repo whose name is purely numeric. The reviewThreads query in the merge-pr
+// workflow must use `-f` (raw-field, always string) for owner and repo.
+func TestMergePRReviewThreadsUsesStringFields(t *testing.T) {
+	profile, err := Load("core")
+	require.NoError(t, err)
+
+	data, err := fs.ReadFile(profile.FS, "workflows/merge-pr.yaml")
+	require.NoError(t, err)
+	body := string(data)
+
+	// Sanity: the reviewThreads GraphQL query is still present.
+	require.Contains(t, body, "reviewThreads(first:100)",
+		"merge-pr.yaml lost the reviewThreads GraphQL query — PR #655 regression?")
+
+	// The owner/repo bindings must be -f (raw-string), not -F (typed).
+	// Match across whitespace to tolerate line-continuation reformatting.
+	bad := regexp.MustCompile(`-F\s+(owner|repo)=`)
+	if loc := bad.FindStringIndex(body); loc != nil {
+		snippet := body[max0(loc[0]-40):min(len(body), loc[1]+40)]
+		t.Fatalf("merge-pr.yaml binds owner/repo with `gh api -F` — issue #656 requires -f for GraphQL String! fields. Near:\n%s",
+			strings.TrimSpace(snippet))
+	}
+
+	// And the fix should be present: both -f owner= and -f repo=.
+	require.Regexp(t, `-f\s+owner=`, body,
+		"merge-pr.yaml must bind owner with `-f` (raw-string) for the GraphQL String! constraint")
+	require.Regexp(t, `-f\s+repo=`, body,
+		"merge-pr.yaml must bind repo with `-f` (raw-string) for the GraphQL String! constraint")
+}
+
+func max0(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }


### PR DESCRIPTION
Closes #656.

## Summary

`gh api -F` auto-coerces all-numeric strings to `Int`. The `reviewThreads` GraphQL query in `merge-pr.yaml` binds `owner` and `repo` as `String!`, so any org or repo with a purely-numeric name (e.g. owner `"42"`) would fail with a GraphQL type error.

- Switch `owner` / `repo` bindings from `-F` to `-f` (raw-string).
- Leave `-F num="$PR"` unchanged (`num` is `Int!`).
- Add a profiles guard test (`TestMergePRReviewThreadsUsesStringFields`) that pins the embedded `merge-pr.yaml` to the correct `-f` binding, alongside the existing PR #600 / #645 pins, so a future embedded-profile edit can't silently reintroduce the regression.

## Test plan

- [x] `go test ./internal/profiles/...` passes locally (1.28s)
- [x] New guard fails if `-F owner=` or `-F repo=` is reintroduced (regex-checked)
- [x] Guard also asserts `-f owner=` / `-f repo=` are present (positive check)
- [x] `go build`, `goimports`, `go vet` all green
- [x] foxguard + golangci-lint pre-commit hooks green

## Impact

- Latent bug; does not affect `nicholls-inc/xylem` itself.
- Ships via the PR #652 embedded-profile-drift guard, so existing daemon checkouts pick it up on restart.

## Why this is cheap

One-line workflow edit + one test method in an existing test file. Diff is well under 100 lines; guard test gives us regression coverage without invoking `gh` or spawning a subprocess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)