### PR TITLE
fix(retry): accept StateCancelled so cancelled vessels are recoverable (#658)

### DIFF
--- a/cli/cmd/xylem/retry.go
+++ b/cli/cmd/xylem/retry.go
@@ -35,7 +35,7 @@ func cmdRetry(q *queue.Queue, cfg *config.Config, id string, fromScratch bool) e
 		return fmt.Errorf("retry error: %w", err)
 	}
 
-	if vessel.State != queue.StateFailed && vessel.State != queue.StateTimedOut {
+	if vessel.State != queue.StateFailed && vessel.State != queue.StateTimedOut && vessel.State != queue.StateCancelled {
 		return fmt.Errorf("error: vessel %s is not in a retryable state (current: %s)", id, vessel.State)
 	}
 	if err := recovery.RetryAuthorized(cfg.StateDir, vessel.ID); err != nil {

--- a/cli/cmd/xylem/retry_test.go
+++ b/cli/cmd/xylem/retry_test.go
@@ -300,6 +300,39 @@ func TestRetryTimedOutVessel(t *testing.T) {
 	}
 }
 
+// TestRetryCancelledVessel exercises the operator-recovery handle for issue #658:
+// a vessel the operator cancelled during a worker-stall rep must be reachable
+// again through `xylem retry`, since the GitHub issue stays `ready-for-work`
+// and the scanner dedups the base ID indefinitely (cli/internal/scanner/scanner.go:101-110).
+func TestRetryCancelledVessel(t *testing.T) {
+	q := newRetryTestQueue(t)
+	cfg := newRetryTestConfig(t)
+	now := time.Now().UTC()
+	v := queue.Vessel{
+		ID: "issue-60", Source: "github-issue", Workflow: "implement-harness",
+		Ref:   "https://github.com/owner/repo/issues/60",
+		State: queue.StatePending, CreatedAt: now,
+	}
+	q.Enqueue(v)                                                  //nolint:errcheck
+	q.Update("issue-60", queue.StateRunning, "")                  //nolint:errcheck
+	q.Update("issue-60", queue.StateCancelled, "operator cancel") //nolint:errcheck
+
+	if err := cmdRetry(q, cfg, "issue-60", true); err != nil {
+		t.Fatalf("unexpected error retrying cancelled vessel: %v", err)
+	}
+
+	retry, err := q.FindByID("issue-60-retry-1")
+	if err != nil {
+		t.Fatalf("retry vessel not found: %v", err)
+	}
+	if retry.State != queue.StatePending {
+		t.Errorf("retry should be pending, got %s", retry.State)
+	}
+	if retry.RetryOf != "issue-60" {
+		t.Errorf("retry_of should be issue-60, got %s", retry.RetryOf)
+	}
+}
+
 func TestRetryNonRetryableVessel(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

Closes the manual-recovery gap described in #658 for base-ID vessels that an operator cancelled during a worker-stall rep.

- `cli/cmd/xylem/retry.go:38` now accepts `StateCancelled` alongside `StateFailed` and `StateTimedOut`.
- New test `TestRetryCancelledVessel` asserts cancelled vessels round-trip through `cmdRetry` into a pending `-retry-1` vessel.

This is suggestion (2) in #658 — the lowest-risk operator handle. Scanner-side state-aware dedup (suggestions 1/3) is intentionally out of scope for this PR.

## Why this is enough for the bug reporter

Once merged, the operator recipe for a stalled base-ID issue is:

```
xylem cancel issue-NNN       # already worked
xylem retry issue-NNN        # previously failed, now succeeds
```

The retry creates `issue-NNN-retry-1` with a fresh ID, bypassing the scanner's ID-keyed dedup entirely. No queue-file editing required.

## Test plan

- [x] `cd cli && go build ./cmd/xylem`
- [x] `cd cli && goimports -l .` (no output)
- [x] `cd cli && go vet ./...`
- [x] `cd cli && go test ./internal/scanner ./internal/queue ./cmd/xylem`
- [x] `go test ./cmd/xylem -run TestRetryCancelledVessel -v` passes

Closes #658 (for the retry-gate arm; scanner-side follow-up remains).