### PR TITLE
fix(scanner): chain terminal duplicate-ID collisions as -retry-N (#658)

### DIFF
--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -100,10 +100,28 @@ func (s *Scanner) Scan(ctx context.Context) (ScanResult, error) {
 
 			enqueued, err := s.Queue.Enqueue(vessel)
 			if errors.Is(err, queue.ErrDuplicateID) {
-				// Changed-fingerprint retry path currently reuses the original
-				// ID, which collides with the failed record (I9). Skip rather
-				// than crash the scan; the correct fix (route through Update
-				// or use RetryID for a new-ID retry) is scanner-side.
+				// ID collision. Inspect the existing row: if it is in a
+				// recoverable terminal state (cancelled, failed, timed_out),
+				// chain the scan result as a new -retry-N vessel so the issue
+				// is not stranded. `completed` and active states fall through
+				// to a skip — active is already live, completed would silently
+				// redo shipped work. See issue #658.
+				chained, newVessel, chainErr := s.chainTerminalRetry(vessel)
+				if chainErr != nil {
+					log.Printf("warn: scanner: duplicate vessel ID %q, chain retry failed: %v", vessel.ID, chainErr)
+					scanErrs = append(scanErrs, chainErr)
+					result.Skipped++
+					continue
+				}
+				if chained {
+					result.Added++
+					if s.RunHooks {
+						if hookErr := entry.src.OnEnqueue(ctx, newVessel); hookErr != nil {
+							log.Printf("warn: OnEnqueue hook for chained vessel %s failed: %v", newVessel.ID, hookErr)
+						}
+					}
+					continue
+				}
 				log.Printf("warn: scanner: duplicate vessel ID %q, skipping", vessel.ID)
 				result.Skipped++
 				continue
@@ -142,6 +160,54 @@ func (s *Scanner) Scan(ctx context.Context) (ScanResult, error) {
 		}
 	}
 	return result, errors.Join(scanErrs...)
+}
+
+// chainTerminalRetry handles the ErrDuplicateID case where the colliding queue
+// row is in a recoverable terminal state (cancelled, failed, timed_out). It
+// allocates a fresh -retry-N ID via recovery.RetryID, sets RetryOf to the
+// original ID, and re-enqueues. Returns (true, nil) if a new vessel was
+// enqueued; (false, nil) if the collision should fall through to skip
+// (existing row is active or completed); (false, err) on a hard error.
+//
+// Only one retry attempt is made; a second collision (e.g. race against a
+// concurrent enqueue) falls through to skip rather than looping.
+func (s *Scanner) chainTerminalRetry(vessel queue.Vessel) (bool, queue.Vessel, error) {
+	originalID := vessel.ID
+	existing, err := s.Queue.FindByID(originalID)
+	if err != nil || existing == nil {
+		// No existing row to inspect — ErrDuplicateID must have been spurious
+		// (race, or queue just compacted). Skip this tick; next scan will
+		// re-evaluate.
+		return false, queue.Vessel{}, nil
+	}
+	switch existing.State {
+	case queue.StateCancelled, queue.StateFailed, queue.StateTimedOut:
+		// Recoverable terminal: chain.
+	default:
+		// Active (pending/running/waiting) or completed: do not chain.
+		return false, queue.Vessel{}, nil
+	}
+
+	vessel.ID = recovery.RetryID(originalID, s.Queue)
+	vessel.RetryOf = originalID
+	enqueued, enqErr := s.Queue.Enqueue(vessel)
+	if enqErr != nil {
+		if errors.Is(enqErr, queue.ErrDuplicateID) {
+			// Race: another process allocated the same -retry-N between
+			// RetryID and Enqueue. Skip rather than loop.
+			return false, queue.Vessel{}, nil
+		}
+		return false, queue.Vessel{}, enqErr
+	}
+	if !enqueued {
+		return false, queue.Vessel{}, nil
+	}
+	if err := recovery.UpdateRetryOutcome(s.Config.StateDir, originalID, "enqueued"); err != nil {
+		// Recovery bookkeeping is best-effort; the vessel IS in the queue.
+		log.Printf("warn: scanner: chain retry UpdateRetryOutcome failed for %q: %v", originalID, err)
+	}
+	log.Printf("info: scanner: chained terminal %s vessel %q as %q (retry_of=%s)", existing.State, originalID, vessel.ID, originalID)
+	return true, vessel, nil
 }
 
 func (s *Scanner) budgetGate() budgetGate {

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -554,23 +554,162 @@ func TestScanReenqueuesChangedFailedIssue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Spec I9 (docs/invariants/queue.md) forbids duplicate IDs. The
-	// changed-fingerprint path currently reuses the original ID, which the
-	// queue now rejects; the scanner logs the collision and skips. The
-	// scanner-side fix (route changed-fingerprint retries through Update or
-	// a RetryID-style new ID) is tracked as a separate gap.
-	if result.Added != 0 {
-		t.Fatalf("expected duplicate-ID re-enqueue to be skipped, added=%d", result.Added)
+	// Spec I9 (docs/invariants/queue.md) forbids duplicate IDs. Per #658,
+	// when the colliding row is in a recoverable terminal state (failed,
+	// cancelled, timed_out) the scanner now chains a fresh -retry-N vessel
+	// rather than skipping — otherwise the issue is stranded forever.
+	if result.Added != 1 {
+		t.Fatalf("expected changed-fingerprint collision to chain (added=1), got added=%d", result.Added)
 	}
-	if result.Skipped != 1 {
-		t.Fatalf("expected duplicate-ID re-enqueue to be counted as skipped, skipped=%d", result.Skipped)
+	if result.Skipped != 0 {
+		t.Fatalf("expected changed-fingerprint collision to chain (skipped=0), got skipped=%d", result.Skipped)
 	}
 	vessels, err := q.List()
 	if err != nil {
 		t.Fatalf("list queue: %v", err)
 	}
+	if len(vessels) != 2 {
+		t.Fatalf("expected 2 queue entries (original + chained retry), got %d", len(vessels))
+	}
+	retry := vessels[len(vessels)-1]
+	if retry.ID != "issue-1-retry-1" {
+		t.Fatalf("expected chained ID issue-1-retry-1, got %q", retry.ID)
+	}
+	if retry.RetryOf != "issue-1" {
+		t.Fatalf("expected RetryOf=issue-1, got %q", retry.RetryOf)
+	}
+	if retry.State != queue.StatePending {
+		t.Fatalf("expected chained retry StatePending, got %q", retry.State)
+	}
+}
+
+// TestScanChainsCancelledTerminalVessel covers issue #658: when the scanner
+// finds a GitHub issue whose existing queue row is cancelled (operator
+// cancelled a wedged vessel; cf. loop 281 worker-stall rep #12), it must
+// chain a fresh -retry-N vessel rather than skip on ErrDuplicateID.
+func TestScanChainsCancelledTerminalVessel(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{
+		{Number: 1, Title: "wedged issue", Body: "body", URL: "https://github.com/owner/repo/issues/1", Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}}},
+	}
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	for _, prefix := range []string{"fix", "feat"} {
+		r.set([]byte(""), "git", "ls-remote", "--heads", "origin", fmt.Sprintf("%s/issue-%d-*", prefix, 1))
+		r.set([]byte("[]"), "gh", "pr", "list", "--repo", "owner/repo", "--search", fmt.Sprintf("head:%s/issue-%d-", prefix, 1), "--state", "open", "--json", "number,headRefName", "--limit", "5")
+	}
+
+	// Seed a cancelled base-ID row (the stranded case).
+	if _, err := q.Enqueue(queue.Vessel{
+		ID:        "issue-1",
+		Source:    "github-issue",
+		Ref:       "https://github.com/owner/repo/issues/1",
+		Workflow:  "fix-bug",
+		Meta:      map[string]string{"issue_num": "1"},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("enqueue seed: %v", err)
+	}
+	if _, err := q.Dequeue(); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if err := q.Update("issue-1", queue.StateCancelled, "operator cancel"); err != nil {
+		t.Fatalf("cancel seed: %v", err)
+	}
+
+	s := New(cfg, q, r)
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Added != 1 {
+		t.Fatalf("expected cancelled-collision to chain (added=1), got added=%d skipped=%d", result.Added, result.Skipped)
+	}
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(vessels) != 2 {
+		t.Fatalf("expected 2 vessels (cancelled base + chained retry), got %d", len(vessels))
+	}
+	retry := vessels[len(vessels)-1]
+	if retry.ID != "issue-1-retry-1" {
+		t.Fatalf("chain ID: got %q, want issue-1-retry-1", retry.ID)
+	}
+	if retry.RetryOf != "issue-1" {
+		t.Fatalf("chain RetryOf: got %q, want issue-1", retry.RetryOf)
+	}
+	if retry.State != queue.StatePending {
+		t.Fatalf("chain state: got %q, want pending", retry.State)
+	}
+	// The base cancelled row must remain sealed (I2 terminal immutability).
+	base := vessels[0]
+	if base.ID != "issue-1" || base.State != queue.StateCancelled {
+		t.Fatalf("base row mutated: id=%q state=%q", base.ID, base.State)
+	}
+}
+
+// TestScanSkipsCompletedDuplicateID confirms that the chain path does NOT
+// fire for completed vessels — re-enqueueing a completed vessel would
+// silently redo shipped work. Completed collisions must still skip.
+func TestScanSkipsCompletedDuplicateID(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{
+		{Number: 1, Title: "completed", Body: "body", URL: "https://github.com/owner/repo/issues/1", Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}}},
+	}
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	for _, prefix := range []string{"fix", "feat"} {
+		r.set([]byte(""), "git", "ls-remote", "--heads", "origin", fmt.Sprintf("%s/issue-%d-*", prefix, 1))
+		r.set([]byte("[]"), "gh", "pr", "list", "--repo", "owner/repo", "--search", fmt.Sprintf("head:%s/issue-%d-", prefix, 1), "--state", "open", "--json", "number,headRefName", "--limit", "5")
+	}
+
+	if _, err := q.Enqueue(queue.Vessel{
+		ID:        "issue-1",
+		Source:    "github-issue",
+		Ref:       "https://github.com/owner/repo/issues/1",
+		Workflow:  "fix-bug",
+		Meta:      map[string]string{"issue_num": "1"},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := q.Dequeue(); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if err := q.Update("issue-1", queue.StateCompleted, ""); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	s := New(cfg, q, r)
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Added != 0 {
+		t.Fatalf("expected completed-collision to skip (added=0), got added=%d", result.Added)
+	}
+	if result.Skipped != 1 {
+		t.Fatalf("expected completed-collision to skip (skipped=1), got skipped=%d", result.Skipped)
+	}
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
 	if len(vessels) != 1 {
-		t.Fatalf("expected 1 queue entry (duplicate rejected), got %d", len(vessels))
+		t.Fatalf("expected 1 vessel (no chain on completed), got %d", len(vessels))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Scanner's second dedup check (ID collision) now re-emits via `recovery.RetryID` when the existing row is `cancelled`, `failed`, or `timed_out`, instead of skipping silently.
- Sets `RetryOf` to the original ID so the chain is observable.
- `completed` and active states (pending/running/waiting) still fall through to skip — chaining completed would redo shipped work; active is already covered by the upstream Ref dedup.
- Only one retry per scan (second collision falls through) to avoid racing a concurrent enqueue into a loop.

This is the scanner-side half of #658. PR #659 (merged) already fixed the `xylem retry` gate. With both landed, stranded issues #649/#650/#653 will re-enter the queue on the next scan tick.

## Test plan

- [x] `cd cli && go build ./cmd/xylem`
- [x] `goimports -l .` (clean)
- [x] `go vet ./...`
- [x] `go test ./internal/scanner ./internal/queue ./cmd/xylem`
- [ ] Daemon picks up PR via merge-pr vessel once CI green
- [ ] After merge + auto-upgrade, verify #649/#650/#653 re-dequeue on next scan

Tests added/updated:
- `TestScanReenqueuesChangedFailedIssue` — asserts chain behaviour (was asserting the gap).
- `TestScanChainsCancelledTerminalVessel` — new, covers operator-cancelled stranded case.
- `TestScanSkipsCompletedDuplicateID` — new, pins completed-state negative path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)