### PR TITLE
docs(assurance): add Xylem projection section to assurance-hierarchy.md

### DIFF
--- a/docs/assurance/ROADMAP.md
+++ b/docs/assurance/ROADMAP.md
@@ -77,7 +77,7 @@ Stop and re-plan the entire roadmap if any of the following becomes true:
 
 ## References
 
-- `docs/research/assurance-hierarchy.md` — the 6-layer hierarchy this roadmap operationalizes
+- `docs/research/assurance-hierarchy.md` — the 6-layer hierarchy this roadmap operationalizes (includes "Xylem projection" section mapping layers to current Go-ecosystem reach)
 - `docs/research/literature-review.md` — prior art (GS AI, Kleppmann, Midspiral, Axiom, Harmonic, de Moura, Skomarovsky)
 - `docs/invariants/queue.md`, `scanner.md`, `runner.md` — load-bearing module invariant specs
 - `.claude/rules/protected-surfaces.md` — governance for invariant docs and property tests

--- a/docs/assurance/immediate/05-hierarchy-xylem-projection.md
+++ b/docs/assurance/immediate/05-hierarchy-xylem-projection.md
@@ -1,7 +1,7 @@
 # 05: Amend Assurance Hierarchy With Xylem Projection Section
 
 **Horizon:** Immediate
-**Status:** Not started
+**Status:** Done
 **Estimated cost:** 2 hours
 **Depends on:** nothing
 **Unblocks:** everything that cites the hierarchy as its north star

--- a/docs/research/assurance-hierarchy.md
+++ b/docs/research/assurance-hierarchy.md
@@ -60,6 +60,41 @@ The hierarchy contains two distinct chains with different failure modes and veri
 
 Residual risk concentrates at the top of the specification chain — Layer 6 — which is where the research opportunity lies.
 
+## Xylem projection
+
+This section states the current concrete reach of each layer within the xylem
+codebase (Go, concurrent daemon, no verified Go compiler available). It is
+maintained alongside `docs/assurance/ROADMAP.md` and should be updated whenever
+a roadmap item changes a layer's reach.
+
+**Layer 1 (formally verified pure code).** Restricted to sequential pure logic
+— queue state machine (I7), retry-DAG acyclicity (I10), budget-gate arithmetic,
+class-slot accounting, dedup-key hashing. Tooling: Dafny via the `crosscheck`
+plugin, compiled to Go via `crosscheck:extract-code`. See `docs/assurance/next/06-queue-dafny-kernel.md` and `09-retry-dag-dafny-kernel.md`.
+
+**Layer 2 (compilation correctness).** No Go equivalent of CompCert exists. The
+Go toolchain is part of the trusted computing base. This layer is **not
+addressable** in the near term.
+
+**Layer 3 (contract graph verification).** Pairwise contracts via Gobra are
+near-term (item #10 — queue only). End-to-end subgraph verification (scanner →
+queue → runner) is aspirational (item #13 — Go-native extension of the existing
+Rust+Lean contract-graph-verifier PoC).
+
+**Layer 4 (implementation-spec alignment).** Delivered by Dafny-verified
+kernels as they land. `verify-kernel` workflow phase (#08) gates merges on
+`dafny_verify` of any touched `.dfy` files.
+
+**Layer 5 (spec-intent alignment).** `intent-check` workflow phase (#07) —
+claimcheck-analog using two-LLM back-translation. Probabilistic; expect
+~96% accuracy on curated benchmarks and unknown real-PR performance until
+item #07 is operating.
+
+**Layer 6 (spec completeness).** Best-effort. `acceptance-oracle` workflow
+phase (#11) gives observable user-behavior assurance; `spec-adversary` phase
+(#14) explores adversarial property discovery. No theorem proves spec
+completeness; these are both iterative practices.
+
 ## Supporting Workflow Elements
 
 Two additional practices sit alongside the hierarchy rather than within it:


### PR DESCRIPTION
Closes #646

Salvaged from vessel `issue-646-retry-1` (phase completed cleanly, cost $0.48, trace `443fe9c5515a8510e8aa8d4bb9132222`). The PR phase hit a sandbox egress block and could not push; commit `18d63f3` sat stranded in the local daemon worktree. Pushed by hand to avoid re-spending the budget on a redo.

## Summary
- Adds a "Xylem projection" section to `docs/research/assurance-hierarchy.md` mapping the 6-layer hierarchy to xylem's current reach
- Marks roadmap item #05 as Done in `docs/assurance/immediate/05-hierarchy-xylem-projection.md`
- Cross-references the new section from `docs/assurance/ROADMAP.md`

## Scope
Docs-only. No code, no protected surfaces (verified against `.claude/rules/protected-surfaces.md`).

## Test plan
- [x] `git merge-tree` against main — no conflicts
- [x] Diff limited to 3 doc files, 37+/2-
- [ ] CI green