### PR TITLE
ci(invariants): enforce invariant-to-test coverage mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,20 @@ name: CI
 on:
   push:
     branches: [main]
-    paths: ["cli/**", ".golangci.yml", ".xylem/workflows/**"]
+    paths:
+      - "cli/**"
+      - ".golangci.yml"
+      - ".xylem/workflows/**"
+      - "docs/invariants/**"
+      - "scripts/check_invariant_coverage.py"
   pull_request:
     branches: [main]
-    paths: ["cli/**", ".golangci.yml", ".xylem/workflows/**"]
+    paths:
+      - "cli/**"
+      - ".golangci.yml"
+      - ".xylem/workflows/**"
+      - "docs/invariants/**"
+      - "scripts/check_invariant_coverage.py"
 
 jobs:
   go-checks:
@@ -37,3 +47,11 @@ jobs:
 
       - run: go build ./cmd/xylem
       - run: go test ./...
+
+  invariant-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check invariant↔test coverage mapping
+        run: python3 scripts/check_invariant_coverage.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,3 +58,14 @@ repos:
         language: system
         pass_filenames: false
         files: ^\.foxguard/(baseline\.json|justifications\.md)$
+
+      # Enforces 1:1 coverage between docs/invariants/<module>.md invariant
+      # headers and `// Invariant <ID>:` comments in the module's property
+      # tests. Prevents silent drift between specs and tests. See
+      # docs/invariants/README.md § Coverage enforcement.
+      - id: invariant-coverage
+        name: invariant-coverage
+        entry: python3 scripts/check_invariant_coverage.py
+        language: system
+        pass_filenames: false
+        files: ^(docs/invariants/.+\.md|cli/internal/.+_invariants_prop_test\.go|scripts/check_invariant_coverage\.py)$

--- a/docs/invariants/README.md
+++ b/docs/invariants/README.md
@@ -1,0 +1,76 @@
+# Module invariant specifications
+
+This directory holds the load-bearing behavioral contracts for xylem's core modules:
+
+- [`queue.md`](queue.md) — the Vessel queue (enqueue/dequeue/state transitions/recovery)
+- [`runner.md`](runner.md) — phase execution, gates, retries, timeouts
+- [`scanner.md`](scanner.md) — source polling, dedup, enqueue
+
+Each module's invariants are numbered (`I1`, `I1a`, `I2`, …; scanner uses `S1`, `S2`, …) and tested in the matching `cli/internal/<module>/*_invariants_prop_test.go` file.
+
+These documents and their property tests are **protected surfaces** (see [`.claude/rules/protected-surfaces.md`](../../.claude/rules/protected-surfaces.md)): they must not be modified, deleted, or weakened without an explicit human-authored amendment.
+
+## Coverage enforcement
+
+Every invariant declared in a module spec **must** be referenced by at least one `// Invariant <ID>: <Name>` comment in the module's property-test file, and every such comment **must** refer to an invariant declared in that module's spec.
+
+This is enforced mechanically by [`scripts/check_invariant_coverage.py`](../../scripts/check_invariant_coverage.py), which runs:
+
+- as a **pre-commit hook** (see `.pre-commit-config.yaml`, hook id `invariant-coverage`)
+- as a **CI job** (see `.github/workflows/ci.yml`, job `invariant-coverage`)
+
+The check fails the build if a declared invariant has no covering comment (missing coverage) or if a test comment refers to an invariant that is not declared in the module doc (orphan comment).
+
+### Header format (in the doc)
+
+Invariants are declared with a bold-wrapped header at the start of a line:
+
+```markdown
+**I1. At-most-one active per ref.** …prose…
+**I1a. Enqueue of an active ref is a no-op.** …prose…
+**S3. Pause marker aborts the tick before any side effect.** …prose…
+```
+
+The regex is strict: `^\*\*([A-Z]+\d+[a-z]?)\.\s` — anything that doesn't match is not recognised as an invariant declaration.
+
+### Comment format (in the test)
+
+Above the test that enforces the invariant:
+
+```go
+// Invariant I1: At-most-one active per ref.
+func TestPropQueueInvariant_I1_AtMostOneActivePerRef(t *testing.T) { … }
+```
+
+The regex is strict: `^//\s*Invariant\s+([A-Z]+\d+[a-z]?):\s`. Variations like `// Invariant: I1`, `// I1:`, or IDs without a digit (e.g. `Ix`) are not recognised.
+
+IDs must contain a digit by construction. A typo that drops the digit (e.g. renaming a test comment from `I1` to `Ix`) is invisible to the regex: the check will surface it as **missing coverage on the original ID** (`I1`), not as an orphan comment on `Ix`. This is intentional — the regex refuses to guess at malformed labels — but it means test comments should be grepped whenever an invariant is renamed.
+
+### Coverage scoping
+
+IDs are scoped **per module**. `queue.md`'s `I1` and `runner.md`'s `I1` are different invariants; each is expected to be covered in its own package's property test.
+
+### Aspirational opt-out
+
+If an invariant is declared in the spec but is intentionally not yet covered by a property test, mark the header with the literal HTML comment `<!-- aspirational -->` on the same line:
+
+```markdown
+**I14. Planned but not yet enforced.** <!-- aspirational -->
+```
+
+Aspirational invariants are skipped by the missing-coverage check. **Orphan-comment checks still apply** — a test comment whose ID is not declared in the module doc is always an error.
+
+Use this marker sparingly: every aspirational entry is a standing IOU against the module's guarantees.
+
+## Adding a new invariant
+
+1. Write the prose in the module's spec with a `**IN. Name.**` header.
+2. Add a property test in `cli/internal/<module>/*_invariants_prop_test.go` with a `// Invariant IN: Name.` comment above it.
+3. Run `python3 scripts/check_invariant_coverage.py` locally (or let the pre-commit hook run it).
+4. Commit both files together.
+
+If you cannot yet write the test, mark the header with `<!-- aspirational -->` and file an issue to cover it.
+
+## Removing an invariant
+
+Removing an invariant is a human-authored amendment, not a mechanical change. Propose the removal in a PR description, justify it against the module's guarantees, and obtain human review before merging. The enforcement check does **not** prevent deletion — it only prevents silent drift between the spec and the tests.

--- a/scripts/check_invariant_coverage.py
+++ b/scripts/check_invariant_coverage.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Enforce invariant-to-test coverage mapping between specs and property tests.
+
+For every module with an invariant spec at ``docs/invariants/<module>.md``, this
+script verifies that every invariant ID declared in the doc appears in at least
+one ``// Invariant <ID>: ...`` comment inside the module's property-test file
+(``cli/internal/<module>/*invariants_prop_test.go``). Conversely, every such
+comment must refer to an invariant declared in that module's doc.
+
+Invariant headers in the doc look like:
+
+    **I1. At-most-one active per ref.**
+    **I1a. Enqueue of an active ref is a no-op.**
+    **S3. Pause marker aborts the tick before any side effect.**
+
+Test-side comments look like:
+
+    // Invariant I1: At-most-one active per ref.
+    // Invariant S3: Pause marker aborts the tick before any side effect.
+
+Headers carrying the literal HTML comment ``<!-- aspirational -->`` on the same
+line are exempt from the missing-coverage check. Orphan-comment checks still
+apply: a test comment whose ID is not declared in the module doc is always an
+error.
+
+Coverage scoping is **per module**, not global. Queue's ``I1`` and runner's
+``I1`` refer to different invariants; each is expected to be covered in its own
+package's property-test file.
+
+Exit codes:
+  0 - every required invariant is covered; no orphan comments
+  1 - one or more coverage violations
+  2 - input files missing or malformed
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs" / "invariants"
+INTERNAL_DIR = REPO_ROOT / "cli" / "internal"
+
+# Invariant header: **<prefix><digits>[suffix]. ...** at line start.
+# Group 1 is the identifier (e.g. I1, I1a, S8, I14).
+HEADER_RE = re.compile(r"^\*\*([A-Z]+\d+[a-z]?)\.\s", re.MULTILINE)
+
+# Aspirational opt-out marker on the same line as the header.
+ASPIRATIONAL_RE = re.compile(
+    r"^\*\*([A-Z]+\d+[a-z]?)\..*<!--\s*aspirational\s*-->",
+    re.MULTILINE,
+)
+
+# Test-side comment: // Invariant <ID>: ... (literal "Invariant", ID, colon).
+# Matches only at the start of a stripped line so in-prose refs do not match.
+TEST_COMMENT_RE = re.compile(r"^//\s*Invariant\s+([A-Z]+\d+[a-z]?):\s")
+
+
+@dataclass
+class ModuleCoverage:
+    module: str
+    doc_path: Path
+    test_paths: list[Path]
+    declared: set[str] = field(default_factory=set)
+    aspirational: set[str] = field(default_factory=set)
+    covered: set[str] = field(default_factory=set)
+    comment_sites: list[tuple[str, Path, int]] = field(default_factory=list)
+
+
+def discover_modules() -> list[ModuleCoverage]:
+    """Locate (module, doc, test_paths) triples for every invariant doc."""
+    if not DOCS_DIR.is_dir():
+        print(f"ERROR: {DOCS_DIR} is missing", file=sys.stderr)
+        sys.exit(2)
+
+    modules: list[ModuleCoverage] = []
+    for doc in sorted(DOCS_DIR.glob("*.md")):
+        stem = doc.stem
+        if stem.lower() == "readme":
+            continue
+        module_dir = INTERNAL_DIR / stem
+        test_paths = sorted(module_dir.glob("*invariants_prop_test.go")) if module_dir.is_dir() else []
+        modules.append(
+            ModuleCoverage(module=stem, doc_path=doc, test_paths=test_paths)
+        )
+    return modules
+
+
+def load_doc(cov: ModuleCoverage) -> None:
+    text = cov.doc_path.read_text()
+    for m in HEADER_RE.finditer(text):
+        cov.declared.add(m.group(1))
+    for m in ASPIRATIONAL_RE.finditer(text):
+        cov.aspirational.add(m.group(1))
+
+
+def load_tests(cov: ModuleCoverage) -> None:
+    for path in cov.test_paths:
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            m = TEST_COMMENT_RE.match(line.lstrip())
+            if m:
+                inv_id = m.group(1)
+                cov.covered.add(inv_id)
+                cov.comment_sites.append((inv_id, path, lineno))
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def main() -> int:
+    modules = discover_modules()
+    if not modules:
+        print(f"ERROR: no invariant docs found under {DOCS_DIR}", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+
+    for cov in modules:
+        load_doc(cov)
+
+        if not cov.declared:
+            failures.append(
+                f"{rel(cov.doc_path)}: no invariant headers found "
+                f"(expected lines like `**I1. ...**`)"
+            )
+            continue
+
+        if not cov.test_paths:
+            expected_dir = INTERNAL_DIR / cov.module
+            failures.append(
+                f"{rel(cov.doc_path)}: no property test file found at "
+                f"{rel(expected_dir)}/*invariants_prop_test.go"
+            )
+            continue
+
+        load_tests(cov)
+
+        # Missing coverage: declared in doc and not aspirational, yet no comment.
+        required = cov.declared - cov.aspirational
+        for inv_id in sorted(required - cov.covered):
+            failures.append(
+                f"{rel(cov.doc_path)}: invariant {inv_id} is declared but has no "
+                f"`// Invariant {inv_id}: ...` comment in "
+                f"{rel(INTERNAL_DIR / cov.module)}/*invariants_prop_test.go"
+            )
+
+        # Orphan comments: test refers to an ID not in the module doc.
+        for inv_id in sorted(cov.covered - cov.declared):
+            sites = ", ".join(
+                f"{rel(p)}:{ln}"
+                for _id, p, ln in cov.comment_sites
+                if _id == inv_id
+            )
+            failures.append(
+                f"{rel(cov.doc_path)}: `// Invariant {inv_id}:` refers to an invariant "
+                f"not declared in this module doc (sites: {sites})"
+            )
+
+    if failures:
+        print("invariant coverage check FAILED:", file=sys.stderr)
+        for msg in failures:
+            print(f"  {msg}", file=sys.stderr)
+        print(
+            "\nFix by either:\n"
+            "  - adding a `// Invariant <ID>: <Name>` comment above the test that "
+            "enforces the invariant,\n"
+            "  - updating the spec so the ID is declared, or\n"
+            "  - marking the header with `<!-- aspirational -->` if it is "
+            "intentionally not yet covered.\n"
+            "See docs/invariants/README.md for the full workflow.",
+            file=sys.stderr,
+        )
+        return 1
+
+    total_declared = sum(len(m.declared) for m in modules)
+    total_aspirational = sum(len(m.aspirational) for m in modules)
+    total_required = total_declared - total_aspirational
+    total_covered = sum(len((m.declared - m.aspirational) & m.covered) for m in modules)
+    print(
+        f"invariant coverage OK: {total_covered}/{total_required} required "
+        f"invariants covered across {len(modules)} module(s) "
+        f"({total_aspirational} aspirational)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes item **#01** of the deterministic-assurance roadmap
([docs/assurance/immediate/01-invariant-test-coverage-ci.md](../blob/main/docs/assurance/immediate/01-invariant-test-coverage-ci.md)).

Makes the governance rule in `docs/invariants/*.md` (every declared invariant has a covering property test, and every test comment refers to a declared invariant) **mechanically enforced** in pre-commit and CI.

## What this adds

- **`scripts/check_invariant_coverage.py`** (195 LOC) — enforces bidirectional mapping:
  - Doc headers: `**I1. Name.**` (regex `^\*\*([A-Z]+\d+[a-z]?)\.\s`)
  - Test comments: `// Invariant I1: Name.` (regex `^//\s*Invariant\s+([A-Z]+\d+[a-z]?):\s`)
  - Scoped **per-module** (queue's `I1` ≠ runner's `I1`).
  - Aspirational opt-out via `<!-- aspirational -->` on the header line.
  - Exit codes: `0` clean, `1` violations, `2` malformed inputs.
- **Pre-commit hook** `invariant-coverage` (local, `language: system`).
- **CI job** `invariant-coverage` parallel to `go-checks`; widened workflow `paths` to trigger on `docs/invariants/**` and the script itself.
- **`docs/invariants/README.md`** — documents the enforcement mechanism, the aspirational opt-out, and the add/remove workflows.

## Empirical validation

Three induced failures on `cli/internal/queue/queue_invariants_prop_test.go` reproduced the three acceptance-criterion failure modes from the roadmap. All reverted before commit.

1. **Rename comment `I1 → I99`:**
   ```
   invariant coverage check FAILED:
     docs/invariants/queue.md: invariant I1 is declared but has no `// Invariant I1: ...` comment in cli/internal/queue/*invariants_prop_test.go
     docs/invariants/queue.md: `// Invariant I99:` refers to an invariant not declared in this module doc (sites: cli/internal/queue/queue_invariants_prop_test.go:214)
   ```

2. **Delete the `// Invariant I1:` comment:**
   ```
   invariant coverage check FAILED:
     docs/invariants/queue.md: invariant I1 is declared but has no `// Invariant I1: ...` comment in cli/internal/queue/*invariants_prop_test.go
   ```

3. **Add an orphan comment for undeclared ID `I99`:**
   ```
   invariant coverage check FAILED:
     docs/invariants/queue.md: `// Invariant I99:` refers to an invariant not declared in this module doc (sites: cli/internal/queue/queue_invariants_prop_test.go:215)
   ```

Clean baseline: `invariant coverage OK: 35/35 required invariants covered across 3 module(s) (0 aspirational).`

Runtime: 30–50 ms (budget: 10 s).

## Design notes

- **Protected-surfaces resolution.** The roadmap originally listed edits to `docs/invariants/queue.md § Governance`, which is on the protected-surfaces list. Deliverable §4 explicitly allowed a `README.md` alternative — that is what this PR takes. `queue.md § Governance` remains untouched; the README is the pointer.
- **Non-digit ID typo behaviour.** The regex (`[A-Z]+\d+[a-z]?`) requires a digit. A typo that drops the digit (e.g. `I1 → Ix`) is invisible to the regex: the check surfaces it as **missing coverage on the original ID**, not as an orphan on the malformed label. This is intentional (reject guesses) and is called out in `docs/invariants/README.md § Comment format`.
- **Scope.** Two new untracked files + two edits to existing tracked files. No Go source changes; no behavioural changes to xylem. Fails closed on violations.

## Test plan

- [x] Script passes on clean tree (35/35 across queue/runner/scanner)
- [x] Three induced-failure modes from roadmap acceptance criteria reproduced and diagnosed correctly
- [x] Both YAML files parse (`yaml.safe_load`)
- [x] Pre-commit hook wired and runs: `pre-commit run invariant-coverage --all-files` → `Passed`
- [x] Pre-commit runs the hook on this very commit (see commit hook output)
- [ ] CI job passes on this PR (watch `invariant-coverage` job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)