### PR TITLE
config: consolidate to 3 sources, drop profiles, command-based PR creation

### DIFF
--- a/.xylem.yml
+++ b/.xylem.yml
@@ -29,7 +29,7 @@ sources:
   issues:
     type: github
     repo: "nicholls-inc/xylem"
-    exclude: [wontfix, duplicate, in-progress, no-bot]
+    exclude: [wontfix, duplicate, in-progress, no-bot, xylem-failed]
     tasks:
       triage:
         labels: [needs-triage]
@@ -37,12 +37,14 @@ sources:
         tier: high
         status_labels:
           running: in-progress
+          failed: xylem-failed
       refine:
         labels: [needs-refinement]
         workflow: refine-issue
         tier: high
         status_labels:
           running: in-progress
+          failed: xylem-failed
       fix-bug:
         labels: [bug, ready-for-work]
         workflow: fix-bug

--- a/.xylem.yml
+++ b/.xylem.yml
@@ -1,78 +1,68 @@
 # xylem configuration
-# Docs: https://github.com/nicholls-inc/claude-code-marketplace/tree/main/xylem
-#
-# EMERGENCY: sources block materialized from profiles to work around #555
-# (profile overlay not expanded to runtime config). Remove this block once
-# #555 lands and the daemon expands profiles at startup.
-#
-# STABILIZATION 2026-04-17: Reduced to core development loop only.
-# Scheduled analytical/meta workflows disabled. See DISABLED block at bottom.
-# To re-enable a source: move it back up into the sources: block.
+# Docs: https://github.com/nicholls-inc/xylem
 
-profiles: [core, self-hosting-xylem]
+# No embedded profiles — workflows and prompts are read from .xylem/ on disk.
+# Dropping profiles: disables the materializer, so local edits survive restart.
 
-# --- Sources from core profile ---
+# --- Label / flag flow ---
+#
+# Issue lifecycle:
+#   needs-triage       → triage         → removes needs-triage, adds needs-refinement
+#   needs-refinement   → refine-issue   → removes needs-refinement, adds ready-for-work
+#   bug + ready-for-work        → fix-bug          → PR opened with ready-to-merge
+#   enhancement + ready-for-work → implement-feature → PR opened with ready-to-merge
+#
+# PR lifecycle:
+#   pr_opened / pr_head_updated (+ ready-to-merge) → review-pr      → posts review
+#   review_submitted                               → respond-to-pr-review → fixes/resolves
+#   checks_failed                                  → fix-pr-checks  → fixes CI
+#   needs-conflict-resolution                      → resolve-conflicts → clean branch
+#   ready-to-merge + green CI + all threads resolved → merge-pr     → merged
+#
+# Status labels prevent double-processing:
+#   in-progress      — added to issues when a vessel starts; removed on complete
+#   pr-vessel-active — added to PRs when a vessel starts; removed on complete
+#   xylem-failed     — added when a vessel fails (requires human triage)
+#   pr-vessel-merged — added by merge-pr on successful merge
+
 sources:
-  # harness-impl bugs route to implement-harness (correct gates: cd cli && go test)
-  # instead of fix-bug (broken: make test). See #562.
-  harness-impl-bugs:
+  issues:
     type: github
     repo: "nicholls-inc/xylem"
     exclude: [wontfix, duplicate, in-progress, no-bot]
     tasks:
-      fix:
-        labels: [bug, ready-for-work, harness-impl]
-        workflow: implement-harness
-        tier: med
-  harness-impl-features:
-    type: github
-    repo: "nicholls-inc/xylem"
-    exclude: [wontfix, duplicate, in-progress, no-bot]
-    tasks:
-      implement:
-        labels: [enhancement, ready-for-work, harness-impl]
-        workflow: implement-harness
-        tier: med
-  bugs:
-    type: github
-    repo: "nicholls-inc/xylem"
-    exclude: [wontfix, duplicate, in-progress, no-bot, harness-impl]
-    tasks:
-      fix:
-        labels: [bug, ready-for-work]
-        workflow: fix-bug
-        tier: med
-  features:
-    type: github
-    repo: "nicholls-inc/xylem"
-    exclude: [wontfix, duplicate, in-progress, no-bot, harness-impl]
-    tasks:
-      implement:
-        labels: [enhancement, ready-for-work]
-        workflow: implement-feature
-        tier: med
-  triage:
-    type: github
-    repo: "nicholls-inc/xylem"
-    exclude: [wontfix, duplicate, in-progress, no-bot]
-    tasks:
-      issues:
+      triage:
         labels: [needs-triage]
         workflow: triage
         tier: high
-  refinement:
-    type: github
-    repo: "nicholls-inc/xylem"
-    exclude: [wontfix, duplicate, in-progress, no-bot]
-    tasks:
-      issues:
+        status_labels:
+          running: in-progress
+      refine:
         labels: [needs-refinement]
         workflow: refine-issue
         tier: high
-  pr-lifecycle:
+        status_labels:
+          running: in-progress
+      fix-bug:
+        labels: [bug, ready-for-work]
+        workflow: fix-bug
+        tier: med
+        status_labels:
+          running: in-progress
+          failed: xylem-failed
+      implement-feature:
+        labels: [enhancement, ready-for-work]
+        workflow: implement-feature
+        tier: med
+        status_labels:
+          running: in-progress
+          failed: xylem-failed
+
+  # Event-driven PR work: review on open/update, respond to reviews, fix CI
+  pr-events:
     type: github-pr-events
     repo: "nicholls-inc/xylem"
-    exclude: [no-bot]
+    exclude: [no-bot, pr-vessel-active]
     tasks:
       review-opened:
         workflow: review-pr
@@ -80,100 +70,44 @@ sources:
         on:
           pr_opened: true
           require_labels: [ready-to-merge]
+        status_labels:
+          running: pr-vessel-active
+          failed: xylem-failed
       review-updated:
         workflow: review-pr
         tier: high
         on:
           pr_head_updated: true
           require_labels: [ready-to-merge]
-      respond-to-review:
+        status_labels:
+          running: pr-vessel-active
+          failed: xylem-failed
+      respond:
         workflow: respond-to-pr-review
         tier: high
         on:
           review_submitted: true
           author_deny:
             - "github-actions[bot]"
-      fix-checks:
-        workflow: fix-pr-checks
-        tier: med
-        on:
-          checks_failed: true
-  merges:
-    type: github-pr
-    repo: "nicholls-inc/xylem"
-    exclude: [no-bot]
-    tasks:
-      ready:
-        labels: [ready-to-merge]
-        workflow: merge-pr
-        tier: low
-  conflicts:
-    type: github-pr
-    repo: "nicholls-inc/xylem"
-    exclude: [no-bot]
-    tasks:
-      resolve:
-        labels: [needs-conflict-resolution]
-        workflow: resolve-conflicts
-        tier: med
-  # Scheduled: core operations only
-  diagnose-failures:
-    type: scheduled
-    repo: "nicholls-inc/xylem"
-    schedule: "2h"
-    timeout: "45m"
-    tasks:
-      hourly-diagnose-failures:
-        workflow: diagnose-failures
-        ref: diagnose-failures
-        tier: high
-  release-cadence:
-    type: scheduled
-    repo: "nicholls-inc/xylem"
-    schedule: "4h"
-    timeout: "15m"
-    tasks:
-      label-mature-release-pr:
-        workflow: release-cadence
-        ref: release-cadence
-        tier: low
-
-  # --- Sources from self-hosting-xylem overlay ---
-  pr-self-review:
-    type: github-pr
-    repo: "nicholls-inc/xylem"
-    exclude: [no-bot, pr-vessel-active]
-    tasks:
-      self-review:
-        labels: [ready-to-merge]
-        workflow: pr-self-review
-        tier: high
         status_labels:
           running: pr-vessel-active
           failed: xylem-failed
-  harness-pr-lifecycle:
-    type: github-pr-events
-    repo: "nicholls-inc/xylem"
-    exclude: [no-bot, pr-vessel-active]
-    tasks:
-      respond-reviews:
-        workflow: respond-to-pr-review
-        tier: high
-        on:
-          review_submitted: true
-          author_allow:
-            - "copilot-pull-request-reviewer[bot]"
       fix-checks:
         workflow: fix-pr-checks
         tier: med
         on:
           checks_failed: true
-  harness-merge:
+        status_labels:
+          running: pr-vessel-active
+          failed: xylem-failed
+
+  # Label-driven PR work: merge when ready, resolve conflicts
+  pr-ops:
     type: github-pr
     repo: "nicholls-inc/xylem"
     exclude: [no-bot, pr-vessel-active]
     tasks:
-      merge-ready:
+      merge:
         labels: [ready-to-merge]
         workflow: merge-pr
         tier: low
@@ -181,11 +115,6 @@ sources:
           running: pr-vessel-active
           completed: pr-vessel-merged
           failed: xylem-failed
-  conflict-resolution:
-    type: github-pr
-    repo: "nicholls-inc/xylem"
-    exclude: [no-bot, pr-vessel-active]
-    tasks:
       resolve-conflicts:
         labels: [needs-conflict-resolution]
         workflow: resolve-conflicts
@@ -193,44 +122,13 @@ sources:
         status_labels:
           running: pr-vessel-active
           failed: xylem-failed
-  harness-post-merge:
-    type: github-merge
-    repo: "nicholls-inc/xylem"
-    exclude: ["autorelease: tagged", no-bot]
-    tasks:
-      unblock-deps:
-        workflow: unblock-wave
-        tier: low
-
-# --- DISABLED 2026-04-17 (stabilization phase) ---
-# These sources are not in active use. Move back into sources: to re-enable.
-#
-# adaptation:           adapt-repo (xylem-adapt-repo label trigger)
-# lessons-hygiene:      lessons @daily
-# doc-gardener:         doc-garden @daily
-# context-audit:        context-weight-audit @weekly
-# security-compliance:  security-compliance @daily
-# workflow-health:      workflow-health-report @weekly
-# field-report:         field-report @weekly
-# sota-gap:             sota-gap-analysis @weekly
-# hardening-audit:      hardening-audit @monthly
-# continuous-simplicity: continuous-simplicity @weekly
-# continuous-improvement: continuous-improvement @daily
-# metrics-collector:    metrics-collector @daily
-# portfolio-analyst:    portfolio-analyst @weekly
-# audit:                audit @daily
-# initiative-tracker:   initiative-tracker @weekly
-# backlog-refinement:   backlog-refinement @daily
-# ingest-field-reports: ingest-field-reports @weekly
-# autonomy-review:      autonomy-review @weekly
-# ci-watchdog:          ci-watchdog every 30m (heavy when CI red: diagnose+file_issue phases)
 
 daemon:
   auto_upgrade: true
 
 notifications:
   github_discussion:
-    enabled: true
+    enabled: false
     repo: nicholls-inc/xylem
     category: "Status Reports"
     interval: "@daily"
@@ -256,20 +154,10 @@ max_turns: 100
 timeout: "45m"
 state_dir: ".xylem"
 
-# Tiered LLM routing — Opus for analysis/planning, free Copilot for execution.
-#
-# Tiers:
-#   high  → claude-opus-4-6  (Max subscription) — analysis, planning, review, diagnosis
-#   med   → copilot gpt-4.1  (0x premium, free) — implementation, fix-checks, conflict resolution
-#   low   → copilot gpt-5-mini (0x premium, free) — merges, metrics, label tasks, mechanical ops
-#
-# Copilot model multipliers (paid plan): gpt-4o=0x, gpt-4.1=0x, gpt-5-mini=0x, gpt-5.4=1x
-# Source: https://docs.github.com/en/copilot/reference/ai-models/supported-models
-#
-# NOTE: sources using simple 'type: schedule' (no tasks block) inherit default_tier (high)
-# because SourceConfig has no tier field. This is correct — those are all analytical workflows
-# (field-report, doc-garden, context-audit, etc). Convert to 'type: scheduled' with an explicit
-# task block if a schedule source needs a different tier.
+# Tiered LLM routing
+#   high  → claude-opus-4-6  — analysis, planning, review, triage, respond
+#   med   → copilot gpt-4.1  — implementation, fix-checks, conflict resolution
+#   low   → copilot gpt-5-mini — merge (deterministic command, model barely matters)
 providers:
   claude:
     kind: claude
@@ -278,9 +166,9 @@ providers:
     env:
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
     tiers:
-      low: "claude-sonnet-4-6"   # unused — low routes to copilot
-      med: "claude-sonnet-4-6"   # unused — med routes to copilot
-      high: "claude-opus-4-6"     # active: analysis, planning, review tasks
+      low: "claude-sonnet-4-6"
+      med: "claude-sonnet-4-6"
+      high: "claude-opus-4-6"
 
   copilot:
     kind: copilot
@@ -289,9 +177,9 @@ providers:
     env:
       COPILOT_GITHUB_TOKEN: "${COPILOT_GITHUB_TOKEN}"
     tiers:
-      low: "gpt-5-mini"   # active: light structured tasks (0x premium)
-      med: "gpt-4.1"      # active: implementation, fix-checks, conflict resolution (0x premium, more capable than gpt-5-mini)
-      high: "gpt-4.1"     # unused — high routes to claude
+      low: "gpt-5-mini"
+      med: "gpt-4.1"
+      high: "gpt-4.1"
 
 llm_routing:
   default_tier: high

--- a/.xylem/prompts/fix-bug/pr_draft.md
+++ b/.xylem/prompts/fix-bug/pr_draft.md
@@ -1,0 +1,58 @@
+Your sole deliverable is a file named `pr_draft.json` at the worktree root.
+The next phase is a deterministic command that reads this file to create the PR.
+
+## Steps
+
+1. Stage and commit all changes:
+   ```
+   git add -A
+   git commit -m "fix: {{.Issue.Title}}" -m "Fixes {{.Issue.URL}}"
+   ```
+   If nothing to commit, skip the commit step.
+
+2. Rebase on origin/main:
+   ```
+   git fetch origin main
+   git rebase origin/main
+   ```
+
+3. Rerun validation: `{{ if .Validation.Test }}{{ .Validation.Test }}{{ else }}cd cli && go test ./...{{ end }}`
+
+4. Push the rebased branch:
+   ```
+   git push -u origin HEAD
+   ```
+   Use `--force-with-lease` if the rebase rewrote commits.
+
+5. Write `pr_draft.json` at the worktree root with this exact structure:
+
+```json
+{
+  "title": "<descriptive PR title, e.g. fix(pkg): short description>",
+  "body": "<PR body in markdown>"
+}
+```
+
+The PR body must include:
+- One-line summary of the bug fix linking to {{.Issue.URL}}
+- Root cause: what was wrong and why
+- Changes summary: files modified, key types and functions touched
+- Test plan: commands run and what regressions they prevent
+
+## Constraints
+
+- You MUST create `pr_draft.json`. The next phase reads it — if missing, the workflow fails.
+- Do NOT run `gh pr create` — a separate command handles PR creation.
+- Do NOT include `Fixes #N` or `Closes #N` in the body — appended automatically.
+- Do NOT narrate your process. Execute the steps and produce the file.
+
+## Context
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+### Analysis
+{{.PreviousOutputs.analyze}}
+
+### Plan
+{{.PreviousOutputs.plan}}

--- a/.xylem/prompts/implement-feature/pr_draft.md
+++ b/.xylem/prompts/implement-feature/pr_draft.md
@@ -1,0 +1,57 @@
+Your sole deliverable is a file named `pr_draft.json` at the worktree root.
+The next phase is a deterministic command that reads this file to create the PR.
+
+## Steps
+
+1. Stage and commit all changes:
+   ```
+   git add -A
+   git commit -m "feat: {{.Issue.Title}}" -m "Implements {{.Issue.URL}}"
+   ```
+   If nothing to commit, skip the commit step.
+
+2. Rebase on origin/main:
+   ```
+   git fetch origin main
+   git rebase origin/main
+   ```
+
+3. Rerun validation: `{{ if .Validation.Test }}{{ .Validation.Test }}{{ else }}cd cli && go test ./...{{ end }}`
+
+4. Push the rebased branch:
+   ```
+   git push -u origin HEAD
+   ```
+   Use `--force-with-lease` if the rebase rewrote commits.
+
+5. Write `pr_draft.json` at the worktree root with this exact structure:
+
+```json
+{
+  "title": "<descriptive PR title, e.g. feat(pkg): short description>",
+  "body": "<PR body in markdown>"
+}
+```
+
+The PR body must include:
+- One-line summary linking to {{.Issue.URL}}
+- Changes summary: files added/modified, key types and functions touched
+- Test plan: commands run and what they verify
+
+## Constraints
+
+- You MUST create `pr_draft.json`. The next phase reads it — if missing, the workflow fails.
+- Do NOT run `gh pr create` — a separate command handles PR creation.
+- Do NOT include `Fixes #N` or `Closes #N` in the body — appended automatically.
+- Do NOT narrate your process. Execute the steps and produce the file.
+
+## Context
+
+Issue: {{.Issue.Title}}
+URL: {{.Issue.URL}}
+
+### Analysis
+{{.PreviousOutputs.analyze}}
+
+### Plan
+{{.PreviousOutputs.plan}}

--- a/.xylem/prompts/resolve-conflicts/push.md
+++ b/.xylem/prompts/resolve-conflicts/push.md
@@ -14,3 +14,8 @@ git push
 
 Post a comment on the PR summarizing the conflicts that were resolved and the strategy used for each file:
 gh pr comment {{.Issue.Number}} --body "<summary of resolved conflicts>"
+
+Remove the conflict-resolution trigger label so the scanner does not re-queue this PR:
+```
+gh pr edit {{.Issue.Number}} --remove-label "needs-conflict-resolution"
+```

--- a/.xylem/workflows/fix-bug.yaml
+++ b/.xylem/workflows/fix-bug.yaml
@@ -31,7 +31,9 @@ phases:
           threshold: 0.7
     gate:
       type: command
-      run: "make test"
+      run: |
+        set -e
+        {{ if .Validation.Test }}{{ .Validation.Test }}{{ else }}echo "ERROR: validation.test not configured in .xylem.yml" >&2 && exit 1{{ end }}
       retries: 2
   - name: verify
     prompt_file: .xylem/prompts/fix-bug/verify.md
@@ -39,9 +41,44 @@ phases:
     tier: med
     gate:
       type: command
-      run: "make test"
+      run: |
+        set -e
+        {{ if .Validation.Test }}{{ .Validation.Test }}{{ else }}echo "ERROR: validation.test not configured in .xylem.yml" >&2 && exit 1{{ end }}
       retries: 1
-  - name: pr
-    prompt_file: .xylem/prompts/fix-bug/pr.md
+  - name: pr_draft
+    prompt_file: .xylem/prompts/fix-bug/pr_draft.md
     max_turns: 25
     tier: med
+    gate:
+      type: command
+      run: |
+        set -euo pipefail
+        git fetch origin main
+        if ! git merge-base --is-ancestor origin/main HEAD; then
+          echo "ERROR: branch is behind origin/main; rebase before creating the PR" >&2
+          exit 1
+        fi
+        current_branch=$(git branch --show-current)
+        git fetch origin "$current_branch" 2>/dev/null || true
+        if [ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/$current_branch" 2>/dev/null)" ]; then
+          echo "ERROR: branch not pushed or remote does not match HEAD" >&2
+          exit 1
+        fi
+        test -f pr_draft.json || { echo "ERROR: pr_draft.json missing" >&2; exit 1; }
+      retries: 1
+  - name: pr_create
+    type: command
+    run: |
+      set -euo pipefail
+      TITLE=$(jq -r '.title' pr_draft.json)
+      BODY=$(jq -r '.body' pr_draft.json)
+      if [ -z "$TITLE" ] || [ "$TITLE" = "null" ]; then
+        echo "ERROR: title missing or null in pr_draft.json" >&2
+        exit 1
+      fi
+      BODY=$(printf '%s\n\nFixes #{{.Issue.Number}}' "$BODY")
+      gh pr create \
+        --repo {{.Repo.Slug}} \
+        --title "$TITLE" \
+        --body "$BODY" \
+        --label "ready-to-merge"

--- a/.xylem/workflows/implement-feature.yaml
+++ b/.xylem/workflows/implement-feature.yaml
@@ -31,7 +31,9 @@ phases:
           threshold: 0.7
     gate:
       type: command
-      run: "make test"
+      run: |
+        set -e
+        {{ if .Validation.Test }}{{ .Validation.Test }}{{ else }}echo "ERROR: validation.test not configured in .xylem.yml" >&2 && exit 1{{ end }}
       retries: 2
   - name: verify
     prompt_file: .xylem/prompts/implement-feature/verify.md
@@ -39,9 +41,44 @@ phases:
     tier: med
     gate:
       type: command
-      run: "make test"
+      run: |
+        set -e
+        {{ if .Validation.Test }}{{ .Validation.Test }}{{ else }}echo "ERROR: validation.test not configured in .xylem.yml" >&2 && exit 1{{ end }}
       retries: 1
-  - name: pr
-    prompt_file: .xylem/prompts/implement-feature/pr.md
+  - name: pr_draft
+    prompt_file: .xylem/prompts/implement-feature/pr_draft.md
     max_turns: 25
     tier: med
+    gate:
+      type: command
+      run: |
+        set -euo pipefail
+        git fetch origin main
+        if ! git merge-base --is-ancestor origin/main HEAD; then
+          echo "ERROR: branch is behind origin/main; rebase before creating the PR" >&2
+          exit 1
+        fi
+        current_branch=$(git branch --show-current)
+        git fetch origin "$current_branch" 2>/dev/null || true
+        if [ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/$current_branch" 2>/dev/null)" ]; then
+          echo "ERROR: branch not pushed or remote does not match HEAD" >&2
+          exit 1
+        fi
+        test -f pr_draft.json || { echo "ERROR: pr_draft.json missing" >&2; exit 1; }
+      retries: 1
+  - name: pr_create
+    type: command
+    run: |
+      set -euo pipefail
+      TITLE=$(jq -r '.title' pr_draft.json)
+      BODY=$(jq -r '.body' pr_draft.json)
+      if [ -z "$TITLE" ] || [ "$TITLE" = "null" ]; then
+        echo "ERROR: title missing or null in pr_draft.json" >&2
+        exit 1
+      fi
+      BODY=$(printf '%s\n\nFixes #{{.Issue.Number}}' "$BODY")
+      gh pr create \
+        --repo {{.Repo.Slug}} \
+        --title "$TITLE" \
+        --body "$BODY" \
+        --label "ready-to-merge"


### PR DESCRIPTION
## Summary

- **3 sources replace 11+**: `issues` (triage/refine/fix-bug/implement-feature), `pr-events` (review/respond/fix-checks), `pr-ops` (merge/resolve-conflicts)
- **Drop `profiles:`** — disables the profile materializer so local `.xylem/` edits survive daemon restart (fixes the #651 class of silent revert bugs)
- **Command-based PR creation** — replaces hallucination-prone LLM `pr` phase with `pr_draft` (LLM writes `pr_draft.json`) + `pr_create` (deterministic `gh pr create` command)
- **Status labels on all sources** — `in-progress` / `pr-vessel-active` / `xylem-failed` prevent double-processing
- **Fix `make test` gate** — disk copies of `fix-bug` and `implement-feature` had `make test` (broken since #562); now use `{{ .Validation.Test }}` matching the embedded core profile

## Label / flag flow

```
needs-triage       → triage         → needs-refinement
needs-refinement   → refine-issue   → ready-for-work
bug + ready-for-work        → fix-bug          → PR with ready-to-merge
enhancement + ready-for-work → implement-feature → PR with ready-to-merge
pr_opened/updated (+ ready-to-merge) → review-pr
review_submitted   → respond-to-pr-review
checks_failed      → fix-pr-checks
needs-conflict-resolution → resolve-conflicts
ready-to-merge + green CI + resolved threads → merge-pr → merged
```

## Removed sources

| Removed | Replaced by |
|---|---|
| `harness-impl-bugs`, `harness-impl-features` | `issues.fix-bug`, `issues.implement-feature` |
| `pr-self-review`, `harness-pr-lifecycle`, `harness-merge` | `pr-events` + `pr-ops` |
| `conflict-resolution` | `pr-ops.resolve-conflicts` |
| `harness-post-merge` (unblock-wave) | dropped |
| `diagnose-failures`, `release-cadence` (scheduled) | dropped |

## Test plan

- [ ] Daemon starts cleanly without `profiles:` (falls back to `localWorkflowDefinitions`)
- [ ] Scanner picks up `bug + ready-for-work` issues under `issues.fix-bug`
- [ ] `fix-bug` and `implement-feature` `pr_create` command phase creates PR with `ready-to-merge`
- [ ] `pr-events` source triggers `review-pr` on opened/updated PRs with `ready-to-merge`
- [ ] `pr-ops.merge` task fires for `ready-to-merge` PRs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)