### PR TITLE
docs(scanner): document intentional metadata-reset semantics on chain-retry path

### DIFF
--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -188,6 +188,11 @@ func (s *Scanner) chainTerminalRetry(vessel queue.Vessel) (bool, queue.Vessel, e
 		return false, queue.Vessel{}, nil
 	}
 
+	// Only ID and RetryOf are propagated here; all other metadata fields (MetaRetryCount, MetaFailureFingerprint, MetaUnlockedBy, etc.) are intentionally reset to zero. This retry is deliberately fresh because it is a scanner-detected terminal duplicate, not an operator retry.
+	//
+	// In contrast, recovery.NextRetryVessel (recovery.go:623–693) copies those fields for operator-initiated retries where continuity matters.
+	//
+	// There is no explicit chain-depth cap here: retryCandidate only presents a vessel once per recovery artifact lifecycle, so unbounded chaining would require unbounded new recovery artifacts.
 	vessel.ID = recovery.RetryID(originalID, s.Queue)
 	vessel.RetryOf = originalID
 	enqueued, enqErr := s.Queue.Enqueue(vessel)


### PR DESCRIPTION
## Summary

- Adds a 5-line comment above `vessel.ID = recovery.RetryID(...)` in `chainTerminalRetry()` explaining the intentional metadata-reset semantics
- Clarifies why only `ID` and `RetryOf` are propagated (fresh retry, not operator retry)
- Contrasts with `recovery.NextRetryVessel` (recovery.go:623–693) for reader clarity
- Explains why no explicit chain-depth cap is needed (lifecycle-bounded retryCandidate)

Closes #661. Resolves the unresolved review thread from PR#660 (`PRRT_kwDOR0nGss579fH1`, @hnipps).

## Test plan
- [ ] `go build ./...` passes (verified pre-commit)
- [ ] No behaviour change — pure documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)