### PR TITLE
fix(scanner): chain-depth cap + GitHub open-state check in chainTerminalRetry

### DIFF
--- a/cli/internal/scanner/scanner.go
+++ b/cli/internal/scanner/scanner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/nicholls-inc/xylem/cli/internal/config"
@@ -106,7 +107,7 @@ func (s *Scanner) Scan(ctx context.Context) (ScanResult, error) {
 				// is not stranded. `completed` and active states fall through
 				// to a skip — active is already live, completed would silently
 				// redo shipped work. See issue #658.
-				chained, newVessel, chainErr := s.chainTerminalRetry(vessel)
+				chained, newVessel, chainErr := s.chainTerminalRetry(ctx, vessel)
 				if chainErr != nil {
 					log.Printf("warn: scanner: duplicate vessel ID %q, chain retry failed: %v", vessel.ID, chainErr)
 					scanErrs = append(scanErrs, chainErr)
@@ -171,7 +172,13 @@ func (s *Scanner) Scan(ctx context.Context) (ScanResult, error) {
 //
 // Only one retry attempt is made; a second collision (e.g. race against a
 // concurrent enqueue) falls through to skip rather than looping.
-func (s *Scanner) chainTerminalRetry(vessel queue.Vessel) (bool, queue.Vessel, error) {
+func (s *Scanner) chainTerminalRetry(ctx context.Context, vessel queue.Vessel) (bool, queue.Vessel, error) {
+	// GUARD 1: Chain-depth cap
+	depth := strings.Count(vessel.ID, "-retry-")
+	if depth >= 3 {
+		log.Printf("warn: scanner: vessel %q has reached max chain depth (%d), dropping", vessel.ID, depth)
+		return false, queue.Vessel{}, nil
+	}
 	originalID := vessel.ID
 	existing, err := s.Queue.FindByID(originalID)
 	if err != nil || existing == nil {
@@ -191,8 +198,25 @@ func (s *Scanner) chainTerminalRetry(vessel queue.Vessel) (bool, queue.Vessel, e
 	// Only ID and RetryOf are propagated here; all other metadata fields (MetaRetryCount, MetaFailureFingerprint, MetaUnlockedBy, etc.) are intentionally reset to zero. This retry is deliberately fresh because it is a scanner-detected terminal duplicate, not an operator retry.
 	//
 	// In contrast, recovery.NextRetryVessel (recovery.go:623–693) copies those fields for operator-initiated retries where continuity matters.
-	//
-	// There is no explicit chain-depth cap here: retryCandidate only presents a vessel once per recovery artifact lifecycle, so unbounded chaining would require unbounded new recovery artifacts.
+
+	// GUARD 2: GitHub open-state check
+	if strings.HasPrefix(vessel.Source, "github") {
+		if issueNum, ok := vessel.Meta["issue_num"]; ok && issueNum != "" && strings.Contains(vessel.Ref, "github.com/") {
+			ref := strings.TrimPrefix(vessel.Ref, "https://github.com/")
+			parts := strings.SplitN(ref, "/", 4)
+			if len(parts) >= 2 {
+				repo := parts[0] + "/" + parts[1]
+				out, err := s.CmdRunner.Run(ctx, "gh", "issue", "view", issueNum, "--repo", repo, "--json", "state", "-q", ".state")
+				if err != nil {
+					log.Printf("warn: scanner: could not check issue state for vessel %q: %v, proceeding with chain", vessel.ID, err)
+				} else if strings.EqualFold(strings.TrimSpace(string(out)), "closed") {
+					log.Printf("info: scanner: vessel %q issue #%s is closed, dropping chain", vessel.ID, issueNum)
+					return false, queue.Vessel{}, nil
+				}
+			}
+		}
+	}
+
 	vessel.ID = recovery.RetryID(originalID, s.Queue)
 	vessel.RetryOf = originalID
 	enqueued, enqErr := s.Queue.Enqueue(vessel)

--- a/cli/internal/scanner/scanner_test.go
+++ b/cli/internal/scanner/scanner_test.go
@@ -655,6 +655,89 @@ func TestScanChainsCancelledTerminalVessel(t *testing.T) {
 	}
 }
 
+// TestChainTerminalRetryDepthCap verifies that chainTerminalRetry refuses to chain a vessel
+// whose ID already has depth >= 3 (three or more "-retry-" segments), preventing the
+// unbounded-runaway pattern observed in issue #662 (e.g. issue-400-retry-1-retry-1-...-retry-1).
+func TestChainTerminalRetryDepthCap(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+	s := New(cfg, q, r)
+
+	deepVessel := queue.Vessel{
+		ID:        "issue-1-retry-1-retry-1-retry-1",
+		Source:    "github-issue",
+		Ref:       "https://github.com/owner/repo/issues/1",
+		Workflow:  "fix-bug",
+		Meta:      map[string]string{"issue_num": "1"},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	}
+	chained, _, err := s.chainTerminalRetry(context.Background(), deepVessel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if chained {
+		t.Errorf("depth cap: expected chained=false for depth-3 vessel, got chained=true")
+	}
+}
+
+// TestScanChainSkipsClosedIssue ensures that chaining is skipped if the GitHub issue is closed.
+func TestScanChainSkipsClosedIssue(t *testing.T) {
+	dir := t.TempDir()
+	cfg := makeConfig(dir)
+	q := queue.New(filepath.Join(dir, "queue.jsonl"))
+	r := newMock()
+
+	issues := []ghIssue{
+		{Number: 1, Title: "closed", Body: "body", URL: "https://github.com/owner/repo/issues/1", Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "bug"}}},
+	}
+	r.set(issueJSON(issues), "gh", "issue", "list", "--repo", "owner/repo", "--state", "open", "--json", "number,title,body,url,labels", "--limit", "20", "--label", "bug")
+	for _, prefix := range []string{"fix", "feat"} {
+		r.set([]byte(""), "git", "ls-remote", "--heads", "origin", fmt.Sprintf("%s/issue-%d-*", prefix, 1))
+		r.set([]byte("[]"), "gh", "pr", "list", "--repo", "owner/repo", "--search", fmt.Sprintf("head:%s/issue-%d-", prefix, 1), "--state", "open", "--json", "number,headRefName", "--limit", "5")
+	}
+	r.set([]byte("CLOSED"), "gh", "issue", "view", "1", "--repo", "owner/repo", "--json", "state", "-q", ".state")
+
+	vessel := queue.Vessel{
+		ID:        "issue-1",
+		Source:    "github-issue",
+		Ref:       "https://github.com/owner/repo/issues/1",
+		Workflow:  "fix-bug",
+		Meta:      map[string]string{"issue_num": "1"},
+		State:     queue.StatePending,
+		CreatedAt: time.Now().UTC(),
+	}
+	if _, err := q.Enqueue(vessel); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := q.Dequeue(); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if err := q.Update(vessel.ID, queue.StateCancelled, ""); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+
+	s := New(cfg, q, r)
+	result, err := s.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Added != 0 {
+		t.Errorf("closed issue: got Added=%d, want 0", result.Added)
+	}
+	vessels, err := q.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(vessels) != 1 {
+		t.Errorf("closed issue: got %d vessels, want 1", len(vessels))
+	}
+}
+
 // TestScanSkipsCompletedDuplicateID confirms that the chain path does NOT
 // fire for completed vessels — re-enqueueing a completed vessel would
 // silently redo shipped work. Completed collisions must still skip.


### PR DESCRIPTION
## Summary

Closes #662. Two independent guards to stop the runaway retry pattern observed post-PR#660:

- **Chain-depth cap**: reject any vessel whose ID contains ≥3 `-retry-` segments (`strings.Count(vessel.ID, "-retry-") >= 3`). Prevents the `issue-400-retry-1-retry-1-...-retry-1×6` pattern.
- **GitHub open-state check**: for `github-*` sources, parse the Ref URL for owner/repo, run `gh issue view N --repo owner/repo --json state -q .state`, and drop the chain if the issue is `CLOSED`. Fails-open on transient `gh` errors.
- Adds `context.Context` as first parameter to `chainTerminalRetry` (needed for CmdRunner) and updates the single call site.

## Protected-surface note
No protected surfaces touched.

## Test plan
- [x] `TestChainTerminalRetryDepthCap` — direct unit test of depth cap
- [x] `TestScanChainSkipsClosedIssue` — integration test via `Scan()` mocking `gh issue view`
- [x] `TestScanChainsCancelledTerminalVessel` — existing test still passes
- [x] Full `./internal/scanner/...` suite passes
- [x] Pre-commit checks pass (goimports, go build, foxguard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)