### PR TITLE
fix(implement-harness): pin implement phase to tier:high + prompt anchor

### DIFF
--- a/.xylem/prompts/implement-harness/implement.md
+++ b/.xylem/prompts/implement-harness/implement.md
@@ -1,3 +1,5 @@
+**Your FIRST action MUST be a concrete tool call (Read, Grep, or Edit). Do not describe, narrate, or restate the plan — act immediately.**
+
 Implement the harness spec step according to the plan.
 
 Issue: {{.Issue.Title}}

--- a/.xylem/workflows/implement-harness.yaml
+++ b/.xylem/workflows/implement-harness.yaml
@@ -14,7 +14,7 @@ phases:
   - name: implement
     prompt_file: .xylem/prompts/implement-harness/implement.md
     max_turns: 80
-    tier: med
+    tier: high
     gate:
       type: command
       run: "cd cli && go vet ./... && go build ./cmd/xylem && go test ./..."


### PR DESCRIPTION
## Summary

Closes #666.

Root cause: implement phase ran at `tier:med` → copilot `gpt-4.1` → promise-loop hallucination → SIGKILL at 45 min × 4 vessels, ~$0.20+ each.

- **`.xylem/workflows/implement-harness.yaml`**: change `implement` phase from `tier: med` → `tier: high` (routes to `claude-opus-4-6`). `analyze`/`plan`/`test_critic` already run at `tier:high`; this makes `implement` consistent.
- **`.xylem/prompts/implement-harness/implement.md`**: prepend imperative anchor: `"Your FIRST action MUST be a concrete tool call (Read, Grep, or Edit). Do not describe, narrate, or restate the plan — act immediately."` Belt-and-braces against promise-loop regression.

## Protected-surface note

Both files are in `.claude/rules/protected-surfaces.md`. Amended per operator `/batch` directive 2026-04-19 (human-authored, autonomous-completion session).

## Test plan

- [ ] Verify `implement-harness.yaml` YAML is valid (pre-commit `check yaml` passed)
- [ ] Next implement-harness vessel runs on `claude-opus-4-6` (tier:high) and completes without SIGKILL

🤖 Generated with [Claude Code](https://claude.com/claude-code)