### PR TITLE
fix(implement-feature): add post-pr gate to detect silent PR failures

### DIFF
--- a/.xylem/workflows/implement-feature.yaml
+++ b/.xylem/workflows/implement-feature.yaml
@@ -45,3 +45,19 @@ phases:
     prompt_file: .xylem/prompts/implement-feature/pr.md
     max_turns: 25
     tier: med
+    gate:
+      type: command
+      run: |
+        set -euo pipefail
+        current_branch=$(git branch --show-current)
+        if [ -z "$current_branch" ] || [ "$current_branch" = "main" ]; then
+          echo "ERROR: not on a feature branch (got: '${current_branch:-<empty>}')"
+          exit 1
+        fi
+        pr_num=$(gh pr list --head "$current_branch" --json number --jq '.[0].number // empty' 2>/dev/null || true)
+        if [ -z "$pr_num" ]; then
+          echo "ERROR: no open PR found for branch $current_branch — pr phase failed silently (sandbox 403 or push error)"
+          exit 1
+        fi
+        echo "PR #$pr_num confirmed for branch $current_branch"
+      retries: 1


### PR DESCRIPTION
## Summary

- Adds a `gate` to the `pr` phase in `implement-feature.yaml` that verifies a PR was actually opened on the current feature branch
- Catches silent failures where the pr phase completes (exit 0) but no PR was created (e.g. sandbox 403, push error)
- Gate checks `gh pr list --head <branch>` and fails with a clear error if no PR exists, triggering a retry

## Motivation

Issue #653 documented cases where the `pr` phase was silently completing without creating a PR (due to sandbox 403 errors or push failures). Without this gate, the vessel transitions to `completed` even though no PR was ever opened, losing the work silently.

## Test plan

- [ ] Verify existing `make test` passes (gate is YAML-only, no Go changes)
- [ ] Manual check: gate script correctly detects missing PR on main branch (exits 1)
- [ ] Manual check: gate script passes on a branch with an open PR

Fixes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)