### PR TITLE
test(runner): close I1 per-class and I8 mid-run coverage gaps (roadmap #04 A+D)

### DIFF
--- a/cli/internal/runner/runner_invariants_prop_test.go
+++ b/cli/internal/runner/runner_invariants_prop_test.go
@@ -76,6 +76,94 @@ func TestInvariant_I1_ConcurrencyCapsNeverExceeded(t *testing.T) {
 	})
 }
 
+// Invariant IN: I1
+func TestInvariant_I1_PerClassConcurrencyCapNeverExceeded(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		classACap := rapid.IntRange(1, 2).Draw(rt, "classACap")
+		classBCap := rapid.IntRange(1, 2).Draw(rt, "classBCap")
+		nA := rapid.IntRange(classACap, classACap*3).Draw(rt, "nA")
+		nB := rapid.IntRange(classBCap, classBCap*3).Draw(rt, "nB")
+
+		dir := t.TempDir()
+		cfg := makeTestConfig(dir, classACap+classBCap+4)
+		cfg.ConcurrencyPerClass = map[string]int{
+			"classA": classACap,
+			"classB": classBCap,
+		}
+		cfg.StateDir = filepath.Join(dir, ".xylem")
+		q := queue.New(filepath.Join(dir, "queue.jsonl"))
+
+		// promptToClass is populated before the runner starts; concurrent reads are safe.
+		promptToClass := make(map[string]string)
+		for i := 1; i <= nA; i++ {
+			prompt := fmt.Sprintf("classA-task-%d", i)
+			promptToClass[prompt] = "classA"
+			v := queue.Vessel{
+				ID:            fmt.Sprintf("vessel-A-%d", i),
+				Source:        "manual",
+				Prompt:        prompt,
+				WorkflowClass: "classA",
+				State:         queue.StatePending,
+				CreatedAt:     time.Now().UTC(),
+			}
+			_, err := q.Enqueue(v)
+			require.NoError(t, err)
+		}
+		for i := 1; i <= nB; i++ {
+			prompt := fmt.Sprintf("classB-task-%d", i)
+			promptToClass[prompt] = "classB"
+			v := queue.Vessel{
+				ID:            fmt.Sprintf("vessel-B-%d", i),
+				Source:        "manual",
+				Prompt:        prompt,
+				WorkflowClass: "classB",
+				State:         queue.StatePending,
+				CreatedAt:     time.Now().UTC(),
+			}
+			_, err := q.Enqueue(v)
+			require.NoError(t, err)
+		}
+
+		var currentA, peakA, currentB, peakB int64
+
+		cr := &mockCmdRunner{
+			runPhaseHook: func(_, prompt, _ string, _ ...string) ([]byte, error, bool) {
+				class := promptToClass[prompt]
+				var cur, pk *int64
+				switch class {
+				case "classA":
+					cur, pk = &currentA, &peakA
+				case "classB":
+					cur, pk = &currentB, &peakB
+				default:
+					return []byte("done"), nil, true
+				}
+				c := atomic.AddInt64(cur, 1)
+				for {
+					old := atomic.LoadInt64(pk)
+					if c <= old || atomic.CompareAndSwapInt64(pk, old, c) {
+						break
+					}
+				}
+				time.Sleep(5 * time.Millisecond)
+				atomic.AddInt64(cur, -1)
+				return []byte("done"), nil, true
+			},
+		}
+
+		r := New(cfg, q, &mockWorktree{path: dir}, cr)
+		_, err := r.DrainAndWait(context.Background())
+		require.NoError(t, err)
+
+		if got := int(atomic.LoadInt64(&peakA)); got > classACap {
+			rt.Fatalf("classA peak concurrent executions %d exceeded cap %d", got, classACap)
+		}
+		if got := int(atomic.LoadInt64(&peakB)); got > classBCap {
+			rt.Fatalf("classB peak concurrent executions %d exceeded cap %d", got, classBCap)
+		}
+	})
+}
+
 // ---------------------------------------------------------------------------
 // I2: NoConcurrentPhaseForVesselID
 // ---------------------------------------------------------------------------
@@ -364,7 +452,30 @@ func TestInvariant_I8_InFlightAccountingExact(t *testing.T) {
 		}
 
 		r := New(cfg, q, &mockWorktree{path: dir}, cr)
+
+		// Mid-run sampling: verify InFlightCount never exceeds cap during execution.
+		stop := make(chan struct{})
+		var sampledPeak int64
+		go func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					c := int64(r.InFlightCount())
+					for {
+						old := atomic.LoadInt64(&sampledPeak)
+						if c <= old || atomic.CompareAndSwapInt64(&sampledPeak, old, c) {
+							break
+						}
+					}
+					time.Sleep(time.Millisecond)
+				}
+			}
+		}()
+
 		_, err := r.DrainAndWait(context.Background())
+		close(stop)
 		require.NoError(t, err)
 
 		if got := r.InFlightCount(); got != 0 {
@@ -375,6 +486,9 @@ func TestInvariant_I8_InFlightAccountingExact(t *testing.T) {
 		r.processMu.Unlock()
 		if remaining != 0 {
 			rt.Fatalf("r.processes has %d entries after Wait, expected 0", remaining)
+		}
+		if got := int(atomic.LoadInt64(&sampledPeak)); got > cap {
+			rt.Fatalf("sampled InFlightCount peak %d exceeded cap %d during execution", got, cap)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Closes two coverage gaps identified in `docs/assurance/immediate/04-close-partial-coverage-gaps.md`:

- **Gap A (I1)**: `TestInvariant_I1_PerClassConcurrencyCapNeverExceeded` — new rapid property test verifying per-class concurrency limits (`ConcurrencyPerClass`) are independently enforced. Draws two classes with separate caps, enqueues vessels with `WorkflowClass` set, tracks per-class peak via atomic counters in the hook, and asserts neither class exceeds its cap. The existing `TestInvariant_I1_ConcurrencyCapsNeverExceeded` only tested the global cap.

- **Gap D (I8)**: Adds a mid-run sampling goroutine to `TestInvariant_I8_InFlightAccountingExact` that polls `r.InFlightCount()` every millisecond during `DrainAndWait` and records the peak. Asserts peak never exceeds `cap`, closing the post-Wait-only gap.

Both changes are strengthening additions. No existing assertions removed. Invariant coverage check: 35/35 required invariants covered.

## Test plan
- [ ] `go test ./internal/runner/ -run "TestInvariant_I1_Per|TestInvariant_I8" -v` passes (100 rapid iterations each)
- [ ] `python3 scripts/check_invariant_coverage.py` reports `35/35`
- [ ] All runner invariant tests green