### PR TITLE
docs(assurance): mark roadmap item #04 as Done (all 6 gaps closed)

### DIFF
--- a/docs/assurance/immediate/04-close-partial-coverage-gaps.md
+++ b/docs/assurance/immediate/04-close-partial-coverage-gaps.md
@@ -1,7 +1,7 @@
 # 04: Close Partial-Coverage Gaps in Runner Property Tests
 
 **Horizon:** Immediate
-**Status:** In progress (PR #675 merged 2026-04-19 — gaps A+D done; PR #680 open 2026-04-19 — gaps B+C; gaps E+F in current PR; issues #677/#676/#679/#678)
+**Status:** Done (PR #675 merged 2026-04-19 — gaps A+D; PR #680 merged 2026-04-20 — gaps B+C+E+F; all 6 gaps closed)
 **Estimated cost:** 1–2 weeks (6 small PRs)
 **Depends on:** #01 (coverage CI helps catch regression after each PR lands)
 **Unblocks:** #10 (Gobra needs a clean invariant-test baseline first)


### PR DESCRIPTION
## Summary

- Updates `docs/assurance/immediate/04-close-partial-coverage-gaps.md` status to **Done**
- PR #675 (merged 2026-04-19) closed gaps A+D
- PR #680 (merged 2026-04-20) closed gaps B+C+E+F

All 6 partial-coverage gaps in `runner_invariants_prop_test.go` are now strengthened and merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)