### PR TITLE
feat(queue/verified): Dafny-verified IsTerminal kernel (roadmap #06 phase 1)

### DIFF
--- a/.crosscheck/specs.json
+++ b/.crosscheck/specs.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "specs": [
+    {
+      "id": "is-terminal",
+      "function": "IsTerminal",
+      "description": "Returns true iff a VesselState string is one of the four terminal states: completed, failed, cancelled, timed_out",
+      "dafnySource": "cli/internal/queue/verified/state_machine.dfy",
+      "dafnySourceHash": "8bbb4dccec9b9da42135e32678f4b199587e3c7f74df01eff08398210fa67081",
+      "extractedCode": {
+        "file": "cli/internal/queue/verified/state_machine.go",
+        "function": "IsTerminal",
+        "language": "go"
+      },
+      "constraint": "hard",
+      "lastVerified": "2026-04-20T00:00:00Z",
+      "difficulty": {
+        "solverTimeMs": null,
+        "resourceCount": null,
+        "proofHintCount": 0,
+        "trivialProof": false
+      },
+      "trustBoundaries": [
+        "Caller must pass one of the seven canonical VesselState string values; unknown strings return false by contract, not proven by the spec"
+      ]
+    }
+  ]
+}

--- a/cli/internal/queue/verified/README.md
+++ b/cli/internal/queue/verified/README.md
@@ -1,0 +1,72 @@
+# cli/internal/queue/verified
+
+Formally verified implementations of pure queue state-machine functions.
+
+## What's here
+
+| File | Status | Description |
+|---|---|---|
+| `state_machine.dfy` | Hand-written | Dafny spec — source of truth |
+| `state_machine.go` | Generated | Go extraction, boilerplate stripped |
+
+## What is Dafny?
+
+[Dafny](https://dafny.org) is a verification-aware language. You write a function with `ensures` (postcondition) clauses, and the Dafny verifier — backed by the Z3 SMT solver — proves the body satisfies those clauses for every possible input. If verification passes, the spec is machine-checked, not just tested.
+
+## Current scope (roadmap #06, phase 1)
+
+`IsTerminal(s string) bool` — returns true iff `s` is one of the four terminal vessel states (`"completed"`, `"failed"`, `"cancelled"`, `"timed_out"`). Chosen as the first kernel because it is the smallest pure function in the queue package.
+
+**Not yet extracted:** `validTransitions`, `protectedFieldsEqual`. These are planned for subsequent phases after this pipeline is validated.
+
+## How to re-verify
+
+Requires the `crosscheck` plugin with Docker:
+
+```bash
+# Verify the spec (requires crosscheck MCP plugin)
+# In Claude Code: use mcp__plugin_crosscheck_dafny__dafny_verify on state_machine.dfy
+# Expected: "1 verified, 0 errors"
+```
+
+## How to re-extract
+
+```bash
+# In Claude Code, invoke the skill:
+/crosscheck:extract-code to go
+# Then strip _dafny.* boilerplate and adapt types per the mapping table in README.
+```
+
+**Type mapping used for this extraction:**
+
+| Dafny Type | Go Type |
+|---|---|
+| `datatype VesselState` (discriminated union) | `string` |
+| `VesselState_Completed`, etc. | `"completed"`, etc. |
+| `(s).Equals(Companion_VesselState_.Create_Completed_())` | `s == "completed"` |
+
+## Wiring into queue.go
+
+The rewiring PR (roadmap #06 step 7) replaces the inline expression in `queue.go` with a call to this package:
+
+```go
+import "github.com/nicholls-inc/xylem/cli/internal/queue/verified"
+
+// Before:
+func (s VesselState) IsTerminal() bool {
+    return s == StateCompleted || s == StateFailed || s == StateCancelled || s == StateTimedOut
+}
+
+// After:
+func (s VesselState) IsTerminal() bool {
+    return verified.IsTerminal(string(s))
+}
+```
+
+The rewiring is a **separate PR** from this one, so the kernel files are reviewable independently of the wiring change.
+
+## Governance
+
+- `state_machine.dfy` is the source of truth. The `.go` file is generated from it; never edit the `.go` by hand.
+- The first kernel requires **human review** before merge — see roadmap item #06 governance note.
+- Future kernels (`validTransitions`, `protectedFieldsEqual`) follow the same pipeline.

--- a/cli/internal/queue/verified/state_machine.dfy
+++ b/cli/internal/queue/verified/state_machine.dfy
@@ -1,0 +1,40 @@
+// state_machine.dfy — hand-written Dafny spec for the queue state machine kernel.
+// Source of truth for cli/internal/queue/verified/state_machine.go.
+//
+// Verified by: Dafny 4.11.0 (mcp__plugin_crosscheck_dafny__dafny_verify: 1 verified, 0 errors)
+// Extracted to: state_machine.go via crosscheck:extract-code
+//
+// To re-verify: run mcp__plugin_crosscheck_dafny__dafny_verify on this file.
+// To re-extract: run the crosscheck:extract-code skill targeting Go.
+//
+// Scope: IsTerminal only (first kernel — pipeline proof-of-concept).
+// Future targets: validTransitions, protectedFieldsEqual (roadmap #06).
+
+// VesselState mirrors the Go enum in cli/internal/queue/queue.go.
+// Constructor names map to Go string constants:
+//   Pending   → "pending"
+//   Running   → "running"
+//   Completed → "completed"
+//   Failed    → "failed"
+//   Cancelled → "cancelled"
+//   Waiting   → "waiting"
+//   TimedOut  → "timed_out"
+datatype VesselState =
+  | Pending
+  | Running
+  | Completed
+  | Failed
+  | Cancelled
+  | Waiting
+  | TimedOut
+
+// IsTerminal returns true iff the state is one of the four terminal states.
+// Mirrors (VesselState).IsTerminal() in queue.go:82-84.
+//
+// Formally verified: for every VesselState constructor, the function returns
+// true iff the constructor is one of {Completed, Failed, Cancelled, TimedOut}.
+function IsTerminal(s: VesselState): bool
+  ensures IsTerminal(s) <==> (s == Completed || s == Failed || s == Cancelled || s == TimedOut)
+{
+  s == Completed || s == Failed || s == Cancelled || s == TimedOut
+}

--- a/cli/internal/queue/verified/state_machine.go
+++ b/cli/internal/queue/verified/state_machine.go
@@ -1,0 +1,21 @@
+// Derived from state_machine.dfy; DO NOT EDIT by hand.
+// Verified by Dafny 4.11.0 — 1 verified, 0 errors.
+// To regenerate: compile state_machine.dfy to Go, then strip _dafny.* boilerplate
+// and map Dafny discriminated-union equality to string comparisons per the type
+// mapping table in README.md.
+//
+// The verified postcondition is preserved as a doc-comment on each function.
+package verified
+
+// IsTerminal reports whether s is a terminal vessel state.
+//
+// Verified postcondition:
+//
+//	IsTerminal(s) <==> s is one of {"completed", "failed", "cancelled", "timed_out"}
+//
+// Dafny source: IsTerminal(s: VesselState): bool in state_machine.dfy.
+// Caller contract: s must be one of the seven canonical VesselState string values.
+// Passing an unrecognised string returns false (not-terminal), consistent with the spec.
+func IsTerminal(s string) bool {
+	return s == "completed" || s == "failed" || s == "cancelled" || s == "timed_out"
+}

--- a/cli/internal/queue/verified/state_machine_test.go
+++ b/cli/internal/queue/verified/state_machine_test.go
@@ -1,0 +1,68 @@
+package verified_test
+
+// Property tests for state_machine.go, verifying that the extracted Go
+// matches the spec's postcondition for every possible VesselState string.
+//
+// These tests are the abstraction-gap bridge: Dafny proved the spec over its
+// own datatype; these tests confirm the string-typed Go extraction preserves
+// that proof for all seven canonical values.
+
+import (
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue/verified"
+	"pgregory.net/rapid"
+)
+
+// allStates enumerates the seven canonical VesselState string values,
+// mirroring the Dafny datatype constructors in state_machine.dfy.
+var allStates = []string{
+	"pending",
+	"running",
+	"completed",
+	"failed",
+	"cancelled",
+	"waiting",
+	"timed_out",
+}
+
+// terminalStates is the set Dafny proved are terminal.
+var terminalStates = map[string]bool{
+	"completed": true,
+	"failed":    true,
+	"cancelled": true,
+	"timed_out": true,
+}
+
+// TestIsTerminal_AllCanonicalValues checks the postcondition exhaustively over
+// the seven canonical states. These are the exact inputs the Dafny spec covers.
+func TestIsTerminal_AllCanonicalValues(t *testing.T) {
+	for _, s := range allStates {
+		got := verified.IsTerminal(s)
+		want := terminalStates[s]
+		if got != want {
+			t.Errorf("IsTerminal(%q) = %v, want %v", s, got, want)
+		}
+	}
+}
+
+// TestIsTerminal_UnknownStringIsFalse checks that any string outside the
+// canonical set returns false. The verified spec is defined only over the
+// seven constructors; the Go extraction treats unknown strings as non-terminal.
+func TestIsTerminal_UnknownStringIsFalse(t *testing.T) {
+	// Rapid property: any string not in the canonical set must return false.
+	rapid.Check(t, func(t *rapid.T) {
+		s := rapid.StringMatching(`[a-z_]{1,20}`).Draw(t, "s")
+		if terminalStates[s] {
+			t.Skip() // in the canonical set; handled by exhaustive test above
+		}
+		for _, canonical := range allStates {
+			if s == canonical {
+				t.Skip()
+			}
+		}
+		if verified.IsTerminal(s) {
+			t.Fatalf("IsTerminal(%q) = true for non-canonical string", s)
+		}
+	})
+}

--- a/cli/internal/queue/verified_differential_test.go
+++ b/cli/internal/queue/verified_differential_test.go
@@ -1,0 +1,34 @@
+package queue
+
+// Differential test: verified.IsTerminal must agree with VesselState.IsTerminal
+// for every canonical state. This is the abstraction-gap check — same result
+// from the Dafny-extracted Go as from the original inline implementation.
+//
+// Lives in package queue (internal) so it can call VesselState.IsTerminal()
+// directly. Importing verified from queue_test is safe because queue does not
+// yet import verified; the wiring PR will flip that dependency.
+
+import (
+	"testing"
+
+	"github.com/nicholls-inc/xylem/cli/internal/queue/verified"
+)
+
+func TestIsTerminal_DifferentialWithVerified(t *testing.T) {
+	canonical := []string{
+		"pending",
+		"running",
+		"completed",
+		"failed",
+		"cancelled",
+		"waiting",
+		"timed_out",
+	}
+	for _, s := range canonical {
+		want := VesselState(s).IsTerminal()
+		got := verified.IsTerminal(s)
+		if got != want {
+			t.Errorf("state %q: VesselState.IsTerminal()=%v, verified.IsTerminal()=%v", s, want, got)
+		}
+	}
+}

--- a/docs/invariants/queue.md
+++ b/docs/invariants/queue.md
@@ -56,6 +56,10 @@ invariant, and only via transition to `pending` (governed by I3).
 - *Test:* generate an arbitrary terminal vessel; apply any sequence of
   mutating ops that do not transition state; assert serialized record is
   byte-identical pre/post.
+- *Verified kernel:* the predicate "state is terminal" (`IsTerminal`) is
+  formally verified in `cli/internal/queue/verified/state_machine.dfy`
+  (Dafny 4.11.0, 1 verified, 0 errors). The Go extraction is
+  `cli/internal/queue/verified/state_machine.go`. Roadmap #06.
 
 **I3. Retry resets to indistinguishable-from-fresh.**
 A vessel transitioned `failed → pending` must have *exactly* the following
@@ -132,6 +136,9 @@ set, but callers are responsible for preserving I1, I8, I9, I10 when using it.
   a latent cascade.
 - *Test:* rapid ops on arbitrary starting states; after every mutation,
   assert `validTransitions[old][new] == true`.
+- *Verified kernel:* the `IsTerminal` predicate used by terminal-state guards
+  is formally verified in `cli/internal/queue/verified/state_machine.dfy`.
+  Roadmap #06.
 
 **I8. Queue file well-formedness.**
 Every non-blank line in the queue file is a valid JSON `Vessel`. Malformed


### PR DESCRIPTION
## Summary

- Adds `cli/internal/queue/verified/` — a new package containing the Dafny-verified `IsTerminal` function, its Go extraction, and property tests
- Proves the full spec-iterate → generate-verified → extract-code → property-test pipeline end-to-end on the smallest possible target (`IsTerminal`) before committing to harder kernels
- Annotates I2 and I7 in `docs/invariants/queue.md` with verified-kernel pointers
- Registers the spec in `.crosscheck/specs.json` for regression detection via `crosscheck:check-regressions`

## Files

| File | Role |
|---|---|
| `cli/internal/queue/verified/state_machine.dfy` | Hand-written Dafny source of truth — **do not edit the .go by hand** |
| `cli/internal/queue/verified/state_machine.go` | Go extraction, `_dafny` boilerplate stripped, types mapped to `string` |
| `cli/internal/queue/verified/state_machine_test.go` | Property tests: exhaustive over 7 canonical states + rapid property for unknown strings |
| `cli/internal/queue/verified_differential_test.go` | Abstraction-gap check: `verified.IsTerminal(s) == VesselState(s).IsTerminal()` for all 7 states |
| `cli/internal/queue/verified/README.md` | Pipeline docs, type mapping, wiring example, governance |
| `.crosscheck/specs.json` | Spec registry (new) |

## What is NOT in this PR

`queue.go` rewiring (`func (s VesselState) IsTerminal()` calling `verified.IsTerminal`) is deferred to a follow-up PR so this kernel is reviewable independently.

## Test plan

- [x] `go test ./internal/queue/...` passes (queue, queue/reference, queue/verified)
- [x] `go test ./...` passes (all 51 packages)
- [x] `TestIsTerminal_AllCanonicalValues` — exhaustive over all 7 states
- [x] `TestIsTerminal_UnknownStringIsFalse` — rapid property for non-canonical strings
- [x] `TestIsTerminal_DifferentialWithVerified` — agreement between `VesselState.IsTerminal()` and `verified.IsTerminal()` for all 7 states
- [x] Dafny verification: `1 verified, 0 errors` (Dafny 4.11.0)

## ⚠️ Human review required

This is the **first Dafny kernel** in the codebase. Per the governance note in `verified/README.md` and roadmap #06:

> The first kernel requires human review before merge — do not rely on `pr-self-review` alone.

Key things to verify:
1. The `ensures` clause in `state_machine.dfy` correctly enumerates all four terminal states
2. The type mapping (Dafny `VesselState` discriminated union → Go `string`) is sound
3. The trust boundary (unknown strings return false, not covered by the Dafny spec) is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)