### PR TITLE
feat(queue/verified): wire queue.go to Dafny-verified kernel (#06 phase 4)

### DIFF
--- a/cli/internal/queue/queue.go
+++ b/cli/internal/queue/queue.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gofrs/flock"
 	"github.com/nicholls-inc/xylem/cli/internal/dtu"
+	"github.com/nicholls-inc/xylem/cli/internal/queue/verified"
 )
 
 // writeInterrupt is a test-only hook. When non-nil it is invoked at enumerated
@@ -79,8 +80,9 @@ var ErrDuplicateID = errors.New("duplicate vessel ID")
 var ErrTerminalImmutable = errors.New("terminal vessel is immutable")
 
 // IsTerminal reports whether s is a terminal vessel state.
+// Delegates to the Dafny-verified kernel in the verified sub-package.
 func (s VesselState) IsTerminal() bool {
-	return s == StateCompleted || s == StateFailed || s == StateCancelled || s == StateTimedOut
+	return verified.IsTerminal(string(s))
 }
 
 // isSealedTerminal reports whether s is a terminal state with no legal
@@ -298,11 +300,7 @@ func (q *Queue) Update(id string, state VesselState, errMsg string) error {
 			previous := vessels[i]
 
 			// Validate state transition.
-			allowed, knownState := validTransitions[vessels[i].State]
-			if !knownState {
-				return fmt.Errorf("%w: unknown current state %s for vessel %s", ErrInvalidTransition, vessels[i].State, id)
-			}
-			if !allowed[state] {
+			if !verified.ValidTransition(string(vessels[i].State), string(state)) {
 				return fmt.Errorf("%w: cannot move vessel %s from %s to %s", ErrInvalidTransition, id, vessels[i].State, state)
 			}
 
@@ -462,11 +460,7 @@ func (q *Queue) UpdateVessel(vessel Vessel) error {
 			}
 			previous := vessels[i]
 			if previous.State != vessel.State {
-				allowed, knownState := validTransitions[previous.State]
-				if !knownState {
-					return fmt.Errorf("%w: unknown current state %s for vessel %s", ErrInvalidTransition, previous.State, vessel.ID)
-				}
-				if !allowed[vessel.State] {
+				if !verified.ValidTransition(string(previous.State), string(vessel.State)) {
 					return fmt.Errorf("%w: cannot move vessel %s from %s to %s", ErrInvalidTransition, vessel.ID, previous.State, vessel.State)
 				}
 			} else if isSealedTerminal(previous.State) && !protectedFieldsEqual(previous, vessel) {
@@ -499,8 +493,7 @@ func (q *Queue) Cancel(id string) error {
 				continue
 			}
 			previous := vessels[i]
-			allowed, knownState := validTransitions[vessels[i].State]
-			if !knownState || !allowed[StateCancelled] {
+			if !verified.ValidTransition(string(vessels[i].State), string(StateCancelled)) {
 				return fmt.Errorf("cannot cancel vessel %s in state %s", id, vessels[i].State)
 			}
 			now := queueNow()

--- a/cli/internal/queue/verified_differential_test.go
+++ b/cli/internal/queue/verified_differential_test.go
@@ -1,12 +1,15 @@
 package queue
 
-// Differential tests: verified functions must agree with the original Go
-// implementations for all canonical inputs. These are abstraction-gap checks —
-// same result from Dafny-extracted Go as from the original inline logic.
+// Differential tests: verified functions must agree with the hand-enumerated
+// truth tables below and with the validTransitions map (used by property tests).
 //
-// Lives in package queue (internal) so it can reference unexported types and
-// vars (VesselState.IsTerminal, validTransitions map). The wiring PR will flip
-// the dependency direction; until then queue does not import verified.
+// After wiring, VesselState.IsTerminal() delegates to verified.IsTerminal, so a
+// cross-check between the two would be tautological. TestIsTerminal_TruthTable
+// instead checks the verified function (and its delegate) against an independent
+// enumeration so a future regression in either direction is caught. The
+// ValidTransition differential test remains meaningful: production code calls
+// verified.ValidTransition while queue_invariants_prop_test.go checks the
+// validTransitions map — these two sources of truth must stay consistent.
 
 import (
 	"testing"
@@ -14,25 +17,30 @@ import (
 	"github.com/nicholls-inc/xylem/cli/internal/queue/verified"
 )
 
-func TestIsTerminal_DifferentialWithVerified(t *testing.T) {
-	canonical := []string{
-		"pending",
-		"running",
-		"completed",
-		"failed",
-		"cancelled",
-		"waiting",
-		"timed_out",
+func TestIsTerminal_TruthTable(t *testing.T) {
+	want := map[string]bool{
+		"pending":   false,
+		"running":   false,
+		"waiting":   false,
+		"failed":    true,
+		"completed": true,
+		"cancelled": true,
+		"timed_out": true,
 	}
-	for _, s := range canonical {
-		want := VesselState(s).IsTerminal()
-		got := verified.IsTerminal(s)
-		if got != want {
-			t.Errorf("state %q: VesselState.IsTerminal()=%v, verified.IsTerminal()=%v", s, want, got)
+	for s, expected := range want {
+		if got := VesselState(s).IsTerminal(); got != expected {
+			t.Errorf("VesselState(%q).IsTerminal() = %v, want %v", s, got, expected)
+		}
+		if got := verified.IsTerminal(s); got != expected {
+			t.Errorf("verified.IsTerminal(%q) = %v, want %v", s, got, expected)
 		}
 	}
 }
 
+// TestValidTransition_DifferentialWithMap guards that the validTransitions map
+// (the oracle for queue_invariants_prop_test.go) and verified.ValidTransition
+// (the production implementation after wiring) remain in sync. A divergence here
+// means property tests are exercising a different state machine than production.
 func TestValidTransition_DifferentialWithMap(t *testing.T) {
 	canonical := []string{
 		"pending",
@@ -53,7 +61,7 @@ func TestValidTransition_DifferentialWithMap(t *testing.T) {
 			}
 		}
 	}
-	// Test unknown from-state: map returns false (nil inner map), verified returns false.
+	// Unknown from-state: map returns false (nil inner map), verified returns false.
 	for _, to := range canonical {
 		want := validTransitions["unknown"][VesselState(to)]
 		got := verified.ValidTransition("unknown", to)
@@ -61,7 +69,7 @@ func TestValidTransition_DifferentialWithMap(t *testing.T) {
 			t.Errorf("ValidTransition(%q, %q): map=%v, verified=%v", "unknown", to, want, got)
 		}
 	}
-	// Test unknown to-state with each known from-state: map returns false, verified returns false.
+	// Unknown to-state: map returns false, verified returns false.
 	for _, from := range canonical {
 		want := validTransitions[VesselState(from)]["unknown"]
 		got := verified.ValidTransition(from, "unknown")

--- a/docs/assurance/ROADMAP.md
+++ b/docs/assurance/ROADMAP.md
@@ -37,7 +37,7 @@ xylem's current pragmatic projection of that hierarchy:
 
 | # | Item | Cost | Doc |
 |---|------|------|-----|
-| 6 | Queue state machine Dafny-verified kernel | 1–2 weeks | [next/06-queue-dafny-kernel.md](next/06-queue-dafny-kernel.md) — In progress: IsTerminal (PR #685) + ValidTransition + lightweight-verify of protectedFieldsEqual done (PR #687); Dafny-extract of protectedFieldsEqual deferred to #10 (Gobra); wiring pending |
+| 6 | Queue state machine Dafny-verified kernel | 1–2 weeks | [next/06-queue-dafny-kernel.md](next/06-queue-dafny-kernel.md) — **Complete**: IsTerminal (PR #685) + ValidTransition + lightweight-verify of protectedFieldsEqual (PR #687); queue.go wired to verified kernel (2026-04-20); Dafny-extract of protectedFieldsEqual deferred to #10 (Gobra) |
 | 7 | `intent-check` workflow phase (claimcheck-analog) | 1 week | [next/07-intent-check-phase.md](next/07-intent-check-phase.md) |
 | 8 | `verify-kernel` workflow phase | 2 days | [next/08-verify-kernel-phase.md](next/08-verify-kernel-phase.md) |
 | 9 | Retry-DAG acyclicity Dafny-verified kernel | 3 days | [next/09-retry-dag-dafny-kernel.md](next/09-retry-dag-dafny-kernel.md) |

--- a/docs/assurance/next/06-queue-dafny-kernel.md
+++ b/docs/assurance/next/06-queue-dafny-kernel.md
@@ -1,7 +1,7 @@
 # 06: Queue State Machine Dafny-Verified Kernel
 
 **Horizon:** Next (4–8 weeks)
-**Status:** In progress
+**Status:** Complete (2026-04-20)
 **Estimated cost:** 1–2 weeks
 **Depends on:** #01 (coverage CI), #02 (I9 fix), #03 (naive reference — gives a property-test oracle against which the extracted Go can be validated)
 **Unblocks:** #07 (intent-check has a concrete Dafny artifact to reason about), #08 (verify-kernel gate has something to verify), #09 (retry-DAG follows same pipeline)
@@ -115,11 +115,13 @@ Executed by a human operator (not the xylem daemon — first kernel requires man
 - `docs/invariants/queue.md` — I2 status row updated ✗→✓ (protectedFieldsEqual guard already present at queue.go:472; stale line reference corrected); summary updated; governance amendment per user direction 2026-04-20
 - `cli/internal/queue/queue_invariants_prop_test.go` — file-header comment updated: I2 removed from skip list (no t.Skip in TestPropQueueInvariant_I2_TerminalImmutability)
 
+**Phase 4 — Wiring queue.go (2026-04-20):** Production callers now invoke the verified kernel.
+- `cli/internal/queue/queue.go` — `IsTerminal()` method delegates to `verified.IsTerminal(string(s))`; three `validTransitions` map look-ups replaced with `verified.ValidTransition(string(from), string(to))`. The `validTransitions` map is retained (it is the oracle for `queue_invariants_prop_test.go`, which is a protected surface).
+- `cli/internal/queue/verified_differential_test.go` — `TestIsTerminal_DifferentialWithVerified` repurposed as `TestIsTerminal_TruthTable` (independent ground truth, not tautological after delegation); `TestValidTransition_DifferentialWithMap` retained to guard that the map used by property tests stays in sync with the verified function used by production.
+- All queue tests pass (`go test ./internal/queue/` clean).
+
 **Scoping decision — protectedFieldsEqual:**
 `protectedFieldsEqual` is deferred to **#10 (Gobra)**, which handles Go-native `*time.Time` and `map[string]string` without extraction gymnastics. Reason for deferral from #06: the function operates on the 19-field `Vessel` struct which has `*time.Time` and `map[string]string` fields. Modelling these in Dafny requires either abstract ghost types (no extractable code) or a full Vessel datatype whose Go extraction doesn't interoperate with the real `queue.Vessel` without a conversion shim — which defeats the purpose of extraction. The existing Go implementation is already a compile-time-explicit field enumeration (not reflection), providing adequate assurance for I2. Kill criteria were not triggered; this is an intentional rescope per the kill-criteria guidance ("perhaps only `IsTerminal` first").
-
-**Remaining:**
-- Wiring `queue.go` to call `verified.IsTerminal` and `verified.ValidTransition` — deferred follow-up PR (roadmap #06 step 7)
 
 **Phase 3 — Lightweight verification of `protectedFieldsEqual` (2026-04-20):** delivered alongside Phase 2 in PR #687.
 - `cli/internal/queue/verified/protectedfields_verify.md` — semi-formal contract analysis: 11 contracts (C1–C11), 19-field coverage table, helper analysis for `timePtrEqual` and `stringMapEqual`, verification gaps, upgrade path to #10 (Gobra)

--- a/docs/assurance/next/06-queue-dafny-kernel.md
+++ b/docs/assurance/next/06-queue-dafny-kernel.md
@@ -115,11 +115,6 @@ Executed by a human operator (not the xylem daemon — first kernel requires man
 - `docs/invariants/queue.md` — I2 status row updated ✗→✓ (protectedFieldsEqual guard already present at queue.go:472; stale line reference corrected); summary updated; governance amendment per user direction 2026-04-20
 - `cli/internal/queue/queue_invariants_prop_test.go` — file-header comment updated: I2 removed from skip list (no t.Skip in TestPropQueueInvariant_I2_TerminalImmutability)
 
-**Phase 4 — Wiring queue.go (2026-04-20):** Production callers now invoke the verified kernel.
-- `cli/internal/queue/queue.go` — `IsTerminal()` method delegates to `verified.IsTerminal(string(s))`; three `validTransitions` map look-ups replaced with `verified.ValidTransition(string(from), string(to))`. The `validTransitions` map is retained (it is the oracle for `queue_invariants_prop_test.go`, which is a protected surface).
-- `cli/internal/queue/verified_differential_test.go` — `TestIsTerminal_DifferentialWithVerified` repurposed as `TestIsTerminal_TruthTable` (independent ground truth, not tautological after delegation); `TestValidTransition_DifferentialWithMap` retained to guard that the map used by property tests stays in sync with the verified function used by production.
-- All queue tests pass (`go test ./internal/queue/` clean).
-
 **Scoping decision — protectedFieldsEqual:**
 `protectedFieldsEqual` is deferred to **#10 (Gobra)**, which handles Go-native `*time.Time` and `map[string]string` without extraction gymnastics. Reason for deferral from #06: the function operates on the 19-field `Vessel` struct which has `*time.Time` and `map[string]string` fields. Modelling these in Dafny requires either abstract ghost types (no extractable code) or a full Vessel datatype whose Go extraction doesn't interoperate with the real `queue.Vessel` without a conversion shim — which defeats the purpose of extraction. The existing Go implementation is already a compile-time-explicit field enumeration (not reflection), providing adequate assurance for I2. Kill criteria were not triggered; this is an intentional rescope per the kill-criteria guidance ("perhaps only `IsTerminal` first").
 
@@ -127,3 +122,8 @@ Executed by a human operator (not the xylem daemon — first kernel requires man
 - `cli/internal/queue/verified/protectedfields_verify.md` — semi-formal contract analysis: 11 contracts (C1–C11), 19-field coverage table, helper analysis for `timePtrEqual` and `stringMapEqual`, verification gaps, upgrade path to #10 (Gobra)
 - `cli/internal/queue/protectedfields_verify_test.go` — companion tests: per-field mutation coverage (19 fields), exclusion tests (4 excluded fields), reflexivity and symmetry property tests (rapid), unit tests for `timePtrEqual` (6 cases) and `stringMapEqual` (10 cases)
 - `docs/assurance/medium-term/10-gobra-queue.md` — updated: `protectedFieldsEqual` added to Gobra scope with rationale; acceptance criterion added; read-only file list updated with correct line references (queue.go:98, 124)
+
+**Phase 4 — Wiring queue.go (2026-04-20):** Production callers now invoke the verified kernel.
+- `cli/internal/queue/queue.go` — `IsTerminal()` method delegates to `verified.IsTerminal(string(s))`; three `validTransitions` map look-ups replaced with `verified.ValidTransition(string(from), string(to))`. The `validTransitions` map is retained (it is the oracle for `queue_invariants_prop_test.go`, which is a protected surface).
+- `cli/internal/queue/verified_differential_test.go` — `TestIsTerminal_DifferentialWithVerified` repurposed as `TestIsTerminal_TruthTable` (independent ground truth, not tautological after delegation); `TestValidTransition_DifferentialWithMap` retained to guard that the map used by property tests stays in sync with the verified function used by production.
+- All queue tests pass (`go test ./internal/queue/` clean).


### PR DESCRIPTION
## Summary

- `VesselState.IsTerminal()` now delegates to `verified.IsTerminal(string(s))`
- Three `validTransitions` map look-ups in `Update`, `UpdateVessel`, and `Cancel` replaced with `verified.ValidTransition(string(from), string(to))`
- `validTransitions` map retained — `queue_invariants_prop_test.go` (protected surface) uses it as oracle
- `TestIsTerminal_DifferentialWithVerified` repurposed as `TestIsTerminal_TruthTable` (independent truth table; cross-checking two implementations was tautological after delegation)
- `TestValidTransition_DifferentialWithMap` retained: guards that the map oracle (property tests) and the verified function (production) stay in sync

This is step 7 of roadmap #06, closing out the queue state machine Dafny-verified kernel item.

## Test plan
- [ ] `go test ./internal/queue/` passes clean
- [ ] `TestIsTerminal_TruthTable` asserts all 7 canonical states against hand-enumerated expected values
- [ ] `TestValidTransition_DifferentialWithMap` still exercises all 49 canonical pairs + unknown from/to-state edge cases
- [ ] Human review required per #06 acceptance criteria (first kernel establishes the pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)